### PR TITLE
docs(input-color): document known accessibility issues

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -8,6 +8,10 @@ The component InputColor is a wrapper for the native HTML element `<input type="
 
 - With NVDA, the element is announced as "clickable" and not as an input element.
 - It's not possible to select a color using a screen reader.
+- **9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar:** Die Beschriftung wird vom Screenreader nicht ausgegeben. Nur linear Lesend, daher ist bei hideLabel gar kein Label erschließbar.
+- **9.1.3.2 Sinnvolle Reihenfolge:** Beim öffnen der Farbauswahl von "Color with error" gibt es keine Ausgabe. Mit der Tab-Taste gelangt man da nicht rein, nur mit Pfeiltasten. Sehr unverständlich mit Screenreader.
+- **9.2.4.3 Schlüssige Reihenfolge bei Tastaturbedienung:** Die Fokusreihenfolge bei "Color with error" ist sehr merkwürdig. Man kommt nicht drauf das man mit Pfeiltasten da rein muss. Besonders weil es auf Schwarz auch nicht sichtbar ist.
+- **9.2.4.7 Aktuelle Position des Fokus deutlich:** Der Fokus ist auf schwarzem Farbicon in "Color with error" nicht sichtbar.
 
 For full accessibility, consider using predefined colors lists, e.g. using KolSelect or KolCheckbox.
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -20,6 +20,7 @@ The component InputColor is a wrapper for the native HTML element `<input type="
 For full accessibility, consider using predefined colors lists, e.g. using KolSelect or KolCheckbox.
 
 [🐞 GitHub issue #5549](https://github.com/public-ui/kolibri/issues/5549)
+[🐞 GitHub issue #7455](https://github.com/public-ui/kolibri/pull/7455)
 
 ## `aria-sort` changes sometimes not announced in NVDA
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -8,10 +8,14 @@ The component InputColor is a wrapper for the native HTML element `<input type="
 
 - With NVDA, the element is announced as "clickable" and not as an input element.
 - It's not possible to select a color using a screen reader.
-- **9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar:** Die Beschriftung wird vom Screenreader nicht ausgegeben. Nur linear Lesend, daher ist bei hideLabel gar kein Label erschließbar.
-- **9.1.3.2 Sinnvolle Reihenfolge:** Beim öffnen der Farbauswahl von "Color with error" gibt es keine Ausgabe. Mit der Tab-Taste gelangt man da nicht rein, nur mit Pfeiltasten. Sehr unverständlich mit Screenreader.
-- **9.2.4.3 Schlüssige Reihenfolge bei Tastaturbedienung:** Die Fokusreihenfolge bei "Color with error" ist sehr merkwürdig. Man kommt nicht drauf das man mit Pfeiltasten da rein muss. Besonders weil es auf Schwarz auch nicht sichtbar ist.
-- **9.2.4.7 Aktuelle Position des Fokus deutlich:** Der Fokus ist auf schwarzem Farbicon in "Color with error" nicht sichtbar.
+- **9.1.3.1h Labeling of form elements programmatically detectable:**  
+  The label is not announced by the screen reader. Since it reads linearly, no label is perceivable when `hideLabel` is used.
+- **9.1.3.2 Meaningful sequence:**  
+  When opening the color selection for "Color with error," there is no output. It is not accessible via the Tab key, only with the arrow keys, making it very confusing for screen reader users.
+- **9.2.4.3 Logical keyboard navigation order:**  
+  The focus order for "Color with error" is very unusual. Users do not realize that they have to use arrow keys to enter. This is especially problematic since it is not visible on black.
+- **9.2.4.7 Clearly visible focus position:**  
+  The focus is not visible on the black color icon in "Color with error."
 
 For full accessibility, consider using predefined colors lists, e.g. using KolSelect or KolCheckbox.
 


### PR DESCRIPTION
## What changed?

This PR only extends `KNOWN_ISSUES.md` with additional known accessibility problems of the `kol-input-color` component. The new entries document BITV/WCAG findings for the "Color with error" case: programmatically undetectable labeling (9.1.3.1h), missing meaningful sequence / no output when opening the color selection (9.1.3.2), an unusual keyboard navigation order that requires arrow keys (9.2.4.3), and a focus position that is not clearly visible on the black color icon (9.2.4.7). A reference link to PR #7455 is added. There are no code changes and no impact on the shipped library.

## Linked issues

- Refs #7221 — input-color accessibility

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ergänzt ausschließlich `KNOWN_ISSUES.md` um weitere bekannte Barrierefreiheits-Probleme der Komponente `kol-input-color`. Die neuen Einträge dokumentieren BITV/WCAG-Befunde für den Fall „Color with error": programmatisch nicht erkennbare Beschriftung (9.1.3.1h), fehlende sinnvolle Reihenfolge / keine Ausgabe beim Öffnen der Farbauswahl (9.1.3.2), eine ungewöhnliche Tastaturnavigations-Reihenfolge, die Pfeiltasten erfordert (9.2.4.3), und eine auf dem schwarzen Farb-Icon nicht klar sichtbare Fokusposition (9.2.4.7). Ein Verweislink auf PR #7455 wird ergänzt. Es gibt keine Code-Änderungen und keine Auswirkung auf die ausgelieferte Bibliothek.

### Verknüpfte Tickets

- Referenziert #7221 — Barrierefreiheit von input-color

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `KNOWN_ISSUES.md` — zusätzliche bekannte Barrierefreiheits-Probleme für `kol-input-color` dokumentiert.

</details>