### PR TITLE
fix: backspace behavior at input date

### DIFF
--- a/packages/components/src/components/input-date/controller.ts
+++ b/packages/components/src/components/input-date/controller.ts
@@ -114,8 +114,8 @@ export class InputDateController extends InputIconController implements InputDat
 		);
 	};
 
-	protected onChange(event: Event): void {
-		super.onChange(event);
+	protected onBlur(event: Event): void {
+		super.onBlur(event);
 
 		// set the value here when the value is switched between blank and set (or vice versa) to enable value resets via setting null as value.
 		if (!!(event.target as HTMLInputElement).value !== !!this.component._value) {


### PR DESCRIPTION
Change the value of input-date on blur instead of at the onChange-event.

Allows to remove single blocks of the date or time without deleting the complete input.

Closes: #5800