### PR TITLE
fix(samples): initialize error-list formRef with null for correct type handling

### DIFF
--- a/packages/samples/react/src/components/form/error-list.tsx
+++ b/packages/samples/react/src/components/form/error-list.tsx
@@ -4,7 +4,7 @@ import React, { useRef } from 'react';
 import { SampleDescription } from '../SampleDescription';
 
 export const FormErrorList: FC = () => {
-	const formRef = useRef<HTMLKolFormElement>();
+	const formRef = useRef<HTMLKolFormElement | null>(null);
 	return (
 		<>
 			<SampleDescription>


### PR DESCRIPTION
## What changed?

In the React sample `packages/samples/react/src/components/form/error-list.tsx`, the `formRef` was changed from `useRef<HTMLKolFormElement>()` to `useRef<HTMLKolFormElement | null>(null)`. The ref is now explicitly initialized with `null` and typed as nullable, which is the correct typing for a DOM-element ref. This is a one-line, type-only change with no runtime or visual effect.

## Why?

No dedicated issue for this exact change — it was made on the error-list feature branch (Refs #7310). Declaring `useRef` without an initial value yields an incorrect/loose ref type; initializing it with `null` gives the correct nullable type and keeps the sample type-safe alongside the new `focusErrorList()`/scroll handling.

## Linked issues

- Refs #7310 — Feature Callback bei ErrorList: the surrounding work adds a callback to focus/scroll to the error list; this sample consumes the resulting `formRef`.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Im React-Beispiel `packages/samples/react/src/components/form/error-list.tsx` wurde `formRef` von `useRef<HTMLKolFormElement>()` auf `useRef<HTMLKolFormElement | null>(null)` geändert. Die Ref wird nun explizit mit `null` initialisiert und als nullable typisiert — die korrekte Typisierung für eine DOM-Element-Ref. Einzeilige, rein typbezogene Änderung ohne Laufzeit- oder visuellen Effekt.

### Warum?

Kein eigenes Issue für genau diese Änderung — sie entstand auf dem Error-List-Feature-Branch (Referenziert #7310). Ein `useRef` ohne Initialwert liefert einen falschen/losen Ref-Typ; die Initialisierung mit `null` ergibt den korrekten nullable-Typ und hält das Beispiel typsicher.

### Verknüpfte Tickets

- Referenziert #7310 — Feature Callback bei ErrorList: Die umgebende Arbeit ergänzt einen Callback zum Fokussieren/Scrollen der Fehlerliste; dieses Beispiel nutzt die daraus entstehende `formRef`.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/form/error-list.tsx` — `formRef` mit `null` initialisiert und als nullable typisiert

</details>