### PR TITLE
fix(progress): hide the decorative bar and cycle from screen readers via aria-hidden

### DIFF
--- a/packages/components/src/components/progress/shadow.tsx
+++ b/packages/components/src/components/progress/shadow.tsx
@@ -81,6 +81,7 @@ export class KolProgress implements ProgressAPI {
 		return (
 			<Host class="kol-progress">
 				<div
+					aria-hidden="true"
 					class={{
 						cycle: this.state._variant === 'cycle',
 						bar: this.state._variant === 'bar',

--- a/packages/components/src/components/progress/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/progress/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _value=0 _unit="kg" 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -30,7 +30,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _value=0 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -57,7 +57,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _value=17 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -84,7 +84,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _value=21 _unit="kg" 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -111,7 +111,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _value=100 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -138,7 +138,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 _value=0 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -165,7 +165,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 _value=42 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -192,7 +192,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 
 exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 _value=100 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="bar">
+    <div aria-hidden="true" class="bar">
       <div class="label">
         Label
       </div>
@@ -219,7 +219,7 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42 _value=0 _unit="kg" 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>
@@ -248,7 +248,7 @@ exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42 _value=0 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>
@@ -277,7 +277,7 @@ exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42 _value=17 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>
@@ -306,7 +306,7 @@ exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42 _value=21 _unit="kg" 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>
@@ -335,7 +335,7 @@ exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42 _value=42 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>
@@ -364,7 +364,7 @@ exports[`kol-progress should render with _label="Label" _variant="cycle" _max=42
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=100 _value=0 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>
@@ -393,7 +393,7 @@ exports[`kol-progress should render with _label="Label" _variant="cycle" _max=10
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=100 _value=42 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>
@@ -422,7 +422,7 @@ exports[`kol-progress should render with _label="Label" _variant="cycle" _max=10
 exports[`kol-progress should render with _label="Label" _variant="cycle" _max=100 _value=100 1`] = `
 <kol-progress class="kol-progress">
   <template shadowrootmode="open">
-    <div class="cycle">
+    <div aria-hidden="true" class="cycle">
       <svg viewBox="0 0 120 120" width="100" xmlns="http://www.w3.org/2000/svg">
         <circle class="background" cx="60" cy="60" fill="currentColor" r="54.5" stroke="currentColor" stroke-width="8"></circle>
         <circle class="whitespace" cx="60" cy="60" fill="currentColor" r="59" stroke="currentColor" stroke-width="3"></circle>

--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -15,13 +15,6 @@ export const ROUTES = new Map();
  *
  */
 
-ROUTES.set('handout/basic', {
-	viewportSize: {
-		width: 1920,
-		height: 1280,
-	},
-	waitForTimeout: 500,
-});
 ROUTES.set('abbr/basic', {
 	axe: {
 		skipFailures: false,


### PR DESCRIPTION
## What changed?

`KolProgress` now marks its visual container — the `bar` / `cycle` block that holds the label, SVG and value — with `aria-hidden="true"`, so the decorative rendering is no longer exposed to assistive technology. The change is in `packages/components/src/components/progress/shadow.tsx`, and the component snapshots were regenerated to include the attribute. Alongside this, the obsolete `handout/basic` route was removed from the visual-regression setup (`packages/tools/visual-tests/tests/sample-app.routes.js`) and its snapshots deleted.

## Why?

The progress component rendered its value and label inside a purely visual block that assistive technology read as generic text. Marking that block decorative (`aria-hidden`) stops screen readers from announcing the redundant visual markup. This accessibility hardening was made as part of the progress rework tracked under #7397 (branch `feature/2/7397-aria-hidden-progress`).

## Linked issues

- Refs #7397 — Inkorrekte Prozentanzeige beim Progress: umbrella issue for the progress rework; the reported percentage-width bug is fixed in companion PRs, while this PR adds the `aria-hidden` accessibility change.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolProgress` kennzeichnet seinen visuellen Container — den `bar`-/`cycle`-Block mit Label, SVG und Wert — jetzt mit `aria-hidden="true"`, sodass die dekorative Darstellung nicht mehr an assistive Technologien weitergegeben wird. Die Änderung liegt in `packages/components/src/components/progress/shadow.tsx`; die Snapshots wurden entsprechend neu erzeugt. Zusätzlich wurde die veraltete Route `handout/basic` aus dem Setup der visuellen Regressionstests (`packages/tools/visual-tests/tests/sample-app.routes.js`) entfernt und deren Snapshots gelöscht.

### Warum?

Die Progress-Komponente rendert Wert und Label in einem rein visuellen Block, den assistive Technologien als generischen Text vorlasen. Die Kennzeichnung dieses Blocks als dekorativ (`aria-hidden`) verhindert, dass Screenreader die redundante visuelle Auszeichnung ansagen. Diese Barrierefreiheits-Härtung erfolgte im Rahmen der unter #7397 geführten Progress-Überarbeitung (Branch `feature/2/7397-aria-hidden-progress`).

### Verknüpfte Tickets

- Referenziert #7397 — Inkorrekte Prozentanzeige beim Progress: Sammel-Ticket der Progress-Überarbeitung; der gemeldete Breiten-Bug wird in Begleit-PRs behoben, dieser PR ergänzt die `aria-hidden`-Barrierefreiheitsänderung.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/progress/shadow.tsx` — visueller `bar`/`cycle`-Container erhält `aria-hidden="true"`.
- `packages/components/src/components/progress/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshots um das neue Attribut ergänzt.
- `packages/tools/visual-tests/tests/sample-app.routes.js` — veraltete Route `handout/basic` entfernt (samt zugehöriger Snapshots).

</details>