### PR TITLE
avatar: In chrome, the visible texts in the avatar shift when the font size is changed manually

### DIFF
--- a/packages/components/src/components/avatar/style.scss
+++ b/packages/components/src/components/avatar/style.scss
@@ -31,5 +31,6 @@
 		/*theme?*/
 		background: #d3d3d3;
 		font-size: rem(32);
+		font-size: 2.7706vi;
 	}
 }

--- a/packages/components/src/components/avatar/style.scss
+++ b/packages/components/src/components/avatar/style.scss
@@ -30,7 +30,6 @@
 		justify-content: center;
 		/*theme?*/
 		background: #d3d3d3;
-		font-size: rem(32);
-		font-size: 2.7706vi;
+		font-size: 40px;
 	}
 }


### PR DESCRIPTION
Refs: #6638

vi als fontsize größe zusätzlich hinzugefügt (falls Browser es nicht unterstützen, wird weiterhin die alte fontsize verwendet)