### PR TITLE
chore(theme-bwst): add npm publish metadata and bump version to 2.2.6-rc.1

### DIFF
--- a/packages/themes/bwst/package.json
+++ b/packages/themes/bwst/package.json
@@ -1,7 +1,45 @@
 {
 	"name": "@public-ui/theme-bwst",
-	"version": "1.0.0-alpha.0",
-	"private": true,
+	"version": "2.2.6-rc.1",
+	"license": "EUPL-1.2",
+	"homepage": "https://public-ui.github.io",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/public-ui/kolibri"
+	},
+	"bugs": {
+		"url": "https://github.com/public-ui/kolibri/issues",
+		"email": "kolibri@itzbund.de"
+	},
+	"author": {
+		"name": "Informationstechnikzentrum Bund",
+		"email": "kolibri@itzbund.de"
+	},
+	"description": "Contains the default theme for KoliBri - The accessible HTML-Standard.",
+	"keywords": [
+		"accessibility",
+		"accessible",
+		"bitv",
+		"designsystem",
+		"design",
+		"web components",
+		"webcomponents",
+		"aria",
+		"wai",
+		"axe",
+		"custom elements",
+		"styleguide",
+		"style",
+		"guide",
+		"ui",
+		"html",
+		"css",
+		"web",
+		"a11y",
+		"w3c",
+		"webstandard",
+		"wcag"
+	],
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {


### PR DESCRIPTION
## What changed?

`packages/themes/bwst/package.json` was updated to make the `@public-ui/theme-bwst` package publishable: the `version` was bumped from `1.0.0-alpha.0` to `2.2.6-rc.1`, the `private: true` flag was removed, and publish/discovery metadata was added — `license` (`EUPL-1.2`), `homepage`, `repository`, `bugs`, `author`, `description` and a `keywords` list. No source, build or runtime behaviour changed; this only affects the package manifest.

## Why?

No linked issue applies here — the PR body references #7383, but that issue is about the visual-test `maxDiffPixelRatio` and is unrelated to this change (the branch was shared). Motivation derived from the diff: the metadata and the removal of `private` prepare the bwst theme package for publishing to npm alongside the other theme packages.

## Linked issues

- No applicable linked issue (see Notes below).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`packages/themes/bwst/package.json` wurde angepasst, um das Paket `@public-ui/theme-bwst` veröffentlichbar zu machen: Die `version` wurde von `1.0.0-alpha.0` auf `2.2.6-rc.1` angehoben, das Flag `private: true` entfernt und Publish-/Auffindbarkeits-Metadaten ergänzt — `license` (`EUPL-1.2`), `homepage`, `repository`, `bugs`, `author`, `description` sowie eine `keywords`-Liste. Es wurde kein Quell-, Build- oder Laufzeitverhalten geändert; betroffen ist nur das Paket-Manifest.

### Warum?

Es passt kein verknüpftes Ticket: Der PR-Text referenziert #7383, dieses Ticket betrifft aber die `maxDiffPixelRatio` der Visual-Tests und hat mit dieser Änderung nichts zu tun (gemeinsamer Branch). Aus dem Diff abgeleitet: Die Metadaten und das Entfernen von `private` bereiten das bwst-Theme-Paket auf die npm-Veröffentlichung vor.

### Verknüpfte Tickets

Keine passenden verknüpften Tickets (siehe Hinweis unten).

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/themes/bwst/package.json` — Version angehoben, `private` entfernt, Lizenz-/Repository-/Autor-/Beschreibungs-/Keyword-Metadaten für die npm-Veröffentlichung ergänzt.

</details>