### PR TITLE
Toaster Fabricator

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -105,7 +105,6 @@
 		"jest": "26.6.3",
 		"jest-cli": "26.6.3",
 		"lighthouse": "10.4.0",
-		"mathjs": "11.9.1",
 		"mustache": "4.2.0",
 		"postcss": "8.4.28",
 		"postcss-sorting": "8.0.2",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,10 +1,9 @@
-export { ToasterService } from './components/toast/toaster';
-
 export * from './components.d';
 export { register } from './core';
 export * from './enums/bund';
 export { translations } from './i18n';
 export * from './kolibri';
+export { ToasterService, fabricator as toasterFabricator } from './components/toast/toaster';
 export { Optgroup, Option, SelectOption } from './types/input/types';
 export { configKoliBri } from './utils/dev.utils';
 export { KoliBriDevHelper } from './utils/prop.validators';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -3,7 +3,7 @@ export { register } from './core';
 export * from './enums/bund';
 export { translations } from './i18n';
 export * from './kolibri';
-export { ToasterService, fabricator as toasterFabricator } from './components/toast/toaster';
+export { ToasterService } from './components/toast/toaster';
 export { Optgroup, Option, SelectOption } from './types/input/types';
 export { configKoliBri } from './utils/dev.utils';
 export { KoliBriDevHelper } from './utils/prop.validators';

--- a/packages/components/src/utils/dev.utils.ts
+++ b/packages/components/src/utils/dev.utils.ts
@@ -1,5 +1,4 @@
 import { ModalService } from '../components/modal/service';
-import { ToasterService } from '../components/toast/toaster';
 import { processEnv } from './reuse';
 
 let WINDOW: Window | null = null;
@@ -122,15 +121,9 @@ export const initKoliBri = (): void => {
 	if (KoliBri === null) {
 		KoliBri = getWindow().KoliBri || {};
 		const Modal = new ModalService();
-		const Toaster = new ToasterService(getDocument());
 		Object.defineProperty(KoliBri, 'Modal', {
 			get: function (): ModalService {
 				return Modal;
-			},
-		});
-		Object.defineProperty(KoliBri, 'Toaster', {
-			get: function (): ToasterService {
-				return Toaster;
 			},
 		});
 		initMeta();


### PR DESCRIPTION
A singleton fabricator class, that creates ToasterService instances for each document.

Remove toaster service initialization in dev utils.

Add functionality to dispose a toaster service instance.

Refs: #4392