### PR TITLE
fix: correct positioning of tooltips inside accordions

### DIFF
--- a/packages/components/src/components/accordion/style.css
+++ b/packages/components/src/components/accordion/style.css
@@ -9,11 +9,7 @@
 }
 .content {
 	inset: 0 0 auto 0;
-	position: absolute;
 	width: 100%;
-}
-.wrapper {
-	position: relative;
 }
 .transition {
 	transition: height 0.3s ease-in-out;


### PR DESCRIPTION
Remove the position absolute and relative from the base CSS of the accordion.

Closes: #3850