### PR TITLE
fix(table): skip non-numeric header widths (e.g. 'auto') in the min-width sum - avoids invalid CSS

### DIFF
--- a/packages/components/src/schema/props/table-header-cells.ts
+++ b/packages/components/src/schema/props/table-header-cells.ts
@@ -17,6 +17,12 @@ export type PropTableHeaderCells = {
 	headerCells: TableHeaderCellsPropType;
 };
 
+/* constants */
+/**
+ * Regular expression to validate the width of a header cell.
+ */
+const HEADER_CELL_WIDTH_VALIDATOR = /^\d+(\.\d+)?([a-z]+)?$/;
+
 /* validator */
 export const validateTableHeaderCells = (component: Generic.Element.Component, value?: TableHeaderCellsPropType): void => {
 	emptyStringByArrayHandler(value, () => {
@@ -45,7 +51,7 @@ export const validateTableHeaderCells = (component: Generic.Element.Component, v
 							const widths: string[] = [];
 							headerCells.horizontal?.forEach((headerRow) => {
 								headerRow.forEach((headerCell) => {
-									if (headerCell.width && headerCell.width !== 'auto') {
+									if (headerCell.width && HEADER_CELL_WIDTH_VALIDATOR.test(headerCell.width)) {
 										widths.push(headerCell.width);
 									}
 								});

--- a/packages/components/src/schema/props/table-header-cells.ts
+++ b/packages/components/src/schema/props/table-header-cells.ts
@@ -45,7 +45,7 @@ export const validateTableHeaderCells = (component: Generic.Element.Component, v
 							const widths: string[] = [];
 							headerCells.horizontal?.forEach((headerRow) => {
 								headerRow.forEach((headerCell) => {
-									if (headerCell.width) {
+									if (headerCell.width && headerCell.width !== 'auto') {
 										widths.push(headerCell.width);
 									}
 								});


### PR DESCRIPTION
## What changed?

In `packages/components/src/schema/props/table-header-cells.ts`, the table header-cell validation now guards the width values used to compute the table's minimum width. A new `HEADER_CELL_WIDTH_VALIDATOR` regex (`/^\d+(\.\d+)?([a-z]+)?$/`) is applied, and a header cell's `width` is only added to the summed widths list when it matches — i.e. a plain number with an optional decimal and an optional unit. Non-numeric widths such as `auto` are therefore excluded from the sum. Single-file change (+7 / −1).

## Why?

This is part of the table auto-min-width work (issue #7322): when no external `_minWidth` is set, the table derives its minimum width from the sum of the column widths so a horizontal scrollbar appears automatically once the columns exceed the container. A non-numeric width like `auto` cannot be summed and would produce an invalid CSS length in the computed `min-width`/`calc()`, breaking the table layout. Filtering such values out keeps the computed minimum width valid.

## Linked issues

- Refs #7322 — Automatische horizontale Scroll-Aktivierung für Tabellen durch Berechnung der Mindestbreite: the table should compute its min-width from the column widths (default `5em` per column when unset) and scroll horizontally on overflow; this PR hardens the width collection against non-numeric values.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/schema/props/table-header-cells.ts` werden die für die Mindestbreiten-Berechnung genutzten Breitenwerte jetzt geprüft. Ein neues Regex `HEADER_CELL_WIDTH_VALIDATOR` (`/^\d+(\.\d+)?([a-z]+)?$/`) wird angewandt, und die `width` einer Header-Zelle wird nur in die Summenliste aufgenommen, wenn sie passt — also eine Zahl mit optionaler Dezimalstelle und optionaler Einheit. Nicht-numerische Breiten wie `auto` werden damit aus der Summe ausgeschlossen. Änderung in einer Datei (+7 / −1).

### Warum?

Teil der Tabellen-Auto-Mindestbreite (Ticket #7322): Ohne extern gesetztes `_minWidth` berechnet die Tabelle ihre Mindestbreite aus der Summe der Spaltenbreiten, damit automatisch ein horizontaler Scrollbalken erscheint, sobald die Spalten den Container überschreiten. Eine nicht-numerische Breite wie `auto` lässt sich nicht summieren und würde zu einer ungültigen CSS-Länge in der berechneten `min-width`/`calc()` führen und das Tabellenlayout brechen. Das Herausfiltern solcher Werte hält die berechnete Mindestbreite gültig.

### Verknüpfte Tickets

- Referenziert #7322 — Automatische horizontale Scroll-Aktivierung für Tabellen durch Berechnung der Mindestbreite: Die Tabelle soll ihre Mindestbreite aus den Spaltenbreiten berechnen (Default `5em` pro Spalte) und bei Überlauf horizontal scrollen; dieser PR härtet das Einsammeln der Breiten gegen nicht-numerische Werte.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `components/src/schema/props/table-header-cells.ts` — Regex-Validierung der Header-Zellen-Breiten; nicht-numerische Werte (z. B. `auto`) werden aus der Mindestbreiten-Summe ausgeschlossen.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyHMhz7CWiVtTe12x1aKLn