### PR TITLE
style(tooltip): halve the fade-in duration to 0.25s - snappier appearance on hover and focus

### DIFF
--- a/packages/components/src/components/tooltip/style.scss
+++ b/packages/components/src/components/tooltip/style.scss
@@ -9,7 +9,7 @@
 		display: contents;
 
 		&__floating {
-			animation-duration: 0.5s;
+			animation-duration: 0.25s;
 			animation-iteration-count: 1;
 			animation-name: fadeInOpacity;
 			animation-timing-function: ease-in;


### PR DESCRIPTION
## What changed?

A single CSS value in `packages/components/src/components/tooltip/style.scss`: the `&__floating` fade-in `animation-duration` is reduced from `0.5s` to `0.25s`. No markup, structure or API changes — only the timing of the existing `fadeInOpacity` animation.

## Why?

Per issue #7353 the tooltip's fade-in felt sluggish at half a second. Halving it to `0.25s` makes the tooltip appear more promptly when an element is hovered or focused, improving perceived responsiveness without sacrificing the fade effect.

## Linked issues

- Closes #7353 — _🚀 Feature: Tooltip Transition reduzieren_: the request to shorten the tooltip fade duration to 0.25s.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein einzelner CSS-Wert in `packages/components/src/components/tooltip/style.scss`: die `animation-duration` des Fade-ins (`&__floating`) wird von `0.5s` auf `0.25s` reduziert. Kein Markup, keine Struktur- oder API-Änderung — nur das Timing der bestehenden `fadeInOpacity`-Animation.

### Warum?

Laut Ticket #7353 wirkte das Einblenden des Tooltips bei einer halben Sekunde träge. Die Halbierung auf `0.25s` lässt den Tooltip beim Hover bzw. Fokus zügiger erscheinen und verbessert die wahrgenommene Reaktionsfreude, ohne den Fade-Effekt aufzugeben.

### Verknüpfte Tickets

- Schließt #7353 — _🚀 Feature: Tooltip Transition reduzieren_: der Wunsch, die Fade-Dauer des Tooltips auf 0,25 s zu verkürzen.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/tooltip/style.scss` — Fade-in-`animation-duration` von `0.5s` auf `0.25s` reduziert.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vwsLYixbH2eqJmr22uWqi