### PR TITLE
ci: use GitHub App token for CLA assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,14 +11,21 @@ jobs:
     if: github.repository == 'public-ui/kolibri'
     runs-on: ubuntu-latest
     steps:
+      - name: 'Create GitHub app token'
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          repositories: "kolibri,.github-private"
+
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.3.1
+        uses: contributor-assistant/github-action@v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: 'cla/kolibri/signatures-v1.0.json'
           path-to-document: 'https://github.com/public-ui/kolibri/blob/main/docs/CLA.md' # e.g. a CLA or a DCO document


### PR DESCRIPTION
## What changed?

This PR changes how the CLA Assistant workflow (`.github/workflows/cla.yml`) authenticates: instead of a personal access token it now uses a scoped GitHub App token. A new `Create GitHub app token` step (`actions/create-github-app-token@v1`) mints a token from the `APP_ID`/`PRIVATE_KEY` secrets for the `kolibri` and `.github-private` repositories, and both the `GITHUB_TOKEN` and `PERSONAL_ACCESS_TOKEN` env vars are wired to that generated token. The `contributor-assistant/github-action` is bumped from `v2.3.1` to `v2.6.1`. This removes the dependency on a long-lived personal access token. No library runtime code is affected.

## Linked issues

- Refs #7000 — CLA / CI configuration

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ändert die Authentifizierung des CLA-Assistant-Workflows (`.github/workflows/cla.yml`): Statt eines persönlichen Access-Tokens wird nun ein scoped GitHub-App-Token verwendet. Ein neuer Schritt `Create GitHub app token` (`actions/create-github-app-token@v1`) erzeugt aus den Secrets `APP_ID`/`PRIVATE_KEY` ein Token für die Repositories `kolibri` und `.github-private`; sowohl `GITHUB_TOKEN` als auch `PERSONAL_ACCESS_TOKEN` werden auf dieses Token gesetzt. Die `contributor-assistant/github-action` wird von `v2.3.1` auf `v2.6.1` angehoben. Damit entfällt die Abhängigkeit von einem langlebigen persönlichen Access-Token. Bibliotheks-Laufzeitcode ist nicht betroffen.

### Verknüpfte Tickets

- Referenziert #7000 — CLA / CI-Konfiguration

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/cla.yml` — GitHub-App-Token-Schritt ergänzt, `GITHUB_TOKEN`/`PERSONAL_ACCESS_TOKEN` auf das App-Token umgestellt, Action von `v2.3.1` auf `v2.6.1` angehoben.

</details>