### PR TITLE
chore: use rimraf instead of rm -rf

### DIFF
--- a/packages/adapters/react-standalone/package.json
+++ b/packages/adapters/react-standalone/package.json
@@ -43,12 +43,13 @@
 	],
 	"scripts": {
 		"build": "pnpm postinstall && node scripts/make-standalone.js",
-		"postinstall": "rm -rf dist && cpy \"node_modules/@public-ui/react/dist/*.mjs\" dist --dot",
+		"postinstall": "rimraf dist && cpy \"node_modules/@public-ui/react/dist/*.mjs\" dist --dot",
 		"prepack": "pnpm build"
 	},
 	"devDependencies": {
 		"@public-ui/react": "1.7.0-rc.0",
-		"cpy-cli": "5.0.0"
+		"cpy-cli": "5.0.0",
+		"rimraf": "3.0.2"
 	},
 	"peerDependencies": {
 		"@public-ui/components": "1.7.0-rc.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,6 +414,9 @@ importers:
       cpy-cli:
         specifier: 5.0.0
         version: 5.0.0
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
 
   packages/adapters/solid:
     devDependencies:


### PR DESCRIPTION
Allows to run the postinstall script of the react-standalone project in windows.