### PR TITLE
fix(tabs): rebuild tab panels when the _tabs prop changes

### DIFF
--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -385,6 +385,7 @@ export class KolTabs implements TabsAPI {
 			{
 				hooks: {
 					beforePatch: this.syncSelectedAndTabs,
+					afterPatch: this.refreshTabPanels,
 				},
 			},
 		);
@@ -400,37 +401,43 @@ export class KolTabs implements TabsAPI {
 		this.validateBehavior(this._behavior);
 	}
 
-	private readonly handleTabPanels = () => {
-		if (this.tabPanelHost instanceof HTMLDivElement) {
-			for (let i = this.tabPanelHost.children.length; i < this.state._tabs.length; i++) {
-				const div = document.createElement('div');
-				div.setAttribute('aria-labelledby', `${this.state._label.replace(/\s/g, '-')}-tab-${i}`);
-				div.setAttribute('id', `tabpanel-${i}`);
-				div.setAttribute('role', 'tabpanel');
-				div.setAttribute('hidden', '');
-				const slot = document.createElement('slot');
-				slot.setAttribute('name', `tabpanel-slot-${i}`);
-				div.appendChild(slot);
-				this.tabPanelHost.appendChild(div);
-				if (this.host?.children instanceof HTMLCollection && this.host?.children[i] /* SSR instanceof HTMLElement */) {
-					// div.appendChild(this.host?.children[0]);
-					this.host?.children[i].setAttribute('slot', `tabpanel-slot-${i}`);
-				}
+	private refreshTabPanels = () => {
+		if (!this.tabPanelHost) return;
+		// Clear existing panels
+		while (this.tabPanelHost.firstChild) {
+			this.tabPanelHost.removeChild(this.tabPanelHost.firstChild);
+		}
+		for (let i = 0; i < this.state._tabs?.length; i++) {
+			const div = document.createElement('div');
+			div.setAttribute('aria-labelledby', `${this.state._label.replace(/\s/g, '-')}-tab-${i}`);
+			div.setAttribute('id', `tabpanel-${i}`);
+			div.setAttribute('role', 'tabpanel');
+			div.setAttribute('hidden', '');
+			const slot = document.createElement('slot');
+			slot.setAttribute('name', `tabpanel-slot-${i}`);
+			div.appendChild(slot);
+			this.tabPanelHost?.appendChild(div);
+
+			if (this.host?.children instanceof HTMLCollection && this.host?.children[i] /* SSR instanceof HTMLElement */) {
+				this.host.children[i].setAttribute('slot', `tabpanel-slot-${i}`);
 			}
 		}
+		this.updateVisiblePanel();
+	};
+
+	private updateVisiblePanel = () => {
+		if (!this.tabPanelHost) return;
+		Array.from(this.tabPanelHost.children).forEach((child, i) => {
+			if (i === this.state._selected) {
+				child.removeAttribute('hidden');
+			} else {
+				child.setAttribute('hidden', '');
+			}
+		});
 	};
 
 	public componentDidRender(): void {
-		this.handleTabPanels();
-		if (this.tabPanelHost instanceof HTMLDivElement) {
-			for (let i = 0; i < this.tabPanelHost.children.length; i++) {
-				if (i !== this.state._selected) {
-					this.tabPanelHost.children[i].setAttribute('hidden', '');
-				} else {
-					this.tabPanelHost.children[i].removeAttribute('hidden');
-				}
-			}
-		}
+		this.refreshTabPanels();
 	}
 
 	private focusTabById(index: number): void {

--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -418,7 +418,7 @@ export class KolTabs implements TabsAPI {
 			div.appendChild(slot);
 			this.tabPanelHost?.appendChild(div);
 
-			if (this.host?.children instanceof HTMLCollection && this.host?.children[i] /* SSR instanceof HTMLElement */) {
+			if (typeof HTMLCollection !== 'undefined' && this.host?.children instanceof HTMLCollection && this.host?.children[i] /* SSR instanceof HTMLElement */) {
 				this.host.children[i].setAttribute('slot', `tabpanel-slot-${i}`);
 			}
 		}

--- a/packages/components/src/components/tabs/tabs.e2e.ts
+++ b/packages/components/src/components/tabs/tabs.e2e.ts
@@ -1,0 +1,19 @@
+import { expect } from '@playwright/test';
+import { test } from '@stencil/playwright';
+
+test.describe('Dynamic Tabs', () => {
+	test('should update tabs when _tabs prop changes', async ({ page }) => {
+		const initialTabs = [{ _label: 'First tab' }, { _label: 'Second Tab' }];
+		await page.setContent(`<kol-tabs _tabs='${JSON.stringify(initialTabs)}' _label="Tabs"> <div>Content 1</div> <div>Content 2</div> </kol-tabs>`);
+		const kolTabs = page.locator('kol-tabs');
+		await expect(kolTabs.getByRole('tab', { name: 'First tab' })).toBeVisible();
+		await expect(kolTabs.getByRole('tab', { name: 'Second Tab' })).toBeVisible();
+		await kolTabs.evaluate((el: HTMLKolTabsElement) => {
+			el._tabs = JSON.stringify([{ _label: 'Updated Tab A' }, { _label: 'Updated Tab B' }, { _label: 'Updated Tab C' }]);
+		});
+		await expect(kolTabs.getByRole('tab', { name: 'Updated Tab A' })).toBeVisible();
+		await expect(kolTabs.getByRole('tab', { name: 'Updated Tab B' })).toBeVisible();
+		await expect(kolTabs.getByRole('tab', { name: 'Updated Tab C' })).toBeVisible();
+		await expect(kolTabs.getByRole('tab', { name: 'First tab' })).toHaveCount(0);
+	});
+});

--- a/packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap
@@ -10,7 +10,20 @@ exports[`kol-tabs should render with _label="Text" _selected=1 _tabs=[{"_icons":
         <kol-button-wc _ariacontrols="tabpanel-2" _disabled="" _icons="codicon codicon-briefcase" _id="Text-tab-2" _label="Deaktivierter Tab" _role="tab" _tabindex="-1" _value="2"></kol-button-wc>
         <kol-button-wc _ariacontrols="tabpanel-3" _icons="codicon codicon-telescope" _id="Text-tab-3" _label="Letzter Tab" _role="tab" _tabindex="-1" _value="3"></kol-button-wc>
       </div>
-      <div class="tabs-content"></div>
+      <div class="tabs-content">
+        <div aria-labelledby="Text-tab-0" hidden="" id="tabpanel-0" role="tabpanel">
+          <slot name="tabpanel-slot-0"></slot>
+        </div>
+        <div aria-labelledby="Text-tab-1" id="tabpanel-1" role="tabpanel">
+          <slot name="tabpanel-slot-1"></slot>
+        </div>
+        <div aria-labelledby="Text-tab-2" hidden="" id="tabpanel-2" role="tabpanel">
+          <slot name="tabpanel-slot-2"></slot>
+        </div>
+        <div aria-labelledby="Text-tab-3" hidden="" id="tabpanel-3" role="tabpanel">
+          <slot name="tabpanel-slot-3"></slot>
+        </div>
+      </div>
     </div>
   </template>
 </kol-tabs>


### PR DESCRIPTION
## What changed?

Fixes `kol-tabs` not updating its tab panels when the `_tabs` prop changes at runtime. In `packages/components/src/components/tabs/shadow.tsx` the old `handleTabPanels` only *appended* panels for tabs beyond the existing count and never removed or rebuilt them, so replacing `_tabs` left stale panels behind. It is replaced by `refreshTabPanels`, which clears all existing panels and recreates one `role="tabpanel"` element per current tab, then calls a new `updateVisiblePanel` to toggle the `hidden` attribute for the selected index. The rebuild is wired to run both on the mutation-observer `afterPatch` hook and in `componentDidRender`, and the `HTMLCollection` check is guarded with `typeof HTMLCollection !== 'undefined'` for SSR. A Playwright E2E test verifies that changing `_tabs` swaps the rendered tabs, and the component snapshot is updated to include the rendered tab panels.

## Linked issues

- Refs #7390 — dynamic `_tabs` update handling

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt, dass `kol-tabs` seine Tab-Panels nicht aktualisiert, wenn sich die `_tabs`-Prop zur Laufzeit ändert. In `packages/components/src/components/tabs/shadow.tsx` hängte das alte `handleTabPanels` nur Panels für Tabs über die vorhandene Anzahl hinaus *an* und entfernte bzw. baute sie nie neu, sodass ein Austausch von `_tabs` veraltete Panels hinterließ. Es wird durch `refreshTabPanels` ersetzt, das alle vorhandenen Panels löscht und je aktuellem Tab ein `role="tabpanel"`-Element neu erzeugt und anschließend über das neue `updateVisiblePanel` das `hidden`-Attribut für den ausgewählten Index setzt. Der Neuaufbau läuft über den `afterPatch`-Hook des Mutation-Observers und in `componentDidRender`; die `HTMLCollection`-Prüfung wird für SSR mit `typeof HTMLCollection !== 'undefined'` abgesichert. Ein Playwright-E2E-Test prüft, dass ein Ändern von `_tabs` die gerenderten Tabs austauscht; der Komponenten-Snapshot wird um die gerenderten Tab-Panels ergänzt.

### Verknüpfte Tickets

- Referenziert #7390 — dynamische `_tabs`-Aktualisierung

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tabs/shadow.tsx` — `refreshTabPanels`/`updateVisiblePanel` bauen Panels bei Änderung neu auf
- `packages/components/src/components/tabs/tabs.e2e.ts` — neuer E2E-Test für dynamische `_tabs`-Änderungen
- `packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshot um die gerenderten Tab-Panels ergänzt

</details>