### PR TITLE
fix(single-select): dispatch input and change events on clear - consumers were not notified on reset

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -92,20 +92,22 @@ export class KolSingleSelect implements SingleSelectAPI {
 		if (this.state._disabled) {
 			return;
 		} else {
+			const emptyValue = '';
 			this._focusedOptionIndex = -1;
-			this._value = '';
-			this._inputValue = '';
+			this._value = emptyValue;
+			this._inputValue = emptyValue;
 			this._filteredOptions = [...this.state._options];
 
-			this.controller.setFormAssociatedValue(this._value);
+			this.controller.onFacade.onInput(new Event('input'), true, emptyValue);
+			this.controller.onFacade.onChange(new Event('change'), emptyValue);
 		}
 	}
 
 	private selectOption(event: Event, option: Option<string>) {
 		this._value = option.value;
 		this._inputValue = option.label as string;
-		this.controller.onFacade.onChange(event, option.value);
 		this.controller.onFacade.onInput(event, false, option.value);
+		this.controller.onFacade.onChange(event, option.value);
 
 		this._filteredOptions = [...this.state._options];
 


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/single-select/shadow.tsx` the `clear` handler now dispatches both an `input` event and a `change` event (via `onFacade.onInput` / `onChange` with an empty value) when the value is reset, where before it only called `setFormAssociatedValue` and emitted nothing. It also corrects the event order in `selectOption` so `onInput` fires before `onChange` (previously `onChange` came first), and introduces a small `emptyValue = ''` constant for readability. One file, +6/−4.

## Why?

Clicking the clear "X" on a SingleSelect emitted neither `input` nor `change`, so forms and consuming applications were never notified when the value was cleared. The fix makes clearing behave consistently with a normal value change.

## Linked issues

- Closes #7398 — Single-Select – Kein Event bei "clear": clearing the value via the "X" button dispatched no `input` / `change` event and left consumers unaware; the PR makes both events fire on clear.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/single-select/shadow.tsx` löst der `clear`-Handler beim Zurücksetzen des Werts nun sowohl ein `input`- als auch ein `change`-Event aus (über `onFacade.onInput` / `onChange` mit leerem Wert); zuvor rief er nur `setFormAssociatedValue` auf und feuerte kein Event. Zusätzlich wird die Event-Reihenfolge in `selectOption` korrigiert, sodass `onInput` vor `onChange` feuert (vorher zuerst `onChange`), und ein `emptyValue = ''`-Konstante zur Lesbarkeit eingeführt. Eine Datei, +6/−4.

### Warum?

Ein Klick auf das Clear-„X" eines SingleSelect löste weder `input` noch `change` aus — Formulare und konsumierende Anwendungen wurden über das Leeren nie informiert. Der Fix lässt das Leeren sich wie eine normale Wertänderung verhalten.

### Verknüpfte Tickets

- Schließt #7398 — Single-Select – Kein Event bei "clear": das Leeren über das „X" löste kein `input`/`change`-Event aus; der PR lässt beide Events beim Leeren feuern.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/single-select/shadow.tsx` — ergänzt `input`/`change`-Dispatch im `clear`-Handler und korrigiert die `input`-vor-`change`-Reihenfolge in `selectOption`.

</details>