### PR TITLE
Fix mailto-link in security document

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,4 +2,4 @@
 
 Wenn Sie glauben, dass Sie eine Sicherheitslücke in unserm Projekt gefunden haben, empfehlen wir Ihnen, uns dies umgehend mitzuteilen. Wir werden alle legitimen Meldungen untersuchen und unser Bestes tun, um das Problem schnell zu beheben.
 
-Kontakt: [kolibri@itzbund.de](kolibri@itzbund.de)
+Kontakt: [kolibri@itzbund.de](mailto:kolibri@itzbund.de)


### PR DESCRIPTION
Der Link wird aktuell als relative URL interpretiert und man landet auf einer 404-Seite.