### PR TITLE
fix(single-select): emit input and change events on option select - a click event was fired instead

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -76,8 +76,8 @@ export class KolCombobox implements ComboboxAPI {
 	};
 
 	private selectOption(option: string) {
-		this.controller.onFacade.onInput(new Event('input', { bubbles: true }), true, option);
-		this.controller.onFacade.onChange(new Event('change', { bubbles: true }), option);
+		this.controller.onFacade.onInput(new CustomEvent('input', { bubbles: true, detail: { name: this.state._name, value: option } }), true, option);
+		this.controller.onFacade.onChange(new CustomEvent('change', { bubbles: true, detail: { name: this.state._name, value: option } }), option);
 		this.controller.setFormAssociatedValue(option);
 		this.state._value = option;
 		this.refInput?.focus();

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -75,9 +75,9 @@ export class KolCombobox implements ComboboxAPI {
 		this.refInput = ref;
 	};
 
-	private selectOption(event: Event, option: string) {
-		this.controller.onFacade.onInput(event, true, option);
-		this.controller.onFacade.onChange(event, option);
+	private selectOption(option: string) {
+		this.controller.onFacade.onInput(new Event('input', { bubbles: true }), true, option);
+		this.controller.onFacade.onChange(new Event('change', { bubbles: true }), option);
 		this.controller.setFormAssociatedValue(option);
 		this.state._value = option;
 		this.refInput?.focus();
@@ -245,8 +245,8 @@ export class KolCombobox implements ComboboxAPI {
 												tabIndex={-1}
 												role="option"
 												aria-selected={this.state._value === option ? 'true' : undefined}
-												onClick={(e) => {
-													this.selectOption(e, option as string);
+												onClick={() => {
+													this.selectOption(option as string);
 													this.toggleListbox();
 												}}
 												onMouseOver={() => {
@@ -260,7 +260,7 @@ export class KolCombobox implements ComboboxAPI {
 												class="combobox__item"
 												onKeyDown={(e) => {
 													if (e.key === 'Enter' || e.key === 'NumpadEnter') {
-														this.selectOption(e, option as string);
+														this.selectOption(option as string);
 														this.toggleListbox();
 														e.preventDefault();
 													}

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -95,18 +95,16 @@ export class KolSingleSelect implements SingleSelectAPI {
 			this.state._value = emptyValue;
 			this._inputValue = emptyValue;
 			this._filteredOptions = [...this.state._options];
-			this.controller.onFacade.onInput(new Event('input', { bubbles: true }), true, emptyValue);
-			this.controller.onFacade.onChange(new Event('change', { bubbles: true }), emptyValue);
+			this.controller.onFacade.onInput(new CustomEvent('input', { bubbles: true, detail: { name: this.state._name, value: emptyValue } }), true, emptyValue);
+			this.controller.onFacade.onChange(new CustomEvent('change', { bubbles: true, detail: { name: this.state._name, value: emptyValue } }), emptyValue);
 		}
 	}
 
 	private selectOption(option: Option<string>) {
 		this.state._value = option.value;
 		this._inputValue = option.label as string;
-
-		this.controller.onFacade.onInput(new Event('input', { bubbles: true }), false, option.value);
-		this.controller.onFacade.onChange(new Event('change', { bubbles: true }), option.value);
-
+		this.controller.onFacade.onInput(new CustomEvent('input', { bubbles: true, detail: { name: this.state._name, value: option.value } }), false, option.value);
+		this.controller.onFacade.onChange(new CustomEvent('change', { bubbles: true, detail: { name: this.state._name, value: option.value } }), option.value);
 		this._filteredOptions = [...this.state._options];
 
 		this.controller.setFormAssociatedValue(this.state._value);
@@ -706,7 +704,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 		}
 		// Event handling
 		stopPropagation(event);
-		tryToDispatchKoliBriEvent('change', this.host, { value: this._value, name: this._name });
+		tryToDispatchKoliBriEvent('change', this.host, this._value);
 
 		// Callback
 		if (typeof this.state._on?.onChange === 'function' && !this._isOpen) {

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -95,16 +95,17 @@ export class KolSingleSelect implements SingleSelectAPI {
 			this.state._value = emptyValue;
 			this._inputValue = emptyValue;
 			this._filteredOptions = [...this.state._options];
-			this.controller.onFacade.onInput(new Event('input'), true, emptyValue);
-			this.controller.onFacade.onChange(new Event('change'), emptyValue);
+			this.controller.onFacade.onInput(new Event('input', { bubbles: true }), true, emptyValue);
+			this.controller.onFacade.onChange(new Event('change', { bubbles: true }), emptyValue);
 		}
 	}
 
-	private selectOption(event: Event, option: Option<string>) {
+	private selectOption(option: Option<string>) {
 		this.state._value = option.value;
 		this._inputValue = option.label as string;
-		this.controller.onFacade.onInput(event, false, option.value);
-		this.controller.onFacade.onChange(event, option.value);
+
+		this.controller.onFacade.onInput(new Event('input', { bubbles: true }), false, option.value);
+		this.controller.onFacade.onChange(new Event('change', { bubbles: true }), option.value);
 
 		this._filteredOptions = [...this.state._options];
 
@@ -280,7 +281,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 												role="option"
 												aria-selected={this.state._value === (option as Option<string>).value ? 'true' : undefined}
 												onClick={(event: Event) => {
-													this.selectOption(event, option as Option<string>);
+													this.selectOption(option as Option<string>);
 													this.refInput?.focus();
 													this.toggleListbox(event);
 												}}
@@ -297,7 +298,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 												class="single-select__item"
 												onKeyDown={(e) => {
 													if (e.key === 'Enter' || e.key === 'NumpadEnter') {
-														this.selectOption(e, option as Option<string>);
+														this.selectOption(option as Option<string>);
 														this.refInput?.focus();
 														this.toggleListbox(e);
 														e.preventDefault();
@@ -384,7 +385,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 			case ' ': {
 				if (this._isOpen) {
 					if (Array.isArray(this._filteredOptions) && this._filteredOptions.length > 0) {
-						this.selectOption(event, this._filteredOptions[this._focusedOptionIndex] as Option<string>);
+						this.selectOption(this._filteredOptions[this._focusedOptionIndex] as Option<string>);
 						this.refInput?.focus();
 						handleEvent(false);
 					}
@@ -705,7 +706,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 		}
 		// Event handling
 		stopPropagation(event);
-		tryToDispatchKoliBriEvent('change', this.host, this._value);
+		tryToDispatchKoliBriEvent('change', this.host, { value: this._value, name: this._name });
 
 		// Callback
 		if (typeof this.state._on?.onChange === 'function' && !this._isOpen) {


### PR DESCRIPTION
## What changed?

`KolSingleSelect` and `KolCombobox` now emit proper `input` and `change` events when an option is selected. Previously `selectOption()` forwarded the raw DOM click/keyboard `Event` to the event facade, so consumers received a `click` event and it carried no field name or value. Both components now construct `CustomEvent('input')` / `CustomEvent('change')` with `bubbles: true` and `detail: { name, value }`. The same corrected events are emitted when the single-select value is cleared. Changed files: `packages/components/src/components/single-select/shadow.tsx` and `packages/components/src/components/combobox/shadow.tsx`.

## Why?

From #7374: selecting an option in `KolSingleSelect` dispatched an `onClick` event instead of the expected `onInput` event. Applications listening for `input`/`change` to detect a value change therefore did not react correctly, and the wrong event carried no usable name/value payload.

## Linked issues

- Refs #7374 — 🐞 Bug: KolSingleSelect Feld löst onClick-Event anstelle des erwarteten onInput-Events aus: selecting an option raised a `click` event instead of `input`, the wrong event for a value change.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolSingleSelect` und `KolCombobox` lösen beim Auswählen einer Option jetzt korrekte `input`- und `change`-Ereignisse aus. Bisher reichte `selectOption()` das rohe DOM-Klick-/Tastatur-`Event` an die Event-Fassade weiter, sodass Konsumenten ein `click`-Ereignis ohne Feldnamen und Wert erhielten. Beide Komponenten erzeugen nun `CustomEvent('input')` / `CustomEvent('change')` mit `bubbles: true` und `detail: { name, value }`. Dieselben korrigierten Ereignisse werden auch beim Leeren des Single-Select-Werts ausgelöst.

### Warum?

Aus #7374: Das Auswählen einer Option in `KolSingleSelect` löste ein `onClick`-Ereignis statt des erwarteten `onInput`-Ereignisses aus. Anwendungen, die zur Erkennung einer Wertänderung auf `input`/`change` hören, reagierten dadurch nicht korrekt, und das falsche Ereignis enthielt keine brauchbaren Name-/Wert-Daten.

### Verknüpfte Tickets

- Referenziert #7374 — 🐞 Bug: KolSingleSelect löst onClick- statt onInput-Event aus: Bei der Auswahl einer Option wurde ein `click`-Ereignis statt `input` ausgelöst — das falsche Ereignis für eine Wertänderung.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/single-select/shadow.tsx` — löst bei Auswahl und beim Leeren `CustomEvent` `input`/`change` mit Name und Wert aus.
- `packages/components/src/components/combobox/shadow.tsx` — gleiche Korrektur für die Optionsauswahl der Combobox.

</details>