### PR TITLE
fix(tabs): rebuild tab panels when _tabs changes dynamically

### DIFF
--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -376,6 +376,7 @@ export class KolTabs implements TabsAPI {
 			{
 				hooks: {
 					beforePatch: this.syncSelectedAndTabs,
+					afterPatch: this.refreshTabPanels,
 				},
 			},
 		);
@@ -391,38 +392,43 @@ export class KolTabs implements TabsAPI {
 		this.validateBehavior(this._behavior);
 	}
 
-	private readonly handleTabPanels = () => {
-		if (this.tabPanelHost instanceof HTMLDivElement) {
-			for (let i = this.tabPanelHost.children.length; i < this.state._tabs.length; i++) {
-				const div = document.createElement('div');
-				div.setAttribute('class', 'kol-tab__panel');
-				div.setAttribute('aria-labelledby', `${this.state._label.replace(/\s/g, '-')}-tab-${i}`);
-				div.setAttribute('id', `tabpanel-${i}`);
-				div.setAttribute('role', 'tabpanel');
-				div.setAttribute('hidden', '');
-				const slot = document.createElement('slot');
-				slot.setAttribute('name', `tabpanel-slot-${i}`);
-				div.appendChild(slot);
-				this.tabPanelHost.appendChild(div);
-				if (this.host?.children instanceof HTMLCollection && this.host?.children[i] /* SSR instanceof HTMLElement */) {
-					// div.appendChild(this.host?.children[0]);
-					this.host?.children[i].setAttribute('slot', `tabpanel-slot-${i}`);
-				}
+	private refreshTabPanels = () => {
+		if (!this.tabPanelHost) return;
+		// Clear existing panels
+		while (this.tabPanelHost.firstChild) {
+			this.tabPanelHost.removeChild(this.tabPanelHost.firstChild);
+		}
+		for (let i = 0; i < this.state._tabs?.length; i++) {
+			const div = document.createElement('div');
+			div.setAttribute('aria-labelledby', `${this.state._label.replace(/\s/g, '-')}-tab-${i}`);
+			div.setAttribute('id', `tabpanel-${i}`);
+			div.setAttribute('role', 'tabpanel');
+			div.setAttribute('hidden', '');
+			const slot = document.createElement('slot');
+			slot.setAttribute('name', `tabpanel-slot-${i}`);
+			div.appendChild(slot);
+			this.tabPanelHost?.appendChild(div);
+
+			if (typeof HTMLCollection !== 'undefined' && this.host?.children instanceof HTMLCollection && this.host?.children[i] /* SSR instanceof HTMLElement */) {
+				this.host.children[i].setAttribute('slot', `tabpanel-slot-${i}`);
 			}
 		}
+		this.updateVisiblePanel();
+	};
+
+	private updateVisiblePanel = () => {
+		if (!this.tabPanelHost) return;
+		Array.from(this.tabPanelHost.children).forEach((child, i) => {
+			if (i === this.state._selected) {
+				child.removeAttribute('hidden');
+			} else {
+				child.setAttribute('hidden', '');
+			}
+		});
 	};
 
 	public componentDidRender(): void {
-		this.handleTabPanels();
-		if (this.tabPanelHost instanceof HTMLDivElement) {
-			for (let i = 0; i < this.tabPanelHost.children.length; i++) {
-				if (i !== this.state._selected) {
-					this.tabPanelHost.children[i].setAttribute('hidden', '');
-				} else {
-					this.tabPanelHost.children[i].removeAttribute('hidden');
-				}
-			}
-		}
+		this.refreshTabPanels();
 	}
 
 	private focusTabById(index: number): void {

--- a/packages/components/src/components/tabs/tabs.e2e.ts
+++ b/packages/components/src/components/tabs/tabs.e2e.ts
@@ -52,4 +52,21 @@ test.describe('kol-tabs', () => {
 			await expect(eventPromise).resolves.toEqual(1);
 		});
 	});
+
+	test.describe('Dynamic Tabs', () => {
+		test('should update tabs when _tabs prop changes', async ({ page }) => {
+			const initialTabs = [{ _label: 'First tab' }, { _label: 'Second Tab' }];
+			await page.setContent(`<kol-tabs _tabs='${JSON.stringify(initialTabs)}' _label="Tabs"> <div>Content 1</div> <div>Content 2</div> </kol-tabs>`);
+			const kolTabs = page.locator('kol-tabs');
+			await expect(kolTabs.getByRole('tab', { name: 'First tab' })).toBeVisible();
+			await expect(kolTabs.getByRole('tab', { name: 'Second Tab' })).toBeVisible();
+			await kolTabs.evaluate((el: HTMLKolTabsElement) => {
+				el._tabs = JSON.stringify([{ _label: 'Updated Tab A' }, { _label: 'Updated Tab B' }, { _label: 'Updated Tab C' }]);
+			});
+			await expect(kolTabs.getByRole('tab', { name: 'Updated Tab A' })).toBeVisible();
+			await expect(kolTabs.getByRole('tab', { name: 'Updated Tab B' })).toBeVisible();
+			await expect(kolTabs.getByRole('tab', { name: 'Updated Tab C' })).toBeVisible();
+			await expect(kolTabs.getByRole('tab', { name: 'First tab' })).toHaveCount(0);
+		});
+	});
 });

--- a/packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap
@@ -10,7 +10,20 @@ exports[`kol-tabs should render with _label="Text" _selected=1 _tabs=[{"_icons":
         <kol-button-wc _ariacontrols="tabpanel-2" _disabled="" _icons="codicon codicon-briefcase" _id="Text-tab-2" _label="Deaktivierter Tab" _role="tab" _tabindex="-1" _value="2"></kol-button-wc>
         <kol-button-wc _ariacontrols="tabpanel-3" _icons="codicon codicon-telescope" _id="Text-tab-3" _label="Letzter Tab" _role="tab" _tabindex="-1" _value="3"></kol-button-wc>
       </div>
-      <div class="kol-tabs__content"></div>
+      <div class="kol-tabs__content">
+        <div aria-labelledby="Text-tab-0" hidden="" id="tabpanel-0" role="tabpanel">
+          <slot name="tabpanel-slot-0"></slot>
+        </div>
+        <div aria-labelledby="Text-tab-1" id="tabpanel-1" role="tabpanel">
+          <slot name="tabpanel-slot-1"></slot>
+        </div>
+        <div aria-labelledby="Text-tab-2" hidden="" id="tabpanel-2" role="tabpanel">
+          <slot name="tabpanel-slot-2"></slot>
+        </div>
+        <div aria-labelledby="Text-tab-3" hidden="" id="tabpanel-3" role="tabpanel">
+          <slot name="tabpanel-slot-3"></slot>
+        </div>
+      </div>
     </div>
   </template>
 </kol-tabs>


### PR DESCRIPTION
## What changed?

This PR fixes `KolTabs` so that tab panels are correctly rebuilt when the `_tabs` property changes at runtime. The previous additive `handleTabPanels` logic only appended missing panels and never removed or relabeled stale ones, so dynamic tab changes left mismatched panels behind. It is replaced by `refreshTabPanels` (wired to the vDOM `afterPatch` hook and `componentDidRender`), which clears and recreates all panels, together with a dedicated `updateVisiblePanel` that toggles the `hidden` attribute for the selected tab. `HTMLCollection` access is now guarded for SSR. A new E2E test verifies that changing `_tabs` updates the rendered tabs, and the snapshot is updated to include the rendered tab panels.

## Linked issues

- Refs #7390 — dynamic `_tabs` handling

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR behebt in `KolTabs`, dass die Tab-Panels bei einer Laufzeit-Änderung der `_tabs`-Property korrekt neu aufgebaut werden. Die bisherige additive `handleTabPanels`-Logik hängte nur fehlende Panels an und entfernte oder aktualisierte veraltete nie, sodass dynamische Tab-Änderungen unpassende Panels zurückließen. Sie wird durch `refreshTabPanels` ersetzt (angebunden an den vDOM-`afterPatch`-Hook und `componentDidRender`), das alle Panels löscht und neu erzeugt, zusammen mit einem eigenen `updateVisiblePanel`, das das `hidden`-Attribut für den ausgewählten Tab umschaltet. Der Zugriff auf `HTMLCollection` wird nun für SSR abgesichert. Ein neuer E2E-Test prüft, dass eine Änderung von `_tabs` die gerenderten Tabs aktualisiert, und der Snapshot wird um die gerenderten Tab-Panels ergänzt.

### Verknüpfte Tickets

- Referenziert #7390 — dynamische Behandlung von `_tabs`

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tabs/shadow.tsx` — dynamisches Neuaufbauen der Tab-Panels (`refreshTabPanels`, `updateVisiblePanel`, `afterPatch`-Hook), SSR-Guard für `HTMLCollection`.
- `packages/components/src/components/tabs/tabs.e2e.ts` — E2E-Test für dynamische `_tabs`-Änderungen.
- `packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshot aktualisiert.

</details>