### PR TITLE
feat(form): scroll to and focus the error list when it appears - keeps errors in view for a11y

### DIFF
--- a/packages/components/src/components/form/shadow.tsx
+++ b/packages/components/src/components/form/shadow.tsx
@@ -53,7 +53,19 @@ export class KolForm implements FormAPI {
 
 	private renderErrorList(errorList?: ErrorListPropType[]): JSX.Element {
 		return (
-			<KolAlertFc type="error" variant="card" label={translate('kol-error-list-message')}>
+			<KolAlertFc
+				ref={(el) => {
+					setTimeout(() => {
+						if (el && typeof el.focus === 'function') {
+							el.scrollIntoView({ behavior: 'smooth' });
+							el.focus();
+						}
+					}, 250);
+				}}
+				type="error"
+				variant="card"
+				label={translate('kol-error-list-message')}
+			>
 				<nav aria-label={translate('kol-error-list')}>
 					<ul>
 						{errorList?.map((error, index) => (


### PR DESCRIPTION
## What changed?

In `KolForm.renderErrorList`, the error-list alert (`KolAlertFc`) now receives a `ref` callback that, about 250 ms after the list renders, smooth-scrolls the alert into view (`scrollIntoView({ behavior: 'smooth' })`) and moves keyboard focus to it. Previously the error list simply rendered in place without changing scroll position or focus. This is a single-file change in the form component targeting the `release/2` (v2) line.

## Why?

From #7323: when a new entry is added to (or changed in) a form's error list, the application must scroll the user to the error list; otherwise the error summary can appear off-screen and go unnoticed after a submit. Scrolling to and focusing the error list keeps validation errors visible and improves accessibility.

## Linked issues

- Refs #7323 — KolForm - errorList - ScrollTo nachdem eine Fehlerliste eingefügt oder geändert wird.: the app should scroll to the error list when an entry is added or changed.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `KolForm.renderErrorList` erhält der Fehlerlisten-Alert (`KolAlertFc`) nun einen `ref`-Callback, der etwa 250 ms nach dem Rendern der Liste den Alert weich in den sichtbaren Bereich scrollt (`scrollIntoView({ behavior: 'smooth' })`) und den Fokus dorthin setzt. Zuvor wurde die Fehlerliste nur an Ort und Stelle gerendert, ohne Scroll-Position oder Fokus zu ändern. Einzeldatei-Änderung in der Form-Komponente für die `release/2`-Linie (v2).

### Warum?

Aus #7323: Wenn ein neuer Eintrag in die Fehlerliste eines Formulars kommt (oder sich diese ändert), muss die Anwendung zur Fehlerliste scrollen; sonst kann die Fehlerübersicht nach dem Absenden außerhalb des sichtbaren Bereichs liegen und übersehen werden. Das Scrollen zur und Fokussieren der Fehlerliste hält Validierungsfehler sichtbar und verbessert die Barrierefreiheit.

### Verknüpfte Tickets

- Referenziert #7323 — KolForm - errorList - ScrollTo nachdem eine Fehlerliste eingefügt oder geändert wird.: Die Anwendung soll zur Fehlerliste scrollen, wenn ein Eintrag hinzugefügt oder geändert wird.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/form/shadow.tsx` — Fehlerlisten-Alert erhält einen `ref`-Callback, der nach ~250 ms weich zur Liste scrollt und sie fokussiert

</details>