### PR TITLE
fix(select): hide disabled options from screen readers

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,6 +2,12 @@
 
 # Known Issues
 
+## select
+
+- Disabled options in KolSelect affect the total count in screen readers When an option in `KolSelect` is set to `disabled: true`, it is still counted by screen readers. This leads to incorrect numbering, for example, NVDA announces "2 of 4" instead of "2 of 3". To ensure the correct order, the `aria-hidden="true"` attribute should be set for `disabled` options. This will hide the disabled option from screen readers and keep the total number of items consistent.
+
+[🐞 GitHub issue #7453](https://github.com/public-ui/kolibri/pull/7453)
+
 ## input-color
 
 The component InputColor is a wrapper for the native HTML element `<input type="color">` which has accessibility problems:

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -18,7 +18,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select accesskey="V" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -54,7 +54,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -90,7 +90,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--disabled" disabled="" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -126,7 +126,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -168,7 +168,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -210,7 +210,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -248,7 +248,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -287,7 +287,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -323,7 +323,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -360,7 +360,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select accesskey="V" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -396,7 +396,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -432,7 +432,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--disabled" disabled="" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -468,7 +468,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -510,7 +510,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -552,7 +552,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -590,7 +590,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -629,7 +629,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -665,7 +665,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -701,7 +701,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -738,7 +738,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -774,7 +774,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--touched" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -810,7 +810,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -846,7 +846,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -883,7 +883,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -919,7 +919,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--touched" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -955,7 +955,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">

--- a/packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx
+++ b/packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx
@@ -42,6 +42,7 @@ const NativeOptionFc: FC<NativeOptionProps> = ({
 			)}
 			selected={isSelected}
 			disabled={disabled}
+			aria-hidden={disabled ? 'true' : undefined} //See Known Issue: https://github.com/public-ui/kolibri/blob/develop/KNOWN_ISSUES.md
 			value={index || value}
 			{...other}
 		>

--- a/packages/samples/react/src/components/select/partials/cases.tsx
+++ b/packages/samples/react/src/components/select/partials/cases.tsx
@@ -9,7 +9,7 @@ import { COUNTRY_OPTIONS } from '../../../shares/country';
 
 const SALUTATION_OPTIONS: SelectOption<string>[] = [
 	{
-		label: 'Select salutation',
+		label: 'No salutation',
 		value: '',
 	},
 	{
@@ -25,6 +25,10 @@ const SALUTATION_OPTIONS: SelectOption<string>[] = [
 		value: 'Divers',
 	},
 ];
+
+const SALUTATION_OPTIONS_DISABLED = SALUTATION_OPTIONS.map((option, index) =>
+	index === 0 ? { label: 'Select salutation', value: '', disabled: true } : option,
+);
 
 type GroupedOptionsType = Record<string, Optgroup<StencilUnknown>>;
 
@@ -58,7 +62,7 @@ export const SelectCases = forwardRef<HTMLKolSelectElement, Components.KolSelect
 				}}
 			/>
 			<KolSelect {...props} _options={SALUTATION_OPTIONS} _label="Disabled" _disabled />
-			<KolSelect {...props} _options={SALUTATION_OPTIONS} _label="Salutation with error" _msg={{ _type: 'error', _description: ERROR_MSG }} _touched />
+			<KolSelect {...props} _options={SALUTATION_OPTIONS_DISABLED} _label="Salutation with error" _msg={{ _type: 'error', _description: ERROR_MSG }} _touched />
 			<KolSelect {...props} _options={COUNTRY_OPTIONS} _label="Multiple choice" _multiple />
 			<KolSelect
 				{...props}

--- a/packages/samples/react/src/components/select/partials/cases.tsx
+++ b/packages/samples/react/src/components/select/partials/cases.tsx
@@ -9,9 +9,8 @@ import { COUNTRY_OPTIONS } from '../../../shares/country';
 
 const SALUTATION_OPTIONS: SelectOption<string>[] = [
 	{
-		label: 'No choice',
+		label: 'Select salutation',
 		value: '',
-		disabled: true,
 	},
 	{
 		label: 'Mrs.',


### PR DESCRIPTION
## What changed?

This PR adds `aria-hidden="true"` to disabled options rendered by the `NativeOption` functional component (`functional-components/inputs/NativeOption/NativeOption.tsx`), which backs `KolSelect`. As a result, screen readers no longer count disabled options, fixing incorrect item numbering (for example NVDA announcing "2 of 4" instead of "2 of 3") and keeping the announced option count consistent. The select snapshot tests are updated accordingly, the issue is documented in `KNOWN_ISSUES.md`, and the React select sample is reworked so the first salutation option is enabled by default with a dedicated disabled-first-option variant for the error case.

## Linked issues

- Refs #7226 — accessible handling of disabled select options

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ergänzt `aria-hidden="true"` an deaktivierten Optionen, die von der Functional Component `NativeOption` (`functional-components/inputs/NativeOption/NativeOption.tsx`) gerendert werden und `KolSelect` zugrunde liegen. Dadurch zählen Screenreader deaktivierte Optionen nicht mehr mit, was eine falsche Nummerierung behebt (z. B. NVDA kündigt „2 von 4" statt „2 von 3" an) und die angesagte Optionsanzahl konsistent hält. Die Select-Snapshot-Tests werden entsprechend aktualisiert, das Problem wird in `KNOWN_ISSUES.md` dokumentiert, und das React-Select-Sample wird so überarbeitet, dass die erste Anrede-Option standardmäßig aktiviert ist, mit einer eigenen Variante mit deaktivierter erster Option für den Fehlerfall.

### Verknüpfte Tickets

- Referenziert #7226 — barrierefreier Umgang mit deaktivierten Select-Optionen

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx` — `aria-hidden="true"` für deaktivierte Optionen.
- `packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshots aktualisiert.
- `KNOWN_ISSUES.md` — Select-Known-Issue dokumentiert.
- `packages/samples/react/src/components/select/partials/cases.tsx` — erste Option standardmäßig aktiviert; separate Disabled-Variante für den Fehlerfall.

</details>