### PR TITLE
fix: emit proper input/change events with name and value in single-select and combobox

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -29,6 +29,7 @@ import KolInputContainerFc from '../../functional-component-wrappers/InputContai
 import CustomSuggestionsToggleFc from '../../functional-components/CustomSuggestionsToggle';
 import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggestionsOption/CustomSuggestionsOption';
 import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
+import { EventDetail } from '../../schema/interfaces/EventDetail';
 
 /**
  * @slot - Die Beschriftung des Eingabefeldes.
@@ -77,9 +78,16 @@ export class KolCombobox implements ComboboxAPI {
 		this.refInput = ref;
 	};
 
-	private selectOption(event: Event, option: string) {
-		this.controller.onFacade.onInput(event, true, option);
-		this.controller.onFacade.onChange(event, option);
+	private selectOption(option: string) {
+		this.controller.onFacade.onInput(
+			new CustomEvent<EventDetail>('input', { bubbles: true, detail: { name: this.state._name as string, value: option } }),
+			true,
+			option,
+		);
+		this.controller.onFacade.onChange(
+			new CustomEvent<EventDetail>('change', { bubbles: true, detail: { name: this.state._name as string, value: option } }),
+			option,
+		);
 		this.controller.setFormAssociatedValue(option);
 		this.state._value = option;
 		this.refInput?.focus();
@@ -224,8 +232,8 @@ export class KolCombobox implements ComboboxAPI {
 											if (el) this.refSuggestions[index] = el;
 										}}
 										selected={this.state._value === option}
-										onClick={(e) => {
-											this.selectOption(e, option as string);
+										onClick={() => {
+											this.selectOption(option as string);
 											this.toggleListbox();
 										}}
 										onMouseOver={() => {
@@ -238,7 +246,7 @@ export class KolCombobox implements ComboboxAPI {
 										}}
 										onKeyDown={(e) => {
 											if (e.key === 'Enter' || e.key === 'NumpadEnter') {
-												this.selectOption(e, option as string);
+												this.selectOption(option as string);
 												this.toggleListbox();
 												e.preventDefault();
 											}

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -31,6 +31,7 @@ import CustomSuggestionsToggleFc from '../../functional-components/CustomSuggest
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper';
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper';
 import KolInputStateWrapperFc from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
+import { EventDetail } from '../../schema/interfaces/EventDetail';
 
 /**
  * @slot - The input field label.
@@ -99,16 +100,30 @@ export class KolSingleSelect implements SingleSelectAPI {
 			this._inputValue = emptyValue;
 			this._filteredOptions = [...this.state._options];
 
-			this.controller.onFacade.onInput(new Event('input'), true, emptyValue);
-			this.controller.onFacade.onChange(new Event('change'), emptyValue);
+			this.controller.onFacade.onInput(
+				new CustomEvent<EventDetail>('input', { bubbles: true, detail: { name: this.state._name as string, value: emptyValue } }),
+				true,
+				emptyValue,
+			);
+			this.controller.onFacade.onChange(
+				new CustomEvent<EventDetail>('change', { bubbles: true, detail: { name: this.state._name as string, value: emptyValue } }),
+				emptyValue,
+			);
 		}
 	}
 
-	private selectOption(event: Event, option: Option<string>) {
+	private selectOption(option: Option<string>) {
 		this._value = option.value;
 		this._inputValue = option.label as string;
-		this.controller.onFacade.onInput(event, false, option.value);
-		this.controller.onFacade.onChange(event, option.value);
+		this.controller.onFacade.onInput(
+			new CustomEvent<EventDetail>('input', { bubbles: true, detail: { name: this.state._name as string, value: option.value } }),
+			false,
+			option.value,
+		);
+		this.controller.onFacade.onChange(
+			new CustomEvent<EventDetail>('change', { bubbles: true, detail: { name: this.state._name as string, value: option.value } }),
+			option.value,
+		);
 
 		this._filteredOptions = [...this.state._options];
 
@@ -259,7 +274,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 										}}
 										selected={this._value === (option as Option<string>).value}
 										onClick={(event: Event) => {
-											this.selectOption(event, option as Option<string>);
+											this.selectOption(option as Option<string>);
 											this.refInput?.focus();
 											this.toggleListbox(event);
 										}}
@@ -275,7 +290,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 										}}
 										onKeyDown={(e) => {
 											if (e.key === 'Enter' || e.key === 'NumpadEnter') {
-												this.selectOption(e, option as Option<string>);
+												this.selectOption(option as Option<string>);
 												this.refInput?.focus();
 												this.toggleListbox(e);
 												e.preventDefault();
@@ -347,7 +362,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 			case ' ': {
 				if (this._isOpen) {
 					if (Array.isArray(this._filteredOptions) && this._filteredOptions.length > 0) {
-						this.selectOption(event, this._filteredOptions[this._focusedOptionIndex] as Option<string>);
+						this.selectOption(this._filteredOptions[this._focusedOptionIndex] as Option<string>);
 						this.refInput?.focus();
 						handleEvent(false);
 					}

--- a/packages/components/src/schema/interfaces/EventDetail.ts
+++ b/packages/components/src/schema/interfaces/EventDetail.ts
@@ -1,0 +1,4 @@
+export interface EventDetail {
+	name: string;
+	value: string;
+}


### PR DESCRIPTION
## What changed?

Fixes the `input` and `change` events emitted by `kol-single-select` and `kol-combobox` when an option is selected. Previously `selectOption` forwarded the raw DOM click/keydown `Event` to `controller.onFacade.onInput`/`onChange`, so the emitted events had the wrong type and carried no structured payload. `selectOption` (and the single-select "clear" path) now construct dedicated `CustomEvent<EventDetail>('input')` / `CustomEvent<EventDetail>('change')` events with `bubbles: true` and a `detail` of `{ name, value }`, where `name` is the component's `_name` and `value` is the selected option's value. A new shared `EventDetail` interface (`packages/components/src/schema/interfaces/EventDetail.ts`) types this payload, and the `selectOption` signature drops its now-unused `event` parameter at all call sites.

## Linked issues

- Refs #7374 — wrong event emitted by single-select / combobox

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt die von `kol-single-select` und `kol-combobox` beim Auswählen einer Option ausgelösten `input`- und `change`-Events. Bisher reichte `selectOption` das rohe DOM-Klick-/Keydown-`Event` an `controller.onFacade.onInput`/`onChange` weiter, sodass die ausgelösten Events den falschen Typ hatten und keine strukturierte Nutzlast trugen. `selectOption` (und der Single-Select-„Clear"-Pfad) erzeugen nun eigene `CustomEvent<EventDetail>('input')`/`CustomEvent<EventDetail>('change')`-Events mit `bubbles: true` und einem `detail` von `{ name, value }` — `name` ist der `_name` der Komponente, `value` der Wert der gewählten Option. Ein neues, geteiltes `EventDetail`-Interface (`packages/components/src/schema/interfaces/EventDetail.ts`) typisiert die Nutzlast; die `selectOption`-Signatur entfernt an allen Aufrufstellen den nun ungenutzten `event`-Parameter.

### Verknüpfte Tickets

- Referenziert #7374 — falsches Event bei Single-Select / Combobox

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/combobox/shadow.tsx` — `selectOption` löst korrekte `input`/`change`-CustomEvents mit `{ name, value }` aus
- `packages/components/src/components/single-select/shadow.tsx` — gleiches für Auswahl und „Clear"-Pfad
- `packages/components/src/schema/interfaces/EventDetail.ts` — neues `EventDetail`-Interface für die Event-Nutzlast

</details>