### PR TITLE
fix: tooltips arrow position

### DIFF
--- a/packages/components/src/components/tooltip/style.css
+++ b/packages/components/src/components/tooltip/style.css
@@ -29,7 +29,7 @@
 
 	kol-tooltip-wc .tooltip-arrow {
 		height: 10px;
-		position: fixed;
+		position: absolute;
 		transform: rotate(45deg);
 		width: 10px;
 		z-index: 999;


### PR DESCRIPTION
Set the position to absolute to correct the placement of the arrow of the tooltips.

Closes: #5824