### PR TITLE
Include "types" property in package.json exports

### DIFF
--- a/packages/adapters/react/package.json
+++ b/packages/adapters/react/package.json
@@ -67,13 +67,13 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs"
 		}
 	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
 	"files": [
 		"dist"
 	]

--- a/packages/adapters/solid/package.json
+++ b/packages/adapters/solid/package.json
@@ -63,13 +63,13 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs"
 		}
 	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
 	"files": [
 		"dist"
 	]

--- a/packages/adapters/vue/package.json
+++ b/packages/adapters/vue/package.json
@@ -64,13 +64,13 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.mjs",
 			"require": "./dist/index.cjs"
 		}
 	},
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
 	"files": [
 		"dist"
 	]


### PR DESCRIPTION
Folgende Fehlermeldungen hatte ich beim einbinden der Bibliothek in ein bestehendes React + Vite + TS Projekt (ebenfalls mit Vue + Vite):
`Could not find a declaration file for module '@public-ui/themes'. 'c:/dev/node_modules/@public-ui/themes/dist/index.mjs' implicitly has an 'any' type. There are types at 'c:/dev/node_modules/@public-ui/themes/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@public-ui/themes' library may need to update its package.json or typings.ts(7016)`

Ich habe die Eigenschaft "types" direkt in den Abschnitt "exports" der Datei package.json-Datei verschoben, um das Problem der Auflösung der TypeScript-Deklarationsdatei für das Paket @public-ui/themes zu beheben.

> Das types Feld im package.json wird nicht mehr verwendet, wenn es ein exports Feld gibt:
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing