### PR TITLE
fix: link component attribute download with string content for file names

### DIFF
--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -51,6 +51,7 @@ export class KolLinkWc implements API {
 	};
 
 	private readonly getRenderValues = () => {
+		const { _download } = this.state;
 		/**
 		 * DX
 		 * Das möchte ich ungern für HTML machen, sondern nur für Barrierefreiheitsthemen.
@@ -90,7 +91,7 @@ export class KolLinkWc implements API {
 			href: typeof this.state._href === 'string' && this.state._href.length > 0 ? this.state._href : 'javascript:void(0);',
 			target: typeof this.state._target === 'string' && this.state._target.length > 0 ? this.state._target : undefined,
 			rel: isExternal ? 'noopener' : undefined,
-			download: this.state._download === true || this.state._download === 'true' ? '' : this.state._download,
+			download: typeof _download === 'string' ? _download : _download === true ? '' : undefined,
 		};
 
 		if ((this.state._useCase === 'image' || this.state._hideLabel === true) && !this.state._label) {

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -90,7 +90,7 @@ export class KolLinkWc implements API {
 			href: typeof this.state._href === 'string' && this.state._href.length > 0 ? this.state._href : 'javascript:void(0);',
 			target: typeof this.state._target === 'string' && this.state._target.length > 0 ? this.state._target : undefined,
 			rel: isExternal ? 'noopener' : undefined,
-			download: this.state._download === true || this.state._download === 'true' ? '' :  this.state._download,
+			download: this.state._download === true || this.state._download === 'true' ? '' : this.state._download,
 		};
 
 		if ((this.state._useCase === 'image' || this.state._hideLabel === true) && !this.state._label) {

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -90,7 +90,7 @@ export class KolLinkWc implements API {
 			href: typeof this.state._href === 'string' && this.state._href.length > 0 ? this.state._href : 'javascript:void(0);',
 			target: typeof this.state._target === 'string' && this.state._target.length > 0 ? this.state._target : undefined,
 			rel: isExternal ? 'noopener' : undefined,
-			download: (typeof this.state._download === 'string' && this.state._download === 'true') || this.state._download === true ? true : undefined,
+			download: this.state._download === true || this.state._download === 'true' ? '' :  this.state._download,
 		};
 
 		if ((this.state._useCase === 'image' || this.state._hideLabel === true) && !this.state._label) {

--- a/packages/components/src/components/link/test/html.mock.ts
+++ b/packages/components/src/components/link/test/html.mock.ts
@@ -23,35 +23,36 @@ export const getLinkHtml = (props: LinkProps, innerHTML = ''): string => {
 <kol-link>
   <mock:shadow-root>
   <kol-link-wc>
-    <a${state._hideLabel === true && typeof state._label === 'string' ? ` aria-label="${state._label}"` : ''} class="${state._hideLabel === true ? ' icon-only hide-label' : ''
-		}${typeof state._target === 'string' && state._target !== '_self' ? ' external-link' : ''}" href="${typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
-		}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
-		}${state._download !== undefined && state._download !== false
-			? ` download${state._download === true ? `=""` : `="${state._download}"`}`
-			: ''
-		}>
+    <a${state._hideLabel === true && typeof state._label === 'string' ? ` aria-label="${state._label}"` : ''} class="${
+		state._hideLabel === true ? ' icon-only hide-label' : ''
+	}${typeof state._target === 'string' && state._target !== '_self' ? ' external-link' : ''}" href="${
+		typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
+	}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${
+		typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
+	}${state._download !== undefined && state._download !== false ? ` download${state._download === true ? `=""` : `="${state._download}"`}` : ''}>
 			${getSpanWcHtml(
-			{
-				...state,
-				_label: hasExpertSlot ? false : state._label || state._href,
-			},
-			{
-				expert: `<slot name="expert" slot="expert"></slot><slot slot="expert"></slot>`,
-			},
-			{
-				additionalAttrs: '',
-			}
-		)}
-			${typeof state._target === 'string' && state._target !== '_self'
-			? getIconHtml(
 				{
-					_label: 'Der Link wird in einem neuen Tab geöffnet.',
-					_icon: 'codicon codicon-link-external',
+					...state,
+					_label: hasExpertSlot ? false : state._label || state._href,
 				},
-				' class="external-link-icon"'
-			)
-			: ''
-		}
+				{
+					expert: `<slot name="expert" slot="expert"></slot><slot slot="expert"></slot>`,
+				},
+				{
+					additionalAttrs: '',
+				}
+			)}
+			${
+				typeof state._target === 'string' && state._target !== '_self'
+					? getIconHtml(
+							{
+								_label: 'Der Link wird in einem neuen Tab geöffnet.',
+								_icon: 'codicon codicon-link-external',
+							},
+							' class="external-link-icon"'
+					  )
+					: ''
+			}
     </a>
 		${getTooltipHtml(
 			{

--- a/packages/components/src/components/link/test/html.mock.ts
+++ b/packages/components/src/components/link/test/html.mock.ts
@@ -29,7 +29,11 @@ export const getLinkHtml = (props: LinkProps, innerHTML = ''): string => {
 		typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
 	}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${
 		typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
-	}${state._download !== undefined && state._download !== false ? ` download${state._download === true || state._download === 'true' ? `=""` : `="${state._download}"`}` : ''}>
+	}${
+		state._download !== undefined && state._download !== false
+			? ` download${state._download === true || state._download === 'true' ? `=""` : `="${state._download}"`}`
+			: ''
+	}>
 			${getSpanWcHtml(
 				{
 					...state,

--- a/packages/components/src/components/link/test/html.mock.ts
+++ b/packages/components/src/components/link/test/html.mock.ts
@@ -29,7 +29,7 @@ export const getLinkHtml = (props: LinkProps, innerHTML = ''): string => {
 		typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
 	}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${
 		typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
-	}${state._download ? ` download${typeof state._download === 'string' ? `="${state._download}"` : ''}` : ''}>
+	}${state._download !== undefined && state._download !== false ? ` download${state._download === true || state._download === 'true' ? `=""` : `="${state._download}"`}` : ''}>
 			${getSpanWcHtml(
 				{
 					...state,

--- a/packages/components/src/components/link/test/html.mock.ts
+++ b/packages/components/src/components/link/test/html.mock.ts
@@ -31,7 +31,7 @@ export const getLinkHtml = (props: LinkProps, innerHTML = ''): string => {
 		typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
 	}${
 		state._download !== undefined && state._download !== false
-			? ` download${state._download === true || state._download === 'true' ? `=""` : `="${state._download}"`}`
+			? ` download${state._download === true ? `=""` : `="${state._download}"`}`
 			: ''
 	}>
 			${getSpanWcHtml(

--- a/packages/components/src/components/link/test/html.mock.ts
+++ b/packages/components/src/components/link/test/html.mock.ts
@@ -23,40 +23,35 @@ export const getLinkHtml = (props: LinkProps, innerHTML = ''): string => {
 <kol-link>
   <mock:shadow-root>
   <kol-link-wc>
-    <a${state._hideLabel === true && typeof state._label === 'string' ? ` aria-label="${state._label}"` : ''} class="${
-		state._hideLabel === true ? ' icon-only hide-label' : ''
-	}${typeof state._target === 'string' && state._target !== '_self' ? ' external-link' : ''}" href="${
-		typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
-	}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${
-		typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
-	}${
-		state._download !== undefined && state._download !== false
+    <a${state._hideLabel === true && typeof state._label === 'string' ? ` aria-label="${state._label}"` : ''} class="${state._hideLabel === true ? ' icon-only hide-label' : ''
+		}${typeof state._target === 'string' && state._target !== '_self' ? ' external-link' : ''}" href="${typeof state._href === 'string' && state._href.length > 0 ? state._href : 'javascript:void(0)'
+		}"${typeof state._selector === 'string' ? ' role="link" tabindex="0"' : ''}${typeof state._target === 'string' ? `${state._target === '_self' ? '' : 'rel="noopener"'} target="${state._target}"` : ''
+		}${state._download !== undefined && state._download !== false
 			? ` download${state._download === true ? `=""` : `="${state._download}"`}`
 			: ''
-	}>
+		}>
 			${getSpanWcHtml(
-				{
-					...state,
-					_label: hasExpertSlot ? false : state._label || state._href,
-				},
-				{
-					expert: `<slot name="expert" slot="expert"></slot><slot slot="expert"></slot>`,
-				},
-				{
-					additionalAttrs: '',
-				}
-			)}
-			${
-				typeof state._target === 'string' && state._target !== '_self'
-					? getIconHtml(
-							{
-								_label: 'Der Link wird in einem neuen Tab geöffnet.',
-								_icon: 'codicon codicon-link-external',
-							},
-							' class="external-link-icon"'
-					  )
-					: ''
+			{
+				...state,
+				_label: hasExpertSlot ? false : state._label || state._href,
+			},
+			{
+				expert: `<slot name="expert" slot="expert"></slot><slot slot="expert"></slot>`,
+			},
+			{
+				additionalAttrs: '',
 			}
+		)}
+			${typeof state._target === 'string' && state._target !== '_self'
+			? getIconHtml(
+				{
+					_label: 'Der Link wird in einem neuen Tab geöffnet.',
+					_icon: 'codicon codicon-link-external',
+				},
+				' class="external-link-icon"'
+			)
+			: ''
+		}
     </a>
 		${getTooltipHtml(
 			{

--- a/packages/components/src/components/link/test/snapshot.spec.tsx
+++ b/packages/components/src/components/link/test/snapshot.spec.tsx
@@ -24,7 +24,7 @@ executeTests<LinkProps>(
 		_target: ['_self', '_blank', 'egal'],
 		_targetDescription: ['Der Link wird in einem neuen Tab geöffnet.'],
 		_tooltipAlign: ['top', 'right', 'bottom', 'left'],
-		_download: [true, false],
+		_download: [false, true, 'false', 'true', 'download-file.zip', undefined],
 	},
 	getLinkHtml,
 	{

--- a/packages/components/src/components/link/test/snapshot.spec.tsx
+++ b/packages/components/src/components/link/test/snapshot.spec.tsx
@@ -24,7 +24,7 @@ executeTests<LinkProps>(
 		_target: ['_self', '_blank', 'egal'],
 		_targetDescription: ['Der Link wird in einem neuen Tab geöffnet.'],
 		_tooltipAlign: ['top', 'right', 'bottom', 'left'],
-		_download: [false, true, 'false', 'true', 'download-file.zip', undefined],
+		_download: [false, true, undefined, 'download-file.zip'],
 	},
 	getLinkHtml,
 	{


### PR DESCRIPTION
The `download` attribute can be a string like a file name.