### PR TITLE
fix: enable first and last button at pagination

### DIFF
--- a/packages/library/src/components/pagination/component.tsx
+++ b/packages/library/src/components/pagination/component.tsx
@@ -125,7 +125,7 @@ export class KolPagination implements Generic.Element.ComponentApi<RequiredProps
 					{this.state._hasButtons.first && (
 						<kol-button
 							_customClass={this.state._customClass}
-							_disabled={this.state._page <= 2}
+							_disabled={this.state._page <= 1}
 							_icon={leftDoubleArrowIcon}
 							_iconOnly
 							_label="Direkt zur ersten Seite"
@@ -162,7 +162,7 @@ export class KolPagination implements Generic.Element.ComponentApi<RequiredProps
 					{this.state._hasButtons.last && (
 						<kol-button
 							_customClass={this.state._customClass}
-							_disabled={count - 1 <= this.state._page}
+							_disabled={count <= this.state._page}
 							_icon={rightDoubleArrowIcon}
 							_iconOnly
 							_label="Direkt zur letzten Seite"

--- a/packages/storybook/src/998-changelog.stories.mdx
+++ b/packages/storybook/src/998-changelog.stories.mdx
@@ -113,6 +113,7 @@ _data="[{'symbol':'🌟','desc':'Neue Funktion'},{'symbol':'🚹','desc':'Barrie
 		<li>🔧 InputDate: Mapping von _min, _max und _value optimiert</li>
 		<li>🔧 Table: Überflüssige Aria-Auszeichnung (aria-readonly) entfernt</li>
 		<li>🔧 Nav, Table: Icon-Identifier ergänzt</li>
+		<li>🔧 Erste und letzte Seite Buttons in der Pagination sind immer aktiv, wenn man nicht bereits auf der entsprechenden Seite ist</li>
 		<li>📚 Cheat Sheet: Generator-Script zum Erzeugen und Synchronisieren eine Cheat-Sheet für die Entwicklung</li>
 	</ul>
 </kol-details>


### PR DESCRIPTION
The first page button is always enabled except the first page is the current one.

The last page button is always enabled except the last page is shown.

Closes #521