### PR TITLE
fix: remove not-allowed cursor when inputs are read-only

### DIFF
--- a/packages/themes/bmf/src/index.ts
+++ b/packages/themes/bmf/src/index.ts
@@ -288,7 +288,6 @@ export const BMF = KoliBri.createTheme('bmf', {
 		.input:hover {
 			border-color: var(--color-midnight);
 		}
-		input:read-only,
 		input:disabled {
 			cursor: not-allowed;
 		}
@@ -368,7 +367,6 @@ export const BMF = KoliBri.createTheme('bmf', {
 		.input:hover {
 			border-color: var(--color-midnight);
 		}
-		input:read-only,
 		input:disabled {
 			cursor: not-allowed;
 		}
@@ -609,7 +607,6 @@ export const BMF = KoliBri.createTheme('bmf', {
 		.input:hover {
 			border-color: var(--color-midnight);
 		}
-		input:read-only,
 		input:disabled {
 			cursor: not-allowed;
 		}
@@ -696,7 +693,6 @@ export const BMF = KoliBri.createTheme('bmf', {
 		.input:hover {
 			border-color: var(--color-midnight);
 		}
-		input:read-only,
 		input:disabled {
 			cursor: not-allowed;
 		}
@@ -789,7 +785,6 @@ export const BMF = KoliBri.createTheme('bmf', {
 		.input:hover {
 			border-color: var(--color-midnight);
 		}
-		textarea:read-only,
 		textarea:disabled {
 			cursor: not-allowed;
 		}
@@ -2353,7 +2348,6 @@ export const BMF = KoliBri.createTheme('bmf', {
 		.input:hover {
 			border-color: var(--color-midnight);
 		}
-		input:read-only,
 		input:disabled {
 			cursor: not-allowed;
 		}

--- a/packages/themes/default/src/components/input-color.scss
+++ b/packages/themes/default/src/components/input-color.scss
@@ -57,7 +57,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	input:read-only,
 	input:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/default/src/components/input-email.scss
+++ b/packages/themes/default/src/components/input-email.scss
@@ -50,7 +50,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	input:read-only,
 	input:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/default/src/components/input-file.scss
+++ b/packages/themes/default/src/components/input-file.scss
@@ -56,7 +56,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	input:read-only,
 	input:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/default/src/components/input-number.scss
+++ b/packages/themes/default/src/components/input-number.scss
@@ -50,7 +50,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	input:read-only,
 	input:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/default/src/components/input-password.scss
+++ b/packages/themes/default/src/components/input-password.scss
@@ -50,7 +50,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	input:read-only,
 	input:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/default/src/components/input-range.scss
+++ b/packages/themes/default/src/components/input-range.scss
@@ -46,7 +46,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	input:read-only,
 	input:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/default/src/components/input-text.scss
+++ b/packages/themes/default/src/components/input-text.scss
@@ -50,7 +50,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	input:read-only,
 	input:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/default/src/components/textarea.scss
+++ b/packages/themes/default/src/components/textarea.scss
@@ -53,7 +53,6 @@
 	.input:hover {
 		border-color: var(--color-primary);
 	}
-	textarea:read-only,
 	textarea:disabled {
 		cursor: not-allowed;
 	}

--- a/packages/themes/itzbund/src/index.ts
+++ b/packages/themes/itzbund/src/index.ts
@@ -744,7 +744,6 @@ export const ITZBund = KoliBri.createTheme('itzbund', {
 		textarea::placeholder {
 			color: var(--default-border);
 		}
-		textarea:read-only,
 		textarea:disabled {
 			cursor: not-allowed;
 			border-color: var(--border-default);

--- a/packages/themes/itzbund/src/index.ts
+++ b/packages/themes/itzbund/src/index.ts
@@ -746,6 +746,9 @@ export const ITZBund = KoliBri.createTheme('itzbund', {
 		}
 		textarea:disabled {
 			cursor: not-allowed;
+		}
+		textarea:disabled,
+		textarea:read-only {
 			border-color: var(--border-default);
 			background-color: var(--background-light-grey);
 		}


### PR DESCRIPTION
Themes: bmf, default and itzbund

Closes: #5814 