### PR TITLE
fix: download property in link component

### DIFF
--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -2,10 +2,10 @@ import { Component, Element, h, Host, JSX, Prop, State, Watch } from '@stencil/c
 
 import { translate } from '../../i18n';
 import { LinkUseCase } from '../../types/button-link';
-import { States as LinkStates } from '../link/types';
 import { Stringified } from '../../types/common';
 import { KoliBriIconProp } from '../../types/icon';
 import { AlignPropType } from '../../types/props/align';
+import { AlternativeButtonLinkRolePropType, validateAlternativeButtonLinkRole } from '../../types/props/alternative-button-link-role';
 import { validateAriaControls } from '../../types/props/aria-controls';
 import { AriaCurrentPropType, validateAriaCurrent, validateListenAriaCurrent } from '../../types/props/aria-current';
 import { validateAriaSelected } from '../../types/props/aria-selected';
@@ -14,16 +14,16 @@ import { validateHideLabel } from '../../types/props/hide-label';
 import { validateHref } from '../../types/props/href';
 import { validateIcon, watchIconAlign } from '../../types/props/icon';
 import { LabelWithExpertSlotPropType, validateLabelWithExpertSlot } from '../../types/props/label';
+import { LinkOnCallbacksPropType, validateLinkCallbacks } from '../../types/props/link-on-callbacks';
+import { LinkTargetPropType, validateLinkTarget } from '../../types/props/link-target';
 import { validateStealth } from '../../types/props/stealth';
+import { TooltipAlignPropType, validateTooltipAlign } from '../../types/props/tooltip-align';
 import { a11yHintDisabled, devHint, devWarning } from '../../utils/a11y.tipps';
 import { ariaCurrentSubject, mapBoolean2String, scrollBySelector, setEventTarget, watchBoolean, watchString } from '../../utils/prop.validators';
 import { propagateFocus } from '../../utils/reuse';
 import { validateTabIndex } from '../../utils/validators/tab-index';
-import { AlternativeButtonLinkRolePropType, validateAlternativeButtonLinkRole } from '../../types/props/alternative-button-link-role';
-import { TooltipAlignPropType, validateTooltipAlign } from '../../types/props/tooltip-align';
-import { LinkTargetPropType, validateLinkTarget } from '../../types/props/link-target';
+import { States as LinkStates } from '../link/types';
 import { API } from './types';
-import { LinkOnCallbacksPropType, validateLinkCallbacks } from '../../types/props/link-on-callbacks';
 
 /**
  * @internal
@@ -90,6 +90,7 @@ export class KolLinkWc implements API {
 			href: typeof this.state._href === 'string' && this.state._href.length > 0 ? this.state._href : 'javascript:void(0);',
 			target: typeof this.state._target === 'string' && this.state._target.length > 0 ? this.state._target : undefined,
 			rel: isExternal ? 'noopener' : undefined,
+			download: (typeof this.state._download === 'string' && this.state._download === 'true') || this.state._download === true ? true : undefined,
 		};
 
 		if ((this.state._useCase === 'image' || this.state._hideLabel === true) && !this.state._label) {

--- a/packages/components/src/components/link/test/html.mock.ts
+++ b/packages/components/src/components/link/test/html.mock.ts
@@ -1,7 +1,7 @@
 import { mixMembers } from 'stencil-awesome-test';
 
-import { LinkProps, States } from '../../link/types';
 import { getIconHtml } from '../../icon/test/html.mock';
+import { LinkProps, States } from '../../link/types';
 import { getSpanWcHtml } from '../../span/test/html.mock';
 import { getTooltipHtml } from '../../tooltip/test/html.mock';
 
@@ -29,7 +29,7 @@ export const getLinkHtml = (props: LinkProps, innerHTML = ''): string => {
 		typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
 	}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${
 		typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
-	}>
+	}${state._download ? ' download' : ''}>
 			${getSpanWcHtml(
 				{
 					...state,

--- a/packages/components/src/components/link/test/html.mock.ts
+++ b/packages/components/src/components/link/test/html.mock.ts
@@ -29,7 +29,7 @@ export const getLinkHtml = (props: LinkProps, innerHTML = ''): string => {
 		typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
 	}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${
 		typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
-	}${state._download ? ' download' : ''}>
+	}${state._download ? ` download${typeof state._download === 'string' ? `="${state._download}"`: ''}` : ''}>
 			${getSpanWcHtml(
 				{
 					...state,

--- a/packages/components/src/components/link/test/snapshot.spec.tsx
+++ b/packages/components/src/components/link/test/snapshot.spec.tsx
@@ -3,8 +3,8 @@ import { executeTests } from 'stencil-awesome-test';
 import { h } from '@stencil/core';
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
 
-import { LinkProps } from '../../link/types';
 import { COMPONENTS } from '../../component-list';
+import { LinkProps } from '../../link/types';
 import { getLinkHtml } from './html.mock';
 
 executeTests<LinkProps>(
@@ -24,6 +24,7 @@ executeTests<LinkProps>(
 		_target: ['_self', '_blank', 'egal'],
 		_targetDescription: ['Der Link wird in einem neuen Tab geöffnet.'],
 		_tooltipAlign: ['top', 'right', 'bottom', 'left'],
+		_download: [true, false],
 	},
 	getLinkHtml,
 	{


### PR DESCRIPTION
Include the `_download` property into the anchor tag of the `kol-link-wc` component.