### PR TITLE
fix: remove unnecessary ts comiler type

### DIFF
--- a/packages/create-kolibri/templates/angular-app/tsconfig.app.json
+++ b/packages/create-kolibri/templates/angular-app/tsconfig.app.json
@@ -15,7 +15,7 @@
 		"target": "es2015",
 		"typeRoots": ["node_modules/@types"],
 		"lib": ["es2018", "dom"],
-		"types": ["@public-ui/components", "mocha", "node"],
+		"types": ["mocha", "node"],
 		"forceConsistentCasingInFileNames": true,
 		"removeComments": false,
 		"strict": false


### PR DESCRIPTION
Remove @public-ui/components as type from tsconfig.app.json in angular-app template.

Closes: #4100