### PR TITLE
refactor: remove the non-functional _tabIndex prop from delegatesFocus components

### DIFF
--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -66,7 +66,6 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 				_role="link"
 				_shortKey={this._shortKey}
 				_syncValueBySelector={this._syncValueBySelector}
-				_tabIndex={this._tabIndex}
 				_tooltipAlign={this._tooltipAlign}
 				_type={this._type}
 				_value={this._value}
@@ -156,11 +155,6 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	 * @internal
 	 */
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
-
-	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
 
 	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -67,7 +67,6 @@ export class KolButton implements ButtonProps, FocusableElement {
 				_role={this._role}
 				_shortKey={this._shortKey}
 				_syncValueBySelector={this._syncValueBySelector}
-				_tabIndex={this._tabIndex}
 				_tooltipAlign={this._tooltipAlign}
 				_type={this._type}
 				_value={this._value}
@@ -160,11 +159,6 @@ export class KolButton implements ButtonProps, FocusableElement {
 	 * @internal
 	 */
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
-
-	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
 
 	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -426,11 +426,6 @@ export class KolCombobox implements ComboboxAPI {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -545,11 +540,6 @@ export class KolCombobox implements ComboboxAPI {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -232,11 +232,6 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -366,11 +361,6 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -194,11 +194,6 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -310,11 +305,6 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -278,11 +278,6 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _step?: number;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -426,11 +421,6 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -245,12 +245,6 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	 * @internal
 	 */
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
-
-	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
 	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
@@ -400,11 +394,6 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -194,11 +194,6 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -308,11 +303,6 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -236,11 +236,6 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -383,11 +378,6 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -259,11 +259,6 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -414,11 +409,6 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -238,11 +238,6 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -355,11 +350,6 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -283,11 +283,6 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -409,11 +404,6 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -265,11 +265,6 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -424,11 +419,6 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -58,7 +58,6 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 				_on={this._on}
 				_role="button"
 				_shortKey={this._shortKey}
-				_tabIndex={this._tabIndex}
 				_target={this._target}
 				_tooltipAlign={this._tooltipAlign}
 				_variant={this._variant}
@@ -134,11 +133,6 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 	 * Adds a visual short key hint to the component.
 	 */
 	@Prop() public _shortKey?: ShortKeyPropType;
-
-	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
 
 	/**
 	 * Defines where to open the link.

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -56,7 +56,6 @@ export class KolLink implements LinkProps, FocusableElement {
 				_on={this._on}
 				_role={this._role}
 				_shortKey={this._shortKey}
-				_tabIndex={this._tabIndex}
 				_target={this._target}
 				_tooltipAlign={this._tooltipAlign}
 			>
@@ -130,11 +129,6 @@ export class KolLink implements LinkProps, FocusableElement {
 	 * Adds a visual short key hint to the component.
 	 */
 	@Prop() public _shortKey?: ShortKeyPropType;
-
-	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
 
 	/**
 	 * Defines where to open the link.

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -489,11 +489,6 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -606,11 +601,6 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -83,7 +83,6 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 						_on={this.clickButtonHandler}
 						_role={this._role}
 						_syncValueBySelector={this._syncValueBySelector}
-						_tabIndex={this._tabIndex}
 						_tooltipAlign={this._tooltipAlign}
 						_type={this._type}
 						_value={this._value}
@@ -180,11 +179,6 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	 * @internal
 	 */
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
-
-	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
 
 	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -242,11 +242,6 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
 
 	/**
-	 * Defines which tab-index the primary element of the component has. (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)
-	 */
-	@Prop() public _tabIndex?: number;
-
-	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
 	 */
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
@@ -390,11 +385,6 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Watch('_syncValueBySelector')
 	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
 		this.controller.validateSyncValueBySelector(value);
-	}
-
-	@Watch('_tabIndex')
-	public validateTabIndex(value?: number): void {
-		this.controller.validateTabIndex(value);
 	}
 
 	@Watch('_touched')

--- a/packages/components/src/schema/components/combobox.ts
+++ b/packages/components/src/schema/components/combobox.ts
@@ -25,7 +25,6 @@ type OptionalProps = {
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	placeholder: string;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &
@@ -48,7 +47,6 @@ type OptionalStates = {
 	hint: string;
 	icons: KoliBriHorizontalIcons;
 	on: InputTypeOnDefault;
-	tabIndex: number;
 	placeholder: string;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/input-checkbox.ts
+++ b/packages/components/src/schema/components/input-checkbox.ts
@@ -51,7 +51,6 @@ type OptionalProps = {
 	icons: Stringified<InputCheckboxIconsProp>;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
-	tabIndex: number;
 	value: Stringified<StencilUnknown>;
 	variant: InputCheckboxVariant;
 } & PropAccessKey &
@@ -79,7 +78,6 @@ type RequiredStates = {
 type OptionalStates = {
 	hint: string;
 	on: InputTypeOnDefault;
-	tabIndex: number;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideLabel &

--- a/packages/components/src/schema/components/input-color.ts
+++ b/packages/components/src/schema/components/input-color.ts
@@ -25,7 +25,6 @@ type OptionalProps = {
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	smartButton: Stringified<ButtonProps>;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &
@@ -48,7 +47,6 @@ type OptionalStates = {
 	icons: KoliBriHorizontalIcons;
 	on: InputTypeOnDefault;
 	smartButton: ButtonProps;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/input-date.ts
+++ b/packages/components/src/schema/components/input-date.ts
@@ -55,7 +55,6 @@ type OptionalStates = {
 	placeholder: string;
 	smartButton: ButtonProps;
 	step: number;
-	tabIndex: number;
 	value: Iso8601 | null;
 } & PropAccessKey &
 	PropSyncValueBySelector &

--- a/packages/components/src/schema/components/input-email.ts
+++ b/packages/components/src/schema/components/input-email.ts
@@ -33,7 +33,6 @@ type OptionalProps = {
 	pattern: string;
 	placeholder: string;
 	smartButton: Stringified<ButtonProps>;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &
@@ -66,7 +65,6 @@ type OptionalStates = {
 	pattern: string;
 	placeholder: string;
 	smartButton: ButtonProps;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/input-file.ts
+++ b/packages/components/src/schema/components/input-file.ts
@@ -27,7 +27,6 @@ type OptionalProps = {
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	smartButton: Stringified<ButtonProps>;
-	tabIndex: number;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideMsg &
@@ -46,7 +45,6 @@ type OptionalStates = {
 	icons: KoliBriHorizontalIcons;
 	on: InputTypeOnDefault;
 	smartButton: ButtonProps;
-	tabIndex: number;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideLabel &

--- a/packages/components/src/schema/components/input-number.ts
+++ b/packages/components/src/schema/components/input-number.ts
@@ -45,7 +45,6 @@ type OptionalStates = {
 	placeholder: string;
 	smartButton: ButtonProps;
 	step: number;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/input-password.ts
+++ b/packages/components/src/schema/components/input-password.ts
@@ -31,7 +31,6 @@ type OptionalProps = {
 	pattern: string;
 	placeholder: string;
 	smartButton: Stringified<ButtonProps>;
-	tabIndex: number;
 	value: string;
 	msg: Stringified<MsgPropType>;
 } & PropAccessKey &
@@ -62,7 +61,6 @@ type OptionalStates = {
 	pattern: string;
 	placeholder: string;
 	smartButton: ButtonProps;
-	tabIndex: number;
 	value: string | null;
 } & PropAccessKey &
 	PropPasswordVariant &

--- a/packages/components/src/schema/components/input-radio.ts
+++ b/packages/components/src/schema/components/input-radio.ts
@@ -24,7 +24,6 @@ type OptionalProps = {
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	orientation: Orientation;
-	tabIndex: number;
 	value: StencilUnknown;
 } & PropAccessKey &
 	PropDisabled &
@@ -47,7 +46,6 @@ type RequiredStates = {
 type OptionalStates = {
 	hint: string;
 	on: InputTypeOnDefault;
-	tabIndex: number;
 	value: StencilUnknown;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/input-range.ts
+++ b/packages/components/src/schema/components/input-range.ts
@@ -27,7 +27,6 @@ type OptionalProps = {
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	step: number;
-	tabIndex: number;
 	value: number;
 } & PropAccessKey &
 	PropDisabled &
@@ -52,7 +51,6 @@ type OptionalStates = {
 	min: number;
 	on: InputTypeOnDefault;
 	step: number;
-	tabIndex: number;
 	value: number;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/input-text.ts
+++ b/packages/components/src/schema/components/input-text.ts
@@ -33,7 +33,6 @@ type OptionalProps = {
 	pattern: string;
 	placeholder: string;
 	smartButton: Stringified<ButtonProps>;
-	tabIndex: number;
 	type: InputTextType;
 	value: string;
 } & PropAccessKey &
@@ -68,7 +67,6 @@ type OptionalStates = {
 	pattern: string;
 	placeholder: string;
 	smartButton: ButtonProps;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/single-select.ts
+++ b/packages/components/src/schema/components/single-select.ts
@@ -25,7 +25,6 @@ type OptionalProps = {
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	placeholder: string;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &
@@ -46,7 +45,6 @@ type OptionalStates = {
 	hint: string;
 	icons: KoliBriHorizontalIcons;
 	on: InputTypeOnDefault;
-	tabIndex: number;
 	placeholder: string;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/components/textarea.ts
+++ b/packages/components/src/schema/components/textarea.ts
@@ -34,7 +34,6 @@ type OptionalProps = {
 	on: InputTypeOnDefault;
 	placeholder: string;
 	resize: CSSResize;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropAdjustHeight &
@@ -68,7 +67,6 @@ type OptionalStates = {
 	maxLength: number;
 	on: InputTypeOnDefault;
 	placeholder: string;
-	tabIndex: number;
 	value: string;
 } & PropAccessKey &
 	PropDisabled &

--- a/packages/components/src/schema/types/input/control/number.ts
+++ b/packages/components/src/schema/types/input/control/number.ts
@@ -21,7 +21,6 @@ export type OptionalInputProps<T> = {
 	required: boolean;
 	smartButton: Stringified<ButtonProps>;
 	step: number;
-	tabIndex: number;
 	touched: boolean;
 	value: T | null;
 };


### PR DESCRIPTION
## What changed?

Removes the `_tabIndex` prop (and its `@Watch('_tabIndex')` / `validateTabIndex` handler) from every component that already uses `delegatesFocus: true`, together with its declarations in the corresponding schema `*Props`/`*States` types. Affected components: `button`, `button-link`, `combobox`, `input-checkbox`, `input-color`, `input-date`, `input-email`, `input-file`, `input-number`, `input-password`, `input-radio`, `input-range`, `input-text`, `link`, `link-button`, `single-select`, `split-button`, and `textarea` — plus the shared `schema/types/input/control/number.ts`. The change is deletion-only (186 lines removed, 0 added); no runtime behaviour changes because the prop was already inert.

## Why?

From #7215 (bug): in #6869 these components were given `delegatesFocus: true` as the replacement for a manual `_tabIndex`. With focus delegation in place, the `_tabIndex` prop on the host no longer had any effect, so it remained on the public API as a misleading, dead option. Removing it cleans up the API surface and prevents consumers from relying on a prop that does nothing.

## Why (breaking)?

`_tabIndex` (`_tab-index`) is removed from the public API of the listed components. Because it was already non-functional under `delegatesFocus`, no runtime behaviour changes — but TypeScript consumers that still set it must delete those usages to avoid type errors.

## Linked issues

- Closes #7215 — *Property `_tabindex` von Komponenten mit `delegatesFocus` entfernen*: the prop had no effect after `delegatesFocus: true` was introduced in #6869 and should be removed.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [x] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Entfernt die Prop `_tabIndex` (samt `@Watch('_tabIndex')` / `validateTabIndex`) aus allen Komponenten, die bereits `delegatesFocus: true` nutzen, sowie deren Deklarationen in den zugehörigen Schema-`*Props`/`*States`-Typen. Betroffen: `button`, `button-link`, `combobox`, `input-checkbox`, `input-color`, `input-date`, `input-email`, `input-file`, `input-number`, `input-password`, `input-radio`, `input-range`, `input-text`, `link`, `link-button`, `single-select`, `split-button`, `textarea` — plus das geteilte `schema/types/input/control/number.ts`. Reine Löschung (186 Zeilen entfernt, 0 hinzugefügt); kein Laufzeit-Verhalten ändert sich, da die Prop bereits wirkungslos war.

### Warum?

Aus #7215 (Bug): In #6869 erhielten diese Komponenten `delegatesFocus: true` als Ersatz für ein manuelles `_tabIndex`. Mit der Fokus-Delegation hatte die `_tabIndex`-Prop am Host keinen Effekt mehr und blieb als irreführende, tote Option in der öffentlichen API. Das Entfernen bereinigt die API-Oberfläche.

### Warum (Breaking)?

`_tabIndex` (`_tab-index`) wird aus der öffentlichen API der genannten Komponenten entfernt. Da sie unter `delegatesFocus` bereits wirkungslos war, ändert sich kein Laufzeitverhalten — TypeScript-Konsumenten, die sie noch setzen, müssen die Verwendung entfernen, um Typfehler zu vermeiden.

### Verknüpfte Tickets

- Schließt #7215 — *Property `_tabindex` von Komponenten mit `delegatesFocus` entfernen*: die Prop hatte nach Einführung von `delegatesFocus: true` (#6869) keinen Effekt mehr.

### Art der Änderung

💥 Breaking Change

### Geänderte Dateien

- `packages/components/src/components/*/shadow.tsx` (18 Komponenten) — `_tabIndex`-Prop und -Watcher entfernt.
- `packages/components/src/schema/components/*.ts` — `tabIndex` aus `*Props`/`*States` entfernt.
- `packages/components/src/schema/types/input/control/number.ts` — `tabIndex` aus den geteilten Input-Props entfernt.

</details>