### PR TITLE
docs(table): fix broken cross-reference links in the table readmes

### DIFF
--- a/packages/components/src/components/table-stateful/readme.md
+++ b/packages/components/src/components/table-stateful/readme.md
@@ -1,5 +1,3 @@
-# TableStateful
-
 Synonyme: Data Table, Details List, Data Grid
 
 <kol-alert _type="warning" _variant="card">
@@ -9,7 +7,7 @@ Synonyme: Data Table, Details List, Data Grid
 Die **TableStateful**-Komponente dient primär der übersichtlichen Darstellung von Datenmengen. Dabei ist sie so ausgelegt, dass sie alle von den Daten abhängige Werte automatisch ermittelt und die Tabelle entsprechend darstellt. Hierzu gehören beispielsweise die optionalen Funktionalitäten Spaltensortierung oder Pagination.
 
 <kol-indented-text _summary="Backend-seitige Pagination">
-	Bei sehr großen Datenmengen ist auch eine manuelle Nutzung der TableStateless-Komponente möglich. Das bedeutet, dass die Tabelle seitenweise "manuell" befüllt wird. Hierzu kann einfach anstatt der Table-Pagination eine "eigene" Pagination unter der Tabelle mittels der Pagination-Komponente verwendet werden. Eine mögliche Sortierung muss ebenfalls über die `onSort`-Events selber implementiert werden. Siehe [KolTableStateless](../table-stateless/readme.md).
+	Bei sehr großen Datenmengen ist auch eine manuelle Nutzung der TableStateless-Komponente möglich. Das bedeutet, dass die Tabelle seitenweise "manuell" befüllt wird. Hierzu kann einfach anstatt der Table-Pagination eine "eigene" Pagination unter der Tabelle mittels der Pagination-Komponente verwendet werden. Eine mögliche Sortierung muss ebenfalls über die `onSort`-Events selber implementiert werden. Siehe <kol-link _href="table-stateless" _label="KolTableStateless" />.
 </kol-indented-text>
 
 ## Konstruktion

--- a/packages/components/src/components/table-stateful/readme.md
+++ b/packages/components/src/components/table-stateful/readme.md
@@ -1,3 +1,5 @@
+# TableStateful
+
 Synonyme: Data Table, Details List, Data Grid
 
 <kol-alert _type="warning" _variant="card">

--- a/packages/components/src/components/table-stateless/readme.md
+++ b/packages/components/src/components/table-stateless/readme.md
@@ -6,7 +6,7 @@ Synonyme: Data Table, Details List, Data Grid
   <kol-badge _color="#476af5" _label="Preview"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da die Barrierefreiheitstests noch ausstehen. Die verschiedenen Tests können aufgrund der Modularität bei neuen Komponenten und Funktionalitäten meist erst nach einem Release erfolgen. Wir empfehlen daher, die Komponente noch nicht in Produktion zu verwenden.
 </kol-alert>
 
-Die **TableStateless**-Komponente ist für die reine Darstellung der KoliBri-Tabelle verantwortlich. Für eine Tabellen-Komponente, die Sortierung und Paginierung mit den zur Verfügung gestellten Daten automatisch übernehmen kann, siehe [KolTableStateful](../table-stateful/readme.md).
+Die **TableStateless**-Komponente ist für die reine Darstellung der KoliBri-Tabelle verantwortlich. Für eine Tabellen-Komponente, die Sortierung und Paginierung mit den zur Verfügung gestellten Daten automatisch übernehmen kann, siehe <kol-link _href="table-stateful" _label="KolTableStateful" />.
 
 TableStateless bietet sich insbesondere bei größeren Datenmengen an, wenn es nicht praktikabel ist, die komplette Datenmenge zur Filterung und Sortierung in den Browser auszuliefern.
 


### PR DESCRIPTION
## What changed?

Replaces the relative Markdown links between the two table readmes — `[KolTableStateless](../table-stateless/readme.md)` in `table-stateful/readme.md` and `[KolTableStateful](../table-stateful/readme.md)` in `table-stateless/readme.md` — with `<kol-link _href="table-stateless" .../>` / `<kol-link _href="table-stateful" .../>` so the cross-references resolve inside the rendered documentation site.

## Why?

The relative `../*/readme.md` Markdown paths did not resolve on the documentation site; using `kol-link` with a site-relative href restores the navigation between the two table component pages.

## Linked issues

- Refs #7155 — Deprecate `@public-ui/themes`: this PR was carried out as part of the documentation cleanup tracked under that issue.

> ℹ️ **Partial:** the readme link fix is tangential to the actual themes deprecation in #7155 (handled in #7249); it only corrects the cross-reference links.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die relativen Markdown-Links zwischen den beiden Tabellen-Readmes (`[KolTableStateless](../table-stateless/readme.md)` bzw. `[KolTableStateful](../table-stateful/readme.md)`) werden durch `<kol-link _href="table-stateless" .../>` / `<kol-link _href="table-stateful" .../>` ersetzt, damit die Querverweise in der gerenderten Dokumentation aufgelöst werden.

### Warum?

Die relativen `../*/readme.md`-Pfade wurden auf der Doku-Seite nicht aufgelöst; `kol-link` mit seiten-relativem `href` stellt die Navigation zwischen den beiden Tabellenseiten wieder her.

### Verknüpfte Tickets

- Referenziert #7155 — Deprecate `@public-ui/themes`: Teil der Doku-Bereinigung unter diesem Ticket.

> ℹ️ **Teilweise:** Die Link-Korrektur ist nur am Rande mit der eigentlichen Themes-Deprecation (#7249) verbunden.

### Art der Änderung

🔧 Intern (keine Release-Note nötig)

### Geänderte Dateien

- `packages/components/src/components/table-stateful/readme.md` — Querverweis auf TableStateless via `kol-link`.
- `packages/components/src/components/table-stateless/readme.md` — Querverweis auf TableStateful via `kol-link`.

</details>