### PR TITLE
fix(select): hide disabled options from screen readers

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,6 +2,12 @@
 
 # Known Issues
 
+## select
+
+- Disabled options in KolSelect affect the total count in screen readers When an option in `KolSelect` is set to `disabled: true`, it is still counted by screen readers. This leads to incorrect numbering, for example, NVDA announces "2 of 4" instead of "2 of 3". To ensure the correct order, the `aria-hidden="true"` attribute should be set for `disabled` options. This will hide the disabled option from screen readers and keep the total number of items consistent.
+
+[🐞 GitHub issue #7454](https://github.com/public-ui/kolibri/pull/7454)
+
 ## input-color
 
 The component InputColor is a wrapper for the native HTML element `<input type="color">` which has accessibility problems:
@@ -47,17 +53,19 @@ The `search` of this component is highly browser-dependent. For example, the clo
 
 ## Screen reader only reads last selected in Select
 
-KolSelect is using native HTML `<select>`. 
+KolSelect is using native HTML `<select>`.
 
-When using KolSelect with the `multiple` property, the native HTML `<select>` may cause problems with screen readers. 
+When using KolSelect with the `multiple` property, the native HTML `<select>` may cause problems with screen readers.
 Often the entire selection is not read out, but only the last one. Therefore, the KolSelect has no full accessibility.
 
 ## Limited Styling Capabilities for `<select>` and `<option>` Elements
+
 [Stackblitz Example](https://stackblitz.com/edit/vitejs-vite-nthnce?file=src%2Fstyle.css)
 
 The `<select>` element and its `<option>` tags offer limited styling options. Specifically, states such as "selected", "focus" or "active" cannot be reliably customized using CSS. This leads to challenges in meeting accessibility standards, especially in ensuring sufficient contrast ratios.
 
 **Impact**:
+
 - **Limited Customization**: The visual state of dropdown options (e.g., on focus or selection) cannot be consistently customized across all browsers. This makes it difficult to create an accessible visual experience for all users.
 
 - **Browser-Dependent Rendering**: The appearance of the `<select>` element varies across browsers and operating systems, resulting in inconsistent user experiences.

--- a/packages/components/src/components/select/readme.md
+++ b/packages/components/src/components/select/readme.md
@@ -4,6 +4,8 @@ Synonyme: Datalist, Dropdown
 
 Die **Select**-Komponente erzeugt eine Auswahlliste, aus der eine oder mehrere vorgegebene Möglichkeiten ausgewählt werden können.
 
+Die Komponente hat Known-Issues bezüglich Browserabhängigkeit und Barrierefreiheit. Näheres kann unter [KNOWN_ISSUES.md](https://github.com/public-ui/kolibri/blob/develop/KNOWN_ISSUES.md) nachgelssen werden.
+
 ## Konstruktion
 
 ### Code

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -191,6 +191,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 										return (
 											<option
 												disabled={option.disabled}
+												aria-hidden={option.disabled ? 'true' : undefined}
 												key={key}
 												// label={option.label}
 												selected={isSelected(this.state._value, (option as unknown as Option<W3CInputValue>).value)}

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select accesskey="V" autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -44,7 +44,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -74,7 +74,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" disabled="" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -104,7 +104,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -134,7 +134,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -164,7 +164,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -194,7 +194,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -224,7 +224,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -254,7 +254,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -285,7 +285,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select accesskey="V" autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -315,7 +315,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -345,7 +345,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" disabled="" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -375,7 +375,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -405,7 +405,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -435,7 +435,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -465,7 +465,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -495,7 +495,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -525,7 +525,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -555,7 +555,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -586,7 +586,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -616,7 +616,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -646,7 +646,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option disabled="" value="-0">
+            <option aria-hidden="true" disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -676,7 +676,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -707,7 +707,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -737,7 +737,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -767,7 +767,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option disabled="" selected="" value="-0">
+            <option aria-hidden="true" disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">

--- a/packages/components/src/components/single-select/controller.ts
+++ b/packages/components/src/components/single-select/controller.ts
@@ -44,7 +44,7 @@ export class SingleSelectController extends InputIconController implements Singl
 	}
 
 	public validateValue(value?: StencilUnknown): void {
-		watchValidator(this.component, '_value', v => v !== undefined, new Set([`StencilUnknown`]), value);
+		watchValidator(this.component, '_value', (v) => v !== undefined, new Set([`StencilUnknown`]), value);
 	}
 
 	public validatePlaceholder(value?: string): void {

--- a/packages/samples/react/src/components/select/partials/cases.tsx
+++ b/packages/samples/react/src/components/select/partials/cases.tsx
@@ -9,7 +9,7 @@ import { COUNTRY_OPTIONS } from '../../../shares/country';
 
 const SALUTATION_OPTIONS: SelectOption<string>[] = [
 	{
-		label: 'Select salutation',
+		label: 'No salutation',
 		value: '',
 	},
 	{
@@ -25,6 +25,10 @@ const SALUTATION_OPTIONS: SelectOption<string>[] = [
 		value: 'Divers',
 	},
 ];
+
+const SALUTATION_OPTIONS_DISABLED = SALUTATION_OPTIONS.map((option, index) =>
+	index === 0 ? { label: 'Select salutation', value: '', disabled: true } : option,
+);
 
 export const SelectCases = forwardRef<HTMLKolSelectElement, Components.KolSelect>(function SelectCases(props, ref) {
 	return (
@@ -45,7 +49,7 @@ export const SelectCases = forwardRef<HTMLKolSelectElement, Components.KolSelect
 				}}
 			/>
 			<KolSelect {...props} _options={SALUTATION_OPTIONS} _label="Disabled" _disabled />
-			<KolSelect {...props} _options={SALUTATION_OPTIONS} _label="Salutation with error" _msg={{ _type: 'error', _description: ERROR_MSG }} _touched />
+			<KolSelect {...props} _options={SALUTATION_OPTIONS_DISABLED} _label="Salutation with error" _msg={{ _type: 'error', _description: ERROR_MSG }} _touched />
 			<KolSelect {...props} _options={COUNTRY_OPTIONS} _label="Multiple choice" _multiple />
 			<KolSelect
 				{...props}

--- a/packages/samples/react/src/components/select/partials/cases.tsx
+++ b/packages/samples/react/src/components/select/partials/cases.tsx
@@ -9,9 +9,8 @@ import { COUNTRY_OPTIONS } from '../../../shares/country';
 
 const SALUTATION_OPTIONS: SelectOption<string>[] = [
 	{
-		label: 'No choice',
+		label: 'Select salutation',
 		value: '',
-		disabled: true,
 	},
 	{
 		label: 'Mrs.',


### PR DESCRIPTION
## What changed?

This PR adds `aria-hidden="true"` to disabled `<option>` elements rendered by `KolSelect` (`select/shadow.tsx`) so that screen readers no longer count disabled options. This fixes incorrect item numbering — for example NVDA announcing "2 of 4" instead of "2 of 3" — and keeps the announced option count consistent. The select snapshot tests are updated accordingly, the issue is documented in `KNOWN_ISSUES.md` and linked from the select readme, and the React select sample is reworked so the first salutation option is enabled by default while a dedicated disabled-first-option variant demonstrates the error case. An arrow-function style in `single-select/controller.ts` is also normalized.

## Linked issues

- Refs #7226 — accessible handling of disabled select options

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ergänzt `aria-hidden="true"` an deaktivierten `<option>`-Elementen von `KolSelect` (`select/shadow.tsx`), sodass Screenreader deaktivierte Optionen nicht mehr mitzählen. Damit wird eine falsche Nummerierung behoben — z. B. kündigt NVDA „2 von 4" statt „2 von 3" an — und die angesagte Optionsanzahl bleibt konsistent. Die Select-Snapshot-Tests werden entsprechend aktualisiert, das Problem wird in `KNOWN_ISSUES.md` dokumentiert und aus der Select-Readme verlinkt, und das React-Select-Sample wird so überarbeitet, dass die erste Anrede-Option standardmäßig aktiviert ist, während eine eigene Variante mit deaktivierter erster Option den Fehlerfall zeigt. Zusätzlich wird ein Arrow-Function-Stil in `single-select/controller.ts` vereinheitlicht.

### Verknüpfte Tickets

- Referenziert #7226 — barrierefreier Umgang mit deaktivierten Select-Optionen

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/select/shadow.tsx` — `aria-hidden="true"` für deaktivierte Optionen.
- `packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshots aktualisiert.
- `packages/components/src/components/select/readme.md` — Hinweis auf Known Issues ergänzt.
- `packages/components/src/components/single-select/controller.ts` — Arrow-Function-Stil vereinheitlicht.
- `KNOWN_ISSUES.md` — Select-Known-Issue dokumentiert.
- `packages/samples/react/src/components/select/partials/cases.tsx` — erste Option standardmäßig aktiviert; separate Disabled-Variante für den Fehlerfall.

</details>