### PR TITLE
ci(publish): fix env indentation for the bwst publish step and raise visual-test tolerance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,8 +188,8 @@ jobs:
         run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
         working-directory: packages/themes/bwst
         env:
-        NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
-        NPM_CONFIG_PROVENANCE: true
+          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
       - name: Build and publish themes
         run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
         working-directory: packages/themes

--- a/packages/tools/visual-tests/tests/theme-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/theme-snapshots.spec.js
@@ -67,7 +67,7 @@ ROUTES.forEach((options, route) => {
 		});
 		await expect(page).toHaveScreenshot({
 			fullPage: true,
-			maxDiffPixelRatio: 0.01,
+			maxDiffPixelRatio: 0.02,
 			...options,
 		});
 	});


### PR DESCRIPTION
## What changed?

Two changes. In `.github/workflows/publish.yml`, the `NODE_AUTH_TOKEN` and `NPM_CONFIG_PROVENANCE` keys under the bwst theme publish step were mis-indented (aligned with `env:` instead of nested beneath it); they are now correctly indented so the token and provenance setting actually apply to that publish step. In `packages/tools/visual-tests/tests/theme-snapshots.spec.js`, the second `maxDiffPixelRatio` was raised from `0.01` to `0.02`. No component or runtime code changed.

## Why?

The workflow indentation fix ensures the bwst theme `pnpm publish` step receives its npm auth token and provenance flag instead of silently dropping them. The `maxDiffPixelRatio` bump relates to #7383, which reported that the strict visual-test threshold produced excessive, near-identical diffs.

## Linked issues

- Refs #7383 — Visual tests - reconfigure `maxDiffPixelRatio`: covers the tolerance bump only; the `publish.yml` indentation fix is not part of that issue.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Zwei Änderungen. In `.github/workflows/publish.yml` waren die Schlüssel `NODE_AUTH_TOKEN` und `NPM_CONFIG_PROVENANCE` im bwst-Theme-Publish-Schritt falsch eingerückt (auf Höhe von `env:` statt darunter); sie sind jetzt korrekt eingerückt, sodass Token und Provenance-Einstellung tatsächlich auf diesen Publish-Schritt angewendet werden. In `packages/tools/visual-tests/tests/theme-snapshots.spec.js` wurde der zweite `maxDiffPixelRatio` von `0.01` auf `0.02` angehoben. Es wurde kein Komponenten- oder Laufzeitcode geändert.

### Warum?

Die Einrückungskorrektur stellt sicher, dass der `pnpm publish`-Schritt des bwst-Themes seinen npm-Auth-Token und das Provenance-Flag erhält, statt sie stillschweigend zu verwerfen. Die Anhebung von `maxDiffPixelRatio` bezieht sich auf #7383, wo gemeldet wurde, dass der zu strenge Visual-Test-Schwellenwert übermäßig viele, nahezu identische Diffs erzeugte.

### Verknüpfte Tickets

- Referenziert #7383 — Visual tests - reconfigure `maxDiffPixelRatio`: betrifft nur die Toleranz-Anhebung; die Einrückungskorrektur in `publish.yml` ist nicht Teil dieses Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/publish.yml` — Einrückung von `NODE_AUTH_TOKEN`/`NPM_CONFIG_PROVENANCE` im bwst-Publish-Schritt korrigiert.
- `packages/tools/visual-tests/tests/theme-snapshots.spec.js` — zweiter `maxDiffPixelRatio` von `0.01` auf `0.02` angehoben.

</details>