### PR TITLE
Toast API: Add option `immediate` to closeAll method

### DIFF
--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -43,7 +43,7 @@ export class KolToastContainer implements ToasterAPI {
 			this.state = {
 				...this.state,
 				_toastStates: this.state._toastStates.map((localToastState) =>
-					localToastState.id === newToastState.id
+					localToastState.id === newToastState.id && localToastState.status !== 'removing'
 						? {
 								...localToastState,
 								status: 'settled',
@@ -86,9 +86,11 @@ export class KolToastContainer implements ToasterAPI {
 				_toastStates: [],
 			};
 		} else {
+			const toastsToClose = [...this.state._toastStates]; // Create a snapshot of the open toasts at the time closeAll has been called
+
 			this.state = {
 				...this.state,
-				_toastStates: this.state._toastStates.map((localToastState) => ({
+				_toastStates: toastsToClose.map((localToastState) => ({
 					...localToastState,
 					status: 'removing',
 				})),
@@ -97,7 +99,7 @@ export class KolToastContainer implements ToasterAPI {
 			setTimeout(() => {
 				this.state = {
 					...this.state,
-					_toastStates: [],
+					_toastStates: this.state._toastStates.filter((toastState) => toastsToClose.every((toastToClose) => toastToClose.id !== toastState.id)),
 				};
 			}, TRANSITION_TIMEOUT);
 		}

--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -79,21 +79,28 @@ export class KolToastContainer implements ToasterAPI {
 
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
-	public async closeAll() {
-		this.state = {
-			...this.state,
-			_toastStates: this.state._toastStates.map((localToastState) => ({
-				...localToastState,
-				status: 'removing',
-			})),
-		};
-
-		setTimeout(() => {
+	public async closeAll(immediate: boolean = false) {
+		if (immediate) {
 			this.state = {
 				...this.state,
 				_toastStates: [],
 			};
-		}, TRANSITION_TIMEOUT);
+		} else {
+			this.state = {
+				...this.state,
+				_toastStates: this.state._toastStates.map((localToastState) => ({
+					...localToastState,
+					status: 'removing',
+				})),
+			};
+
+			setTimeout(() => {
+				this.state = {
+					...this.state,
+					_toastStates: [],
+				};
+			}, TRANSITION_TIMEOUT);
+		}
 	}
 
 	private handleToastRef(toastState: ToastState, element?: HTMLDivElement) {

--- a/packages/components/src/components/toaster/toaster.tsx
+++ b/packages/components/src/components/toaster/toaster.tsx
@@ -55,9 +55,9 @@ export class ToasterService {
 		}
 	}
 
-	public closeAll(): void {
+	public closeAll(immediate: boolean = false): void {
 		if (this.toastContainerElement && typeof this.toastContainerElement.closeAll === 'function') {
-			void this.toastContainerElement.closeAll();
+			void this.toastContainerElement.closeAll(immediate);
 		}
 	}
 }

--- a/packages/samples/react/src/components/toast/basic.tsx
+++ b/packages/samples/react/src/components/toast/basic.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { ToasterService } from '@public-ui/components';
 import { KolButton } from '@public-ui/react';
@@ -10,22 +10,6 @@ import type { FC } from 'react';
 
 export const ToastBasic: FC = () => {
 	const toaster = ToasterService.getInstance(document);
-
-	useEffect(() => {
-		async function createNotification() {
-			await toaster.enqueue({
-				label: 'Fehler',
-				type: 'error',
-				description: `Eine Fehlermeldung ${new Date().getTime()}`,
-			});
-		}
-		void createNotification();
-
-		return () => {
-			toaster.closeAll();
-		};
-	}, []);
-
 	const handleButtonClickSimple = () => {
 		void toaster.enqueue({
 			description: 'Toasty',

--- a/packages/samples/react/src/components/toast/basic.tsx
+++ b/packages/samples/react/src/components/toast/basic.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { ToasterService } from '@public-ui/components';
 import { KolButton } from '@public-ui/react';
@@ -10,6 +10,22 @@ import type { FC } from 'react';
 
 export const ToastBasic: FC = () => {
 	const toaster = ToasterService.getInstance(document);
+
+	useEffect(() => {
+		async function createNotification() {
+			await toaster.enqueue({
+				label: 'Fehler',
+				type: 'error',
+				description: `Eine Fehlermeldung ${new Date().getTime()}`,
+			});
+		}
+		void createNotification();
+
+		return () => {
+			toaster.closeAll();
+		};
+	}, []);
+
 	const handleButtonClickSimple = () => {
 		void toaster.enqueue({
 			description: 'Toasty',


### PR DESCRIPTION
Add option `immediate` to closeAll method to allow instant cleanup without animation delay

Refs: #6270