### PR TITLE
fix: logo and kolibri component apapts to the size of it's container

### DIFF
--- a/packages/components/src/components/kolibri/style.css
+++ b/packages/components/src/components/kolibri/style.css
@@ -4,3 +4,6 @@ text {
 	letter-spacing: normal;
 	word-spacing: normal;
 }
+svg {
+	max-height: 100%;
+}

--- a/packages/components/src/components/logo/style.css
+++ b/packages/components/src/components/logo/style.css
@@ -4,3 +4,6 @@ text {
 	letter-spacing: normal;
 	word-spacing: normal;
 }
+svg {
+	max-height: 100%;
+}


### PR DESCRIPTION
The svg element is set to max-height 100% to stay inside the area set outside the component.

Closes: #4952