### PR TITLE
refactor(table): remove the _minWidth afterPatch derivation - the value is now set explicitly

### DIFF
--- a/packages/components/src/schema/props/table-header-cells.ts
+++ b/packages/components/src/schema/props/table-header-cells.ts
@@ -17,12 +17,6 @@ export type PropTableHeaderCells = {
 	headerCells: TableHeaderCellsPropType;
 };
 
-/* constants */
-/**
- * Regular expression to validate the width of a header cell.
- */
-const HEADER_CELL_WIDTH_VALIDATOR = /^\d+(\.\d+)?([a-z]+)?$/;
-
 /* validator */
 export const validateTableHeaderCells = (component: Generic.Element.Component, value?: TableHeaderCellsPropType): void => {
 	emptyStringByArrayHandler(value, () => {
@@ -44,24 +38,6 @@ export const validateTableHeaderCells = (component: Generic.Element.Component, v
 					true,
 				new Set(['TableHeaderCellsPropType']),
 				value,
-				{
-					hooks: {
-						afterPatch: (value: unknown, state: Record<string, unknown>): void => {
-							const headerCells = value as TableHeaderCells;
-							const widths: string[] = [];
-							headerCells.horizontal?.forEach((headerRow) => {
-								headerRow.forEach((headerCell) => {
-									if (headerCell.width && HEADER_CELL_WIDTH_VALIDATOR.test(headerCell.width)) {
-										widths.push(headerCell.width);
-									}
-								});
-							});
-							if (widths.length > 0) {
-								state._minWidth = `calc(${widths.join(' + ')})`;
-							}
-						},
-					},
-				},
 			);
 		});
 	});


### PR DESCRIPTION
## What changed?

Removes the `HEADER_CELL_WIDTH_VALIDATOR` regular-expression constant and the `afterPatch` hook from `validateTableHeaderCells` in `packages/components/src/schema/props/table-header-cells.ts`. That hook previously summed the horizontal header-cell `width` values and wrote `state._minWidth = calc(… + …)` as a side effect during header-cell validation. After this change the file is a plain header-cells validator with no side effect on `_minWidth`. It is a deletion-only change (24 lines, one file) on the `release/2` branch; no public prop signature changes.

## Why?

Part of the #7322 rework of how tables obtain their min-width. `_minWidth` is being turned into an explicit, validated property (see the v3 counterpart #7379), so the previous validation-time auto-derivation from header widths is no longer the mechanism and the now-unused constant and hook were removed. No dedicated issue for the cleanup itself beyond the epic #7322; motivation confirmed from the diff and the `7322-…-v2` branch.

## Linked issues

- Refs #7322 — Automatische horizontale Scroll-Aktivierung für Tabellen durch Berechnung der Mindestbreite: the epic reworking how a table's min-width is derived; this PR is its `release/2` (v2) cleanup step.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Entfernt die Konstante `HEADER_CELL_WIDTH_VALIDATOR` (regulärer Ausdruck) und den `afterPatch`-Hook aus `validateTableHeaderCells` in `packages/components/src/schema/props/table-header-cells.ts`. Dieser Hook summierte zuvor die `width`-Werte der horizontalen Header-Zellen und schrieb als Seiteneffekt der Header-Zellen-Validierung `state._minWidth = calc(… + …)`. Nach der Änderung ist die Datei ein reiner Header-Zellen-Validator ohne Seiteneffekt auf `_minWidth`. Es handelt sich um eine reine Löschung (24 Zeilen, eine Datei) auf dem Branch `release/2`; keine Änderung an öffentlichen Prop-Signaturen.

### Warum?

Teil des #7322-Umbaus, wie Tabellen ihre Mindestbreite ermitteln. `_minWidth` wird zu einer expliziten, validierten Eigenschaft umgebaut (siehe das v3-Gegenstück #7379), daher ist die bisherige Herleitung aus den Header-Breiten zur Validierungszeit nicht mehr der Mechanismus und die ungenutzte Konstante samt Hook wurde entfernt. Kein eigenes Ticket für die Bereinigung selbst außer dem Epic #7322; Motivation aus dem Diff und dem Branch `7322-…-v2` bestätigt.

### Verknüpfte Tickets

- Referenziert #7322 — Automatische horizontale Scroll-Aktivierung für Tabellen durch Berechnung der Mindestbreite: das Epic zum Umbau der Mindestbreiten-Herleitung; dieser PR ist der `release/2`-(v2-)Bereinigungsschritt.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/schema/props/table-header-cells.ts` — Konstante `HEADER_CELL_WIDTH_VALIDATOR` und `afterPatch`-Hook (Herleitung von `_minWidth`) entfernt.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUe9T8SN9dTbhjis74X2d