### PR TITLE
chore: optimize switch icon positioning

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -36,7 +36,7 @@ import { FontAwesome, FontAwesomeOssPrefix } from "./enums/font-awesome";
 import { Icofont } from "./types/icofont";
 import { Loading } from "./utils/validators/loading";
 import { SuggestionsPropType } from "./types/props/suggestions";
-import { InputCheckboxIcon, InputCheckboxVariant } from "./components/input-checkbox/types";
+import { InputCheckboxIconProp, InputCheckboxVariant } from "./components/input-checkbox/types";
 import { InputTypeOnDefault, InputTypeOnOff, Option, SelectOption } from "./types/input/types";
 import { Iso8601 } from "./types/input/iso8601";
 import { InputDateType, InputNumberType } from "./types/input/control/number";
@@ -95,7 +95,7 @@ export { FontAwesome, FontAwesomeOssPrefix } from "./enums/font-awesome";
 export { Icofont } from "./types/icofont";
 export { Loading } from "./utils/validators/loading";
 export { SuggestionsPropType } from "./types/props/suggestions";
-export { InputCheckboxIcon, InputCheckboxVariant } from "./components/input-checkbox/types";
+export { InputCheckboxIconProp, InputCheckboxVariant } from "./components/input-checkbox/types";
 export { InputTypeOnDefault, InputTypeOnOff, Option, SelectOption } from "./types/input/types";
 export { Iso8601 } from "./types/input/iso8601";
 export { InputDateType, InputNumberType } from "./types/input/control/number";
@@ -893,7 +893,7 @@ export namespace Components {
         /**
           * Defines the icon classnames (e.g. `_icon="fa-solid fa-user"`).
          */
-        "_icon"?: Stringified<InputCheckboxIcon>;
+        "_icon"?: Stringified<InputCheckboxIconProp>;
         /**
           * Defines the internal ID of the primary component element.
          */
@@ -4274,7 +4274,7 @@ declare namespace LocalJSX {
         /**
           * Defines the icon classnames (e.g. `_icon="fa-solid fa-user"`).
          */
-        "_icon"?: Stringified<InputCheckboxIcon>;
+        "_icon"?: Stringified<InputCheckboxIconProp>;
         /**
           * Defines the internal ID of the primary component element.
          */

--- a/packages/components/src/components/input-checkbox/component.tsx
+++ b/packages/components/src/components/input-checkbox/component.tsx
@@ -9,7 +9,7 @@ import { stopPropagation, tryToDispatchKoliBriEvent } from '../../utils/events';
 import { propagateFocus } from '../../utils/reuse';
 import { getRenderStates } from '../input/controller';
 import { InputCheckboxController } from './controller';
-import { API, InputCheckboxIcon, InputCheckboxVariant, States } from './types';
+import { API, InputCheckboxIconProp, InputCheckboxVariant, States } from './types';
 import { CheckedPropType } from '../../types/props/checked';
 import { IndeterminatePropType } from '../../types/props/indeterminate';
 import { SyncValueBySelectorPropType } from '../../types/props/sync-value-by-selector';
@@ -69,8 +69,8 @@ export class KolInputCheckbox implements API {
 						<kol-icon
 							class="icon"
 							onClick={this.handleIconClick.bind(this)}
-							_ariaLabel=""
 							_icon={this.state._indeterminate ? this.state._icon.indeterminate : this.state._checked ? this.state._icon.checked : this.state._icon.unchecked}
+							_label=""
 						/>
 						<input
 							ref={this.catchRef}
@@ -156,7 +156,7 @@ export class KolInputCheckbox implements API {
 	/**
 	 * Defines the icon classnames (e.g. `_icon="fa-solid fa-user"`).
 	 */
-	@Prop() public _icon?: Stringified<InputCheckboxIcon>;
+	@Prop() public _icon?: Stringified<InputCheckboxIconProp>;
 
 	/**
 	 * Defines the internal ID of the primary component element.
@@ -289,7 +289,7 @@ export class KolInputCheckbox implements API {
 	}
 
 	@Watch('_icon')
-	public validateIcon(value?: Stringified<InputCheckboxIcon>): void {
+	public validateIcon(value?: Stringified<InputCheckboxIconProp>): void {
 		this.controller.validateIcon(value);
 	}
 

--- a/packages/components/src/components/input-checkbox/controller.ts
+++ b/packages/components/src/components/input-checkbox/controller.ts
@@ -8,8 +8,8 @@ import { a11yHint, devHint } from '../../utils/a11y.tipps';
 import { setState, watchValidator } from '../../utils/prop.validators';
 import { isString } from '../../utils/validator';
 import { InputCheckboxRadioController } from '../input-radio/controller';
-import { InputCheckboxIcon, InputCheckboxVariant, Props, Watches } from './types';
 import { HideErrorPropType, validateHideError } from '../../types/props/hide-error';
+import { InputCheckboxIconProp, InputCheckboxIconState, InputCheckboxVariant, Props, Watches } from './types';
 
 export class InputCheckboxController extends InputCheckboxRadioController implements Watches {
 	protected readonly component: Generic.Element.Component & Props;
@@ -44,15 +44,25 @@ export class InputCheckboxController extends InputCheckboxRadioController implem
 		});
 	}
 
-	public validateIcon(value?: Stringified<InputCheckboxIcon>): void {
+	public validateIcon(value?: Stringified<InputCheckboxIconProp>): void {
 		watchValidator(
 			this.component,
-			'_icons',
+			'_icon',
 			(value): boolean => {
 				return typeof value === 'object' && value !== null && (isString(value.checked, 1) || isString(value.indeterminate, 1) || isString(value.unchecked, 1));
 			},
 			new Set(['InputCheckboxIcons']),
-			value
+			value,
+			{
+				hooks: {
+					beforePatch: (nextValue: unknown, nextState: Map<string, unknown>, component: Generic.Element.Component) => {
+						nextState.set('_icon', {
+							...(component.state._icon as InputCheckboxIconState),
+							...(nextValue as InputCheckboxIconProp),
+						});
+					},
+				},
+			}
 		);
 	}
 

--- a/packages/components/src/components/input-checkbox/switch.css
+++ b/packages/components/src/components/input-checkbox/switch.css
@@ -24,6 +24,7 @@
 	transform: translateX(0.75em);
 }
 .switch .icon {
+	cursor: pointer;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -42,4 +43,16 @@
 }
 .switch:has(input:indeterminate) .icon {
 	transform: translate(0.75em, -50%);
+}
+
+/* Incomming */
+.switch .icon {
+	left: 0;
+	transform: translate(0.15em, -48%);
+}
+.switch:has(input:checked) .icon {
+	transform: translate(2.15em, -48%);
+}
+.switch:has(input:indeterminate) .icon {
+	transform: translate(1.15em, -48%);
 }

--- a/packages/components/src/components/input-checkbox/types.ts
+++ b/packages/components/src/components/input-checkbox/types.ts
@@ -21,17 +21,26 @@ export type InputCheckboxVariant =
 	| 'default'
 	| 'switch';
 
-export type InputCheckboxIcon = {
+export type InputCheckboxIconProp =
+	| {
+			checked: AnyIconFontClass;
+			indeterminate?: AnyIconFontClass;
+			unchecked?: AnyIconFontClass;
+	  }
+	| {
+			checked?: AnyIconFontClass;
+			indeterminate: AnyIconFontClass;
+			unchecked?: AnyIconFontClass;
+	  }
+	| {
+			checked?: AnyIconFontClass;
+			indeterminate?: AnyIconFontClass;
+			unchecked: AnyIconFontClass;
+	  };
+
+export type InputCheckboxIconState = {
 	checked: AnyIconFontClass;
-	indeterminate?: AnyIconFontClass;
-	unchecked?: AnyIconFontClass;
-} & {
-	checked?: AnyIconFontClass;
 	indeterminate: AnyIconFontClass;
-	unchecked?: AnyIconFontClass;
-} & {
-	checked?: AnyIconFontClass;
-	indeterminate?: AnyIconFontClass;
 	unchecked: AnyIconFontClass;
 };
 
@@ -41,7 +50,7 @@ type OptionalProps = {
 	alert: boolean;
 	error: string;
 	hint: string;
-	icon: Stringified<InputCheckboxIcon>;
+	icon: Stringified<InputCheckboxIconProp>;
 	on: InputTypeOnDefault;
 	tabIndex: number;
 	/**
@@ -63,7 +72,7 @@ type OptionalProps = {
 export type Props = Generic.Element.Members<RequiredProps, OptionalProps>;
 
 type RequiredStates = {
-	icon: InputCheckboxIcon;
+	icon: InputCheckboxIconState;
 	id: string;
 	value: StencilUnknown;
 	variant: InputCheckboxVariant;

--- a/packages/samples/react/src/components/input-checkbox/partials/variants.tsx
+++ b/packages/samples/react/src/components/input-checkbox/partials/variants.tsx
@@ -18,11 +18,52 @@ export const InputCheckboxVariant: FC<Props> = ({ variant }) => {
 	return (
 		<fieldset>
 			<legend>Checkbox ({variant})</legend>
-			<KolInputCheckbox _variant={variant} _label="Nicht ausgewählt" _value={false} />
-			<KolInputCheckbox _variant={variant} _label="Unbestimmt (Indeterminate)" _value={null} _indeterminate />
-			<KolInputCheckbox _variant={variant} _label="Ausgewählt" _value={true} _checked />
-			<KolInputCheckbox _variant={variant} _label="Disabled" _value={true} _disabled />
-			<KolInputCheckbox ref={ref} _variant={variant} _label="Mit Fehler" _value={true} _error={ERROR_MSG} _touched />
+			<KolInputCheckbox
+				_icon={{
+					unchecked: 'codicon codicon-close',
+				}}
+				_variant={variant}
+				_label="Nicht ausgewählt"
+				_value={false}
+			/>
+			<KolInputCheckbox
+				_icon={{
+					unchecked: 'codicon codicon-close',
+				}}
+				_variant={variant}
+				_label="Unbestimmt (Indeterminate)"
+				_value={null}
+				_indeterminate
+			/>
+			<KolInputCheckbox
+				_icon={{
+					unchecked: 'codicon codicon-close',
+				}}
+				_variant={variant}
+				_label="Ausgewählt"
+				_value={true}
+				_checked
+			/>
+			<KolInputCheckbox
+				_icon={{
+					unchecked: 'codicon codicon-close',
+				}}
+				_variant={variant}
+				_label="Disabled"
+				_value={true}
+				_disabled
+			/>
+			<KolInputCheckbox
+				ref={ref}
+				_icon={{
+					unchecked: 'codicon codicon-close',
+				}}
+				_variant={variant}
+				_label="Mit Fehler"
+				_value={true}
+				_error={ERROR_MSG}
+				_touched
+			/>
 		</fieldset>
 	);
 };


### PR DESCRIPTION
- [x] behebt kleine Bugs
- [x] richtet die Icons für BMF und Default richtig aus
- [x] Verwendung in Sample App
- [x] Wollen wir `Close` oder `Plus` als `unchecked`?