### PR TITLE
fix(input-radio): remove forced focus on click - it desynced focus from the selected radio

### DIFF
--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -75,7 +75,6 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 				class: `kol-form-field__input--orientation-${this.state._orientation}`,
 			},
 			tooltipAlign: this._tooltipAlign,
-			onClick: () => this.inputRef?.focus(),
 			alert: this.showAsAlert(),
 			hideLabel: false,
 		};


### PR DESCRIPTION
## What changed?

Removes the `onClick: () => this.inputRef?.focus()` handler from `KolInputRadio`'s form-field configuration in `input-radio/shadow.tsx`. Clicking a radio button no longer forces focus back onto the group's input ref, letting the browser keep focus in sync with the actual selection.

## Why?

Per the linked issue, the forced focus desynchronized keyboard focus from the current selection: arrow-key navigation either lagged behind the selection or got stuck on the first selectable radio, and clicking a radio activated it but moved focus to the first radio instead.

## Linked issues

- Closes #7350 — Fehlerhafter Fokus bei Input-Radio: focus was out of sync with the selection when navigating radios with the arrow keys or clicking them.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Handler `onClick: () => this.inputRef?.focus()` wird aus der Form-Field-Konfiguration von `KolInputRadio` (`input-radio/shadow.tsx`) entfernt. Ein Klick auf einen Radio-Button erzwingt damit nicht mehr den Fokus auf das Input-Ref der Gruppe, sodass der Browser den Fokus synchron zur Auswahl hält.

### Warum?

Laut Issue lief der Fokus durch das erzwungene `focus()` nicht synchron zur Auswahl: Die Pfeiltasten-Navigation hinkte hinterher oder blieb am ersten Radio hängen, und ein Klick aktivierte zwar den Radio, setzte den Fokus aber auf den ersten.

### Verknüpfte Tickets

- Schließt #7350 — Fehlerhafter Fokus bei Input-Radio: Fokus war beim Navigieren/Klicken nicht synchron zur Auswahl.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-radio/shadow.tsx` — erzwungenen `onClick`-Fokus entfernt.

</details>