### PR TITLE
Radio button: Define visible background color for forced-colors mode

### DIFF
--- a/packages/components/src/components/input-radio/style.css
+++ b/packages/components/src/components/input-radio/style.css
@@ -41,7 +41,7 @@
 	}
 	@media (forced-colors: active) {
 		input:checked:before {
-			background: highlight !important; /* Give it a visible background in forcer colors mode */
+			background: highlight !important; /* Give it a visible background in forced colors mode */
 		}
 	}
 

--- a/packages/components/src/components/input-radio/style.css
+++ b/packages/components/src/components/input-radio/style.css
@@ -39,6 +39,11 @@
 	input:checked:before {
 		background-color: #000;
 	}
+	@media (forced-colors: active) {
+		input:checked:before {
+			background: highlight !important; /* Give it a visible background in forcer colors mode */
+		}
+	}
 
 	fieldset {
 		display: flex;

--- a/packages/tools/kolibri-cli/src/migrate/shares/reuse.ts
+++ b/packages/tools/kolibri-cli/src/migrate/shares/reuse.ts
@@ -20,7 +20,7 @@ export function logAndCreateError(msg: string, hint?: string) {
 				hint,
 				`
 `,
-		  )
+			)
 		: '';
 	console.log(
 		chalk.red(


### PR DESCRIPTION
Screenshot: Beispiel aus Chrome auf macOS.

 <img width="435" alt="image" src="https://github.com/public-ui/kolibri/assets/971072/43c6f6ad-3262-46bc-86ad-594f9aad098e">

Test Deployment: https://6578a6b9fd59a009416a1f09--magenta-gingersnap-274e19.netlify.app/
