### PR TITLE
Remove deprecated-annotations for ariaControls and ariaExpanded

### DIFF
--- a/packages/components/src/schema/components/button.ts
+++ b/packages/components/src/schema/components/button.ts
@@ -27,9 +27,6 @@ export type RequiredButtonProps = PropLabelWithExpertSlot;
 export type OptionalButtonProps = {
 	tabIndex: number;
 	value: Stringified<StencilUnknown>;
-	/**
-	 * @deprecated
-	 */
 	ariaExpanded: AriaExpandedPropType;
 } & PropAccessKey &
 	PropAlternativeButtonLinkRole &

--- a/packages/components/src/schema/props/aria-controls.ts
+++ b/packages/components/src/schema/props/aria-controls.ts
@@ -5,13 +5,9 @@ import { watchString } from '../utils';
 /* types */
 /**
  * Defines which elements are being controlled. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
- * @deprecated
  */
 type AriaControlsPropType = string;
 
-/**
- * @deprecated
- */
 export type PropAriaControls = {
 	ariaControls: AriaControlsPropType;
 };


### PR DESCRIPTION
Refs: #7015

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [x] Meaningful pull request title for the release notes
- [x] Pull request is linked to an issue and all changes relate to the issue
- [x] Tests to protect this code implemented (if applicable)
- [x] Manual test performed successfully (if applicable)
- [x] Documentation or migration has been updated (if applicable)
