### PR TITLE
chore: typos and spelling

### DIFF
--- a/docs/tutorials/NEW_COMPONENT.md
+++ b/docs/tutorials/NEW_COMPONENT.md
@@ -24,7 +24,7 @@ Folgende Grundprinzipien gelten für das Schreiben von Quellcode:
 |.   7.   | Component-Identifier in die `stencil.config.js` eintragen                                                                               |
 |   ...   | ...                                                                                                                                     |
 |   ...   | Klasse in Komponenten-Liste für Tests aufnehmen (packages/components/src/components/component-list.ts)                                  |
-|   ...   | Alle autogeneierten Daten zur Komponenten mit einchecken                                                                                |
+|   ...   | Alle autogeneierten Daten zur Komponente mit einchecken                                                                                |
 
 ## Schritt 0
 
@@ -51,7 +51,7 @@ Inhalt:
 - `@Component` (außerhalb der Klasse),
 - `@Prop`: alphabetisch sortiert,
 - `@State`: Standardwerte werden hier gesetzt,
-- `@Watch`: werden bei Änderungen des Wertes aufgerufen, Validierung und übernahme des Wertes in den State,
+- `@Watch`: werden bei Änderungen des Wertes aufgerufen, Validierung und Übernahme des Wertes in den State,
 - `public componentWillLoad()`: Initialer Hook, alle Validierungsmethoden hier aufrufen
 - `public render()`: Render-Methode, erstellt das HTML, das gerendert werden soll
 
@@ -59,7 +59,7 @@ Inhalt:
 
 Datei: `styles.css`;
 Wichtig: `packages/components/src/components/README.md` beachten.
-Sofern Styling für mehrere komponenten verwendet werden soll, Datei passend benennen und direkt unter `/packages/components/src/components/` erstellen und in styles.css importieren.
+Sofern Styling für mehrere Komponenten verwendet werden soll, Datei passend benennen und direkt unter `/packages/components/src/components/` erstellen und in styles.css importieren.
 
 ## Schritt 5 - Beispiel in index.html erstellen
 

--- a/docs/tutorials/NEW_COMPONENT.md
+++ b/docs/tutorials/NEW_COMPONENT.md
@@ -30,7 +30,7 @@ Folgende Grundprinzipien gelten für das Schreiben von Quellcode:
 
 Als erstes wird der **Name** der neuen Komponenten in der **Schema**-Datei (`src/schema/tag-names.ts`) hinterlegt.
 
-## Schritt 1 - Verzeichnins anlegen
+## Schritt 1 - Verzeichnis anlegen
 
 Eine Vorlage ist unter `/docs/tutorials/component` zu finden. Ziel: `/packages/components/src/components/[component-name]`.
 Sofern eine Variante ohne ShadowDOM für andere Komponenten benötigt wird, ist die Komponente selbst, mit `shadow: false` anzulegen und diese Komponente in `shadow.tsx` einzubinden.

--- a/docs/tutorials/NEW_COMPONENT.md
+++ b/docs/tutorials/NEW_COMPONENT.md
@@ -1,6 +1,6 @@
 # Neue Komponente erstellen
 
-> Schritt-für-Schritt-Anleitung, wie man einen neue Komponente im Teilmodul `components` erstellt.
+> Schritt-für-Schritt-Anleitung, wie man eine neue Komponente im Teilmodul `components` erstellt.
 
 ## Grundprinzipien
 
@@ -15,7 +15,7 @@ Folgende Grundprinzipien gelten für das Schreiben von Quellcode:
 | Schritt | Kurzbeschreibung                                                                                                                        |
 | :-----: | --------------------------------------------------------------------------------------------------------------------------------------- |
 |    0    | Name im Schema hinterlegen                                                                                                              |
-|    1    | Verzeichnis anlegen<br>- component.tsx(optional)<br>- readme.md<br>- shadow.tsx: Komponente mit shadowDOM<br>- styles.css<br>- types.ts |
+|    1    | Verzeichnis anlegen<br>- component.tsx(optional)<br>- readme.md<br>- shadow.tsx: Komponente mit Shadow DOM<br>- styles.css<br>- types.ts |
 |    2    | API spezifizieren                                                                                                                       |
 |    3    | Klasse zur API implementieren<br>- Props<br>- State<br>- Watcher<br>- Initialer Hook<br>- Render-Methode                                |
 |    4    | Styling anlegen                                                                                                                         |
@@ -33,9 +33,9 @@ Als erstes wird der **Name** der neuen Komponenten in der **Schema**-Datei (`src
 ## Schritt 1 - Verzeichnis anlegen
 
 Eine Vorlage ist unter `/docs/tutorials/component` zu finden. Ziel: `/packages/components/src/components/[component-name]`.
-Sofern eine Variante ohne ShadowDOM für andere Komponenten benötigt wird, ist die Komponente selbst, mit `shadow: false` anzulegen und diese Komponente in `shadow.tsx` einzubinden.
+Sofern eine Variante ohne Shadow DOM für andere Komponenten benötigt wird, ist die Komponente selbst, mit `shadow: false` anzulegen und diese Komponente in `shadow.tsx` einzubinden.
 Andernfalls ist die Komponente direkt mit `shadow: true` in `shadow.tsx` zu implementieren.
-Ziel: shadow.tsx existiert immer und liefert die Komponente mit ShadowDOM.
+Ziel: shadow.tsx existiert immer und liefert die Komponente mit Shadow DOM.
 Die `readme.md` wird automatisch bei `pnpm build` erzeugt, sollte sie bereits existieren wird der automatisch generierte Inhalt angehängt.
 
 ## Schritt 2 - API spezifizieren

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -772,7 +772,7 @@ export namespace Components {
          */
         "_required"?: boolean;
         /**
-          * Ermöglicht den Slotnamen zu bestimmen. Wird nur verwendet, wenn sonst mehrere Slots mit dem gleichen Namen innerhalb eines ShadowDOMs existieren würden.
+          * Ermöglicht den Slotnamen zu bestimmen. Wird nur verwendet, wenn sonst mehrere Slots mit dem gleichen Namen innerhalb eines Shadow DOMs existieren würden.
          */
         "_slotName"?: string;
         /**
@@ -3996,7 +3996,7 @@ declare namespace LocalJSX {
          */
         "_required"?: boolean;
         /**
-          * Ermöglicht den Slotnamen zu bestimmen. Wird nur verwendet, wenn sonst mehrere Slots mit dem gleichen Namen innerhalb eines ShadowDOMs existieren würden.
+          * Ermöglicht den Slotnamen zu bestimmen. Wird nur verwendet, wenn sonst mehrere Slots mit dem gleichen Namen innerhalb eines Shadow DOMs existieren würden.
          */
         "_slotName"?: string;
         /**

--- a/packages/components/src/components/input/component.tsx
+++ b/packages/components/src/components/input/component.tsx
@@ -167,7 +167,7 @@ export class KolInput implements Props {
 	@Prop() public _required?: boolean = false;
 
 	/**
-	 * Ermöglicht den Slotnamen zu bestimmen. Wird nur verwendet, wenn sonst mehrere Slots mit dem gleichen Namen innerhalb eines ShadowDOMs existieren würden.
+	 * Ermöglicht den Slotnamen zu bestimmen. Wird nur verwendet, wenn sonst mehrere Slots mit dem gleichen Namen innerhalb eines Shadow DOMs existieren würden.
 	 * @internal
 	 */
 	@Prop() public _slotName?: string;

--- a/packages/storybook/src/85-icons.mdx
+++ b/packages/storybook/src/85-icons.mdx
@@ -5,26 +5,26 @@ import { Meta } from '@storybook/addon-docs';
 # Rahmenbedingungen
 
 - Einige Komponenten ermöglichen die Verwendung von Icons (Button)
-- Icons werden auch in den Komponenten implizit verwendet und können theorisch nicht von außen geändert werden. (Accordion, Nav u.a.)
+- Icons werden auch in den Komponenten implizit verwendet und können theoretisch nicht von außen geändert werden. (Accordion, Nav u.a.)
 
-# Lösungansätz
+# Lösungansatz
 
 ## Für jede Icon-Font eine Komponente
 
 - Aufwendig
-- Die Komponnenten müssten mit allen weitern Icon-Komponentnen kompatibel sein
+- Die Komponenten müssten mit allen weitern Icon-Komponenten kompatibel sein
 
 ## Es gibt eine generische KolIcon
 
 - Icon font wird über Assets eingebunden
-- Icon Identifier keine Auto-Vervollsätndigung, da jede Icon-Font anderes Naming hat
+- Icon Identifier keine Auto-Vervollständigung, da jede Icon-Font anderes Naming hat
 - ggf. Problem bei Icon-Wiederverwendung innerhalb von Sub-Shadow DOMs (Accordion, Nav) (Icon nicht sichtbar)
 
 ## Icon-Identifier standardisieren
 
 - alle relevanten Icons ermitteln und eine Liste von Icon-Identifier erstellen (arrow-right, home usw. 50)
 - nur über neues Release erweiterbar (gibt es eine Lösung ?!)
-- je Theme wird ein CSS-Mapping auf eine beliebige Icon-Font gemacht (.kol-icon {font-family: FontAwesomPro Plus;} .home {content: '&#1233;'})
+- je Theme wird ein CSS-Mapping auf eine beliebige Icon-Font gemacht (.kol-icon {font-family: FontAwesomePro Plus;} .home {content: '&#1233;'})
 
 # Ausprobieren
 

--- a/packages/storybook/src/85-icons.mdx
+++ b/packages/storybook/src/85-icons.mdx
@@ -18,7 +18,7 @@ import { Meta } from '@storybook/addon-docs';
 
 - Icon font wird über Assets eingebunden
 - Icon Identifier keine Auto-Vervollsätndigung, da jede Icon-Font anderes Naming hat
-- ggf. Problem bei Icon-Wiederverwendung innerhalb von Sub-ShadowDoms (Accordion, Nav) (Icon nicht sichtbar)
+- ggf. Problem bei Icon-Wiederverwendung innerhalb von Sub-Shadow DOMs (Accordion, Nav) (Icon nicht sichtbar)
 
 ## Icon-Identifier standardisieren
 


### PR DESCRIPTION
- It's written as `Shadow DOM` in the ["Shadow DOM W3C Specifications"](https://www.w3.org/TR/shadow-dom/) 