### PR TITLE
feat(progress): add class `_type` to wrapper

### DIFF
--- a/packages/components/src/components/progress/component.tsx
+++ b/packages/components/src/components/progress/component.tsx
@@ -26,36 +26,40 @@ const createProgressSVG = (state: States): JSX.Element => {
 	switch (state._type) {
 		case 'cycle':
 			return (
-				<svg width="100" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
-					<circle fill="none" stroke="#efefef" cx="6px" cy="6px" r="5px"></circle>
-					<text aria-hidden="true" font-size="0.1em" x="50%" y="50%" text-anchor="middle" fill="currentColor">
-						{state._label && (
-							<tspan text-anchor="middle" x="50%" dy="-0.5em">
-								{state._label}
-							</tspan>
-						)}
-						<tspan text-anchor="middle" x="50%" dy={state._label ? '1em' : '0em'}>
-							{state._value}
-							{state._unit}
-						</tspan>
-					</text>
-					<circle
-						class="cycle"
-						stroke-linecap="round"
-						stroke-dasharray={`${Math.round((state._value / state._max) * 32)}px 32px`}
-						fill="none"
-						stroke="#0075ff"
-						cx="6px"
-						cy="6px"
-						r="5px"
-					></circle>
-				</svg>
+				<div>
+					<div class={state._type}>
+						<svg width="100" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+							<circle fill="none" stroke="#efefef" cx="6px" cy="6px" r="5px"></circle>
+							<text aria-hidden="true" font-size="0.1em" x="50%" y="50%" text-anchor="middle" fill="currentColor">
+								{state._label && (
+									<tspan text-anchor="middle" x="50%" dy="-0.5em">
+										{state._label}
+									</tspan>
+								)}
+								<tspan text-anchor="middle" x="50%" dy={state._label ? '1em' : '0em'}>
+									{state._value}
+									{state._unit}
+								</tspan>
+							</text>
+							<circle
+								class="cycle"
+								stroke-linecap="round"
+								stroke-dasharray={`${Math.round((state._value / state._max) * 32)}px 32px`}
+								fill="none"
+								stroke="#0075ff"
+								cx="6px"
+								cy="6px"
+								r="5px"
+							></circle>
+						</svg>
+					</div>
+				</div>
 			);
 		default:
 			return (
 				<div>
 					{state._label && <div>{state._label}</div>}
-					<div style={{ display: 'flex', gap: '0.3em' }}>
+					<div style={{ display: 'flex', gap: '0.3em' }} class={state._type}>
 						<svg width="100" viewBox="0 0 24 2" xmlns="http://www.w3.org/2000/svg">
 							<line stroke-width="2" x1="1" stroke-linecap="round" y1="1" x2="23" y2="1" fill="#efefef" stroke="#efefef"></line>
 							<line

--- a/packages/components/src/components/progress/component.tsx
+++ b/packages/components/src/components/progress/component.tsx
@@ -26,40 +26,36 @@ const createProgressSVG = (state: States): JSX.Element => {
 	switch (state._type) {
 		case 'cycle':
 			return (
-				<div>
-					<div class={state._type}>
-						<svg width="100" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
-							<circle fill="none" stroke="#efefef" cx="6px" cy="6px" r="5px"></circle>
-							<text aria-hidden="true" font-size="0.1em" x="50%" y="50%" text-anchor="middle" fill="currentColor">
-								{state._label && (
-									<tspan text-anchor="middle" x="50%" dy="-0.5em">
-										{state._label}
-									</tspan>
-								)}
-								<tspan text-anchor="middle" x="50%" dy={state._label ? '1em' : '0em'}>
-									{state._value}
-									{state._unit}
-								</tspan>
-							</text>
-							<circle
-								class="cycle"
-								stroke-linecap="round"
-								stroke-dasharray={`${Math.round((state._value / state._max) * 32)}px 32px`}
-								fill="none"
-								stroke="#0075ff"
-								cx="6px"
-								cy="6px"
-								r="5px"
-							></circle>
-						</svg>
-					</div>
-				</div>
+				<svg class={state._type} width="100" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+					<circle fill="none" stroke="#efefef" cx="6px" cy="6px" r="5px"></circle>
+					<text aria-hidden="true" font-size="0.1em" x="50%" y="50%" text-anchor="middle" fill="currentColor">
+						{state._label && (
+							<tspan text-anchor="middle" x="50%" dy="-0.5em">
+								{state._label}
+							</tspan>
+						)}
+						<tspan text-anchor="middle" x="50%" dy={state._label ? '1em' : '0em'}>
+							{state._value}
+							{state._unit}
+						</tspan>
+					</text>
+					<circle
+						class="cycle"
+						stroke-linecap="round"
+						stroke-dasharray={`${Math.round((state._value / state._max) * 32)}px 32px`}
+						fill="none"
+						stroke="#0075ff"
+						cx="6px"
+						cy="6px"
+						r="5px"
+					></circle>
+				</svg>
 			);
 		default:
 			return (
-				<div>
+				<div class={state._type}>
 					{state._label && <div>{state._label}</div>}
-					<div style={{ display: 'flex', gap: '0.3em' }} class={state._type}>
+					<div style={{ display: 'flex', gap: '0.3em' }} >
 						<svg width="100" viewBox="0 0 24 2" xmlns="http://www.w3.org/2000/svg">
 							<line stroke-width="2" x1="1" stroke-linecap="round" y1="1" x2="23" y2="1" fill="#efefef" stroke="#efefef"></line>
 							<line

--- a/packages/components/src/components/progress/component.tsx
+++ b/packages/components/src/components/progress/component.tsx
@@ -55,7 +55,7 @@ const createProgressSVG = (state: States): JSX.Element => {
 			return (
 				<div class={state._type}>
 					{state._label && <div>{state._label}</div>}
-					<div style={{ display: 'flex', gap: '0.3em' }} >
+					<div style={{ display: 'flex', gap: '0.3em' }}>
 						<svg width="100" viewBox="0 0 24 2" xmlns="http://www.w3.org/2000/svg">
 							<line stroke-width="2" x1="1" stroke-linecap="round" y1="1" x2="23" y2="1" fill="#efefef" stroke="#efefef"></line>
 							<line


### PR DESCRIPTION
Ich weiß nicht ob es damit getan ist um #3115 damit zu beheben, oder ob noch weitere Schritt notwendig sind. 

Ich bräuchte auch nochmal einen Rat wie ich das ganze dann auch prüfen kann. Beim Versuch die `components` zu starten, kam folgender Fehler:

```
❯ cd packages/components
❯ pnpm start

> @public-ui/components@1.5.1 start /.../public-ui/packages/components
> cross-env NODE_ENV=development stencil build --dev --serve --watch --no-open

[50:01.1]  @stencil/core
[50:01.4]  v3.3.0 🍭
[50:02.8]  build, kolibri, dev mode, started ...
[50:02.8]  transpile started ...
[50:04.6]  transpile finished in 1.74 s
[50:04.6]  copy started ...
[50:04.6]  generate lazy + source maps started ...
[50:04.7]  copy finished (86 files) in 144 ms
[50:04.9]  generate lazy + source maps finished in 332 ms

[ ERROR ]  Rollup: Parse Error: ./src/components/input-date/component.tsx:566:9
           Duplicate export 'KolInputDate' (Note that you need plugins to import files that are not JavaScript) Error
           parsing:
           /.../public-ui/packages/components/src/components/input-date/component.tsx,
           line: 566, column: 9

[50:04.9]  build failed, watching for changes... in 2.13 s

[50:04.9]  http://localhost:3333/
```

fixes #3115 