### PR TITLE
fix: initial reset of manual typing date values

### DIFF
--- a/packages/library/src/components/input-date/component.tsx
+++ b/packages/library/src/components/input-date/component.tsx
@@ -176,7 +176,7 @@ export class KolInputDate implements ComponentApi {
 	/**
 	 * Gibt den Wert des Eingabefeldes an.
 	 */
-	@Prop() public _value?: Iso8601 | Date | null;
+	@Prop({ mutable: true }) public _value?: Iso8601 | Date | null;
 
 	/**
 	 * @see: components/abbr/component.tsx (@State)
@@ -233,7 +233,11 @@ export class KolInputDate implements ComponentApi {
 		setState(this, '_on', {
 			...value,
 			onChange: (e: Event, v: unknown) => {
-				this._value = v as Iso8601;
+				// set the value here when the value is switched between blank and set (or vice versa) to enable value resets via setting null as value.
+				if (!!v !== !!this._value) {
+					this._value = v as Iso8601;
+				}
+
 				if (value?.onChange) {
 					value.onChange(e, v);
 				}

--- a/packages/library/src/components/input-number/component.tsx
+++ b/packages/library/src/components/input-number/component.tsx
@@ -209,7 +209,7 @@ export class KolInputNumber implements ComponentApi {
 	/**
 	 * Gibt den Wert des Eingabefeldes an.
 	 */
-	@Prop() public _value?: number | Iso8601 | null;
+	@Prop({ mutable: true }) public _value?: number | Iso8601 | null;
 
 	/**
 	 * @see: components/abbr/component.tsx (@State)

--- a/packages/library/src/components/input-number/controller.ts
+++ b/packages/library/src/components/input-number/controller.ts
@@ -78,7 +78,11 @@ export class InputNumberController extends InputIconController implements Watche
 
 	protected onChange(event: Event): void {
 		super.onChange(event);
-		this.component._value = (event.target as HTMLInputElement).value as number | Iso8601;
+
+		// set the value here when the value is switched between blank and set (or vice versa) to enable value resets via setting null as value.
+		if (!!(event.target as HTMLInputElement).value !== !!this.component._value) {
+			this.component._value = (event.target as HTMLInputElement).value as number | Iso8601;
+		}
 	}
 
 	/**


### PR DESCRIPTION
When entering the date value to KolInputDate or number value of KolInputNumber, the first digit was initial cleared. This happened because the value of the field was changed from undefined to a blank string. The mapping of the value from the HTML input tag to the date or number component now happens only when the value is switched between general blank values and date or number values.

To prevent stencil warnings, the value props are marked as mutable.

Closes: #2536