### PR TITLE
chore: update npm-run-all to version 7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"license-report": "6.7.1",
 		"lint-staged": "15.4.3",
 		"npm-check-updates": "17.1.14",
-		"npm-run-all": "4.1.5",
+		"npm-run-all2": "7.0.2",
 		"prettier": "3.4.2",
 		"rimraf": "6.0.1",
 		"ts-node": "10.9.2",
@@ -17,7 +17,7 @@
 		"typescript": "5.7.3"
 	},
 	"engines": {
-		"pnpm": "^9"
+		"pnpm": "^9 || ^10"
 	},
 	"private": true,
 	"scripts": {

--- a/packages/designer/package.json
+++ b/packages/designer/package.json
@@ -56,7 +56,7 @@
 		"cpy-cli": "5.0.0",
 		"eslint-plugin-jsx-a11y": "6.10.2",
 		"nightwatch-axe-verbose": "2.3.1",
-		"npm-run-all": "4.1.5",
+		"npm-run-all2": "7.0.2",
 		"playwright": "1.50.0",
 		"react-dev-utils": "12.0.1",
 		"rimraf": "6.0.1",

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -43,7 +43,7 @@
 		"eslint-plugin-react": "7.37.4",
 		"formik": "2.4.6",
 		"nightwatch-axe-verbose": "2.3.1",
-		"npm-run-all": "4.1.5",
+		"npm-run-all2": "7.0.2",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-number-format": "5.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,9 @@ importers:
       npm-check-updates:
         specifier: 17.1.14
         version: 17.1.14
-      npm-run-all:
-        specifier: 4.1.5
-        version: 4.1.5
+      npm-run-all2:
+        specifier: 7.0.2
+        version: 7.0.2
       prettier:
         specifier: 3.4.2
         version: 3.4.2
@@ -557,7 +557,7 @@ importers:
         version: 1.3.54(chromedriver@130.0.4)(esbuild@0.23.0)(typescript@5.7.3)
       '@leanup/stack-solid':
         specifier: 1.3.54
-        version: 1.3.54(@babel/core@7.25.2)(solid-js@1.9.4)(vite@5.4.6(@types/node@22.10.2)(less@4.2.0)(sass@1.83.4)(terser@5.37.0))(webpack@5.97.1(@swc/core@1.5.28)(esbuild@0.23.0))
+        version: 1.3.54(@babel/core@7.24.7)(solid-js@1.9.4)(vite@5.4.6(@types/node@22.10.2)(less@4.2.0)(sass@1.83.4)(terser@5.37.0))(webpack@5.97.1(@swc/core@1.5.28)(esbuild@0.23.0))
       '@leanup/stack-webpack':
         specifier: 1.3.54
         version: 1.3.54(@leanup/stack@1.3.54(chromedriver@130.0.4)(esbuild@0.23.0)(typescript@5.7.3))(esbuild@0.23.0)(less@4.2.0)(postcss@8.5.1)(sass@1.83.4)
@@ -588,9 +588,9 @@ importers:
       nightwatch-axe-verbose:
         specifier: 2.3.1
         version: 2.3.1
-      npm-run-all:
-        specifier: 4.1.5
-        version: 4.1.5
+      npm-run-all2:
+        specifier: 7.0.2
+        version: 7.0.2
       playwright:
         specifier: 1.50.0
         version: 1.50.0
@@ -745,9 +745,9 @@ importers:
       nightwatch-axe-verbose:
         specifier: 2.3.1
         version: 2.3.1
-      npm-run-all:
-        specifier: 4.1.5
-        version: 4.1.5
+      npm-run-all2:
+        specifier: 7.0.2
+        version: 7.0.2
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -5821,6 +5821,10 @@ packages:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
@@ -8321,6 +8325,10 @@ packages:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  json-parse-even-better-errors@4.0.0:
+    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -9328,6 +9336,10 @@ packages:
     resolution: {integrity: sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  npm-normalize-package-bin@4.0.0:
+    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   npm-package-arg@11.0.2:
     resolution: {integrity: sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -9348,9 +9360,9 @@ packages:
     resolution: {integrity: sha512-5+bKQRH0J1xG1uZ1zMNvxW0VEyoNWgJpY9UDuluPFLKDfJ9u2JmmjmTJV1srBGQOROfdBMiVvnH2Zvpbm+xkVA==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  npm-run-all@4.1.5:
-    resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
-    engines: {node: '>= 4'}
+  npm-run-all2@7.0.2:
+    resolution: {integrity: sha512-7tXR+r9hzRNOPNTvXegM+QzCuMjzUIIq66VDunL6j60O4RrExx32XUhlrS7UK4VcdGw5/Wxzb3kfNcFix9JKDA==}
+    engines: {node: ^18.17.0 || >=20.5.0, npm: '>= 9'}
     hasBin: true
 
   npm-run-path@2.0.2:
@@ -9799,11 +9811,6 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
-
-  pidtree@0.3.1:
-    resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
-    engines: {node: '>=0.10'}
-    hasBin: true
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
@@ -10594,6 +10601,10 @@ packages:
   read-package-json-fast@3.0.2:
     resolution: {integrity: sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  read-package-json-fast@4.0.0:
+    resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   read-pkg-up@3.0.0:
     resolution: {integrity: sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==}
@@ -11426,10 +11437,6 @@ packages:
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.padend@3.1.6:
-    resolution: {integrity: sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==}
     engines: {node: '>= 0.4'}
 
   string.prototype.repeat@1.0.0:
@@ -12520,6 +12527,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
   wide-align@1.1.5:
@@ -15799,11 +15811,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@leanup/stack-solid@1.3.54(@babel/core@7.25.2)(solid-js@1.9.4)(vite@5.4.6(@types/node@22.10.2)(less@4.2.0)(sass@1.83.4)(terser@5.37.0))(webpack@5.97.1(@swc/core@1.5.28)(esbuild@0.23.0))':
+  '@leanup/stack-solid@1.3.54(@babel/core@7.24.7)(solid-js@1.9.4)(vite@5.4.6(@types/node@22.10.2)(less@4.2.0)(sass@1.83.4)(terser@5.37.0))(webpack@5.97.1(@swc/core@1.5.28)(esbuild@0.23.0))':
     dependencies:
       '@leanup/cli-core-babel': 1.3.54(webpack@5.97.1(@swc/core@1.5.28)(esbuild@0.23.0))
       '@snowpack/plugin-babel': 2.1.7
-      babel-preset-solid: 1.8.17(@babel/core@7.25.2)
+      babel-preset-solid: 1.8.17(@babel/core@7.24.7)
       solid-js: 1.9.4
       vite-plugin-solid: 2.10.2(solid-js@1.9.4)(vite@5.4.6(@types/node@22.10.2)(less@4.2.0)(sass@1.83.4)(terser@5.37.0))
     transitivePeerDependencies:
@@ -18027,6 +18039,15 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
+  babel-plugin-jsx-dom-expressions@0.37.23(@babel/core@7.24.7):
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/types': 7.26.7
+      html-entities: 2.3.3
+      validate-html-nesting: 1.2.2
+
   babel-plugin-jsx-dom-expressions@0.37.23(@babel/core@7.25.2):
     dependencies:
       '@babel/core': 7.25.2
@@ -18105,6 +18126,11 @@ snapshots:
       '@babel/core': 7.25.2
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.25.2)
+
+  babel-preset-solid@1.8.17(@babel/core@7.24.7):
+    dependencies:
+      '@babel/core': 7.24.7
+      babel-plugin-jsx-dom-expressions: 0.37.23(@babel/core@7.24.7)
 
   babel-preset-solid@1.8.17(@babel/core@7.25.2):
     dependencies:
@@ -18962,6 +18988,12 @@ snapshots:
       which: 1.3.1
 
   cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -22255,6 +22287,8 @@ snapshots:
 
   json-parse-even-better-errors@3.0.2: {}
 
+  json-parse-even-better-errors@4.0.0: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -23560,6 +23594,8 @@ snapshots:
 
   npm-normalize-package-bin@3.0.1: {}
 
+  npm-normalize-package-bin@4.0.0: {}
+
   npm-package-arg@11.0.2:
     dependencies:
       hosted-git-info: 7.0.2
@@ -23598,17 +23634,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  npm-run-all@4.1.5:
+  npm-run-all2@7.0.2:
     dependencies:
-      ansi-styles: 3.2.1
-      chalk: 2.4.2
-      cross-spawn: 6.0.5
+      ansi-styles: 6.2.1
+      cross-spawn: 7.0.6
       memorystream: 0.3.1
-      minimatch: 3.1.2
-      pidtree: 0.3.1
-      read-pkg: 3.0.0
+      minimatch: 9.0.5
+      pidtree: 0.6.0
+      read-package-json-fast: 4.0.0
       shell-quote: 1.8.1
-      string.prototype.padend: 3.1.6
+      which: 5.0.0
 
   npm-run-path@2.0.2:
     dependencies:
@@ -24151,8 +24186,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
-
-  pidtree@0.3.1: {}
 
   pidtree@0.6.0: {}
 
@@ -24951,6 +24984,11 @@ snapshots:
     dependencies:
       json-parse-even-better-errors: 3.0.2
       npm-normalize-package-bin: 3.0.1
+
+  read-package-json-fast@4.0.0:
+    dependencies:
+      json-parse-even-better-errors: 4.0.0
+      npm-normalize-package-bin: 4.0.0
 
   read-pkg-up@3.0.0:
     dependencies:
@@ -25998,13 +26036,6 @@ snapshots:
       regexp.prototype.flags: 1.5.4
       set-function-name: 2.0.2
       side-channel: 1.1.0
-
-  string.prototype.padend@3.1.6:
-    dependencies:
-      call-bind: 1.0.7
-      define-properties: 1.2.1
-      es-abstract: 1.23.3
-      es-object-atoms: 1.0.0
 
   string.prototype.repeat@1.0.0:
     dependencies:
@@ -27356,6 +27387,10 @@ snapshots:
       isexe: 2.0.0
 
   which@4.0.0:
+    dependencies:
+      isexe: 3.1.1
+
+  which@5.0.0:
     dependencies:
       isexe: 3.1.1
 


### PR DESCRIPTION
## What changed?

This PR performs tooling/dependency maintenance only and does not change any library runtime code. It replaces the unmaintained `npm-run-all` with `npm-run-all2@7.0.2` in the root, `packages/designer`, and `packages/samples/react` `package.json` files, and widens the `pnpm` engines range to `^9 || ^10`. The `pnpm-lock.yaml` is regenerated accordingly: new transitive dependencies (`cross-spawn@7.0.6`, `json-parse-even-better-errors@4.0.0`, `npm-normalize-package-bin@4.0.0`, `read-package-json-fast@4.0.0`, `which@5.0.0`) are added and obsolete ones (`string.prototype.padend`, `pidtree`) are removed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR umfasst ausschließlich Tooling-/Abhängigkeits-Wartung und ändert keinen Bibliotheks-Laufzeitcode. Das nicht mehr gepflegte `npm-run-all` wird in der Root-, `packages/designer`- und `packages/samples/react`-`package.json` durch `npm-run-all2@7.0.2` ersetzt, und der `pnpm`-Engines-Bereich wird auf `^9 || ^10` erweitert. Die `pnpm-lock.yaml` wird entsprechend neu generiert: neue transitive Abhängigkeiten (`cross-spawn`, `json-parse-even-better-errors`, `npm-normalize-package-bin`, `read-package-json-fast`, `which`) kommen hinzu, veraltete (`string.prototype.padend`, `pidtree`) entfallen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `package.json`, `packages/designer/package.json`, `packages/samples/react/package.json` — `npm-run-all`→`npm-run-all2@7.0.2`; pnpm-Engine auf `^9 || ^10`.
- `pnpm-lock.yaml` — Lockfile neu generiert.

</details>