### PR TITLE
chore: set `label` type to `string | number`

### DIFF
--- a/packages/library/src/types/input/types.ts
+++ b/packages/library/src/types/input/types.ts
@@ -22,7 +22,7 @@ type InputTypeOnFocus = {
 // https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element
 export type Option<T> = {
 	disabled?: boolean;
-	label: string;
+	label: string | number;
 	// selected?: boolean; // wird über den value der *-Komponente gesteuert
 	value: T;
 };


### PR DESCRIPTION
Resolve issue: #2021 

This will add the possibility to add a numbered labels for the option label.