### PR TITLE
refactor(themes): use px not rem for border, radius, shadow, outline - stable when root font scales

### DIFF
--- a/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
@@ -26,9 +26,9 @@
 				&:focus {
 					outline: 0 !important;
 					/* @see https://remysharp.com/til/css/focus-ring-default-styles */
-					outline: rem(5) auto Highlight;
-					outline: rem(5) auto -webkit-focus-ring-color;
-					outline-offset: rem(2);
+					outline: 5px auto Highlight;
+					outline: 5px auto -webkit-focus-ring-color;
+					outline-offset: 2px;
 				}
 			}
 
@@ -120,14 +120,14 @@
 					align-items: center;
 					justify-content: center;
 					background-color: rgb(255, 255, 255);
-					border-width: rem(2);
+					border-width: 2px;
 					line-height: 1.5;
 					transition: all 0.5s ease 0s;
 				}
 
 				&--radio {
 					display: flex;
-					border-width: rem(2);
+					border-width: 2px;
 					border-radius: 100%;
 					height: 1.5em;
 					min-height: 1.5em;
@@ -144,6 +144,7 @@
 
 					&:checked:before {
 						background-color: #000;
+
 						@media (forced-colors: active) {
 							/* Give it a visible background in forced colors mode */
 							background-color: selectedItem !important;

--- a/packages/components/src/components/input-checkbox/style.scss
+++ b/packages/components/src/components/input-checkbox/style.scss
@@ -30,7 +30,7 @@
 
 			margin: 0;
 			border-style: solid;
-			border-width: rem(2);
+			border-width: 2px;
 
 			&:before {
 				content: '';

--- a/packages/components/src/components/input-radio/style.scss
+++ b/packages/components/src/components/input-radio/style.scss
@@ -13,7 +13,7 @@
 
 @layer kol-component {
 	.kol-form-field {
-		--border-width: #{rem(2)};
+		--border-width: 2px;
 		--input-size: 1.5em;
 
 		&__label {

--- a/packages/components/src/components/input-range/style.scss
+++ b/packages/components/src/components/input-range/style.scss
@@ -27,7 +27,7 @@
 			&--range {
 				appearance: none;
 				background-color: #d3d3d3;
-				border: rem(1) solid #000;
+				border: 1px solid #000;
 				display: inline-block;
 				flex-grow: 1;
 				height: rem(8);
@@ -42,12 +42,12 @@
 					background-color: #000;
 					height: rem(20);
 					width: rem(20);
-					border-radius: rem(20);
+					border-radius: 20px;
 					cursor: pointer;
 					-webkit-appearance: none;
 
 					@media (prefers-contrast: more) or (forced-colors: active) {
-						outline: rem(1) solid currentColor;
+						outline: 1px solid currentColor;
 					}
 				}
 
@@ -56,7 +56,7 @@
 					background-color: #000;
 					height: rem(20);
 					width: rem(20);
-					border-radius: rem(20);
+					border-radius: 20px;
 					cursor: pointer;
 					-moz-appearance: none;
 				}

--- a/packages/components/src/components/spin/cycle.scss
+++ b/packages/components/src/components/spin/cycle.scss
@@ -8,6 +8,7 @@
 				height: rem(48);
 			}
 		}
+
 		&__loader {
 			display: block;
 			width: 100%;
@@ -22,7 +23,7 @@
 				position: absolute;
 				inset: 0;
 				border-radius: 50%;
-				border: rem(5) solid #333;
+				border: 5px solid #333;
 				animation: 3s linear infinite prixClipFix;
 			}
 		}
@@ -65,6 +66,7 @@
 	@media (prefers-reduced-motion) {
 		.kol-spin__loader {
 			animation-duration: 4s;
+
 			&::before {
 				animation-duration: 6s;
 			}

--- a/packages/components/src/components/toolbar/style.scss
+++ b/packages/components/src/components/toolbar/style.scss
@@ -11,8 +11,8 @@
 		flex-wrap: wrap;
 
 		&:focus-within {
-			outline: rem(1) solid;
-			outline-offset: rem(2);
+			outline: 1px solid;
+			outline-offset: 2px;
 		}
 	}
 }

--- a/packages/components/src/components/tree/style.scss
+++ b/packages/components/src/components/tree/style.scss
@@ -12,8 +12,8 @@
 		}
 
 		&:focus-within {
-			outline: rem(1) solid;
-			outline-offset: rem(2);
+			outline: 1px solid;
+			outline-offset: 2px;
 		}
 	}
 }

--- a/packages/samples/react/src/style.scss
+++ b/packages/samples/react/src/style.scss
@@ -24,7 +24,7 @@ hr {
 .indented-text {
 	p {
 		font-family: var(--font-family);
-		border-left: rem(-2) solid var(--color-primary-variant);
+		border-left: -2px solid var(--color-primary-variant);
 		padding: 0 calc(8rem / var(--kolibri-root-font-size, 16));
 		margin-left: rem(-2);
 	}
@@ -50,7 +50,7 @@ hr {
 	}
 
 	.app-sidebar {
-		border-right: rem(1) solid gray;
+		border-right: 1px solid gray;
 		position: relative;
 
 		& .scrollable-container-wrapper {

--- a/packages/themes/default/src/components/button-link.scss
+++ b/packages/themes/default/src/components/button-link.scss
@@ -28,6 +28,7 @@
 				border-radius: var(--text-border-radius);
 				outline: var(--text-outline);
 			}
+
 			.kol-span__label {
 				@at-root #{$root}:is(:focus, :hover):not([aria-disabled], [disabled]) & {
 					text-decoration-thickness: 0.25em;
@@ -38,7 +39,7 @@
 
 	.badge-text-hint {
 		background-color: var(--color-mute-variant);
-		border-radius: rem(3);
+		border-radius: 3px;
 		color: var(--color-text);
 		padding: 0 0.3em;
 	}

--- a/packages/themes/default/src/components/card.scss
+++ b/packages/themes/default/src/components/card.scss
@@ -8,7 +8,7 @@
 		height: 100%;
 		background-color: var(--color-light);
 		grid-template-rows: min-content 2fr min-content;
-		box-shadow: 0 0 rem(4) color-mix(in srgb, black 80%, var(--color-subtle)); // darken by 80% to maintain contrast of 3:1
+		box-shadow: 0 0 4px color-mix(in srgb, black 80%, var(--color-subtle)); // darken by 80% to maintain contrast of 3:1
 		border-radius: var(--border-radius);
 
 		&__header {

--- a/packages/themes/default/src/components/drawer.scss
+++ b/packages/themes/default/src/components/drawer.scss
@@ -1,10 +1,11 @@
 @import '../mixins/rem';
 
 $duration: 0.4s;
+
 @layer kol-theme-component {
 	.kol-drawer {
 		&__wrapper {
-			box-shadow: 0 0 rem(4) var(--color-subtle);
+			box-shadow: 0 0 4px var(--color-subtle);
 
 			&--left {
 				animation: slideInLeft $duration forwards;

--- a/packages/themes/default/src/components/input-checkbox.scss
+++ b/packages/themes/default/src/components/input-checkbox.scss
@@ -34,7 +34,7 @@
 			order: 1;
 			width: 100%;
 			border-color: var(--color-subtle);
-			border-width: rem(2);
+			border-width: 2px;
 			border-style: solid;
 			border-radius: var(--border-radius);
 			appearance: none;
@@ -66,7 +66,7 @@
 
 			&:hover {
 				border-color: var(--color-primary);
-				box-shadow: 0 rem(2) rem(8) rem(2) rgba(8, 35, 48, 0.24);
+				box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 			}
 		}
 
@@ -162,13 +162,13 @@
 
 				&__input {
 					height: 100%;
-					border-width: rem(1) 0 rem(1) rem(1);
+					border-width: 1px 0 1px 1px;
 					border-style: solid none solid solid;
 					border-radius: var(--border-radius) 0 0 var(--border-radius);
 				}
 
 				&__label {
-					border-width: rem(1) rem(1) rem(1) 0;
+					border-width: 1px 1px 1px 0;
 					border-style: solid solid solid none;
 					border-radius: 0 var(--border-radius) var(--border-radius) 0;
 
@@ -216,7 +216,7 @@
 						background-color: var(--color-primary-variant);
 						border-color: var(--color-primary-variant);
 						color: var(--color-light);
-						box-shadow: 0 rem(2) rem(8) rem(2) rgba(8, 35, 48, 0.24);
+						box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 					}
 				}
 
@@ -241,13 +241,13 @@
 				&--label-align-left {
 					.kol-field-control {
 						&__input {
-							border-width: rem(1) rem(1) rem(1) 0;
+							border-width: 1px 1px 1px 0;
 							border-style: solid solid solid none;
 							border-radius: 0 var(--border-radius) var(--border-radius) 0;
 						}
 
 						&__label {
-							border-width: rem(1) 0 rem(1) rem(1);
+							border-width: 1px 0 rem(1) rem(1);
 							border-style: solid none solid solid;
 							border-radius: var(--border-radius) 0 0 var(--border-radius);
 						}
@@ -271,7 +271,7 @@
 				&--hide-label {
 					.kol-field-control {
 						&__input {
-							border-width: rem(1);
+							border-width: 1px;
 							border-style: solid;
 							border-radius: var(--border-radius);
 						}
@@ -285,6 +285,7 @@
 							outline: none;
 							cursor: not-allowed;
 						}
+
 						&__label {
 							cursor: not-allowed;
 						}

--- a/packages/themes/default/src/components/input-checkbox.scss
+++ b/packages/themes/default/src/components/input-checkbox.scss
@@ -247,7 +247,7 @@
 						}
 
 						&__label {
-							border-width: 1px 0 rem(1) rem(1);
+							border-width: 1px 0 1px 1px;
 							border-style: solid none solid solid;
 							border-radius: var(--border-radius) 0 0 var(--border-radius);
 						}

--- a/packages/themes/default/src/components/input-radio.scss
+++ b/packages/themes/default/src/components/input-radio.scss
@@ -51,18 +51,18 @@
 		cursor: pointer;
 		width: 100%;
 		border-color: var(--color-subtle);
-		border-width: rem(2);
+		border-width: 2px;
 		border-style: solid;
 		border-radius: 50%;
 		line-height: 1.5;
 
 		&:hover {
 			border-color: var(--color-primary);
-			box-shadow: 0 rem(2) rem(8) rem(2) rgba(8, 35, 48, 0.24);
+			box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 		}
 
 		&:focus {
-			outline-offset: rem(2);
+			outline-offset: 2px;
 			outline: var(--color-primary-variant) solid rem(3);
 			transition: 200ms outline-offset linear;
 

--- a/packages/themes/default/src/components/link-button.scss
+++ b/packages/themes/default/src/components/link-button.scss
@@ -23,7 +23,7 @@
 
 			@at-root #{$root}:focus & {
 				outline-color: var(--color-primary-variant);
-				outline-offset: rem(2);
+				outline-offset: 2px;
 				outline-style: solid;
 				outline-width: calc(var(--border-width) * 2);
 				transition: outline-offset 0.2s linear;

--- a/packages/themes/default/src/components/modal.scss
+++ b/packages/themes/default/src/components/modal.scss
@@ -3,7 +3,7 @@
 @layer kol-theme-component {
 	.kol-modal {
 		&__card {
-			box-shadow: 0 0 rem(4) var(--color-subtle);
+			box-shadow: 0 0 4px var(--color-subtle);
 			border-radius: var(--border-radius);
 		}
 	}

--- a/packages/themes/default/src/components/nav.scss
+++ b/packages/themes/default/src/components/nav.scss
@@ -49,7 +49,7 @@
 				}
 
 				#{$root}__list--vertical & {
-					border-left: rem(2) solid transparent;
+					border-left: 2px solid transparent;
 					padding-left: rem(8);
 				}
 

--- a/packages/themes/default/src/components/pagination.scss
+++ b/packages/themes/default/src/components/pagination.scss
@@ -15,7 +15,7 @@
 	.kol-button__text {
 		background-color: var(--color-light);
 		border-radius: var(--border-radius);
-		border: rem(1) solid var(--color-primary);
+		border: 1px solid var(--color-primary);
 		color: var(--color-primary);
 		font-weight: 700;
 		min-height: var(--a11y-min-size);
@@ -38,7 +38,7 @@
 		.kol-button:is(:active, :hover):not(:disabled) & {
 			background-color: var(--color-primary-variant);
 			border-color: var(--color-primary-variant);
-			box-shadow: 0 rem(2) rem(8) rem(2) rgba(8, 35, 48, 0.24);
+			box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 			color: var(--color-light);
 		}
 

--- a/packages/themes/default/src/components/split-button.scss
+++ b/packages/themes/default/src/components/split-button.scss
@@ -21,7 +21,7 @@
 
 		&__horizontal-line {
 			background-color: var(--color-primary);
-			border-radius: rem(2);
+			border-radius: 2px;
 			width: rem(1);
 		}
 

--- a/packages/themes/default/src/components/tree-item.scss
+++ b/packages/themes/default/src/components/tree-item.scss
@@ -6,7 +6,7 @@
 
 		&__link {
 			display: block;
-			border: rem(1) solid transparent;
+			border: 1px solid transparent;
 
 			.kol-link {
 				display: block;
@@ -17,7 +17,7 @@
 
 			&:hover,
 			&:focus-within {
-				border: rem(1) solid var(--color-primary);
+				border: 1px solid var(--color-primary);
 				background-color: var(--color-primary-variant);
 
 				.kol-link {

--- a/packages/themes/default/src/components/tree.scss
+++ b/packages/themes/default/src/components/tree.scss
@@ -3,7 +3,7 @@
 @layer kol-theme-component {
 	.kol-tree {
 		&__treeview-navigation {
-			border: rem(2) solid transparent;
+			border: 2px solid transparent;
 			border-radius: var(--border-radius);
 		}
 
@@ -11,7 +11,7 @@
 			outline: 0;
 
 			ul {
-				border: rem(2) solid var(--color-primary);
+				border: 2px solid var(--color-primary);
 			}
 		}
 	}

--- a/packages/themes/default/src/global.scss
+++ b/packages/themes/default/src/global.scss
@@ -2,11 +2,11 @@
 
 @layer kol-theme-global {
 	:host {
-		--border-radius: var(--kolibri-border-radius, #{rem(5)});
+		--border-radius: var(--kolibri-border-radius, 5px);
 		--font-family: var(--kolibri-font-family, Verdana, Arial, Calibri, Helvetica, sans-serif);
 		--font-size: var(--kolibri-font-size, #{rem(16)});
 		--spacing: var(--kolibri-spacing, #{rem(4)});
-		--border-width: var(--kolibri-border-width, #{rem(1)});
+		--border-width: var(--kolibri-border-width, 1px);
 		--color-primary: var(--kolibri-color-primary, #004b76);
 		--color-primary-variant: var(--kolibri-color-primary-variant, #0077b6);
 		--color-danger: var(--kolibri-color-danger, #b4003c);
@@ -39,9 +39,9 @@
 	summary:focus {
 		cursor: pointer;
 		outline-color: var(--color-primary-variant);
-		outline-offset: rem(2);
+		outline-offset: 2px;
 		outline-style: solid;
-		outline-width: rem(3);
+		outline-width: 3px;
 		transition: outline-offset 0.2s linear;
 	}
 

--- a/packages/themes/default/src/mixins/button.scss
+++ b/packages/themes/default/src/mixins/button.scss
@@ -67,7 +67,7 @@
 			transition-property: background-color, color, border-color;
 
 			&:hover {
-				box-shadow: 0 rem(2) rem(8) rem(2) rgba(8, 35, 48, 0.24);
+				box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 				background-color: var(--text-background-color);
 				border-color: var(--text-border-color);
 				color: var(--text-color);
@@ -96,7 +96,7 @@
 
 		.badge-text-hint {
 			background-color: var(--color-mute-variant);
-			border-radius: rem(3);
+			border-radius: 3px;
 			color: var(--color-text);
 			padding: 0 0.3em;
 		}

--- a/packages/themes/default/src/mixins/custom-suggestions-options-group.scss
+++ b/packages/themes/default/src/mixins/custom-suggestions-options-group.scss
@@ -3,7 +3,7 @@
 @mixin kol-custom-suggestions-options-group-theme($option-height, $visible-options) {
 	.kol-custom-suggestions-options-group {
 		border-style: solid;
-		border-width: rem(1);
+		border-width: 1px;
 		border-radius: var(--border-radius);
 		border-color: var(--color-subtle);
 		overflow-y: auto;

--- a/packages/themes/default/src/mixins/focus-outline.scss
+++ b/packages/themes/default/src/mixins/focus-outline.scss
@@ -2,14 +2,14 @@
 
 @mixin focus-outline {
 	border-radius: var(--border-radius);
-	outline-offset: rem(2);
+	outline-offset: 2px;
 	outline: var(--color-primary-variant) solid rem(3);
 	transition: 200ms outline-offset linear;
 }
 
 @mixin switch-outline {
 	outline-color: var(--color-primary);
-	outline-offset: rem(2);
+	outline-offset: 2px;
 	outline-style: solid;
-	outline-width: rem(2);
+	outline-width: 2px;
 }

--- a/packages/themes/default/src/mixins/form-field.scss
+++ b/packages/themes/default/src/mixins/form-field.scss
@@ -13,7 +13,7 @@
 		}
 
 		&--error:not(&--hide-msg) {
-			border-left: rem(3) solid var(--color-danger);
+			border-left: 3px solid var(--color-danger);
 			padding-left: rem(16);
 
 			.kol-form-field__msg {

--- a/packages/themes/default/src/mixins/indented-text.scss
+++ b/packages/themes/default/src/mixins/indented-text.scss
@@ -2,7 +2,7 @@
 
 @mixin indented-text {
 	font-family: var(--font-family);
-	border-left: rem(2) solid var(--color-primary-variant);
+	border-left: 2px solid var(--color-primary-variant);
 	padding: 0 rem(18) 0 rem(8);
 	margin-left: rem(-2);
 	width: 100%;

--- a/packages/themes/default/src/mixins/input-error.scss
+++ b/packages/themes/default/src/mixins/input-error.scss
@@ -2,7 +2,7 @@
 @import '../mixins/alert-wc';
 
 @mixin input-error {
-	border-left: rem(3) solid var(--color-danger);
+	border-left: 3px solid var(--color-danger);
 	padding-left: rem(16);
 
 	.input:focus-within {

--- a/packages/themes/default/src/mixins/input.scss
+++ b/packages/themes/default/src/mixins/input.scss
@@ -9,7 +9,7 @@
 		border-color: var(--color-subtle);
 		border-radius: var(--border-radius);
 		border-style: solid;
-		border-width: rem(2);
+		border-width: 2px;
 		padding: 0 rem(8);
 		gap: rem(6);
 

--- a/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
@@ -32,23 +32,26 @@
 		&__focus-element {
 			&:focus {
 				outline-color: var(--color-primary-variant);
-				outline-offset: rem(2);
+				outline-offset: 2px;
 				outline-style: solid;
-				outline-width: rem(3);
+				outline-width: 3px;
 				transition: outline-offset 0.2s linear;
 			}
 		}
 
 		&__cell {
 			padding: rem(8);
+
 			&--header {
 				font-weight: normal;
 				color: var(--color-primary);
 				background-color: var(--color-light);
 			}
+
 			&--ascending,
 			&--descending {
 				font-weight: 700;
+
 				.kol-button {
 					font-weight: 700;
 				}
@@ -92,15 +95,15 @@
 		&__selection-input {
 			&:hover {
 				border-color: var(--color-primary);
-				box-shadow: 0 rem(2) rem(8) rem(2) rgba(8, 35, 48, 0.24);
+				box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 			}
 
 			&:focus {
 				border-color: var(--color-primary);
 				outline-color: var(--color-primary-variant);
 				outline-style: solid;
-				outline-offset: rem(2);
-				outline-width: rem(3);
+				outline-offset: 2px;
+				outline-width: 3px;
 			}
 
 			&:focus:hover {
@@ -110,7 +113,7 @@
 			// CHECKBOX
 			&--checkbox {
 				border-color: var(--color-subtle);
-				border-radius: rem(5);
+				border-radius: 5px;
 
 				&:checked {
 					background-color: var(--color-primary);

--- a/packages/themes/ecl/src/ecl-ec/components/accordion.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/accordion.scss
@@ -10,7 +10,7 @@
 		background-color: var(--color-grey-5);
 		border-color: var(--color-grey-25);
 		border-style: solid;
-		border-width: rem(1);
+		border-width: 1px;
 
 		&__heading-button {
 			.kol-button {
@@ -35,8 +35,8 @@
 				}
 
 				&:focus {
-					outline: rem(2) solid var(--color-blue);
-					outline-offset: rem(-2);
+					outline: 2px solid var(--color-blue);
+					outline-offset: -2px;
 				}
 			}
 

--- a/packages/themes/ecl/src/ecl-ec/components/button-link.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/button-link.scss
@@ -6,7 +6,7 @@
 
 	.badge-text-hint {
 		background-color: var(--color-mute-variant);
-		border-radius: rem(3);
+		border-radius: 3px;
 		color: var(--color-text);
 		padding: 0 0.3em;
 	}

--- a/packages/themes/ecl/src/ecl-ec/components/combobox.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/combobox.scss
@@ -59,7 +59,7 @@ $visible-options: 5;
 
 		&__listbox {
 			border-style: solid;
-			border-width: rem(1);
+			border-width: 1px;
 			border-color: var(--color-blue);
 			overflow-y: auto;
 			overflow-x: hidden;
@@ -98,8 +98,8 @@ $visible-options: 5;
 	input:not([type='range']):focus,
 	select:focus,
 	textarea:focus {
-		border-top: rem(1) solid var(--color-blue);
-		border-bottom: rem(1) solid var(--color-blue);
+		border-top: 1px solid var(--color-blue);
+		border-bottom: 1px solid var(--color-blue);
 	}
 
 	label {
@@ -118,7 +118,7 @@ $visible-options: 5;
 	}
 
 	.input {
-		border: rem(1) solid var(--color-grey-75);
+		border: 1px solid var(--color-grey-75);
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;

--- a/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
@@ -38,7 +38,7 @@
 	.kol-checkbox {
 		.kol-input {
 			background-color: var(--color-white);
-			border-width: rem(2);
+			border-width: 2px;
 			border-style: solid;
 			border-color: var(--color-grey-75);
 			color: var(--color-grey);
@@ -47,9 +47,9 @@
 
 			&:focus {
 				outline-color: var(--color-blue);
-				outline-offset: rem(2);
+				outline-offset: 2px;
 				outline-style: solid;
-				outline-width: rem(2);
+				outline-width: 2px;
 			}
 
 			&:checked {
@@ -166,7 +166,7 @@
 		&:focus-within {
 			outline-color: var(--color-blue-130);
 			outline-style: solid;
-			outline-width: rem(2);
+			outline-width: 2px;
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/input-radio.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-radio.scss
@@ -85,7 +85,7 @@
 
 		&:checked {
 			border-color: var(--color-blue);
-			border-width: rem(7);
+			border-width: 7px;
 		}
 
 		&:focus {
@@ -99,7 +99,7 @@
 		}
 
 		&#{&}--error {
-			border: rem(2) solid var(--color-red);
+			border: 2px solid var(--color-red);
 
 			&:before {
 				display: none;
@@ -107,7 +107,7 @@
 
 			&:checked {
 				border-color: var(--color-red);
-				border-width: rem(7);
+				border-width: 7px;
 			}
 
 			&:not(:disabled) {

--- a/packages/themes/ecl/src/ecl-ec/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/nav.scss
@@ -59,7 +59,7 @@
 	.kol-span {
 		border-color: transparent;
 		border-style: solid;
-		border-width: rem(2);
+		border-width: 2px;
 		color: var(--color-white);
 		font-size: rem(18);
 		justify-items: start;

--- a/packages/themes/ecl/src/ecl-ec/components/pagination.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/pagination.scss
@@ -15,7 +15,7 @@
 
 	.kol-button__text {
 		background-color: var(--color-yellow);
-		border: rem(2) solid var(--color-yellow);
+		border: 2px solid var(--color-yellow);
 		color: var(--color-black);
 		font-weight: var(--font-weight-bold);
 		min-height: var(--a11y-min-size);
@@ -28,8 +28,8 @@
 		}
 
 		.kol-button:focus & {
-			outline-offset: rem(-4);
-			outline: rem(2) solid var(--color-black);
+			outline-offset: -4px;
+			outline: 2px solid var(--color-black);
 		}
 
 		.kol-pagination__button--selected & {

--- a/packages/themes/ecl/src/ecl-ec/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/single-select.scss
@@ -61,7 +61,7 @@ $visible-options: 5;
 
 		&__listbox {
 			border-style: solid;
-			border-width: rem(1);
+			border-width: 1px;
 			border-color: var(--color-blue);
 			max-height: calc($option-height * $visible-options + rem(1));
 			overflow-y: auto;
@@ -104,8 +104,8 @@ $visible-options: 5;
 	input:not([type='range']):focus,
 	select:focus,
 	textarea:focus {
-		border-top: rem(1) solid var(--color-blue);
-		border-bottom: rem(1) solid var(--color-blue);
+		border-top: 1px solid var(--color-blue);
+		border-bottom: 1px solid var(--color-blue);
 	}
 
 	label {
@@ -124,7 +124,7 @@ $visible-options: 5;
 	}
 
 	.input {
-		border: rem(1) solid var(--color-grey-75);
+		border: 1px solid var(--color-grey-75);
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;

--- a/packages/themes/ecl/src/ecl-ec/components/skip-nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/skip-nav.scss
@@ -8,7 +8,7 @@
 			&__text {
 				border-radius: 0;
 				border-style: solid;
-				border-width: rem(2);
+				border-width: 2px;
 				font-weight: var(--font-weight-bold);
 				gap: rem(8);
 				line-height: 1;

--- a/packages/themes/ecl/src/ecl-ec/components/split-button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/split-button.scss
@@ -6,7 +6,7 @@
 		font-family: var(--font-family);
 		border-radius: 0;
 		border-style: solid;
-		border-width: rem(2);
+		border-width: 2px;
 		border-color: var(--color-blue);
 
 		.kol-popover__content {
@@ -23,7 +23,7 @@
 
 		&__horizontal-line {
 			border: 0;
-			border-top: rem(1) solid var(--color-blue);
+			border-top: 1px solid var(--color-blue);
 		}
 
 		@include kol-button('kol-button');

--- a/packages/themes/ecl/src/ecl-ec/components/tabs.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tabs.scss
@@ -8,7 +8,7 @@
 
 	.kol-tabs {
 		&__button-group {
-			border-bottom: rem(1) solid var(--color-grey-25);
+			border-bottom: 1px solid var(--color-grey-25);
 			margin-bottom: rem(-1);
 		}
 
@@ -21,6 +21,7 @@
 					color: var(--color-blue-130);
 				}
 			}
+
 			&:focus {
 				.kol-span {
 					outline: var(--color-blue-130) solid rem(2);
@@ -31,10 +32,10 @@
 				.kol-span {
 					border-color: var(--color-grey-25);
 					border-style: solid;
-					border-width: rem(1);
+					border-width: 1px;
 					border-bottom-color: white;
 					border-top-color: var(--color-blue);
-					box-shadow: 0 rem(-3) var(--color-blue);
+					box-shadow: 0 -3px var(--color-blue);
 					font-weight: var(--font-weight-bold);
 					color: var(--color-blue);
 				}

--- a/packages/themes/ecl/src/ecl-ec/components/toolbar.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/toolbar.scss
@@ -5,7 +5,7 @@
 		padding: var(--spacing-s);
 		border-color: var(--color-grey-25);
 		border-style: solid;
-		border-width: rem(1);
+		border-width: 1px;
 		background-color: var(--color-grey-5);
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
@@ -11,12 +11,12 @@
 
 		&__link {
 			display: block;
-			border: rem(2) solid transparent;
+			border: 2px solid transparent;
 
 			&:hover,
 			&:focus-within {
 				background-color: var(--color-sky);
-				border: rem(2) solid var(--color-yellow-120);
+				border: 2px solid var(--color-yellow-120);
 
 				.kol-link {
 					color: var(--color-black);

--- a/packages/themes/ecl/src/ecl-ec/global.scss
+++ b/packages/themes/ecl/src/ecl-ec/global.scss
@@ -11,8 +11,8 @@
 			padding: rem(4) rem(8);
 			font-size: rem(14);
 			line-height: 1.2;
-			border-radius: rem(2);
-			border: rem(1) solid #626262;
+			border-radius: 2px;
+			border: 1px solid #626262;
 		}
 	}
 

--- a/packages/themes/ecl/src/ecl-ec/mixins/alert-wc.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/alert-wc.scss
@@ -22,7 +22,7 @@
 			padding-inline-start: rem(24);
 			padding-top: rem(24);
 			border-style: solid;
-			border-width: rem(2);
+			border-width: 2px;
 		}
 
 		&--default {

--- a/packages/themes/ecl/src/ecl-ec/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/button.scss
@@ -9,8 +9,9 @@
 		appearance: none;
 		outline: none;
 		text-decoration: none;
+
 		&:focus {
-			outline-offset: rem(-4);
+			outline-offset: -4px;
 			outline: var(--text-focus-outline-color) solid rem(2);
 		}
 
@@ -95,7 +96,7 @@
 
 			border-radius: 0;
 			border-style: solid;
-			border-width: rem(2);
+			border-width: 2px;
 			font-weight: var(--font-weight-bold);
 			margin: 0;
 			min-height: rem(44);
@@ -110,11 +111,11 @@
 			}
 
 			@at-root #{$root}--secondary:focus & {
-				outline-offset: rem(-6);
+				outline-offset: -6px;
 			}
 
 			@at-root #{$root}--ghost:focus & {
-				outline-offset: rem(-2);
+				outline-offset: -2px;
 			}
 		}
 	}

--- a/packages/themes/ecl/src/ecl-ec/mixins/input-container.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/input-container.scss
@@ -1,7 +1,7 @@
 @mixin kol-input-container-theme {
 	.kol-input-container {
 		min-height: rem(44);
-		border: rem(1) solid var(--color-grey-75);
+		border: 1px solid var(--color-grey-75);
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;

--- a/packages/themes/ecl/src/ecl-ec/mixins/input-text.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/input-text.scss
@@ -17,8 +17,8 @@
 	.kol-select,
 	.kol-textarea {
 		&:focus {
-			border-top: rem(1) solid var(--color-blue);
-			border-bottom: rem(1) solid var(--color-blue);
+			border-top: 1px solid var(--color-blue);
+			border-bottom: 1px solid var(--color-blue);
 		}
 	}
 

--- a/packages/themes/ecl/src/ecl-ec/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/kol-table-stateless-wc.scss
@@ -40,6 +40,7 @@
 				font-weight: normal;
 				color: var(--color-midnight);
 			}
+
 			&--ascending,
 			&--descending {
 				font-weight: 700;
@@ -49,12 +50,13 @@
 				}
 			}
 		}
+
 		&__focus-element {
 			&:focus {
 				outline-color: var(--color-blue);
-				outline-offset: rem(2);
+				outline-offset: 2px;
 				outline-style: solid;
-				outline-width: rem(2);
+				outline-width: 2px;
 			}
 		}
 
@@ -87,8 +89,8 @@
 				border-color: var(--color-blue);
 				outline-color: var(--color-blue);
 				outline-style: solid;
-				outline-offset: rem(2);
-				outline-width: rem(2);
+				outline-offset: 2px;
+				outline-width: 2px;
 			}
 
 			// CHECKBOX
@@ -112,7 +114,7 @@
 
 				&:checked {
 					border-color: var(--color-blue);
-					border-width: rem(7);
+					border-width: 7px;
 
 					&:before {
 						background-color: var(--color-white);
@@ -127,6 +129,7 @@
 
 		&__selection-icon {
 			color: var(--color-white);
+
 			@at-root #{$root}__selection--indeterminate & {
 				color: var(--color-blue);
 			}

--- a/packages/themes/ecl/src/ecl-eu/components/accordion.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/accordion.scss
@@ -7,7 +7,7 @@
 	}
 
 	.kol-accordion {
-		border-radius: rem(8);
+		border-radius: 8px;
 		box-shadow:
 			0 rem(2) rem(4) rgb(9 49 142 / 8%),
 			0 0 rem(10) rgb(9 49 142 / 4%),
@@ -22,8 +22,8 @@
 
 		&__heading-button {
 			.kol-button {
-				border-radius: rem(8);
-				outline-offset: rem(-1);
+				border-radius: 8px;
+				outline-offset: -1px;
 				border: 0;
 				border-bottom-color: #cfdaf5;
 				border-bottom-style: solid;
@@ -70,7 +70,7 @@
 		&__content {
 			-webkit-border-start: rem(4) solid #0e47cb;
 			-webkit-margin-start: 0;
-			border-bottom: rem(2) solid #cfdaf5;
+			border-bottom: 2px solid #cfdaf5;
 			border-inline-start: rem(4) solid #0e47cb;
 			color: #515560;
 			font:

--- a/packages/themes/ecl/src/ecl-eu/components/combobox.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/combobox.scss
@@ -76,7 +76,7 @@ $visible-options: 5;
 
 		&__listbox {
 			border-style: solid;
-			border-width: rem(1);
+			border-width: 1px;
 			border-color: var(--color-blue);
 			overflow-y: auto;
 			overflow-x: hidden;
@@ -136,7 +136,7 @@ $visible-options: 5;
 
 	.input {
 		min-height: rem(44);
-		border: rem(1) solid var(--color-grey-75);
+		border: 1px solid var(--color-grey-75);
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;

--- a/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
@@ -38,7 +38,7 @@
 	.kol-checkbox {
 		.kol-input {
 			background-color: var(--color-white);
-			border-width: rem(2);
+			border-width: 2px;
 			border-style: solid;
 			border-color: var(--color-grey-75);
 			color: var(--color-grey);
@@ -47,9 +47,9 @@
 
 			&:focus {
 				outline-color: var(--color-blue);
-				outline-offset: rem(2);
+				outline-offset: 2px;
 				outline-style: solid;
-				outline-width: rem(2);
+				outline-width: 2px;
 			}
 
 			&:checked {
@@ -161,7 +161,7 @@
 		&:focus-within {
 			outline-color: var(--color-blue-130);
 			outline-style: solid;
-			outline-width: rem(2);
+			outline-width: 2px;
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/input-radio.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-radio.scss
@@ -79,8 +79,8 @@
 	}
 
 	.kol-input {
-		outline: rem(2) solid var(--color-grey-75);
-		outline-offset: rem(2);
+		outline: 2px solid var(--color-grey-75);
+		outline-offset: 2px;
 
 		&:before {
 			display: none;
@@ -88,7 +88,7 @@
 
 		&:checked {
 			border-color: var(--color-blue);
-			border-width: rem(7);
+			border-width: 7px;
 		}
 
 		&:focus {
@@ -102,7 +102,7 @@
 		}
 
 		&#{&}--error {
-			border: rem(2) solid var(--color-red);
+			border: 2px solid var(--color-red);
 
 			&:before {
 				display: none;
@@ -110,7 +110,7 @@
 
 			&:checked {
 				border-color: var(--color-red);
-				border-width: rem(7);
+				border-width: 7px;
 			}
 
 			&:not(:disabled) {
@@ -163,8 +163,8 @@
 	// }
 
 	// input[type='radio'] {
-	// 	outline: rem(2) solid var(--color-grey-75);
-	// 	outline-offset: rem(2);
+	// 	outline: 2px solid var(--color-grey-75);
+	// 	outline-offset: 2px;
 	// }
 
 	// input[type='radio']:before {
@@ -173,7 +173,7 @@
 
 	// input[type='radio']:checked {
 	// 	border-color: var(--color-blue);
-	// 	border-width: rem(7);
+	// 	border-width: 7px;
 	// }
 
 	// input[type='radio']:focus {
@@ -194,7 +194,7 @@
 	// }
 
 	// .error input[type='radio'] {
-	// 	border: rem(2) solid var(--color-red);
+	// 	border: 2px solid var(--color-red);
 	// }
 
 	// .error input[type='radio']:before {
@@ -203,7 +203,7 @@
 
 	// .error input[type='radio']:checked {
 	// 	border-color: var(--color-red);
-	// 	border-width: rem(7);
+	// 	border-width: 7px;
 	// }
 
 	// .error input[type='radio']:not(:disabled):hover {

--- a/packages/themes/ecl/src/ecl-eu/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/nav.scss
@@ -64,7 +64,7 @@
 	.kol-span {
 		border-color: transparent;
 		border-style: solid;
-		border-width: rem(2);
+		border-width: 2px;
 		color: var(--color-white);
 		font-size: rem(18);
 		justify-items: start;

--- a/packages/themes/ecl/src/ecl-eu/components/pagination.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/pagination.scss
@@ -8,7 +8,7 @@
 
 	.kol-button {
 		--kolibri-spacing: #{rem(4)};
-		border-radius: rem(4);
+		border-radius: 4px;
 
 		&:focus {
 			outline: none;
@@ -18,7 +18,7 @@
 	.kol-button__text {
 		min-height: var(--a11y-min-size);
 		min-width: var(--a11y-min-size);
-		border-radius: rem(4);
+		border-radius: 4px;
 		font:
 			normal normal 400 rem(16) / rem(20) Arial,
 			sans-serif;
@@ -27,8 +27,8 @@
 		color: #171a22;
 
 		.kol-button:focus-visible & {
-			outline-offset: rem(-4);
-			outline: rem(2) solid var(--color-black);
+			outline-offset: -4px;
+			outline: 2px solid var(--color-black);
 		}
 
 		.kol-button:not(:disabled):active &,

--- a/packages/themes/ecl/src/ecl-eu/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/single-select.scss
@@ -59,7 +59,7 @@ $visible-options: 5;
 
 		&__listbox {
 			border-style: solid;
-			border-width: rem(1);
+			border-width: 1px;
 			border-color: var(--color-blue);
 			max-height: calc($option-height * $visible-options + rem(2));
 			overflow-y: auto;
@@ -125,7 +125,7 @@ $visible-options: 5;
 
 	.input {
 		min-height: rem(44);
-		border: rem(1) solid var(--color-grey-75);
+		border: 1px solid var(--color-grey-75);
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;

--- a/packages/themes/ecl/src/ecl-eu/components/skip-nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/skip-nav.scss
@@ -6,7 +6,7 @@
 
 		.kol-link {
 			&__text {
-				border-radius: rem(4);
+				border-radius: 4px;
 				gap: rem(8);
 				line-height: 1;
 				padding: rem(12);

--- a/packages/themes/ecl/src/ecl-eu/components/split-button.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/split-button.scss
@@ -4,13 +4,13 @@
 	.kol-split-button {
 		font-family: var(--font-family);
 		border-style: solid;
-		border-width: rem(2);
+		border-width: 2px;
 		border-color: var(--color-blue);
-		border-radius: rem(4);
+		border-radius: 4px;
 
 		&__horizontal-line {
 			border: 0;
-			border-top: rem(1) solid var(--color-blue);
+			border-top: 1px solid var(--color-blue);
 		}
 
 		.kol-popover__content {

--- a/packages/themes/ecl/src/ecl-eu/components/tabs.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tabs.scss
@@ -8,7 +8,7 @@
 
 	.kol-tabs {
 		&__button-group {
-			border-bottom: rem(1) solid var(--color-grey-25);
+			border-bottom: 1px solid var(--color-grey-25);
 			margin-bottom: rem(-1);
 		}
 
@@ -21,6 +21,7 @@
 					color: var(--color-blue-130);
 				}
 			}
+
 			&:focus .kol-span {
 				outline: var(--color-blue-130) solid rem(2);
 			}
@@ -29,10 +30,10 @@
 				.kol-span {
 					border-color: var(--color-grey-25);
 					border-style: solid;
-					border-width: rem(1);
+					border-width: 1px;
 					border-bottom-color: white;
 					border-top-color: var(--color-blue);
-					box-shadow: 0 rem(-3) var(--color-blue);
+					box-shadow: 0 -3px var(--color-blue);
 					font-weight: var(--font-weight-bold);
 					color: var(--color-blue);
 				}

--- a/packages/themes/ecl/src/ecl-eu/components/toolbar.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/toolbar.scss
@@ -3,7 +3,7 @@
 @layer kol-theme-component {
 	.kol-toolbar {
 		padding: var(--spacing-s);
-		border-radius: rem(8);
+		border-radius: 8px;
 		box-shadow:
 			0 rem(2) rem(4) rgb(9 49 142 / 8%),
 			0 0 rem(10) rgb(9 49 142 / 4%),

--- a/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
@@ -11,13 +11,13 @@
 
 		&__link {
 			display: block;
-			border: rem(2) solid transparent;
-			border-radius: rem(4);
+			border: 2px solid transparent;
+			border-radius: 4px;
 
 			&:hover,
 			&:focus-within {
 				background-color: var(--color-sky);
-				border: rem(2) solid var(--color-blue);
+				border: 2px solid var(--color-blue);
 
 				.kol-link {
 					color: var(--color-black);

--- a/packages/themes/ecl/src/ecl-eu/global.scss
+++ b/packages/themes/ecl/src/ecl-eu/global.scss
@@ -12,8 +12,8 @@
 			padding: rem(4) rem(8);
 			font-size: rem(14);
 			line-height: 1.2;
-			border-radius: rem(2);
-			border: rem(1) solid #626262;
+			border-radius: 2px;
+			border: 1px solid #626262;
 		}
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/mixins/alert-wc.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/alert-wc.scss
@@ -22,7 +22,7 @@
 			padding-inline-start: rem(24);
 			padding-top: rem(24);
 			border-style: solid;
-			border-width: rem(2);
+			border-width: 2px;
 		}
 
 		&--default {

--- a/packages/themes/ecl/src/ecl-eu/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/button.scss
@@ -8,7 +8,7 @@
 
 		font-family: var(--font-family);
 		appearance: none;
-		border-radius: rem(4);
+		border-radius: 4px;
 		text-decoration: none;
 
 		&--primary {
@@ -70,7 +70,7 @@
 		&__text {
 			min-height: rem(44);
 			min-width: rem(44);
-			border-radius: rem(4);
+			border-radius: 4px;
 			font:
 				normal normal 400 rem(16) / rem(20) arial,
 				sans-serif;
@@ -94,7 +94,7 @@
 
 			@at-root #{$root}--secondary & {
 				padding: calc(rem(12) - rem(2)) calc(rem(16) - rem(2));
-				border: rem(2) solid #0e47cb;
+				border: 2px solid #0e47cb;
 			}
 
 			@at-root #{$root}--secondary.button:focus-visible & {
@@ -102,7 +102,7 @@
 			}
 
 			@at-root #{$root}:focus-visible & {
-				outline-offset: rem(-4);
+				outline-offset: -4px;
 				outline: var(--text-focus-outline-color) solid rem(2);
 			}
 

--- a/packages/themes/ecl/src/ecl-eu/mixins/input-container.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/input-container.scss
@@ -1,7 +1,7 @@
 @mixin kol-input-container-theme {
 	.kol-input-container {
 		min-height: rem(44);
-		border: rem(1) solid var(--color-grey-75);
+		border: 1px solid var(--color-grey-75);
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;

--- a/packages/themes/ecl/src/ecl-eu/mixins/input-text.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/input-text.scss
@@ -17,8 +17,8 @@
 	.kol-select,
 	.kol-textarea {
 		&:focus {
-			border-top: rem(1) solid var(--color-blue);
-			border-bottom: rem(1) solid var(--color-blue);
+			border-top: 1px solid var(--color-blue);
+			border-bottom: 1px solid var(--color-blue);
 		}
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/kol-table-stateless-wc.scss
@@ -18,9 +18,9 @@
 		&__focus-element {
 			&:focus {
 				outline-color: var(--color-blue);
-				outline-offset: rem(2);
+				outline-offset: 2px;
 				outline-style: solid;
-				outline-width: rem(2);
+				outline-width: 2px;
 			}
 		}
 
@@ -61,6 +61,7 @@
 				&--ascending,
 				&--descending {
 					font-weight: 700;
+
 					.kol-button {
 						font-weight: 700;
 					}
@@ -88,8 +89,8 @@
 				border-color: var(--color-blue);
 				outline-color: var(--color-blue);
 				outline-style: solid;
-				outline-offset: rem(2);
-				outline-width: rem(2);
+				outline-offset: 2px;
+				outline-width: 2px;
 			}
 
 			// CHECKBOX
@@ -106,16 +107,16 @@
 			&--radio {
 				display: block;
 				border-color: var(--color-grey-75);
-				outline-offset: rem(2);
+				outline-offset: 2px;
 
 				&:hover {
 					border-color: var(--color-blue);
 				}
 
 				&:checked {
-					outline: rem(2) solid var(--color-blue);
+					outline: 2px solid var(--color-blue);
 					border-color: var(--color-blue);
-					border-width: rem(7);
+					border-width: 7px;
 
 					&:before {
 						background-color: var(--color-white);
@@ -130,6 +131,7 @@
 
 		&__selection-icon {
 			color: var(--color-white);
+
 			@at-root #{$root}__selection--indeterminate & {
 				color: var(--color-blue);
 			}


### PR DESCRIPTION
## What changed?

Across the components package, the sample app, and the shipped themes (`default`, `ecl/ecl-ec`, `ecl/ecl-eu`), SCSS declarations for `border` / `border-width` / `border-radius` / `box-shadow` / `outline` / `outline-width` / `outline-offset` are converted from the `rem(n)` helper (e.g. `border-width: rem(2)` or `#{rem(2)}`) to literal pixel values (`border-width: 2px`). Sizes intended to scale — `height`, `width`, `padding`, `margin` — keep using `rem()`. At the default 16px root font size the rendered output is identical; the difference appears only when the root font size changes, where these decorative/structural sizes now stay fixed instead of scaling. No logic, markup, or TypeScript changes. 66 files, +181/−164, base `develop`.

## Why?

Per the project's CSS code-style conventions (issue #6988, referencing the Code Style wiki), `border-width`, `border-radius`, `box-shadow` and `outline-width` should use fixed `px` rather than `rem`, so border/outline/shadow sizes render predictably and do not scale with the user's root font size.

## Linked issues

- Closes #6988 — Bestimmte CSS-Definitionen wieder von `rem` auf `px` umstellen: decides that these four property families should switch back from `rem()` to fixed `px` per the documented conventions; this PR implements that switch on the `develop` line.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Im Components-Paket, der Beispiel-App und den ausgelieferten Themes (`default`, `ecl/ecl-ec`, `ecl/ecl-eu`) werden SCSS-Deklarationen für `border` / `border-width` / `border-radius` / `box-shadow` / `outline` / `outline-width` / `outline-offset` vom `rem(n)`-Helper auf literale Pixelwerte umgestellt (`border-width: 2px`). Skalierende Größen — `height`, `width`, `padding`, `margin` — nutzen weiterhin `rem()`. Bei der Standard-Wurzelschriftgröße von 16px ist das Ergebnis identisch; der Unterschied zeigt sich nur bei geänderter Wurzelschriftgröße, bei der diese dekorativen/strukturellen Größen nun fix bleiben statt zu skalieren. Keine Logik-, Markup- oder TypeScript-Änderungen. 66 Dateien, +181/−164, Basis `develop`.

### Warum?

Gemäß den CSS-Code-Style-Konventionen des Projekts (Ticket #6988, mit Verweis auf das Code-Style-Wiki) sollen `border-width`, `border-radius`, `box-shadow` und `outline-width` festes `px` statt `rem` verwenden, damit Rahmen-/Outline-/Schatten-Größen vorhersehbar rendern und nicht mit der Wurzelschriftgröße skalieren.

### Verknüpfte Tickets

- Schließt #6988 — Bestimmte CSS-Definitionen wieder von `rem` auf `px` umstellen: legt fest, dass diese vier Eigenschaften von `rem()` auf festes `px` zurückgestellt werden; dieser PR setzt das auf dem `develop`-Zweig um.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/**/*.scss` — Rahmen/Radius/Outline in Basis-Komponenten-Styles auf px.
- `packages/samples/react/src/style.scss` — Unit-Umstellung im Beispiel-Stylesheet.
- `packages/themes/default/**/*.scss`, `packages/themes/ecl/src/ecl-ec/**`, `packages/themes/ecl/src/ecl-eu/**` — rem→px über Komponenten, `global.scss` und Mixins der Themes.

</details>