### PR TITLE
test(visual-tests): raise maxDiffPixelRatio tolerance - 0.0 flagged imperceptible rendering noise

### DIFF
--- a/docs/BREAKING_CHANGES.v3.md
+++ b/docs/BREAKING_CHANGES.v3.md
@@ -24,22 +24,6 @@ The following components have been removed:
 - Visually, the tooltip has been replaced by a simple label shown in parentheses after the abbreviation.
 - The property `_tooltipAlign` has been removed.
 
-### kol-modal
-
-- The property `_activeElement` has been removed. Use the methods `openModal` and `closeModal` instead.
-
-### kol-table-stateful
-
-- The table header property `sort` has been removed. Use `compareFn` instead.
-
-### kol-input-file
-
-- The property `_value` has been removed as it never served a purpose. Use the `getValue()` method instead to access the FileList.
-
-### kol-table-stateful
-
-- The DOM event `kol-selection-change` has been renamed to `kolSelectionChange`.
-
 ### kol-alert
 
 - The default value for the property `_level` changed to `0` which results in rendering a `strong` tag instead of `h1` when no level is provided.
@@ -51,6 +35,21 @@ The following components have been removed:
 ### kol-heading
 
 - The default value for the property `_level` changed to `0` which results in rendering a `strong` tag instead of `h1` when no level is provided.
+
+### kol-input-file
+
+- The property `_value` has been removed as it never served a purpose. Use the `getValue()` method instead to access the FileList.
+
+### kol-modal
+
+- The property `_activeElement` has been removed. Use the methods `openModal` and `closeModal` instead.
+
+### kol-table-stateful
+
+- The table header property `sort` has been removed. Use `compareFn` instead.
+- The property `_minWidth` becomes required. This is to ensure that the inner width of the table and columns are wide enough to display the content. If the table gets too narrow, then the table becomes
+  automatically horizontally scrollbar.
+- The DOM event `kol-selection-change` has been renamed to `kolSelectionChange`.
 
 ### kol-table-stateless
 

--- a/packages/tools/visual-tests/tests/theme-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/theme-snapshots.spec.js
@@ -59,7 +59,7 @@ ROUTES.forEach((options, route) => {
 		}
 		await expect(page).toHaveScreenshot({
 			fullPage: true,
-			maxDiffPixelRatio: 0.0,
+			maxDiffPixelRatio: 0.01,
 			...options,
 		});
 		await page.evaluate(() => {
@@ -67,7 +67,7 @@ ROUTES.forEach((options, route) => {
 		});
 		await expect(page).toHaveScreenshot({
 			fullPage: true,
-			maxDiffPixelRatio: 0.01,
+			maxDiffPixelRatio: 0.02,
 			...options,
 		});
 	});


### PR DESCRIPTION
## What changed?

In `packages/tools/visual-tests/tests/theme-snapshots.spec.js`, the `maxDiffPixelRatio` thresholds for the theme screenshot comparisons were loosened: the first `toHaveScreenshot` call goes from `0.0` to `0.01` and the second from `0.01` to `0.02`. The diff also reorganizes `docs/BREAKING_CHANGES.v3.md` — it re-groups the entries per component and adds a note that `kol-table-stateful`'s `_minWidth` property becomes required (alongside the existing `sort` removal and the `kol-selection-change` → `kolSelectionChange` rename). No component or runtime code changed.

## Why?

Issue #7383 reported that `maxDiffPixelRatio = 0.0` was too strict: imperceptible variations such as anti-aliasing and rendering artifacts triggered visual-test failures and produced excessive, near-identical diffs. Raising the tolerance reduces this noise while still catching meaningful visual changes.

## Linked issues

- Refs #7383 — Visual tests - reconfigure `maxDiffPixelRatio`: a threshold of `0.0` was too strict and generated many near-identical diffs.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/tools/visual-tests/tests/theme-snapshots.spec.js` wurden die `maxDiffPixelRatio`-Schwellen für die Theme-Screenshot-Vergleiche gelockert: Der erste `toHaveScreenshot`-Aufruf geht von `0.0` auf `0.01`, der zweite von `0.01` auf `0.02`. Der Diff strukturiert außerdem `docs/BREAKING_CHANGES.v3.md` um — die Einträge werden je Komponente neu gruppiert und ein Hinweis ergänzt, dass die Eigenschaft `_minWidth` von `kol-table-stateful` verpflichtend wird (neben der bereits dokumentierten `sort`-Entfernung und der Umbenennung `kol-selection-change` → `kolSelectionChange`). Es wurde kein Komponenten- oder Laufzeitcode geändert.

### Warum?

Issue #7383 meldete, dass `maxDiffPixelRatio = 0.0` zu streng war: Nicht wahrnehmbare Abweichungen wie Anti-Aliasing und Rendering-Artefakte lösten Fehlschläge in den Visual-Tests aus und erzeugten übermäßig viele, nahezu identische Diffs. Das Anheben der Toleranz reduziert dieses Rauschen, erkennt aber weiterhin relevante visuelle Änderungen.

### Verknüpfte Tickets

- Referenziert #7383 — Visual tests - reconfigure `maxDiffPixelRatio`: Der Schwellenwert `0.0` war zu streng und erzeugte viele nahezu identische Diffs.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/tests/theme-snapshots.spec.js` — `maxDiffPixelRatio` von `0.0`→`0.01` bzw. `0.01`→`0.02` angehoben.
- `docs/BREAKING_CHANGES.v3.md` — Breaking-Change-Einträge neu gruppiert; Hinweis zu verpflichtendem `_minWidth` bei `kol-table-stateful` ergänzt.

</details>