### PR TITLE
refactor(table): deprecate the _minWidth prop - the table now derives min-width from column widths

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -85,6 +85,7 @@ export class KolTableStateless implements TableStatelessAPI {
 
 	/**
 	 * Defines the table min-width.
+	 * @deprecated This property is deprecated and will be removed in the next major release.
 	 */
 	@Prop() public _minWidth?: string;
 
@@ -124,9 +125,12 @@ export class KolTableStateless implements TableStatelessAPI {
 		});
 	}
 
+	/**
+	 * @deprecated This property is deprecated and will be removed in the next major release.
+	 */
 	@Watch('_minWidth')
 	public validateMinWidth(value?: string): void {
-		watchString(this, '_minWidth', value, {
+		watchString(this, '_deprecatedMinWidth', value, {
 			defaultValue: undefined,
 		});
 	}
@@ -723,7 +727,7 @@ export class KolTableStateless implements TableStatelessAPI {
 				<div ref={(element) => (this.tableDivElement = element)} class="table" tabindex={this.tableDivElementHasScrollbar ? '-1' : undefined}>
 					<table
 						style={{
-							minWidth: this.state._minWidth,
+							minWidth: this.state._deprecatedMinWidth || this.state._minWidth,
 						}}
 					>
 						{/*

--- a/packages/components/src/schema/components/tableStateless.ts
+++ b/packages/components/src/schema/components/tableStateless.ts
@@ -7,6 +7,9 @@ import type { PropTableHeaderCells } from '../props/table-header-cells';
 type RequiredProps = PropLabel & PropTableData & PropTableHeaderCells;
 
 type OptionalProps = {
+	/**
+	 * @deprecated This property is deprecated and will be removed in the next major release.
+	 */
 	minWidth: string;
 } & PropTableCallbacks &
 	PropTableDataFoot &
@@ -18,6 +21,13 @@ type RequiredStates = {
 } & PropLabel;
 
 type OptionalStates = {
+	/**
+	 * @deprecated This property is deprecated and will be removed in the next major release.
+	 */
+	deprecatedMinWidth: string;
+	/**
+	 * Needed for internal use.
+	 */
 	minWidth: string;
 	dataFoot: KoliBriTableDataType[];
 	selection: KoliBriTableSelection;

--- a/packages/components/src/schema/props/table-header-cells.ts
+++ b/packages/components/src/schema/props/table-header-cells.ts
@@ -1,6 +1,6 @@
 import type { Generic } from 'adopted-style-sheets';
-import { emptyStringByArrayHandler, objectObjectHandler, parseJson, watchValidator } from '../utils';
 import type { KoliBriTableHeaderCell, Stringified } from '../types';
+import { emptyStringByArrayHandler, objectObjectHandler, parseJson, watchValidator } from '../utils';
 
 /* types */
 export type TableHeaderCells = {
@@ -23,11 +23,40 @@ export const validateTableHeaderCells = (component: Generic.Element.Component, v
 		objectObjectHandler(value, () => {
 			try {
 				value = parseJson<TableHeaderCells>(value);
-				// eslint-disable-next-line no-empty
 			} catch (e) {
-				// value keeps the original data
+				void e;
 			}
-			watchValidator(component, '_headerCells', (value): boolean => typeof value === 'object' && value !== null, new Set(['TableHeaderCellsPropType']), value);
+			watchValidator(
+				component,
+				'_headerCells',
+				(value): boolean =>
+					typeof value === 'object' &&
+					value !== null &&
+					(value.horizontal === undefined ||
+						(Array.isArray(value.horizontal) && value.horizontal.find((headerRow) => !Array.isArray(headerRow)) === undefined)) &&
+					(value.vertical === undefined || (Array.isArray(value.vertical) && value.vertical.find((headerCol) => !Array.isArray(headerCol)) === undefined)) &&
+					true,
+				new Set(['TableHeaderCellsPropType']),
+				value,
+				{
+					hooks: {
+						afterPatch: (value: unknown, state: Record<string, unknown>): void => {
+							const headerCells = value as TableHeaderCells;
+							const widths: string[] = [];
+							headerCells.horizontal?.forEach((headerRow) => {
+								headerRow.forEach((headerCell) => {
+									if (headerCell.width) {
+										widths.push(headerCell.width);
+									}
+								});
+							});
+							if (widths.length > 0) {
+								state._minWidth = `calc(${widths.join(' + ')})`;
+							}
+						},
+					},
+				},
+			);
 		});
 	});
 };

--- a/packages/samples/react/src/components/table/horizontal-scrollbar.tsx
+++ b/packages/samples/react/src/components/table/horizontal-scrollbar.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React, { useState } from 'react';
 
-import { KolHeading, KolInputCheckbox, KolTable } from '@public-ui/react';
+import { KolAlert, KolHeading, KolInputCheckbox, KolTable } from '@public-ui/react';
 
 import { SampleDescription } from '../SampleDescription';
 
@@ -11,6 +11,9 @@ const DATA = [{ small: 'Small Example', large: 'Larger Example' }];
 const HEADERS: KoliBriTableHeaders = {
 	horizontal: [
 		[
+			/**
+			 * In version 3, the width of the column is required to implicitly calculate the minWidth.
+			 */
 			{ label: 'Large Column', key: 'large', textAlign: 'left', width: '300px' },
 			{ label: 'Small Column', key: 'small', textAlign: 'left', width: '200px' },
 			{ label: 'Larger Column', key: 'large', textAlign: 'left', width: '400px' },
@@ -31,12 +34,18 @@ export const TableHorizontalScrollbar: FC = () => {
 				</p>
 			</SampleDescription>
 
+			<KolAlert _variant="card" _type="warning" _label="Deprecation of minWidth">
+				In version 3, the width of the column will be required for the implicit calculation of the minWidth. This behavior is also implemented in version 2, if
+				the _minWidth property is undefined.
+			</KolAlert>
+			<br />
 			<section className="w-full flex flex-col gap-4">
 				<KolHeading _label="Table with scrollbar" _level={2} />
 
 				<KolTable
 					_label="Table for demonstration purposes with horizontal scrollbar."
-					_minWidth={hasWidthRestriction ? '600px' : 'auto'}
+					// minWidth will be removed in the next major release
+					_minWidth={hasWidthRestriction ? '600px' : undefined}
 					_headers={HEADERS}
 					_data={DATA}
 					className="block"
@@ -47,7 +56,8 @@ export const TableHorizontalScrollbar: FC = () => {
 
 				<KolTable
 					_label="Table for demonstration purposes with horizontal scrollbar with auto minWidth."
-					_minWidth={hasWidthRestriction ? '600px' : 'auto'}
+					// minWidth will be removed in the next major release
+					_minWidth={hasWidthRestriction ? '600px' : undefined}
 					_headers={HEADERS}
 					_data={[]}
 					className="block"


### PR DESCRIPTION
## What changed?

On `KolTableStateless`/`KolTable` the `_minWidth` property (and its `minWidth` schema type and `@Watch` validator) is now marked `@deprecated`. An externally supplied value is routed into a new internal `_deprecatedMinWidth` state, and the table renders `min-width: _deprecatedMinWidth || _minWidth`, so a manually set `_minWidth` still takes precedence. The `_headerCells` validator gained an `afterPatch` hook that sums the `width` of all horizontal header cells and stores the result as an internal `_minWidth` (`calc(w1 + w2 + …)`); a table without an explicit `_minWidth` therefore derives its minimum width from the column widths. The React `horizontal-scrollbar` sample was updated to drop the manual `_minWidth` and surface a deprecation warning via `KolAlert`.

## Why?

Taken from #7322: developers had to hand-maintain a fixed `_minWidth` on every table to keep it horizontally scrollable, and forgetting it left wide tables unusable. Tables should instead activate a horizontal scrollbar automatically once the summed column widths exceed the container, without patching the markup. This PR delivers the V2 step — `_minWidth` stays usable but deprecated, and the min-width is derived from the columns when it is not set externally.

## Linked issues

- Refs #7322 — Automatische horizontale Scroll-Aktivierung für Tabellen durch Berechnung der Mindestbreite: tables should compute their min-width from the column widths instead of a manually maintained `_minWidth`.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Bei `KolTableStateless`/`KolTable` ist die Property `_minWidth` (samt `minWidth`-Schema-Typ und `@Watch`-Validator) nun als `@deprecated` markiert. Ein von außen gesetzter Wert wird in einen neuen internen State `_deprecatedMinWidth` umgeleitet, und die Tabelle rendert `min-width: _deprecatedMinWidth || _minWidth` — ein manuell gesetztes `_minWidth` hat also weiterhin Vorrang. Der `_headerCells`-Validator erhielt einen `afterPatch`-Hook, der die `width`-Werte aller horizontalen Header-Zellen aufsummiert und das Ergebnis als internes `_minWidth` (`calc(w1 + w2 + …)`) speichert; eine Tabelle ohne explizites `_minWidth` leitet ihre Mindestbreite damit aus den Spaltenbreiten ab. Das React-Beispiel `horizontal-scrollbar` wurde angepasst (kein manuelles `_minWidth` mehr, Deprecation-Hinweis via `KolAlert`).

### Warum?

Aus #7322: Entwickler*innen mussten an jeder Tabelle ein festes `_minWidth` pflegen, um sie horizontal scrollbar zu halten; wurde es vergessen, waren breite Tabellen unbedienbar. Tabellen sollen den horizontalen Scrollbalken automatisch aktivieren, sobald die Summe der Spaltenbreiten den Container übersteigt — ohne Nacharbeit am Markup. Dieser PR liefert den V2-Schritt.

### Verknüpfte Tickets

- Referenziert #7322 — Automatische horizontale Scroll-Aktivierung für Tabellen durch Berechnung der Mindestbreite: Die Tabelle soll ihre Mindestbreite aus den Spaltenbreiten berechnen statt aus einem manuell gepflegten `_minWidth`.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/table-stateless/component.tsx` — `_minWidth` als deprecated markiert; extern gesetzter Wert wird auf `_deprecatedMinWidth` umgeleitet; Render nutzt `_deprecatedMinWidth || _minWidth`
- `packages/components/src/schema/components/tableStateless.ts` — Schema: `minWidth` als deprecated; neuer interner State `deprecatedMinWidth`
- `packages/components/src/schema/props/table-header-cells.ts` — Validator erweitert; `afterPatch`-Hook summiert die Spaltenbreiten zu einem internen `_minWidth` (`calc(...)`)
- `packages/samples/react/src/components/table/horizontal-scrollbar.tsx` — Beispiel ohne manuelles `_minWidth` plus Deprecation-Warnung (`KolAlert`)

</details>