### PR TITLE
build(samples-react): make the ECL theme package an optional dependency - sample app must build without it

### DIFF
--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -28,7 +28,6 @@
 		"@leanup/stack-react": "1.3.54",
 		"@leanup/stack-webpack": "1.3.54",
 		"@playwright/test": "1.49.1",
-		"@public-ui-/theme-ecl": "workspace:*",
 		"@public-ui/components": "workspace:*",
 		"@public-ui/react": "workspace:*",
 		"@public-ui/theme-default": "workspace:*",
@@ -76,6 +75,9 @@
 		"webpack-dev-server": "5.2.0",
 		"world_countries_lists": "2.9.0",
 		"yup": "1.5.0"
+	},
+	"optionalDependencies": {
+		"@public-ui-/theme-ecl": "workspace:*"
 	},
 	"files": [
 		".eslintignore",

--- a/packages/samples/react/src/react.main.tsx
+++ b/packages/samples/react/src/react.main.tsx
@@ -6,7 +6,6 @@ import { setTagNameTransformer } from '@public-ui/react';
 import { bootstrap, KoliBriDevHelper } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/dist/loader';
 import { DEFAULT } from '@public-ui/theme-default';
-import { ECL_EC, ECL_EU } from '@public-ui-/theme-ecl';
 
 import { App } from './App';
 
@@ -35,8 +34,17 @@ const getThemes = async () => {
 		return [theme];
 	}
 
+	const optionalThemes: Theme[] = [];
+	const { ECL_EC, ECL_EU } = await import('@public-ui-/theme-ecl');
+
+	if (ECL_EC && ECL_EU) {
+		optionalThemes.push(ECL_EC, ECL_EU);
+	} else {
+		console.warn('Theme package @public-ui-/theme-ecl not available. Continuing without it.');
+	}
+
 	/* List of regular sample app themes */
-	return [DEFAULT, ECL_EC, ECL_EU] as Theme[];
+	return [DEFAULT, ...optionalThemes] as Theme[];
 };
 
 void (async () => {

--- a/packages/samples/react/webpack.config.js
+++ b/packages/samples/react/webpack.config.js
@@ -1,5 +1,7 @@
 const webpack = require('webpack');
 
+const OPTIONAL_THEME_PACKAGE = '@public-ui-/theme-ecl';
+
 module.exports = (...args) => {
 	const config = require('@leanup/stack-react/webpack.config')(...args);
 	const UnoCSS = require('@unocss/webpack').default;
@@ -17,5 +19,25 @@ module.exports = (...args) => {
 		}),
 	);
 	delete config.devServer.proxy;
+
+	config.externals = [
+		...(config.externals || []),
+
+		/* Handle optional theme dependencies */
+		({ request }, callback) => {
+			if (request === OPTIONAL_THEME_PACKAGE) {
+				try {
+					require.resolve(OPTIONAL_THEME_PACKAGE);
+					// Package exists, include it
+					return callback();
+				} catch (e) {
+					// Package doesn't exist, replace with empty module
+					return callback(null, 'null');
+				}
+			}
+			callback();
+		},
+	];
+
 	return config;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,9 +618,6 @@ importers:
       '@playwright/test':
         specifier: 1.49.1
         version: 1.49.1
-      '@public-ui-/theme-ecl':
-        specifier: workspace:*
-        version: link:../../themes/ecl
       '@public-ui/components':
         specifier: workspace:*
         version: link:../../components
@@ -762,6 +759,10 @@ importers:
       yup:
         specifier: 1.5.0
         version: 1.5.0
+    optionalDependencies:
+      '@public-ui-/theme-ecl':
+        specifier: workspace:*
+        version: link:../../themes/ecl
 
   packages/test-tag-name-transformer:
     devDependencies:
@@ -11556,8 +11557,8 @@ packages:
   third-party-web@0.26.1:
     resolution: {integrity: sha512-I5Y7YT4841769UjrAcy/c0G/Bb/4lqBzA7LHzx17z5rxE7zzNhf4gpOME3hK3oktZc36oZQpskUG2UXGrUAECA==}
 
-  third-party-web@0.26.2:
-    resolution: {integrity: sha512-taJ0Us0lKoYBqcbccMuDElSUPOxmBfwlHe1OkHQ3KFf+RwovvBHdXhbFk9XJVQE2vHzxbTwvwg5GFsT9hbDokQ==}
+  third-party-web@0.26.5:
+    resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
@@ -15605,7 +15606,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.39':
     dependencies:
-      third-party-web: 0.26.2
+      third-party-web: 0.26.5
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -25626,7 +25627,7 @@ snapshots:
 
   third-party-web@0.26.1: {}
 
-  third-party-web@0.26.2: {}
+  third-party-web@0.26.5: {}
 
   throat@5.0.0: {}
 


### PR DESCRIPTION
## What changed?

The React sample app (`packages/samples/react`) no longer hard-depends on the ECL theme package. `@public-ui-/theme-ecl` moves from `dependencies` to `optionalDependencies` in `package.json` (and `pnpm-lock.yaml`). `react.main.tsx` now imports the ECL themes lazily via `await import('@public-ui-/theme-ecl')` and only registers `ECL_EC`/`ECL_EU` when the import succeeds, logging a warning and continuing with just the default theme otherwise. `webpack.config.js` gains an `externals` resolver that replaces the optional theme package with an empty module when it cannot be resolved. There is no change to any published component or package.

## Why?

The sample app must build and run even when the ECL theme package is not available in the workspace. Making the dependency optional — with a lazy import and a webpack fallback — prevents a missing ECL theme from breaking the sample build, while still loading it when present. Motivation derived from the diff (see note on the linked issue below).

## Linked issues

The PR body references #7245, but that issue concerns an unrelated topic (a configurable `KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT` for visual tests) and does not match this change — no matching issue; motivation derived from the diff.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die React-Sample-App (`packages/samples/react`) hängt nicht mehr fest vom ECL-Theme-Paket ab. `@public-ui-/theme-ecl` wandert in `package.json` (und `pnpm-lock.yaml`) von `dependencies` zu `optionalDependencies`. `react.main.tsx` importiert die ECL-Themes nun verzögert via `await import('@public-ui-/theme-ecl')` und registriert `ECL_EC`/`ECL_EU` nur, wenn der Import gelingt — andernfalls eine Warnung und Weiterlauf nur mit dem Default-Theme. `webpack.config.js` erhält einen `externals`-Resolver, der das optionale Theme-Paket durch ein leeres Modul ersetzt, wenn es nicht auflösbar ist. Kein veröffentlichtes Component/Paket wird geändert.

### Warum?

Die Sample-App soll auch dann bauen und laufen, wenn das ECL-Theme-Paket im Workspace fehlt. Die optionale Abhängigkeit — mit Lazy-Import und Webpack-Fallback — verhindert, dass ein fehlendes ECL-Theme den Sample-Build bricht, lädt es aber weiterhin, wenn vorhanden. Motivation aus dem Diff abgeleitet (siehe Hinweis zum verknüpften Ticket unten).

### Verknüpfte Tickets

Der PR referenziert #7245, dieses Ticket betrifft jedoch ein anderes Thema (eine konfigurierbare `KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT`-Variable für visuelle Tests) und passt nicht zu dieser Änderung — kein passendes Ticket; Motivation aus dem Diff abgeleitet.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/package.json` — `@public-ui-/theme-ecl` von `dependencies` zu `optionalDependencies` verschoben.
- `packages/samples/react/src/react.main.tsx` — ECL-Themes per Lazy-Import geladen und nur bei Vorhandensein registriert, sonst Warnung.
- `packages/samples/react/webpack.config.js` — `externals`-Resolver ersetzt das optionale Theme-Paket durch ein leeres Modul, wenn nicht auflösbar.
- `pnpm-lock.yaml` — Lockfile an die optionale Abhängigkeit angepasst.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vwsLYixbH2eqJmr22uWqi