### PR TITLE
Fix: Call input components onChange before form onSubmit

### DIFF
--- a/packages/components/src/components/form/component.tsx
+++ b/packages/components/src/components/form/component.tsx
@@ -16,6 +16,7 @@ import { KolAlertTag, KolIndentedTextTag, KolLinkTag } from '../../core/componen
 export class KolForm implements FormAPI {
 	errorListElement?: HTMLElement;
 
+	/* Hint: This method may not be used at all while events are handled in form/controller#propagateSubmitEventToForm */
 	private readonly onSubmit = (event: Event) => {
 		event.preventDefault();
 		event.stopPropagation();
@@ -23,6 +24,7 @@ export class KolForm implements FormAPI {
 			this.state._on?.onSubmit(event as SubmitEvent);
 		}
 	};
+
 	private readonly onReset = (event: Event) => {
 		event.preventDefault();
 		event.stopPropagation();

--- a/packages/components/src/components/form/controller.ts
+++ b/packages/components/src/components/form/controller.ts
@@ -79,24 +79,31 @@ export const propagateSubmitEventToForm = (
 		 *       - https://github.com/public-ui/kolibri/issues/946
 		 */
 		if (form.tagName === 'FORM') {
-			setEventTarget(event, form);
-			form.dispatchEvent(event);
 			if (getExperimentalMode() && (form as HTMLFormElement).noValidate === false) {
 				devHint(`If you have not focusable or hidden form fields in your form, you should enable noValidate for your form.`, {
 					force: true,
 				});
 				// (form as HTMLFormElement).noValidate = true; do not make this implicit
 			}
-			if (typeof (form as HTMLFormElement).requestSubmit === 'function') {
+			// Use setTimeout to ensure onChange has been called first
+			setTimeout(() => {
 				// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit
-				(form as HTMLFormElement).requestSubmit();
-			}
+				if (typeof (form as HTMLFormElement).requestSubmit === 'function') {
+					(form as HTMLFormElement).requestSubmit();
+				} else {
+					setEventTarget(event, form);
+					form.dispatchEvent(event);
+				}
+			});
 		} else if (form.tagName === 'KOL-FORM') {
 			setEventTarget(event, KoliBriDevHelper.querySelector('form', form) as HTMLFormElement);
 			const kolForm = form as FormProps;
-			if (typeof kolForm._on?.onSubmit === 'function') {
-				kolForm._on?.onSubmit(event);
-			}
+			// Use setTimeout to ensure onChange has been called first
+			setTimeout(() => {
+				if (typeof kolForm._on?.onSubmit === 'function') {
+					kolForm._on?.onSubmit(event);
+				}
+			});
 		}
 	}
 };


### PR DESCRIPTION
### :ballot_box_with_check: Definition of Done checklist
- [x] Meaningful title for the release notes
- [x] Pull request is linked to a problem
- [x] All changes relate to the problem
- [x] A11y tests performed successfully or not relevant
- [x] Manual test performed successfully (by reviewer) or not relevant
