### PR TITLE
Introduce new environment variable KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT

### DIFF
--- a/packages/tools/visual-tests/README.md
+++ b/packages/tools/visual-tests/README.md
@@ -48,8 +48,12 @@ Add the following npm scripts to the theme's `package.json`:
 }
 ```
 
-- `THEME_MODULE` defines the relative path to the TypeScript module containing the the theme definitions. Without file extension.
-- `THEME_EXPERT` defines the name of the export within the the module. (e.g., `export const THEME_NAME = {/**/};`) Defaults to `default`.
+### Environment variables
+
+- `THEME_MODULE`: Define the relative path to the TypeScript module containing the theme definitions. Without file extension.
+- `THEME_EXPERT`: Define the name of the export within the module. (e.g., `export const THEME_NAME = {/**/};`) Defaults to `default`.
+- `KOLIBRI_VISUAL_TESTS_TIMEOUT`: Define the Playwright [test timeout](https://playwright.dev/docs/test-timeouts).
+- `KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT`: Define the Playwright [expect timeout](https://playwright.dev/docs/test-timeouts).
 
 Run the tests with `npm test`. The first time, this will create a new folder `snapshots` which is supposed to be committed to the repository.
 In the following runs, new screenshots will be compared to this reference.

--- a/packages/tools/visual-tests/playwright.config.js
+++ b/packages/tools/visual-tests/playwright.config.js
@@ -36,6 +36,10 @@ export default defineConfig({
 		trace: 'on-first-retry',
 	},
 
+	expect: {
+		timeout: process.env.KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT ? Number(process.env.KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT) : undefined,
+	},
+
 	/* Configure projects for major browsers */
 	projects: [
 		// {


### PR DESCRIPTION
Refs: #7245

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [x] Meaningful pull request title for the release notes
- [x] Pull request is linked to an issue and all changes relate to the issue
- [x] Tests to protect this code implemented (if applicable)
- [x] Manual test performed successfully (if applicable)
- [x] Documentation or migration has been updated (if applicable)
