### PR TITLE
fix(details): apply _level and default it to 0 for details and accordion - the prop was ignored

### DIFF
--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -126,7 +126,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 
 	@State() public state: AccordionStates = {
 		_label: '', // ⚠ required
-		_level: 1,
+		_level: 0,
 		_on: {},
 	};
 

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -111,7 +111,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 	/**
 	 * Defines which H-level from 1-6 the heading has. 0 specifies no heading and is shown as bold text.
 	 */
-	@Prop() public _level?: HeadingLevel = 1;
+	@Prop() public _level?: HeadingLevel = 0;
 
 	/**
 	 * Gibt die EventCallback-Funktionen an.

--- a/packages/components/src/components/accordion/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/accordion/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,119 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=false _disabled=false 1`] = `
-<kol-accordion>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <h1 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-accordion__wrapper">
-        <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=false _disabled=true 1`] = `
-<kol-accordion>
-  <template shadowrootmode="open">
-    <div class="collapsible collapsible--disabled kol-accordion" id="nonce">
-      <h1 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-accordion__wrapper">
-        <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=true _disabled=false 1`] = `
-<kol-accordion _open="">
-  <template shadowrootmode="open">
-    <div class="collapsible collapsible--open kol-accordion" id="nonce">
-      <h1 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-remove" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-accordion__wrapper">
-        <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
-          <div class="collapsible__content kol-accordion__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 _open=true _disabled=true 1`] = `
-<kol-accordion _open="">
-  <template shadowrootmode="open">
-    <div class="collapsible collapsible--disabled collapsible--open kol-accordion" id="nonce">
-      <h1 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-remove" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-accordion__wrapper">
-        <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
-          <div class="collapsible__content kol-accordion__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=1 1`] = `
-<kol-accordion>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <h1 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-accordion__wrapper">
-        <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
-exports[`kol-accordion should render with _label="Überschrift" _level=2 1`] = `
-<kol-accordion>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <h2 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h2 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h2>
-      <div class="collapsible__wrapper kol-accordion__wrapper">
-        <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-accordion>
-`;
-
 exports[`kol-accordion should render with _label="Überschrift" _level=3 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
@@ -133,13 +19,13 @@ exports[`kol-accordion should render with _label="Überschrift" _level=3 1`] = `
 </kol-accordion>
 `;
 
-exports[`kol-accordion should render with _label="Überschrift" _level=4 1`] = `
+exports[`kol-accordion should render with _label="Überschrift" _open=false _disabled=false 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
     <div class="collapsible kol-accordion" id="nonce">
-      <h4 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h4 kol-headline--single">
+      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h4>
+      </strong>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -152,13 +38,13 @@ exports[`kol-accordion should render with _label="Überschrift" _level=4 1`] = `
 </kol-accordion>
 `;
 
-exports[`kol-accordion should render with _label="Überschrift" _level=5 1`] = `
+exports[`kol-accordion should render with _label="Überschrift" _open=false _disabled=true 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <h5 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h5 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h5>
+    <div class="collapsible collapsible--disabled kol-accordion" id="nonce">
+      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+        <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
+      </strong>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -171,16 +57,35 @@ exports[`kol-accordion should render with _label="Überschrift" _level=5 1`] = `
 </kol-accordion>
 `;
 
-exports[`kol-accordion should render with _label="Überschrift" _level=6 1`] = `
-<kol-accordion>
+exports[`kol-accordion should render with _label="Überschrift" _open=true _disabled=false 1`] = `
+<kol-accordion _open="">
   <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <h6 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h6 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h6>
+    <div class="collapsible collapsible--open kol-accordion" id="nonce">
+      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-remove" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
+      </strong>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
+          <div class="collapsible__content kol-accordion__content" id="nonce-control">
+            <slot></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-accordion>
+`;
+
+exports[`kol-accordion should render with _label="Überschrift" _open=true _disabled=true 1`] = `
+<kol-accordion _open="">
+  <template shadowrootmode="open">
+    <div class="collapsible collapsible--disabled collapsible--open kol-accordion" id="nonce">
+      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-remove" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
+      </strong>
+      <div class="collapsible__wrapper kol-accordion__wrapper">
+        <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
+          <div class="collapsible__content kol-accordion__content" id="nonce-control">
             <slot></slot>
           </div>
         </div>
@@ -194,9 +99,9 @@ exports[`kol-accordion should render with _label="Überschrift" 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
     <div class="collapsible kol-accordion" id="nonce">
-      <h1 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h1 kol-headline--single">
+      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h1>
+      </strong>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">

--- a/packages/components/src/components/accordion/test/snapshot.spec.tsx
+++ b/packages/components/src/components/accordion/test/snapshot.spec.tsx
@@ -11,10 +11,10 @@ executeSnapshotTests<AccordionProps>(
 	[KolAccordion],
 	[
 		{ ...baseObject },
-		...([1, 2, 3, 4, 5, 6].map((_level) => ({ ...baseObject, _level })) as AccordionProps[]),
-		{ ...baseObject, _level: 1, _open: false, _disabled: false },
-		{ ...baseObject, _level: 1, _open: false, _disabled: true },
-		{ ...baseObject, _level: 1, _open: true, _disabled: true },
-		{ ...baseObject, _level: 1, _open: true, _disabled: false },
+		{ ...baseObject, _level: 3 },
+		{ ...baseObject, _open: false, _disabled: false },
+		{ ...baseObject, _open: false, _disabled: true },
+		{ ...baseObject, _open: true, _disabled: true },
+		{ ...baseObject, _open: true, _disabled: false },
 	],
 );

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -55,8 +55,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	};
 
 	public render(): JSX.Element {
-		const { _open, _label, _disabled } = this.state;
-		const _level = 1;
+		const { _open, _label, _disabled, _level } = this.state;
 
 		const rootClass = 'kol-details';
 
@@ -101,7 +100,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	/**
 	 * Defines which H-level from 1-6 the heading has. 0 specifies no heading and is shown as bold text.
 	 */
-	@Prop() public _level?: HeadingLevel = 1;
+	@Prop() public _level?: HeadingLevel = 0;
 
 	/**
 	 * Defines the callback functions for details.
@@ -116,7 +115,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 
 	@State() public state: DetailsStates = {
 		_label: '', // ⚠ required
-		_level: 1,
+		_level: 0,
 		_on: {},
 	};
 

--- a/packages/components/src/components/details/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/details/test/__snapshots__/snapshot.spec.tsx.snap
@@ -4,9 +4,9 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
 <kol-details>
   <template shadowrootmode="open">
     <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
+      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
+      </strong>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -23,9 +23,9 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
 <kol-details _open="">
   <template shadowrootmode="open">
     <div class="collapsible collapsible--open kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
+      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
         <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
+      </strong>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -42,9 +42,9 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
 <kol-details>
   <template shadowrootmode="open">
     <div class="collapsible collapsible--disabled kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
+      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
         <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
+      </strong>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -61,69 +61,12 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
 <kol-details _open="">
   <template shadowrootmode="open">
     <div class="collapsible collapsible--disabled collapsible--open kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
+      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
         <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
+      </strong>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div class="collapsible__content indented-text kol-details__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=0 1`] = `
-<kol-details>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-details__wrapper">
-        <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=1 1`] = `
-<kol-details>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-details__wrapper">
-        <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=2 1`] = `
-<kol-details>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-details__wrapper">
-        <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
             <slot></slot>
           </div>
         </div>
@@ -137,66 +80,9 @@ exports[`kol-details should render with _label="Zusammenfassung" _level=3 1`] = 
 <kol-details>
   <template shadowrootmode="open">
     <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
+      <h3 class="collapsible__heading kol-details__heading kol-headline kol-headline--h3 kol-headline--single">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-details__wrapper">
-        <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=4 1`] = `
-<kol-details>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-details__wrapper">
-        <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=5 1`] = `
-<kol-details>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
-      <div class="collapsible__wrapper kol-details__wrapper">
-        <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
-          <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
-            <slot></slot>
-          </div>
-        </div>
-      </div>
-    </div>
-  </template>
-</kol-details>
-`;
-
-exports[`kol-details should render with _label="Zusammenfassung" _level=6 1`] = `
-<kol-details>
-  <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
+      </h3>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -213,9 +99,9 @@ exports[`kol-details should render with _label="Zusammenfassung" 1`] = `
 <kol-details>
   <template shadowrootmode="open">
     <div class="collapsible kol-details" id="nonce">
-      <h1 class="collapsible__heading kol-details__heading kol-headline kol-headline--h1 kol-headline--single">
+      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
         <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h1>
+      </strong>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">

--- a/packages/components/src/components/details/test/snapshot.spec.tsx
+++ b/packages/components/src/components/details/test/snapshot.spec.tsx
@@ -9,12 +9,10 @@ executeSnapshotTests<DetailsProps>(
 	[KolDetails],
 	[
 		{ _label: 'Zusammenfassung' },
-
+		{ _label: 'Zusammenfassung', _level: 3 },
 		{ _label: 'Zusammenfassung', _disabled: true, _open: false },
 		{ _label: 'Zusammenfassung', _disabled: true, _open: true },
 		{ _label: 'Zusammenfassung', _disabled: false, _open: false },
 		{ _label: 'Zusammenfassung', _disabled: false, _open: true },
-
-		...[0, 1, 2, 3, 4, 5, 6].map((_level) => ({ _label: 'Zusammenfassung', _level }) as DetailsProps),
 	],
 );


### PR DESCRIPTION
## What changed?

Two related heading-level corrections for the collapsible components:

1. **`kol-details` now honours `_level`.** Its `render()` previously hardcoded `const _level = 1`, so the summary heading was always an `<h1>` regardless of the prop. It now reads `_level` from state, so e.g. `_level="3"` renders an `<h3>` with the `kol-headline--h3` class.
2. **Default `_level` changes from `1` to `0`** on both `kol-details` and `kol-accordion` (in the `@Prop()` initializer and the internal `state`). With `_level` unset, the heading now renders as a neutral bold `<strong>` instead of an `<h1>`, matching the behaviour standardized for the other heading-bearing components.

Snapshots and snapshot specs for both components were updated (the previous details snapshots showed every `_level` value collapsing to `<h1>`, which documented the bug). Files: `accordion/shadow.tsx`, `details/shadow.tsx`, and their `test/__snapshots__` + `test/snapshot.spec.tsx`.

## Why?

Per bug #7108, setting `_level` on `kol-details` had no effect — the heading stayed an `<h1>` (reproducible in the docs live editor). The hardcoded level is removed so the prop works as documented. The default is also moved to `0` so that a details/accordion with no explicit level no longer injects an unintended top-level `<h1>` into the page heading outline.

## Linked issues

- Closes #7108 — 🐞 Bug: _level-property hat keine Auswirkung in KolDetails: setting `_level` to anything other than 1 left the heading as `<h1>`; it now renders the requested level, and the default becomes level 0 (`<strong>`).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [x] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Zwei zusammenhängende Korrekturen der Überschriften-Stufe bei den einklappbaren Komponenten:

1. **`kol-details` berücksichtigt nun `_level`.** Die `render()`-Methode hatte zuvor `const _level = 1` fest verdrahtet, sodass die Zusammenfassungs-Überschrift unabhängig von der Prop immer ein `<h1>` war. Jetzt wird `_level` aus dem State gelesen, sodass z. B. `_level="3"` ein `<h3>` mit der Klasse `kol-headline--h3` erzeugt.
2. **Standardwert von `_level` ändert sich von `1` auf `0`** bei `kol-details` und `kol-accordion` (im `@Prop()`-Initialwert und im internen `state`). Ohne gesetztes `_level` rendert die Überschrift nun ein neutrales, fettes `<strong>` statt eines `<h1>` — analog zum vereinheitlichten Verhalten der übrigen Überschriften-Komponenten.

Snapshots und Snapshot-Specs beider Komponenten wurden angepasst (die bisherigen Details-Snapshots zeigten, dass jeder `_level`-Wert zu `<h1>` kollabierte — das dokumentierte den Bug). Dateien: `accordion/shadow.tsx`, `details/shadow.tsx` sowie deren `test/__snapshots__` + `test/snapshot.spec.tsx`.

### Warum?

Laut Bug #7108 hatte das Setzen von `_level` bei `kol-details` keine Wirkung — die Überschrift blieb ein `<h1>` (reproduzierbar im Live-Editor der Doku). Die feste Stufe wird entfernt, damit die Prop wie dokumentiert funktioniert. Zusätzlich wird der Standard auf `0` gesetzt, damit ein Details/Accordion ohne explizite Stufe kein ungewolltes `<h1>` mehr in das Überschriften-Outline der Seite einfügt.

### Verknüpfte Tickets

- Schließt #7108 — 🐞 Bug: _level-property hat keine Auswirkung in KolDetails: Das Setzen von `_level` auf etwas anderes als 1 ließ die Überschrift als `<h1>`; nun wird die angeforderte Stufe gerendert und der Standard ist Stufe 0 (`<strong>`).

### Art der Änderung

💥 Breaking Change

### Geänderte Dateien

- `packages/components/src/components/details/shadow.tsx` — festes `_level = 1` in `render()` entfernt (liest jetzt `_level` aus dem State); Standard `_level` auf `0`.
- `packages/components/src/components/accordion/shadow.tsx` — Standard `_level` von `1` auf `0`.
- `packages/components/src/components/{details,accordion}/test/__snapshots__/snapshot.spec.tsx.snap`, `.../test/snapshot.spec.tsx` — Snapshots und Specs an das korrigierte Verhalten angepasst.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUe9T8SN9dTbhjis74X2d