### PR TITLE
fix(details): apply _level and default it to 0 for details and accordion - the prop was ignored

### DIFF
--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -115,7 +115,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 	/**
 	 * Defines which H-level from 1-6 the heading has. 0 specifies no heading and is shown as bold text.
 	 */
-	@Prop() public _level?: HeadingLevel = 1;
+	@Prop() public _level?: HeadingLevel = 0;
 
 	/**
 	 * Gibt die EventCallback-Funktionen an.

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -130,7 +130,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 
 	@State() public state: AccordionStates = {
 		_label: '', // ⚠ required
-		_level: 1,
+		_level: 0,
 		_on: {},
 	};
 

--- a/packages/components/src/components/accordion/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/accordion/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,119 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=false _disabled=false 1`] = `
-<kol-accordion class="kol-accordion">
-  <template shadowrootmode="open">
-    <div class="accordion collapsible" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="accordion__wrapper collapsible__wrapper">
-        <div class="accordion__wrapper-animation collapsible__wrapper-animation">
-          <div aria-hidden="true" class="accordion__content collapsible__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=false _disabled=true 1`] = `
-<kol-accordion class="kol-accordion">
-  <template shadowrootmode="open">
-    <div class="accordion collapsible disabled" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="accordion__wrapper collapsible__wrapper">
-        <div class="accordion__wrapper-animation collapsible__wrapper-animation">
-          <div aria-hidden="true" class="accordion__content collapsible__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=true _disabled=false 1`] = `
-<kol-accordion _open="" class="kol-accordion">
-  <template shadowrootmode="open">
-    <div class="accordion collapsible open" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-remove" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="accordion__wrapper collapsible__wrapper">
-        <div class="accordion__wrapper-animation collapsible__wrapper-animation">
-          <div class="accordion__content collapsible__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=true _disabled=true 1`] = `
-<kol-accordion _open="" class="kol-accordion">
-  <template shadowrootmode="open">
-    <div class="accordion collapsible disabled open" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-remove" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="accordion__wrapper collapsible__wrapper">
-        <div class="accordion__wrapper-animation collapsible__wrapper-animation">
-          <div class="accordion__content collapsible__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 1`] = `
-<kol-accordion class="kol-accordion">
-  <template shadowrootmode="open">
-    <div class="accordion collapsible" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="accordion__wrapper collapsible__wrapper">
-        <div class="accordion__wrapper-animation collapsible__wrapper-animation">
-          <div aria-hidden="true" class="accordion__content collapsible__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=2 1`] = `
-<kol-accordion class="kol-accordion">
-  <template shadowrootmode="open">
-    <div class="accordion collapsible" id="nonce">
-      <kol-heading-wc _label="" _level="2" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="accordion__wrapper collapsible__wrapper">
-        <div class="accordion__wrapper-animation collapsible__wrapper-animation">
-          <div aria-hidden="true" class="accordion__content collapsible__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
 exports[`kol-accordion should render with _label="Überschrift" _level=3 1`] = `
 <kol-accordion class="kol-accordion">
   <template shadowrootmode="open">
@@ -133,11 +19,11 @@ exports[`kol-accordion should render with _label="Überschrift" _level=3 1`] = `
 </kol-accordion>
 `;
 
-exports[`kol-accordion should render with _label="Überschrift" _level=4 1`] = `
+exports[`kol-accordion should render with _label="Überschrift" _open=false _disabled=false 1`] = `
 <kol-accordion class="kol-accordion">
   <template shadowrootmode="open">
     <div class="accordion collapsible" id="nonce">
-      <kol-heading-wc _label="" _level="4" class="accordion__heading collapsible__heading">
+      <kol-heading-wc _label="" _level="0" class="accordion__heading collapsible__heading">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="accordion__wrapper collapsible__wrapper">
@@ -152,12 +38,12 @@ exports[`kol-accordion should render with _label="Überschrift" _level=4 1`] = `
 </kol-accordion>
 `;
 
-exports[`kol-accordion should render with _label="Überschrift" _level=5 1`] = `
+exports[`kol-accordion should render with _label="Überschrift" _open=false _disabled=true 1`] = `
 <kol-accordion class="kol-accordion">
   <template shadowrootmode="open">
-    <div class="accordion collapsible" id="nonce">
-      <kol-heading-wc _label="" _level="5" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
+    <div class="accordion collapsible disabled" id="nonce">
+      <kol-heading-wc _label="" _level="0" class="accordion__heading collapsible__heading">
+        <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="accordion__wrapper collapsible__wrapper">
         <div class="accordion__wrapper-animation collapsible__wrapper-animation">
@@ -171,16 +57,35 @@ exports[`kol-accordion should render with _label="Überschrift" _level=5 1`] = `
 </kol-accordion>
 `;
 
-exports[`kol-accordion should render with _label="Überschrift" _level=6 1`] = `
-<kol-accordion class="kol-accordion">
+exports[`kol-accordion should render with _label="Überschrift" _open=true _disabled=false 1`] = `
+<kol-accordion _open="" class="kol-accordion">
   <template shadowrootmode="open">
-    <div class="accordion collapsible" id="nonce">
-      <kol-heading-wc _label="" _level="6" class="accordion__heading collapsible__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
+    <div class="accordion collapsible open" id="nonce">
+      <kol-heading-wc _label="" _level="0" class="accordion__heading collapsible__heading">
+        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-remove" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="accordion__wrapper collapsible__wrapper">
         <div class="accordion__wrapper-animation collapsible__wrapper-animation">
-          <div aria-hidden="true" class="accordion__content collapsible__content" id="nonce-control">
+          <div class="accordion__content collapsible__content" id="nonce-control">
+            <slot></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-accordion>
+`;
+
+exports[`kol-accordion should render with _label="Überschrift" _open=true _disabled=true 1`] = `
+<kol-accordion _open="" class="kol-accordion">
+  <template shadowrootmode="open">
+    <div class="accordion collapsible disabled open" id="nonce">
+      <kol-heading-wc _label="" _level="0" class="accordion__heading collapsible__heading">
+        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-remove" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
+      </kol-heading-wc>
+      <div class="accordion__wrapper collapsible__wrapper">
+        <div class="accordion__wrapper-animation collapsible__wrapper-animation">
+          <div class="accordion__content collapsible__content" id="nonce-control">
             <slot></slot>
           </div>
         </div>
@@ -194,7 +99,7 @@ exports[`kol-accordion should render with _label="Überschrift" 1`] = `
 <kol-accordion class="kol-accordion">
   <template shadowrootmode="open">
     <div class="accordion collapsible" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="accordion__heading collapsible__heading">
+      <kol-heading-wc _label="" _level="0" class="accordion__heading collapsible__heading">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="accordion__heading-button collapsible__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="accordion__wrapper collapsible__wrapper">

--- a/packages/components/src/components/accordion/test/snapshot.spec.tsx
+++ b/packages/components/src/components/accordion/test/snapshot.spec.tsx
@@ -11,10 +11,10 @@ executeSnapshotTests<AccordionProps>(
 	[KolAccordion],
 	[
 		{ ...baseObject },
-		...([1, 2, 3, 4, 5, 6].map((_level) => ({ ...baseObject, _level })) as AccordionProps[]),
-		{ ...baseObject, _level: 1, _open: false, _disabled: false },
-		{ ...baseObject, _level: 1, _open: false, _disabled: true },
-		{ ...baseObject, _level: 1, _open: true, _disabled: true },
-		{ ...baseObject, _level: 1, _open: true, _disabled: false },
+		{ ...baseObject, _level: 3 },
+		{ ...baseObject, _open: false, _disabled: false },
+		{ ...baseObject, _open: false, _disabled: true },
+		{ ...baseObject, _open: true, _disabled: true },
+		{ ...baseObject, _open: true, _disabled: false },
 	],
 );

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -62,8 +62,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	};
 
 	public render(): JSX.Element {
-		const { _open, _label, _disabled } = this.state;
-		const _level = 1;
+		const { _open, _label, _disabled, _level } = this.state;
 
 		const rootClass = 'details';
 
@@ -110,7 +109,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	/**
 	 * Defines which H-level from 1-6 the heading has. 0 specifies no heading and is shown as bold text.
 	 */
-	@Prop() public _level?: HeadingLevel = 1;
+	@Prop() public _level?: HeadingLevel = 0;
 
 	/**
 	 * Defines the callback functions for details.
@@ -125,7 +124,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 
 	@State() public state: DetailsStates = {
 		_label: '', // ⚠ required
-		_level: 1,
+		_level: 0,
 		_on: {},
 	};
 

--- a/packages/components/src/components/details/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/details/test/__snapshots__/snapshot.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
 <kol-details class="kol-details">
   <template shadowrootmode="open">
     <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
+      <kol-heading-wc _label="" _level="0" class="collapsible__heading details__heading">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="collapsible__wrapper details__wrapper">
@@ -23,7 +23,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
 <kol-details _open="" class="kol-details">
   <template shadowrootmode="open">
     <div class="collapsible details open" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
+      <kol-heading-wc _label="" _level="0" class="collapsible__heading details__heading">
         <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="collapsible__wrapper details__wrapper">
@@ -42,7 +42,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
 <kol-details class="kol-details">
   <template shadowrootmode="open">
     <div class="collapsible details disabled" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
+      <kol-heading-wc _label="" _level="0" class="collapsible__heading details__heading">
         <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="collapsible__wrapper details__wrapper">
@@ -61,7 +61,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
 <kol-details _open="" class="kol-details">
   <template shadowrootmode="open">
     <div class="collapsible details disabled open" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
+      <kol-heading-wc _label="" _level="0" class="collapsible__heading details__heading">
         <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="collapsible__wrapper details__wrapper">
@@ -76,125 +76,11 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
 </kol-details>
 `;
 
-exports[`kol-details should render with _label="Zusammenfassung" _level=0 1`] = `
-<kol-details class="kol-details">
-  <template shadowrootmode="open">
-    <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="collapsible__wrapper details__wrapper">
-        <div class="collapsible__wrapper-animation details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content details__content indented-text" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=1 1`] = `
-<kol-details class="kol-details">
-  <template shadowrootmode="open">
-    <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="collapsible__wrapper details__wrapper">
-        <div class="collapsible__wrapper-animation details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content details__content indented-text" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=2 1`] = `
-<kol-details class="kol-details">
-  <template shadowrootmode="open">
-    <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="collapsible__wrapper details__wrapper">
-        <div class="collapsible__wrapper-animation details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content details__content indented-text" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
 exports[`kol-details should render with _label="Zusammenfassung" _level=3 1`] = `
 <kol-details class="kol-details">
   <template shadowrootmode="open">
     <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="collapsible__wrapper details__wrapper">
-        <div class="collapsible__wrapper-animation details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content details__content indented-text" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=4 1`] = `
-<kol-details class="kol-details">
-  <template shadowrootmode="open">
-    <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="collapsible__wrapper details__wrapper">
-        <div class="collapsible__wrapper-animation details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content details__content indented-text" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=5 1`] = `
-<kol-details class="kol-details">
-  <template shadowrootmode="open">
-    <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
-      </kol-heading-wc>
-      <div class="collapsible__wrapper details__wrapper">
-        <div class="collapsible__wrapper-animation details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content details__content indented-text" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=6 1`] = `
-<kol-details class="kol-details">
-  <template shadowrootmode="open">
-    <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
+      <kol-heading-wc _label="" _level="3" class="collapsible__heading details__heading">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="collapsible__wrapper details__wrapper">
@@ -213,7 +99,7 @@ exports[`kol-details should render with _label="Zusammenfassung" 1`] = `
 <kol-details class="kol-details">
   <template shadowrootmode="open">
     <div class="collapsible details" id="nonce">
-      <kol-heading-wc _label="" _level="1" class="collapsible__heading details__heading">
+      <kol-heading-wc _label="" _level="0" class="collapsible__heading details__heading">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button details__heading-button" slot="expert"></kol-button-wc>
       </kol-heading-wc>
       <div class="collapsible__wrapper details__wrapper">

--- a/packages/components/src/components/details/test/snapshot.spec.tsx
+++ b/packages/components/src/components/details/test/snapshot.spec.tsx
@@ -9,12 +9,10 @@ executeSnapshotTests<DetailsProps>(
 	[KolDetails],
 	[
 		{ _label: 'Zusammenfassung' },
-
+		{ _label: 'Zusammenfassung', _level: 3 },
 		{ _label: 'Zusammenfassung', _disabled: true, _open: false },
 		{ _label: 'Zusammenfassung', _disabled: true, _open: true },
 		{ _label: 'Zusammenfassung', _disabled: false, _open: false },
 		{ _label: 'Zusammenfassung', _disabled: false, _open: true },
-
-		...[0, 1, 2, 3, 4, 5, 6].map((_level) => ({ _label: 'Zusammenfassung', _level }) as DetailsProps),
 	],
 );


### PR DESCRIPTION
## What changed?

`KolDetails` now reads `_level` from its component state instead of hard-coding the heading level to `1`, so the `_level` prop actually controls the rendered `kol-heading-wc _level`. In addition, the default `_level` of both `KolDetails` and `KolAccordion` changes from `1` to `0` (level `0` means no heading element, rendered as bold text). Snapshot tests and their recorded fixtures are updated to match the new default and behavior.

## Why?

Per the linked issue, setting `_level` on `KolDetails` had no effect: the summary heading always rendered as `h1` / `headline-h1` regardless of the value passed, because the render method used a hard-coded `const _level = 1`.

## Linked issues

- Closes #7108 — 🐞 Bug: _level-property hat keine Auswirkung in KolDetails: the `_level` prop was ignored and the details heading always rendered as an `h1`.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolDetails` liest `_level` nun aus dem Komponenten-State, statt die Überschriftenebene fest auf `1` zu setzen — die `_level`-Property steuert jetzt tatsächlich das gerenderte `kol-heading-wc _level`. Zusätzlich ändert sich der Standardwert von `_level` bei `KolDetails` und `KolAccordion` von `1` auf `0` (Ebene `0` = keine Überschrift, Darstellung als fetter Text). Snapshot-Tests und ihre Fixtures werden entsprechend aktualisiert.

### Warum?

Laut Issue hatte das Setzen von `_level` in `KolDetails` keine Wirkung: Die Überschrift blieb wegen eines fest kodierten `const _level = 1` immer ein `h1` mit Klasse `headline-h1`.

### Verknüpfte Tickets

- Schließt #7108 — 🐞 Bug: _level-property hat keine Auswirkung in KolDetails: `_level` wurde ignoriert, Details rendert immer `h1`.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/details/shadow.tsx` — `_level` aus State übernehmen; Default `1` → `0`.
- `packages/components/src/components/accordion/shadow.tsx` — Default `_level` `1` → `0`.
- `.../details/test/**` und `.../accordion/test/**` — Snapshot-Tests und Fixtures angepasst.

</details>