### PR TITLE
fix(single-select): keep focus in the search field when opening - it jumped to the selected option

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -71,7 +71,8 @@ export class KolSingleSelect implements SingleSelectAPI {
 			if (this._isOpen) {
 				this.refInput?.focus();
 				const selectedIndex = Array.isArray(this._filteredOptions) ? this._filteredOptions.findIndex((option) => option.label === this._inputValue) : -1;
-				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : 0;
+				const selectedOptionElement = this.refOptions[selectedIndex];
+				selectedOptionElement?.scrollIntoView({ block: 'nearest' });
 				this.focusOption(this._focusedOptionIndex);
 			}
 		}


### PR DESCRIPTION
## What changed?

When `KolSingleSelect` opens its option list, focus now stays in the search input and the currently selected option is only scrolled into view. Previously the component set `_focusedOptionIndex` to the selected option on open, which moved focus onto that option in the listbox instead of the text field. In `packages/components/src/components/single-select/shadow.tsx` the code that reassigned `_focusedOptionIndex` was replaced by a `scrollIntoView({ block: 'nearest' })` call on the selected option element, while `refInput.focus()` keeps the caret in the search field.

## Why?

From #7393: clicking the single-select moved focus straight to the selected entry in the option list instead of into the search field, unlike the combobox, which already behaved correctly. That made keyboard/typeahead interaction inconsistent between the two components.

## Linked issues

- Closes #7393 — Erwartetes Verhalten beim Anklicken eines Single-Selects klären: on open the focus jumped to the selected list entry instead of the search field (the combobox behaved correctly).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Beim Öffnen der Optionsliste von `KolSingleSelect` bleibt der Fokus jetzt im Suchfeld, und die aktuell ausgewählte Option wird lediglich in den sichtbaren Bereich gescrollt. Zuvor setzte die Komponente beim Öffnen `_focusedOptionIndex` auf die ausgewählte Option, wodurch der Fokus statt ins Textfeld auf diese Option in der Listbox sprang. In `packages/components/src/components/single-select/shadow.tsx` wurde die Neuzuweisung von `_focusedOptionIndex` durch einen `scrollIntoView({ block: 'nearest' })`-Aufruf auf das ausgewählte Optionselement ersetzt, während `refInput.focus()` den Cursor im Suchfeld hält.

### Warum?

Aus #7393: Beim Anklicken des Single-Selects sprang der Fokus direkt auf den ausgewählten Eintrag der Auswahlliste statt ins Suchfeld — anders als bei der Combobox, die sich bereits korrekt verhielt. Dadurch war die Tastatur-/Typeahead-Bedienung zwischen beiden Komponenten uneinheitlich.

### Verknüpfte Tickets

- Schließt #7393 — Erwartetes Verhalten beim Anklicken eines Single-Selects klären: Beim Öffnen sprang der Fokus auf den ausgewählten Listeneintrag statt ins Suchfeld (die Combobox verhielt sich korrekt).

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/single-select/shadow.tsx` — beim Öffnen bleibt der Fokus im Suchfeld; die ausgewählte Option wird nur noch per `scrollIntoView` sichtbar gemacht.

</details>