### PR TITLE
Issue discussion templates & workflow update

### DIFF
--- a/.github/DISSCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISSCUSSION_TEMPLATE/ideas.yml
@@ -1,3 +1,5 @@
+title: '🚀 Feature: '
+labels: ['feature']
 body:
   - type: textarea
     attributes:
@@ -5,9 +7,7 @@ body:
       description: |
         Short list of what the feature request aims to address?
 
-        ```diff
-        # Kurze Auflistung dessen, worauf die Anfrage abzielt?
-        ```
+        Kurze Auflistung dessen, worauf die Anfrage abzielt?
       value: |
         1.
         2.
@@ -18,11 +18,9 @@ body:
     attributes:
       label: Non-Goals
       description: |
-        Short list of what the feature request _does not_ aim to address?
-
-        ```diff
-        # Kurze Auflistung dessen, was mit der Anfrage _nicht_ bezweckt wird?
-        ```
+        Short list of what the feature request **does not** aim to address?
+        
+        Kurze Auflistung dessen, was mit der Anfrage **nicht** bezweckt wird?
       value: |
         1.
         2.
@@ -34,20 +32,16 @@ body:
       label: Background / Hintergrund
       description: |
         Discuss prior art, why do you think this feature is needed? Are there current alternatives?
-
-        ```diff
-        # Diskutieren Sie den Stand der Technik, warum glauben Sie, dass diese Funktion benötigt wird? Gibt es aktuelle Alternativen?
-        ```
+        
+        Diskutieren Sie den Stand der Technik, warum glauben Sie, dass diese Funktion benötigt wird? Gibt es aktuelle Alternativen?
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Proposal
+      label: Proposal / Vorschlag
       description: |
         How should this feature be implemented? Are you interested in contributing?
 
-        ```diff
-        # Wie sollte diese Funktion implementiert werden? Wären Sie daran interessiert, einen Beitrag zu leisten?
-        ```
+        Wie sollte diese Funktion implementiert werden? Wären Sie daran interessiert, einen Beitrag zu leisten?
     validations:
       required: true

--- a/.github/DISSCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISSCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,53 @@
+body:
+  - type: textarea
+    attributes:
+      label: Goals
+      description: |
+        Short list of what the feature request aims to address?
+
+        ```diff
+        # Kurze Auflistung dessen, worauf die Anfrage abzielt?
+        ```
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Non-Goals
+      description: |
+        Short list of what the feature request _does not_ aim to address?
+
+        ```diff
+        # Kurze Auflistung dessen, was mit der Anfrage _nicht_ bezweckt wird?
+        ```
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Background / Hintergrund
+      description: |
+        Discuss prior art, why do you think this feature is needed? Are there current alternatives?
+
+        ```diff
+        # Diskutieren Sie den Stand der Technik, warum glauben Sie, dass diese Funktion benötigt wird? Gibt es aktuelle Alternativen?
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: |
+        How should this feature be implemented? Are you interested in contributing?
+
+        ```diff
+        # Wie sollte diese Funktion implementiert werden? Wären Sie daran interessiert, einen Beitrag zu leisten?
+        ```
+    validations:
+      required: true

--- a/.github/DISSCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISSCUSSION_TEMPLATE/q-a.yml
@@ -1,3 +1,5 @@
+title: '🙏 Help: '
+labels: ['help wanted']
 body:
   - type: textarea
     attributes:
@@ -5,9 +7,7 @@ body:
       description: |
         What do you need help with?
 
-        ```diff
-        # Womit brauchen Sie Hilfe?
-        ```
+        Womit brauchen Sie Hilfe?
     validations:
       required: true
   - type: textarea
@@ -15,10 +15,8 @@ body:
       label: Additional information / Zusätzliche Informationen
       description: |
         Any code snippets, error messages, or dependency details that may be related? (`kolibri info`)
-
-        ```diff
-        # Irgendwelche Codeschnipsel, Fehlermeldungen oder Abhängigkeitsdetails, die damit zusammenhängen könnten? (`kolibri info`)
-        ```
+        
+        Irgendwelche Codeschnipsel, Fehlermeldungen oder Abhängigkeitsdetails, die damit zusammenhängen könnten? (`kolibri info`)
       render: js
     validations:
       required: false
@@ -28,8 +26,6 @@ body:
       description: |
         A link to a minimal reproduction is helpful for collaborative debugging!
 
-        ```diff
-        # Ein Link zu einer minimalen Reproduktion ist hilfreich für die gemeinsame Fehlersuche!
-        ```
+        Ein Link zu einer minimalen Reproduktion ist hilfreich für die gemeinsame Fehlersuche!
     validations:
       required: false

--- a/.github/DISSCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISSCUSSION_TEMPLATE/q-a.yml
@@ -14,9 +14,9 @@ body:
     attributes:
       label: Additional information / Zusätzliche Informationen
       description: |
-        Any code snippets, error messages, or dependency details that may be related? (`kolibri info`)
+        Any code snippets, error messages, or dependency details that may be related? (`Please run `npx @public-ui/kolibri-cli info` and paste the result`)
         
-        Irgendwelche Codeschnipsel, Fehlermeldungen oder Abhängigkeitsdetails, die damit zusammenhängen könnten? (`kolibri info`)
+        Irgendwelche Codeschnipsel, Fehlermeldungen oder Abhängigkeitsdetails, die damit zusammenhängen könnten? (`Bitte führe folgenden Befehl aus `npx @public-ui/kolibri-cli info` und kopiere es in das Feld`)
       render: js
     validations:
       required: false

--- a/.github/DISSCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISSCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,35 @@
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        What do you need help with?
+
+        ```diff
+        # Womit brauchen Sie Hilfe?
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information / Zusätzliche Informationen
+      description: |
+        Any code snippets, error messages, or dependency details that may be related? (`kolibri info`)
+
+        ```diff
+        # Irgendwelche Codeschnipsel, Fehlermeldungen oder Abhängigkeitsdetails, die damit zusammenhängen könnten? (`kolibri info`)
+        ```
+      render: js
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: Example / Beispiel
+      description: |
+        A link to a minimal reproduction is helpful for collaborative debugging!
+
+        ```diff
+        # Ein Link zu einer minimalen Reproduktion ist hilfreich für die gemeinsame Fehlersuche!
+        ```
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -13,14 +13,16 @@ body:
 
         If you need help with your own project, you can start a discussion in the ["Q&A" section](https://github.com/public-ui/kolibri/discussions/new?category=q-a)
 
-        ```diff
-        # Diese Vorlage ist zur Meldung von KoliBri-Bugs. Dokumentationsbezogene Bugs sollten stattdessen mit dieser [Vorlage](https://github.com/public-ui/kolibri/issues/new/choose) gemeldet werden.
-        # Funktionsanfragen sollten als [Diskussionen](https://github.com/public-ui/kolibri/discussions/new/choose) eröffnet werden.
+        #### Deutsch:
+        Diese Vorlage ist zur Meldung von KoliBri-Bugs. Dokumentationsbezogene Bugs sollten stattdessen mit dieser [Vorlage](https://github.com/public-ui/kolibri/issues/new/choose) gemeldet werden.
+        Funktionsanfragen sollten als [Diskussionen](https://github.com/public-ui/kolibri/discussions/new/choose) eröffnet werden.
 
-        # Bevor Sie ein neues Problem melden, führen Sie bitte eine [Suche](https://github.com/public-ui/kolibri/issues) nach bestehenden Problemen durch und stimmen Sie dem bestehenden Problem mit :+1: zu. Dies führt zu einer schnelleren Lösung.
+        Bevor Sie ein neues Problem melden, führen Sie bitte eine [Suche](https://github.com/public-ui/kolibri/issues) nach bestehenden Problemen durch und stimmen Sie dem bestehenden Problem mit :+1: zu. Dies führt zu einer schnelleren Lösung.
 
-        # Wenn Sie Hilfe bei Ihrem eigenen Projekt benötigen, können Sie eine Diskussion im ["Q&A"-Bereich](https://github.com/public-ui/kolibri/discussions/new?category=q-a) starten.
-        ```
+        Wenn Sie Hilfe bei Ihrem eigenen Projekt benötigen, können Sie eine Diskussion im ["Q&A"-Bereich](https://github.com/public-ui/kolibri/discussions/new?category=q-a) starten.
+
+        Please fill out the form: / Bitte fülle die folgende Form aus:
+        ------------------------------------------------------------------------------------------------------
   - type: checkboxes
     id: verify_release
     attributes:
@@ -35,22 +37,27 @@ body:
       description: |
         A link to a **public** GitHub repository or a StackBlitz minimal reproduction. Minimal reproductions should be created from our actual released versions (e.g. v1, v2, ...) and should include only changes that contribute to the issue. StackBlitz templates can be found under the followjng url's:
 
-        ```diff
-        # Ein Link zu einem **öffentlichen** GitHub-Repository oder einer StackBlitz-Minimalreproduktion. Minimale Reproduktionen sollten aus unseren aktuell veröffentlichten Versionen (z. B. v1, v2, ...) erstellt werden und nur Änderungen enthalten, die zum Problem beitragen. StackBlitz-Vorlagen können unter den folgenden URLs gefunden werden:
-        ````
+        #### Deutsch:
+        Ein Link zu einem **öffentlichen** GitHub-Repository oder einer StackBlitz-Minimalreproduktion. Minimale Reproduktionen sollten aus unseren aktuell veröffentlichten Versionen (z. B. v1, v2, ...) erstellt werden und nur Änderungen enthalten, die zum Problem beitragen. StackBlitz-Vorlagen können unter den folgenden URLs gefunden werden:
 
-        - [Template (v1)](https://stackblitz.com/edit/vitejs-vite-dcg6xo)
-        - [Template (v2)](https://stackblitz.com/edit/vitejs-vite-kkfhk5)
+        - [KoliBri (v1)](https://stackblitz.com/edit/vitejs-vite-dcg6xo)
+        - [KoliBri (v2)](https://stackblitz.com/edit/vitejs-vite-kkfhk5)
       placeholder: 'https://github.com/user/my-minimal-kolibri-issue-reproduction or https://stackblitz.com/edit/XXXXXX'
     validations:
       required: false
   - type: dropdown
     id: affected_themes
     attributes:
-      label: Which theme(s) are affected? (Select all that apply) / Welche(s) Layout(s) ist/sind betroffen? (Wählen Sie alle zutreffenden aus)
+      label: Which theme(s) are affected? / Welche(s) Layout(s) ist/sind betroffen?
+      description: |
+        If you are not sure select "Not sure". If you see the bug in all themes select "All" or select theme by theme were the bug occurs.
+
+        #### Deutsch:
+        Wenn Sie sich nicht sicher sind, wählen Sie "Not sure". Wenn Sie den Fehler in allen Themes sehen, wählen Sie "All" oder wählen Sie ein Theme nach dem anderen, in dem der Fehler auftritt.
       multiple: true
       options:
         - 'Not sure'
+        - 'All'
         - 'Bundesministerium der Finanzen'
         - 'Default'
         - 'European Comission'
@@ -142,9 +149,8 @@ body:
       description: |
         A step-by-step description of how to reproduce the issue. Screenshots can be provided in the issue body below. If using code blocks, make sure that [syntax highlighting is correct](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) and double check that the rendered preview is not broken.
 
-        ```diff
-        # Eine schrittweise Beschreibung, wie das Problem zu reproduzieren ist. Screenshots können im Problemtext unten bereitgestellt werden. Wenn Sie Codeblöcke verwenden, stellen Sie sicher, dass die [Syntaxhervorhebung korrekt ist] (https://docs.github.com/de/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) und überprüfen Sie, ob die gerenderte Vorschau nicht beschädigt ist.
-        ```
+        #### Deutsch:
+        Eine schrittweise Beschreibung, wie das Problem zu reproduzieren ist. Screenshots können im Problemtext unten bereitgestellt werden. Wenn Sie Codeblöcke verwenden, stellen Sie sicher, dass die [Syntaxhervorhebung korrekt ist] (https://docs.github.com/de/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) und überprüfen Sie, ob die gerenderte Vorschau nicht beschädigt ist.
       placeholder: |
         1. Click X
         2. Y will happen
@@ -158,32 +164,42 @@ body:
       description: |
         A clear and concise description of what the bug is, and what you expected to happen.
 
-        ```diff
-        # Eine klare und prägnante Beschreibung des Fehlers und der erwarteten Reaktion.
-        ```
+        #### Deutsch:
+        Eine klare und prägnante Beschreibung des Fehlers und der erwarteten Reaktion.
       placeholder: 'Following the steps from the previous section, I expected A to happen, but I observed B instead'
     validations:
       required: true
   - type: textarea
     id: environment_info
     attributes:
-      label: Provide environment information
-      description: Please run `kolibri info` in the root directory of your project and paste the results. You might need to use `npx --no-install kolibri info` if kolibri is not in the current PATH.
+      label: Provide environment information / Bereitstellung von Betriebsinformationen
+      description: |
+        Please run `kolibri info` in the root directory of your project and paste the results. You might need to use `npx --no-install kolibri info` if kolibri is not in the current PATH.
+
+        #### Deutsch:
+        Bitte führen Sie `kolibri info` im Hauptverzeichnis Ihres Projekts aus und fügen Sie die Ergebnisse ein. Möglicherweise müssen Sie `npx --no-install kolibri info` verwenden, wenn sich kolibri nicht im aktuellen PFAD befindet.
       render: bash
       placeholder: |
-        Operating System:
-          Platform: darwin
-          Arch: arm64
-          Version: Darwin Kernel Version 22.5.0
-        Binaries:
-          Node: 18.17.1
-          npm: 9.5.1
-          Yarn: 1.22.19
-          pnpm: N/A
-        Relevant Packages:
-          kolibri: 2.1.1
-          react: 18.2.0
-          react-dom: 18.2.0
-          typescript: 5.2.2
+        {
+          "Operating System": {
+            "platform": "darwin",
+            "arch": "arm64",
+            "version": "23.2.0"
+          },
+          "Binaries": {
+            "node": "v20.9.0",
+            "npm": "10.1.0",
+            "yarn": "3.2.4",
+            "pnpm": "9.1.3"
+          },
+          "Relevant Packages": {
+            "@public-ui/core": "N/A",
+            "@public-ui/react": "^2.1.1",
+            "@public-ui/...": "N/A",
+            "react": "^18.3.1",
+            "react-dom": "^18.3.1",
+            "typescript": "N/A"
+          }
+        }
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -70,7 +70,7 @@ body:
     id: error_category
     attributes:
       label: Can you categorise where the error occurs? (If known) / Können Sie einordnen, wo der Fehler auftaucht? (Falls bekannt)
-      placeholder: Nativ (Web Component), React, Angular, ...
+      placeholder: Native (Web Component), React, Angular, ...
     validations:
       required: false
   - type: input
@@ -87,7 +87,6 @@ body:
       multiple: true
       options:
         - 'Not sure'
-        - 'Handout'
         - 'Abbr'
         - 'Accordion'
         - 'Alert'
@@ -115,11 +114,9 @@ body:
         - 'Input-Radio'
         - 'Input-Range'
         - 'Input-Text'
-        - 'Kolibri'
         - 'Link-Button'
         - 'Link-Group'
         - 'Link'
-        - 'Logo'
         - 'Modal'
         - 'Nav'
         - 'Pagination'
@@ -135,11 +132,6 @@ body:
         - 'Toolbar'
         - 'Tree'
         - 'Version'
-        - 'Appointment-Form (Scenario)'
-        - 'Inputs-Get-Value (Scenario)'
-        - 'Custom-Tooltip-Width (Scenario)'
-        - 'Static-Form (Scenario)'
-        - 'Disabled-Interactive-Scenario (Scenario)'
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,0 +1,189 @@
+name: KoliBri Bug
+description: All relevant bugs, e.g. faulty components or examples / Alle relevanten bugs, z.B. fehlerhafte Komponenten oder Beispiele
+title: '🐞 Bug: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is to report KoliBri bugs. Documentation related bug should be reported using [this](https://github.com/public-ui/kolibri/issues/new/choose) issue template instead.
+        Feature requests should be opened as [discussions](https://github.com/public-ui/kolibri/discussions/new/choose).
+
+        Before opening a new issue, please do a [search](https://github.com/public-ui/kolibri/issues) of existing issues and :+1: upvote the existing issue instead. This will result in a quicker resolution.
+
+        If you need help with your own project, you can start a discussion in the ["Q&A" section](https://github.com/public-ui/kolibri/discussions/new?category=q-a)
+
+        ```diff
+        # Diese Vorlage ist zur Meldung von KoliBri-Bugs. Dokumentationsbezogene Bugs sollten stattdessen mit dieser [Vorlage](https://github.com/public-ui/kolibri/issues/new/choose) gemeldet werden.
+        # Funktionsanfragen sollten als [Diskussionen](https://github.com/public-ui/kolibri/discussions/new/choose) eröffnet werden.
+
+        # Bevor Sie ein neues Problem melden, führen Sie bitte eine [Suche](https://github.com/public-ui/kolibri/issues) nach bestehenden Problemen durch und stimmen Sie dem bestehenden Problem mit :+1: zu. Dies führt zu einer schnelleren Lösung.
+
+        # Wenn Sie Hilfe bei Ihrem eigenen Projekt benötigen, können Sie eine Diskussion im ["Q&A"-Bereich](https://github.com/public-ui/kolibri/discussions/new?category=q-a) starten.
+        ```
+  - type: checkboxes
+    id: verify_release
+    attributes:
+      label: Verify current release / Überprüfung der aktuellen Version
+      options:
+        - label: I verified that the issue exists in the latest KoliBri v1 or v2 release / Ich habe mich vergewissert, dass das Problem in der neuesten Version von KoliBri v1 oder v2 auftritt
+          required: true
+  - type: input
+    id: reproduction_url
+    attributes:
+      label: Link to the code that reproduces this issue / Link zu dem Code, der dieses Problem reproduziert
+      description: |
+        A link to a **public** GitHub repository or a StackBlitz minimal reproduction. Minimal reproductions should be created from our actual released versions (e.g. v1, v2, ...) and should include only changes that contribute to the issue. StackBlitz templates can be found under the followjng url's:
+
+        ```diff
+        # Ein Link zu einem **öffentlichen** GitHub-Repository oder einer StackBlitz-Minimalreproduktion. Minimale Reproduktionen sollten aus unseren aktuell veröffentlichten Versionen (z. B. v1, v2, ...) erstellt werden und nur Änderungen enthalten, die zum Problem beitragen. StackBlitz-Vorlagen können unter den folgenden URLs gefunden werden:
+        ````
+
+        - [Template (v1)](https://stackblitz.com/edit/vitejs-vite-dcg6xo)
+        - [Template (v2)](https://stackblitz.com/edit/vitejs-vite-kkfhk5)
+      placeholder: 'https://github.com/user/my-minimal-kolibri-issue-reproduction or https://stackblitz.com/edit/XXXXXX'
+    validations:
+      required: false
+  - type: dropdown
+    id: affected_themes
+    attributes:
+      label: Which theme(s) are affected? (Select all that apply) / Welche(s) Layout(s) ist/sind betroffen? (Wählen Sie alle zutreffenden aus)
+      multiple: true
+      options:
+        - 'Not sure'
+        - 'Bundesministerium der Finanzen'
+        - 'Default'
+        - 'European Comission'
+        - 'European Union'
+        - 'Informationstechnikzentrum Bund'
+        - 'Unstyled'
+    validations:
+      required: true
+  - type: input
+    id: error_category
+    attributes:
+      label: Can you categorise where the error occurs? (If known) / Können Sie einordnen, wo der Fehler auftaucht? (Falls bekannt)
+      placeholder: Nativ (shadow), React, Angular, ...
+    validations:
+      required: false
+  - type: input
+    id: browser_info
+    attributes:
+      label: Which browser or operating system do you used to test KoliBri? (If available) / Welchen Browser bzw. Betriebsystem haben Sie verwendet um KoliBri zu testen? (Falls vorhanden)
+      placeholder: Firefox, Chrome, iOS 12.4, ...
+    validations:
+      required: false
+  - type: dropdown
+    id: affected_components
+    attributes:
+      label: Which component/area(s) are affected? (Select all that apply) / Welche Komponente(n)/Bereich(e) sind betroffen? (Wählen Sie alle zutreffenden Punkte aus)
+      multiple: true
+      options:
+        - 'Not sure'
+        - 'Handout'
+        - 'Abbr'
+        - 'Accordion'
+        - 'Alert'
+        - 'Avatar'
+        - 'Badge'
+        - 'Breadcrumb'
+        - 'Button-Group'
+        - 'Button-Link'
+        - 'Button'
+        - 'Card'
+        - 'Combobox'
+        - 'Details'
+        - 'Form'
+        - 'Heading'
+        - 'Icon'
+        - 'Image'
+        - 'Indented-Text'
+        - 'Input-Checkbox'
+        - 'Input-Color'
+        - 'Input-Date'
+        - 'Input-Email'
+        - 'Input-File'
+        - 'Input-Number'
+        - 'Input-Password'
+        - 'Input-Radio'
+        - 'Input-Range'
+        - 'Input-Text'
+        - 'Kolibri'
+        - 'Link-Button'
+        - 'Link-Group'
+        - 'Link'
+        - 'Logo'
+        - 'Modal'
+        - 'Nav'
+        - 'Pagination'
+        - 'Progress'
+        - 'Quote'
+        - 'Select'
+        - 'Spin'
+        - 'Split-Button'
+        - 'Table'
+        - 'Tabs'
+        - 'Textarea'
+        - 'Toast'
+        - 'Toolbar'
+        - 'Tree'
+        - 'Version'
+        - 'Appointment-Form (Scenario)'
+        - 'Inputs-Get-Value (Scenario)'
+        - 'Custom-Tooltip-Width (Scenario)'
+        - 'Static-Form (Scenario)'
+        - 'Disabled-Interactive-Scenario (Scenario)'
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: To Reproduce / Zum Reproduzieren
+      description: |
+        A step-by-step description of how to reproduce the issue. Screenshots can be provided in the issue body below. If using code blocks, make sure that [syntax highlighting is correct](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) and double check that the rendered preview is not broken.
+
+        ```diff
+        # Eine schrittweise Beschreibung, wie das Problem zu reproduzieren ist. Screenshots können im Problemtext unten bereitgestellt werden. Wenn Sie Codeblöcke verwenden, stellen Sie sicher, dass die [Syntaxhervorhebung korrekt ist] (https://docs.github.com/de/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting) und überprüfen Sie, ob die gerenderte Vorschau nicht beschädigt ist.
+        ```
+      placeholder: |
+        1. Click X
+        2. Y will happen
+        3. Z throws a bug
+    validations:
+      required: true
+  - type: textarea
+    id: current_vs_expected_behavior
+    attributes:
+      label: Current vs. Expected behavior / Aktuelles vs. Erwartetes Verhalten
+      description: |
+        A clear and concise description of what the bug is, and what you expected to happen.
+
+        ```diff
+        # Eine klare und prägnante Beschreibung des Fehlers und der erwarteten Reaktion.
+        ```
+      placeholder: 'Following the steps from the previous section, I expected A to happen, but I observed B instead'
+    validations:
+      required: true
+  - type: textarea
+    id: environment_info
+    attributes:
+      label: Provide environment information
+      description: Please run `kolibri info` in the root directory of your project and paste the results. You might need to use `npx --no-install kolibri info` if kolibri is not in the current PATH.
+      render: bash
+      placeholder: |
+        Operating System:
+          Platform: darwin
+          Arch: arm64
+          Version: Darwin Kernel Version 22.5.0
+        Binaries:
+          Node: 18.17.1
+          npm: 9.5.1
+          Yarn: 1.22.19
+          pnpm: N/A
+        Relevant Packages:
+          kolibri: 2.1.1
+          react: 18.2.0
+          react-dom: 18.2.0
+          typescript: 5.2.2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -48,7 +48,7 @@ body:
   - type: dropdown
     id: affected_themes
     attributes:
-      label: Which theme(s) are affected? / Welche(s) Layout(s) ist/sind betroffen?
+      label: Which theme(s) are affected? / Welche(s) Theme(s) ist/sind betroffen?
       description: |
         If you are not sure select "Not sure". If you see the bug in all themes select "All" or select theme by theme were the bug occurs.
 
@@ -70,7 +70,7 @@ body:
     id: error_category
     attributes:
       label: Can you categorise where the error occurs? (If known) / Können Sie einordnen, wo der Fehler auftaucht? (Falls bekannt)
-      placeholder: Nativ (shadow), React, Angular, ...
+      placeholder: Nativ (Web Component), React, Angular, ...
     validations:
       required: false
   - type: input
@@ -174,10 +174,10 @@ body:
     attributes:
       label: Provide environment information / Bereitstellung von Betriebsinformationen
       description: |
-        Please run `kolibri info` in the root directory of your project and paste the results. You might need to use `npx --no-install kolibri info` if kolibri is not in the current PATH.
+        Please run `kolibri info` in the root directory of your project and paste the results. You might need to use `npx --no-install kolibri info` if kolibri is not in the current PATH or not installed.
 
         #### Deutsch:
-        Bitte führen Sie `kolibri info` im Hauptverzeichnis Ihres Projekts aus und fügen Sie die Ergebnisse ein. Möglicherweise müssen Sie `npx --no-install kolibri info` verwenden, wenn sich kolibri nicht im aktuellen PFAD befindet.
+        Bitte führen Sie `kolibri info` im Hauptverzeichnis Ihres Projekts aus und fügen Sie die Ergebnisse ein. Möglicherweise müssen Sie `npx @public-ui/kolibri-cli info` verwenden, wenn sich kolibri nicht im aktuellen PFAD befindet bzw. nicht installiert ist.
       render: bash
       placeholder: |
         {

--- a/.github/ISSUE_TEMPLATE/2.doc_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.doc_report.yml
@@ -1,9 +1,10 @@
 name: KoliBri Documentation Report
 description: Create a report for KoliBri documentation / Einen Bericht für die KoliBri-Dokumentation erstellen
-title: '💡 Docs: '
+title: '📖 Docs: '
 labels: ['doc']
 body:
   - type: textarea
+    id: update
     attributes:
       label: What is the update you wish to see? / Welche Aktualisierung würden Sie gerne sehen?
       description: |
@@ -15,6 +16,7 @@ body:
     validations:
       required: true
   - type: textarea
+    id: context
     attributes:
       label: Is there any context that might help us understand? / Gibt es irgendeinen Zusammenhang, der uns helfen könnte, es besser zu verstehen? 
       description: |
@@ -26,6 +28,7 @@ body:
     validations:
       required: true
   - type: input
+    id: link
     attributes:
       label: Does the docs page already exist? Please link to it. / Gibt es die Doku-Seite bereits? Bitte verlinken Sie sie.
       description: 'Example: https://public-ui.github.io/docs/components/abbr'

--- a/.github/ISSUE_TEMPLATE/2.doc_report.yml
+++ b/.github/ISSUE_TEMPLATE/2.doc_report.yml
@@ -1,0 +1,33 @@
+name: KoliBri Documentation Report
+description: Create a report for KoliBri documentation / Einen Bericht für die KoliBri-Dokumentation erstellen
+title: '💡 Docs: '
+labels: ['doc']
+body:
+  - type: textarea
+    attributes:
+      label: What is the update you wish to see? / Welche Aktualisierung würden Sie gerne sehen?
+      description: |
+        Example: I would like to fix an example using the `<Link>` component. Or, the `<Link>` component docs are missing information.
+
+        ```diff
+        # Beispiel: Ich möchte ein Beispiel für die Verwendung der `<Link>`-Komponente korrigieren. Oder in der Dokumentation der Komponente `<Link>` fehlen Informationen.
+        ````
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Is there any context that might help us understand? / Gibt es irgendeinen Zusammenhang, der uns helfen könnte, es besser zu verstehen? 
+      description: |
+        A clear description of any added context that might help us understand.
+
+        ```diff
+        # Eine klare Beschreibung jedes zusätzlichen Kontextes, der zum Verständnis beitragen könnte.
+        ````
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Does the docs page already exist? Please link to it. / Gibt es die Doku-Seite bereits? Bitte verlinken Sie sie.
+      description: 'Example: https://public-ui.github.io/docs/components/abbr'
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: KoliBri Feature Request
+    url: https://github.com/public-ui/kolibri/discussions/new/choose
+    about: Feature or docs requests should be opened as discussions.
+  - name: KoliBri Question
+    url: https://github.com/public-ui/kolibri/discussions/new?category=q-a
+    about: Ask questions and discuss with other community members.

--- a/.github/workflows/issue-validation.yml
+++ b/.github/workflows/issue-validation.yml
@@ -1,0 +1,105 @@
+name: Validate Issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  process-issue:
+    if: contains(join(github.event.issue.labels.*.name, ','), 'bug') || contains(join(github.event.issue.labels.*.name, ','), 'doc')
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v2
+
+    - name: Extract issue details
+      id: extract
+      run: |
+        ISSUE_BODY=$(jq -r .issue.body "$GITHUB_EVENT_PATH")
+
+        # Extract form-specific fields if it's a bug report
+        if echo "${{ github.event.issue.labels.*.name }}" | grep -q "bug"; then
+          REPRODUCTION_URL=$(echo "$ISSUE_BODY" | jq -r '.reproduction_url // empty')
+          THEMES=$(echo "$ISSUE_BODY" | jq -r '.affected_themes // empty' | tr '\n' ' ')
+          THEME_SHORT_FORMS=$(echo "$THEMES" | sed 's/Not sure//; s/Bundesministerium der Finanzen/theme: BMF/; s/Default/theme: Default/; s/European Comission/theme: EC/; s/European Union/theme: EU/; s/Informationstechnikzentrum Bund/theme: ITZ/; s/Unstyled/theme: Unstyled/; s/ /,/g' | sed 's/^,*//;s/,*$//')
+          ERROR_CATEGORY=$(echo "$ISSUE_BODY" | jq -r '.error_category // empty')
+          BROWSER_INFO=$(echo "$ISSUE_BODY" | jq -r '.browser_info // empty')
+          COMPONENTS=$(echo "$ISSUE_BODY" | jq -r '.affected_components // empty' | tr '\n' ' ' | sed 's/Not sure//g' | sed 's/ (\(Scenario\))//g' | tr -d ' ')
+          COMPONENTS_LABEL=$(echo "$COMPONENTS" | sed 's/ /,/g' | sed 's/^,*//;s/,*$//')
+          KOLIBRI_VERSION=$(echo "$ISSUE_BODY" | grep -oP 'kolibri: \d+\.\d+\.\d+' | awk '{print $2}')
+          KOLIBRI_MAJOR_VERSION=$(echo "$KOLIBRI_VERSION" | cut -d '.' -f 1)
+          KOLIBRI_LABEL=$(echo "v$KOLIBRI_MAJOR_VERSION")
+
+          # Construct the new issue body with optional fields
+          NEW_ISSUE_BODY=$(echo "$ISSUE_BODY" | sed -E 's/\(.*?\)//g' | sed -E 's/^ *\* +/\n/g' | sed 's/### /\n\n### /g')
+          if [ -n "$REPRODUCTION_URL" ]; then
+            NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Reproduction URL:** $REPRODUCTION_URL\n"
+          fi
+          if [ -n "$ERROR_CATEGORY" ]; then
+            NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Error Category:** $ERROR_CATEGORY\n"
+          fi
+          if [ -n "$BROWSER_INFO" ]; then
+            NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Browser Information:** $BROWSER_INFO\n"
+          fi
+
+          echo "reproduction_url=$REPRODUCTION_URL" >> $GITHUB_OUTPUT
+          echo "themes_labels=$THEME_SHORT_FORMS" >> $GITHUB_OUTPUT
+          echo "error_category=$ERROR_CATEGORY" >> $GITHUB_OUTPUT
+          echo "browser_info=$BROWSER_INFO" >> $GITHUB_OUTPUT
+          echo "components_label=$COMPONENTS_LABEL" >> $GITHUB_OUTPUT
+          echo "kolibri_label=$KOLIBRI_LABEL" >> $GITHUB_OUTPUT
+          echo "issue_body=$NEW_ISSUE_BODY" >> $GITHUB_OUTPUT
+
+        # Extract form-specific fields if it's a documentation report
+        elif echo "${{ github.event.issue.labels.*.name }}" | grep -q "doc"; then
+            DOC_UPDATE=$(echo "$ISSUE_BODY" | jq -r '.update // empty')
+            DOC_CONTEXT=$(echo "$ISSUE_BODY" | jq -r '.context // empty')
+            DOC_LINK=$(echo "$ISSUE_BODY" | jq -r '.doc_link // empty')
+
+            # Construct the new issue body
+            NEW_ISSUE_BODY=$(cat <<EOF
+            **Update Requested:**
+            $DOC_UPDATE
+
+            **Context:**
+            $DOC_CONTEXT
+            EOF
+            )
+
+            if [ -n "$DOC_LINK" ]; then
+                NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Documentation Link:** $DOC_LINK\n"
+            fi
+
+            echo "issue_body=$NEW_ISSUE_BODY" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Check if user is a team member
+      id: check-team
+      run: |
+        USERNAME=${{ github.event.issue.user.login }}
+        ORG="public-ui"
+        TEAM="SpecTeam"
+        RESPONSE=$(curl -H "Authorization: token ${{ secrets.ORG_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/$ORG/teams/$TEAM/memberships/$USERNAME)
+        if echo "$RESPONSE" | grep -q '"state": "active"'; then
+            echo "::set-output name=team_member::true"
+        else
+            echo "::set-output name=team_member::false"
+        fi
+
+    - name: Update issue with labels and new description
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        body: |
+          ${{ steps.extract.outputs.issue_body }}
+
+    - name: Add labels to the issue
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: |
+            ${{ steps.check-team.outputs.team_member == 'true' && 'created-by: kolibri-team' || '' }}
+            ${{ steps.extract.outputs.kolibri_label || '' }}
+            ${{ steps.extract.outputs.themes_labels || '' }}
+            ${{ steps.extract.outputs.components_label || '' }}

--- a/.github/workflows/issue-validation.yml
+++ b/.github/workflows/issue-validation.yml
@@ -44,7 +44,7 @@ jobs:
           reproduction=$(echo $REPRODUCTION || echo "Not defined")
           expacted_behavior=$(echo $EXPACTED_BEHAVIOR || echo "Not defined")
           components=$(echo $COMPONENTS || echo "")
-          components_label=$(echo "${components}" | sed 's/(Scenario)//g' | sed 's/\n/,/g' | sed 's/^,*//;s/,*$//' || echo "")
+          components_label=$(echo "${components}" | sed 's/\n/,/g' | sed 's/^,*//;s/,*$//' || echo "")
           IFS=',' read -r -a components_array <<< "$components_label"
           for component in "${components_array[@]}"; do
             component_no_spaces="${component// /}"

--- a/.github/workflows/issue-validation.yml
+++ b/.github/workflows/issue-validation.yml
@@ -6,100 +6,139 @@ on:
 
 jobs:
   process-issue:
-    if: contains(join(github.event.issue.labels.*.name, ','), 'bug') || contains(join(github.event.issue.labels.*.name, ','), 'doc')
+    if: contains(join(github.event.issue.labels.*.name, ','), 'bug')
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check out the repository
-      uses: actions/checkout@v2
+      - name: Check out the repository
+        uses: actions/checkout@v2
 
-    - name: Extract issue details
-      id: extract
-      run: |
-        ISSUE_BODY=$(jq -r .issue.body "$GITHUB_EVENT_PATH")
+      - name: View the GitHub context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
 
-        # Extract form-specific fields if it's a bug report
-        if echo "${{ github.event.issue.labels.*.name }}" | grep -q "bug"; then
-          REPRODUCTION_URL=$(echo "$ISSUE_BODY" | jq -r '.reproduction_url // empty')
-          THEMES=$(echo "$ISSUE_BODY" | jq -r '.affected_themes // empty' | tr '\n' ' ')
-          THEME_SHORT_FORMS=$(echo "$THEMES" | sed 's/Not sure//; s/Bundesministerium der Finanzen/theme: BMF/; s/Default/theme: Default/; s/European Comission/theme: EC/; s/European Union/theme: EU/; s/Informationstechnikzentrum Bund/theme: ITZ/; s/Unstyled/theme: Unstyled/; s/ /,/g' | sed 's/^,*//;s/,*$//')
-          ERROR_CATEGORY=$(echo "$ISSUE_BODY" | jq -r '.error_category // empty')
-          BROWSER_INFO=$(echo "$ISSUE_BODY" | jq -r '.browser_info // empty')
-          COMPONENTS=$(echo "$ISSUE_BODY" | jq -r '.affected_components // empty' | tr '\n' ' ' | sed 's/Not sure//g' | sed 's/ (\(Scenario\))//g' | tr -d ' ')
-          COMPONENTS_LABEL=$(echo "$COMPONENTS" | sed 's/ /,/g' | sed 's/^,*//;s/,*$//')
-          KOLIBRI_VERSION=$(echo "$ISSUE_BODY" | grep -oP 'kolibri: \d+\.\d+\.\d+' | awk '{print $2}')
-          KOLIBRI_MAJOR_VERSION=$(echo "$KOLIBRI_VERSION" | cut -d '.' -f 1)
-          KOLIBRI_LABEL=$(echo "v$KOLIBRI_MAJOR_VERSION")
+      - uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
 
-          # Construct the new issue body with optional fields
-          NEW_ISSUE_BODY=$(echo "$ISSUE_BODY" | sed -E 's/\(.*?\)//g' | sed -E 's/^ *\* +/\n/g' | sed 's/### /\n\n### /g')
-          if [ -n "$REPRODUCTION_URL" ]; then
-            NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Reproduction URL:** $REPRODUCTION_URL\n"
-          fi
-          if [ -n "$ERROR_CATEGORY" ]; then
-            NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Error Category:** $ERROR_CATEGORY\n"
-          fi
-          if [ -n "$BROWSER_INFO" ]; then
-            NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Browser Information:** $BROWSER_INFO\n"
-          fi
+      - run: cat ${HOME}/issue-parser-result.json       
 
-          echo "reproduction_url=$REPRODUCTION_URL" >> $GITHUB_OUTPUT
-          echo "themes_labels=$THEME_SHORT_FORMS" >> $GITHUB_OUTPUT
-          echo "error_category=$ERROR_CATEGORY" >> $GITHUB_OUTPUT
-          echo "browser_info=$BROWSER_INFO" >> $GITHUB_OUTPUT
-          echo "components_label=$COMPONENTS_LABEL" >> $GITHUB_OUTPUT
-          echo "kolibri_label=$KOLIBRI_LABEL" >> $GITHUB_OUTPUT
-          echo "issue_body=$NEW_ISSUE_BODY" >> $GITHUB_OUTPUT
+      - name: Extract issue details
+        id: extract
+        run: |
+          echo "Extracting issue details..."
 
-        # Extract form-specific fields if it's a documentation report
-        elif echo "${{ github.event.issue.labels.*.name }}" | grep -q "doc"; then
-            DOC_UPDATE=$(echo "$ISSUE_BODY" | jq -r '.update // empty')
-            DOC_CONTEXT=$(echo "$ISSUE_BODY" | jq -r '.context // empty')
-            DOC_LINK=$(echo "$ISSUE_BODY" | jq -r '.doc_link // empty')
+          echo "Processing as a bug report..."
 
-            # Construct the new issue body
-            NEW_ISSUE_BODY=$(cat <<EOF
-            **Update Requested:**
-            $DOC_UPDATE
+          reproduction_url=$(echo $REPRODUCTION_URL || echo "Not defined")
+          themes=$(echo $THEMES || echo "")
+          themes_short_forms=$(echo "${THEMES}" | sed 's/Not sure//; s/All/theme: All/; s/Bundesministerium der Finanzen/theme: BMF/; s/Default/theme: Default/; s/European Comission/theme: EC/; s/European Union/theme: EU/; s/Informationstechnikzentrum Bund/theme: ITZ/; s/Unstyled/theme: Unstyled/' | sed 's/^,*//;s/,*$//')
+          IFS=',' read -r -a themes_array <<< "$themes_short_forms"
+          for theme in "${themes_array[@]}"; do
+            theme_no_spaces="${theme// /}"
+            echo "THEME_LABEL_$theme_no_spaces=$theme_no_spaces" >> $GITHUB_ENV
+          done
 
-            **Context:**
-            $DOC_CONTEXT
-            EOF
-            )
+          error_category=$(echo $CATEGORY || echo "Not defined")
+          browser_info=$(echo $BROWSER || echo "Not defined")
+          reproduction=$(echo $REPRODUCTION || echo "Not defined")
+          expacted_behavior=$(echo $EXPACTED_BEHAVIOR || echo "Not defined")
+          components=$(echo $COMPONENTS || echo "")
+          components_label=$(echo "${components}" | sed 's/(Scenario)//g' | sed 's/\n/,/g' | sed 's/^,*//;s/,*$//' || echo "")
+          IFS=',' read -r -a components_array <<< "$components_label"
+          for component in "${components_array[@]}"; do
+            component_no_spaces="${component// /}"
+            echo "COMPONENT_LABEL_$component_no_spaces=$component_no_spaces" >> $GITHUB_ENV
+          done
 
-            if [ -n "$DOC_LINK" ]; then
-                NEW_ISSUE_BODY="${NEW_ISSUE_BODY}\n**Documentation Link:** $DOC_LINK\n"
-            fi
+          system_info=$(echo $SYSTEM || echo "Not defined")
+          kolibri_version=$(echo "$system_info" | grep -oP '"@public-ui/components": "\K[^"]+' | sed 's/[^0-9.]//g' || echo "N/A")
+          kolibri_major_version=$(echo "$kolibri_version" | cut -d '.' -f 1)
+          kolibri_version_label="v$kolibri_major_version"
+          echo "KOLIBRI_VERSION_LABEL=$kolibri_version_label" >> $GITHUB_ENV
 
-            echo "issue_body=$NEW_ISSUE_BODY" >> $GITHUB_OUTPUT
-        fi
+          NEW_ISSUE_BODY=$(cat <<EOF
+          ### Link to the code that reproduces this issue:
+          $reproduction_url
 
-    - name: Check if user is a team member
-      id: check-team
-      run: |
-        USERNAME=${{ github.event.issue.user.login }}
-        ORG="public-ui"
-        TEAM="SpecTeam"
-        RESPONSE=$(curl -H "Authorization: token ${{ secrets.ORG_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/$ORG/teams/$TEAM/memberships/$USERNAME)
-        if echo "$RESPONSE" | grep -q '"state": "active"'; then
-            echo "::set-output name=team_member::true"
-        else
-            echo "::set-output name=team_member::false"
-        fi
+          ### Can you categorise where the error occurs?
+          $error_category
 
-    - name: Update issue with labels and new description
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        issue-number: ${{ github.event.issue.number }}
-        body: |
-          ${{ steps.extract.outputs.issue_body }}
+          ### Which browser or operating system do you used to test KoliBri?
+          $browser_info
 
-    - name: Add labels to the issue
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        labels: |
-            ${{ steps.check-team.outputs.team_member == 'true' && 'created-by: kolibri-team' || '' }}
-            ${{ steps.extract.outputs.kolibri_label || '' }}
-            ${{ steps.extract.outputs.themes_labels || '' }}
-            ${{ steps.extract.outputs.components_label || '' }}
+          ### How to reproduce issue?
+          $reproduction
+
+          ### Current vs. Expected:
+          $expacted_behavior
+
+          ### Environment informations:
+          $system_info
+          EOF
+          )
+          echo "NEW_ISSUE_BODY<<EOF" >> $GITHUB_ENV
+          echo "$NEW_ISSUE_BODY" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env:
+          REPRODUCTION_URL: ${{ steps.issue-parser.outputs.issueparser_link_to_the_code_that_reproduces_this_issue__link_zu_dem_code_der_dieses_problem_reproduziert }}
+          THEMES: ${{ steps.issue-parser.outputs.issueparser_which_themes_are_affected__welches_layouts_istsind_betroffen }}
+          CATEGORY: ${{ steps.issue-parser.outputs.issueparser_can_you_categorise_where_the_error_occurs_if_known__knnen_sie_einordnen_wo_der_fehler_auftaucht_falls_bekannt }}
+          BROWSER: ${{ steps.issue-parser.outputs.issueparser_which_browser_or_operating_system_do_you_used_to_test_kolibri_if_available__welchen_browser_bzw_betriebsystem_haben_sie_verwendet_um_kolibri_zu_testen_falls_vorhanden }}
+          COMPONENTS: ${{ steps.issue-parser.outputs.issueparser_which_componentareas_are_affected_select_all_that_apply__welche_komponentenbereiche_sind_betroffen_whlen_sie_alle_zutreffenden_punkte_aus }}
+          REPRODUCTION: ${{ steps.issue-parser.outputs.issueparser_to_reproduce__zum_reproduzieren }}
+          EXPACTED_BEHAVIOR: ${{ steps.issue-parser.outputs.issueparser_current_vs_expected_behavior__aktuelles_vs_erwartetes_verhalten }}
+          SYSTEM: ${{ steps.issue-parser.outputs.issueparser_provide_environment_information__bereitstellung_von_betriebsinformationen }}
+
+      - name: Check if user is a team member
+        id: check-team
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          script: |
+            try {
+              
+              const result = await github.rest.teams.getMembershipForUserInOrg({
+                org: context.repo.owner,
+                team_slug: 'specteam',
+                username: context.payload.sender.login
+              });
+
+              if (result.data.state === 'active') {
+                core.setOutput('team_member', 'true');
+              } else {
+                core.setOutput('team_member', 'false');
+              }
+            } catch (error) {
+              core.error(`${error}`);
+              core.setOutput('team_member', 'false');
+            }
+            return
+
+      - name: Update issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelsToAdd = ['bug'];
+
+            if ('${{ steps.check-team.outputs.team_member }}' === 'true') {
+              labelsToAdd.push('created-by: kolibri-team');
+            }
+
+            if ('${{ env.KOLIBRI_VERSION_LABEL }}') {
+              labelsToAdd.push('${{ env.KOLIBRI_VERSION_LABEL }}');
+            }
+
+            for (const key of Object.keys(process.env)) {
+              if ((key.startsWith('THEME_LABEL_') || key.startsWith('COMPONENT_LABEL_')) && process.env[key]) {
+                labelsToAdd.push(process.env[key]);
+              }
+            }
+            core.info(`Labels to add: ${labelsToAdd.join(', ')}`);
+
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: process.env.NEW_ISSUE_BODY,
+              labels: labelsToAdd
+            });

--- a/.github/workflows/issue-validation.yml
+++ b/.github/workflows/issue-validation.yml
@@ -82,7 +82,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
         env:
           REPRODUCTION_URL: ${{ steps.issue-parser.outputs.issueparser_link_to_the_code_that_reproduces_this_issue__link_zu_dem_code_der_dieses_problem_reproduziert }}
-          THEMES: ${{ steps.issue-parser.outputs.issueparser_which_themes_are_affected__welches_layouts_istsind_betroffen }}
+          THEMES: ${{ steps.issue-parser.outputs.issueparser_which_themes_are_affected__welches_themes_istsind_betroffen }}
           CATEGORY: ${{ steps.issue-parser.outputs.issueparser_can_you_categorise_where_the_error_occurs_if_known__knnen_sie_einordnen_wo_der_fehler_auftaucht_falls_bekannt }}
           BROWSER: ${{ steps.issue-parser.outputs.issueparser_which_browser_or_operating_system_do_you_used_to_test_kolibri_if_available__welchen_browser_bzw_betriebsystem_haben_sie_verwendet_um_kolibri_zu_testen_falls_vorhanden }}
           COMPONENTS: ${{ steps.issue-parser.outputs.issueparser_which_componentareas_are_affected_select_all_that_apply__welche_komponentenbereiche_sind_betroffen_whlen_sie_alle_zutreffenden_punkte_aus }}

--- a/packages/tools/kolibri-cli/README.md
+++ b/packages/tools/kolibri-cli/README.md
@@ -39,13 +39,13 @@ Options:
   -h, --help                  display help for command
 
 Commands:
-  info						  Shows the system and KoliBri package informations
+  info						  Shows the system and KoliBri package information
   migrate [options] <string>  This command migrates KoliBri code to the current version.
   help [command]              display help for command
 ```
 
 ### Info
-With the `info` command you can show the actual system and KoliBri package informations.
+With the `info` command you can show the current system and KoliBri package information.
 
 This command is mainly needed for our bug issue templates.
 If errors occur in our packages, we would like to ask you to create an issue under the following link:

--- a/packages/tools/kolibri-cli/README.md
+++ b/packages/tools/kolibri-cli/README.md
@@ -39,9 +39,17 @@ Options:
   -h, --help                  display help for command
 
 Commands:
+  info						  Shows the system and KoliBri package informations
   migrate [options] <string>  This command migrates KoliBri code to the current version.
   help [command]              display help for command
 ```
+
+### Info
+With the `info` command you can show the actual system and KoliBri package informations.
+
+This command is mainly needed for our bug issue templates.
+If errors occur in our packages, we would like to ask you to create an issue under the following link:
+[Submit report](https://github.com/public-ui/kolibri/issues/new/choose)
 
 ### Migrate
 

--- a/packages/tools/kolibri-cli/src/index.ts
+++ b/packages/tools/kolibri-cli/src/index.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import gradient from 'gradient-string';
 
+import info from './info';
 import migrate from './migrate';
 import { getVersionOfPublicUiKoliBriCli } from './migrate/shares/reuse';
 
@@ -28,6 +29,7 @@ const program = new Command();
 program.name('kolibri').description('CLI for executing some helpful commands for KoliBri projects.').version(versionOfPublicUiKoliBriCli);
 
 // Add commands
+info(program);
 migrate(program);
 
 program.parse();

--- a/packages/tools/kolibri-cli/src/info/index.ts
+++ b/packages/tools/kolibri-cli/src/info/index.ts
@@ -40,33 +40,22 @@ const getRelevantPackagesInfo = (): PackageInfo => {
 	const packageJsonPath = path.join(process.cwd(), 'package.json');
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
 
-	const relevantPackages = [
-		'@public-ui/core',
-		'@public-ui/angular-v17',
-		'@public-ui/angular-v16',
-		'@public-ui/angular-v15',
-		'@public-ui/angular-v14',
-		'@public-ui/angular-v13',
-		'@public-ui/angular-v12',
-		'@public-ui/angular-v11',
-		'@public-ui/react',
-		'@public-ui/preact',
-		'@public-ui/react-standalone',
-		'@public-ui/sample-react',
-		'@public-ui/hydrate',
-		'@public-ui/vue',
-		'@public-ui/components',
-		'@public-ui/themes',
-		'@public-ui/solid',
-		'@public-ui/schema',
-		'react',
-		'react-dom',
-		'typescript',
-	];
+	const packagePattern = /^@public-ui\//;
 	const packagesInfo: PackageInfo = {};
 
-	relevantPackages.forEach((pkg) => {
-		packagesInfo[pkg] = packageJson?.dependencies?.[pkg] || packageJson?.devDependencies?.[pkg] || 'N/A';
+	const allDependencies = { ...packageJson?.dependencies, ...packageJson?.devDependencies };
+
+	Object.keys(allDependencies).forEach((pkg) => {
+		if (packagePattern.test(pkg)) {
+			packagesInfo[pkg] = allDependencies?.[pkg];
+		}
+	});
+
+	// Add specific packages not matching the pattern
+	const additionalPackages = ['react', 'react-dom', 'typescript'];
+
+	additionalPackages.forEach((pkg) => {
+		packagesInfo[pkg] = allDependencies?.[pkg] || 'N/A';
 	});
 
 	return packagesInfo;
@@ -79,7 +68,7 @@ const getRelevantPackagesInfo = (): PackageInfo => {
 export default function (program: Command): void {
 	program
 		.command('info')
-		.description('This command returns informations about your system.')
+		.description('This command returns information about your system.')
 		.action(() => {
 			// Gather all information
 			const systemInfo = {

--- a/packages/tools/kolibri-cli/src/info/index.ts
+++ b/packages/tools/kolibri-cli/src/info/index.ts
@@ -29,8 +29,8 @@ type Binaries = { node: string; npm: string; yarn: string; pnpm: string };
 const getBinariesInfo = (): Binaries => ({
 	node: getBinaryVersion('node'),
 	npm: getBinaryVersion('npm'),
-	yarn: getBinaryVersion('yarn'),
 	pnpm: getBinaryVersion('pnpm'),
+	yarn: getBinaryVersion('yarn'),
 });
 
 type PackageInfo = { [key: string]: string };

--- a/packages/tools/kolibri-cli/src/info/index.ts
+++ b/packages/tools/kolibri-cli/src/info/index.ts
@@ -1,0 +1,91 @@
+import type { Command } from 'commander';
+import os from 'os';
+import { execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+
+// Function to get the binary version
+const getBinaryVersion = (command: string): string => {
+	try {
+		return execSync(`${command} --version`, { encoding: 'utf8' }).trim();
+	} catch {
+		return 'N/A';
+	}
+};
+
+type OSInfo = { platform: string; arch: string; version: string };
+
+// Get operating system information
+const getOsInfo = (): OSInfo => ({
+	platform: os.platform(),
+	arch: os.arch(),
+	version: os.release(),
+});
+
+type Binaries = { node: string; npm: string; yarn: string; pnpm: string };
+
+// Get binaries information
+const getBinariesInfo = (): Binaries => ({
+	node: getBinaryVersion('node'),
+	npm: getBinaryVersion('npm'),
+	yarn: getBinaryVersion('yarn'),
+	pnpm: getBinaryVersion('pnpm'),
+});
+
+type PackageInfo = { [key: string]: string };
+
+// Get relevant packages information
+const getRelevantPackagesInfo = (): PackageInfo => {
+	const packageJsonPath = path.join(process.cwd(), 'package.json');
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+	const relevantPackages = [
+		'@public-ui/core',
+		'@public-ui/angular-v17',
+		'@public-ui/angular-v16',
+		'@public-ui/angular-v15',
+		'@public-ui/angular-v14',
+		'@public-ui/angular-v13',
+		'@public-ui/angular-v12',
+		'@public-ui/angular-v11',
+		'@public-ui/react',
+		'@public-ui/preact',
+		'@public-ui/react-standalone',
+		'@public-ui/sample-react',
+		'@public-ui/hydrate',
+		'@public-ui/vue',
+		'@public-ui/components',
+		'@public-ui/themes',
+		'@public-ui/solid',
+		'@public-ui/schema',
+		'react',
+		'react-dom',
+		'typescript',
+	];
+	const packagesInfo: PackageInfo = {};
+
+	relevantPackages.forEach((pkg) => {
+		packagesInfo[pkg] = packageJson?.dependencies?.[pkg] || packageJson?.devDependencies?.[pkg] || 'N/A';
+	});
+
+	return packagesInfo;
+};
+
+/**
+ * This function is used to register the migrate command.
+ * @param {Command} program The program object to register the command
+ */
+export default function (program: Command): void {
+	program
+		.command('info')
+		.description('This command returns informations about your system.')
+		.action(() => {
+			// Gather all information
+			const systemInfo = {
+				'Operating System': getOsInfo(),
+				Binaries: getBinariesInfo(),
+				'Relevant Packages': getRelevantPackagesInfo(),
+			};
+			console.log(JSON.stringify(systemInfo, null, 2));
+		});
+}

--- a/packages/tools/kolibri-cli/src/info/index.ts
+++ b/packages/tools/kolibri-cli/src/info/index.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import { execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { PackageJson } from '../types';
 
 // Function to get the binary version
 const getBinaryVersion = (command: string): string => {
@@ -37,7 +38,7 @@ type PackageInfo = { [key: string]: string };
 // Get relevant packages information
 const getRelevantPackagesInfo = (): PackageInfo => {
 	const packageJsonPath = path.join(process.cwd(), 'package.json');
-	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
 
 	const relevantPackages = [
 		'@public-ui/core',


### PR DESCRIPTION
**Testbar in dem folgenden Repo:**
https://github.com/public-ui/kolibri-ci-testing/issues

**Änderungen:**
- CLI wurde erweitert um einen info command, welcher die system und KoliBri package Informationen wiedergibt
- Issue & discussion templates wurden in Formulare verändert
- Neue GitHub Action zum formatieren von Bug reports

**Zusätzliche TODO's nach merge:**
- Links in den Beschreibungen der Vorlagen müssen in einem nachträglichen hotfix auf die neuen Git URL's geändert werden
- Farben der neuen Label's für Themes und KoliBri-Team anpassen
- kolibri-cli-testing repo entfernen