### PR TITLE
Fix tooltips closing behaviour for Firefox ESR

### DIFF
--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -1,5 +1,5 @@
 import { arrow, autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
-import { Component, Element, Host, JSX, Prop, State, Watch, h } from '@stencil/core';
+import { Component, Element, h, Host, JSX, Prop, State, Watch } from '@stencil/core';
 
 import { AlignPropType, validateAlign } from '../../types/props/align';
 import { IdPropType, validateId } from '../../types/props/id';

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -109,7 +109,7 @@ export class KolTooltip implements API {
 		el.removeEventListener('focusin', this.incrementOverFocusCount);
 		el.removeEventListener('mouseleave', this.decrementOverFocusCount);
 		el.removeEventListener('blur', this.decrementOverFocusCount);
-		el.addEventListener('focusout', this.decrementOverFocusCount);
+		el.removeEventListener('focusout', this.decrementOverFocusCount); //?
 	};
 
 	private resyncListeners = (last?: Element | null, next?: Element | null, replacePreviousSibling = false): void => {

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -95,19 +95,19 @@ export class KolTooltip implements API {
 	};
 
 	private addListeners = (el: Element): void => {
-		el.addEventListener('mouseover', this.incrementOverFocusCount);
+		el.addEventListener('mouseenter', this.incrementOverFocusCount);
 		el.addEventListener('focus', this.incrementOverFocusCount);
 		el.addEventListener('focusin', this.incrementOverFocusCount);
-		el.addEventListener('mouseout', this.decrementOverFocusCount);
+		el.addEventListener('mouseleave', () => this.decrementOverFocusCount);
 		el.addEventListener('blur', this.decrementOverFocusCount);
 		el.addEventListener('focusout', this.decrementOverFocusCount);
 	};
 
 	private removeListeners = (el: Element): void => {
-		el.removeEventListener('mouseover', this.incrementOverFocusCount);
+		el.removeEventListener('mouseenter', this.incrementOverFocusCount);
 		el.removeEventListener('focus', this.incrementOverFocusCount);
 		el.removeEventListener('focusin', this.incrementOverFocusCount);
-		el.removeEventListener('mouseout', this.decrementOverFocusCount);
+		el.removeEventListener('mouseleave', this.decrementOverFocusCount);
 		el.removeEventListener('blur', this.decrementOverFocusCount);
 		el.addEventListener('focusout', this.decrementOverFocusCount);
 	};

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -222,7 +222,6 @@ export class KolTooltip implements API {
 
 	public connectedCallback(): void {
 		this.previousSibling = this.host?.previousElementSibling;
-		this.handleEventListeners();
 	}
 
 	public componentDidRender(): void {


### PR DESCRIPTION
Ich kann nicht 100% erklären, was hier das Problem war. Meine Erkenntnisse:

* Im Firefox ESR werden die `mousein` bzw. `mouseenter` Events _ein zweites mal_ getriggert, wenn man in das Input-Feld klickt. Ich konnte nicht nachvollziehen, _warum_ das bei uns so ist, nur dass es passiert. Vielleicht ein Bug in Kombination mit Webcomponents, der mittlerweile behoben ist?
  * Meine vielleicht nicht so ganz elegante Lösung hier: Den "Counter" für Tooltip-Trigger durch einzelne Booleans ersetzen.
  * In diesem Zuge habe ich auch das `focus`-Event rausgenommen, um etwas Komplexität wegzunehmen. Soweit ich sehen kann war es nicht notwendig, da bereits `focusin` registriert wird.

* Alle Event Listener wurden (unabhängig vom Browser) doppelt registriert. Die Lösung war das Entfernen [dieser Zeile](https://github.com/public-ui/kolibri/pull/5999/files#diff-b9e59e378c7b5a410b7f6ade68d7f7e8ad3b09cd3f038f41a2d3b97aa917698fL225). Soweit ich testen konnte war der Aufruf nicht notwendig, da sowieso immer `componentDidRender` ausgeführt wird. Hier aber gerne ganz genau drauf schauen und mir ggf. Feedback geben, wenn ich etwas nicht bedacht habe.