### PR TITLE
docs(samples): clarify heading labels in table sort-data sample

### DIFF
--- a/packages/samples/react/src/components/table/sort-data.tsx
+++ b/packages/samples/react/src/components/table/sort-data.tsx
@@ -59,11 +59,11 @@ export const TableSortData: FC = () => (
 
 		<section className="w-full grid gap-4">
 			<section className="grid gap-4">
-				<KolHeading _level={2} _label="Vertical" />
+				<KolHeading _level={2} _label="Vertical headers" />
 				<KolTableStateful _label="Sort a date column" _minWidth="auto" _data={DATA.slice(0, 10)} _headers={HEADERS_VERTICAL} className="block" />
 			</section>
 			<section className="grid gap-4">
-				<KolHeading _level={2} _label="Horizontal" />
+				<KolHeading _level={2} _label="Horizontal headers" />
 				<KolTableStateful _label="Sort a date column" _minWidth="auto" _data={DATA} _headers={HEADERS_HORIZONTAL} className="block" />
 			</section>
 		</section>


### PR DESCRIPTION
## What changed?

This PR only clarifies the demo headings in the React table `sort-data` sample. The section labels are renamed from "Vertical" to "Vertical headers" and from "Horizontal" to "Horizontal headers" so the sample makes clear that the headings describe the header orientation of the tables. No library code or public API is affected — the change is limited to demo/sample content.

## Linked issues

- Refs #282 — table sample clarity

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR präzisiert lediglich die Demo-Überschriften im React-Tabellen-Sample `sort-data`. Die Abschnitts-Labels werden von „Vertical" zu „Vertical headers" und von „Horizontal" zu „Horizontal headers" umbenannt, damit das Sample deutlich macht, dass sich die Überschriften auf die Header-Ausrichtung der Tabellen beziehen. Es ist kein Bibliothekscode und keine öffentliche API betroffen — die Änderung beschränkt sich auf Demo-/Sample-Inhalte.

### Verknüpfte Tickets

- Referenziert #282 — Klarheit des Tabellen-Samples

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/table/sort-data.tsx` — Überschriften „Vertical"/„Horizontal" zu „Vertical headers"/„Horizontal headers" präzisiert.

</details>