### PR TITLE
export toaster instance

### DIFF
--- a/packages/components/src/components/toast/toaster.tsx
+++ b/packages/components/src/components/toast/toaster.tsx
@@ -66,3 +66,5 @@ export class ToasterService {
 		this.isOpen = true;
 	}
 }
+
+export const Toaster = new ToasterService(document);

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,5 @@
+import { ToasterService as ToasterServiceInternal } from './components/toast/toaster';
+
 export { register } from './core';
 export * from './components.d';
 export * from './enums/bund';
@@ -5,5 +7,10 @@ export * from './kolibri';
 export { configKoliBri } from './utils/dev.utils';
 export { Optgroup, Option, SelectOption } from './types/input/types';
 export { KoliBriDevHelper } from './utils/prop.validators';
-export { ToasterService } from './components/toast/toaster';
+export { Toaster } from './components/toast/toaster';
 export { translations } from './i18n';
+
+/**
+ * @deprecated Use Toaster instead
+ */
+export const ToasterService = ToasterServiceInternal;


### PR DESCRIPTION
Deprecate exported toaster service class to make clear, that the toaster instance should be used.

Refs: #4392