### PR TITLE
fix(input-radio): match value to option by removing mapString2Unknown

### DIFF
--- a/packages/components/src/components/input-radio/controller.ts
+++ b/packages/components/src/components/input-radio/controller.ts
@@ -4,16 +4,16 @@ import type {
 	InputRadioProps,
 	InputRadioWatches,
 	Optgroup,
-	RadioOption,
 	OptionsPropType,
 	Orientation,
 	PropLabelWithExpertSlot,
+	RadioOption,
 	SelectOption,
 	StencilUnknown,
 	Stringified,
 	W3CInputValue,
 } from '../../schema';
-import { mapString2Unknown, orientationOptions, setState, validateOptions, validateRequired, watchValidator } from '../../schema';
+import { orientationOptions, setState, validateOptions, validateRequired, watchValidator } from '../../schema';
 
 import { InputController } from '../@deprecated/input/controller';
 
@@ -103,7 +103,6 @@ export class InputRadioController extends InputCheckboxRadioController implement
 	}
 
 	public validateValue(value?: Stringified<StencilUnknown>): void {
-		value = mapString2Unknown(value);
 		value = Array.isArray(value) ? (value[0] as StencilUnknown) : value;
 		setState(this.component, '_value', value, {
 			afterPatch: this.afterPatchOptions,

--- a/packages/components/src/components/input-radio/input-radio.e2e.ts
+++ b/packages/components/src/components/input-radio/input-radio.e2e.ts
@@ -2,6 +2,7 @@ import { type E2EPage, test } from '@stencil/playwright';
 import { testInputCallbacksAndEvents, testInputValueReflection } from '../../e2e';
 import type { FillAction } from '../../e2e/utils/FillAction';
 import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 const COMPONENT_NAME = 'kol-input-radio';
 const TEST_VALUE = 'test-value';
@@ -19,4 +20,56 @@ const selectInput = (page: Page & E2EPage) => page.locator('input').first();
 test.describe(COMPONENT_NAME, () => {
 	testInputValueReflection<HTMLKolInputNumberElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OPTIONS_ATTRIBUTE);
 	testInputCallbacksAndEvents<HTMLKolInputNumberElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OMITTED_EVENTS, OPTIONS_ATTRIBUTE, selectInput);
+
+	test.describe('value to option matching', () => {
+		const OBJECT_FIRST = { id: 1, text: 'first' };
+		const OBJECT_SECOND = { id: 2, text: 'second' };
+
+		const TEST_CASES = [
+			{
+				name: 'string value',
+				options: [
+					{ label: 'Option 1', value: 'string1' },
+					{ label: 'Option 2', value: 'string2' },
+				],
+				value: 'string1',
+			},
+			{
+				name: 'number value',
+				options: [
+					{ label: 'Option 1', value: 1 },
+					{ label: 'Option 2', value: 2 },
+				],
+				value: 1,
+			},
+			{
+				name: 'object value',
+				options: [
+					{ label: 'Option 1', value: OBJECT_FIRST },
+					{ label: 'Option 2', value: OBJECT_SECOND },
+				],
+				value: OBJECT_FIRST,
+			},
+		];
+
+		TEST_CASES.forEach(({ name, options, value }) => {
+			test(`should match option with ${name}`, async ({ page }) => {
+				await page.setContent(`<kol-input-radio	_label="Radio Group"></kol-input-radio>`);
+				const kolInputRadio = page.locator('kol-input-radio');
+
+				await kolInputRadio.evaluate(
+					(kolInputRadio: HTMLKolInputRadioElement, { options, value }) => {
+						if (kolInputRadio) {
+							kolInputRadio._options = options;
+							kolInputRadio._value = value;
+						}
+					},
+					{ options, value },
+				);
+
+				const firstOption = kolInputRadio.locator('input[type="radio"]').first();
+				await expect(firstOption).toBeChecked();
+			});
+		});
+	});
 });

--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -5,10 +5,9 @@ import { querySelector } from 'query-selector-shadow-root';
 import rgba from 'rgba-convert';
 import { hex, score } from 'wcag-contrast';
 
-import { Log, getDocument, getExperimentalMode } from './dev.utils';
+import { getDocument, getExperimentalMode, Log } from './dev.utils';
 
 import type { Stringified } from '../types/common';
-import type { StencilUnknown } from '../types/unknown';
 import { devHint } from './a11y.tipps';
 // https://regex101.com/r/lSYLO9/1
 /**
@@ -260,34 +259,6 @@ export const watchJsonArrayString = <T>(
 			}
 		});
 	});
-};
-
-const BOOLEAN = /^(true|false)$/;
-const INTEGER = /^-?(0|[1-9]\d*)$/;
-const FLOAT = /^-?(0.|[1-9]\d*.)\d*[1-9]$/;
-export const mapString2Unknown = (value: StencilUnknown) => {
-	const typeStr = typeof value;
-	const oldValue = `${value as string}`;
-	if (typeof value === 'string') {
-		if (BOOLEAN.test(value)) {
-			value = value === 'true';
-		} else if (INTEGER.test(value)) {
-			value = parseInt(value);
-		} else if (FLOAT.test(value)) {
-			value = parseFloat(value);
-		} else if (JSON_CHARS.test(value)) {
-			try {
-				value = parseJson<StencilUnknown>(value);
-				// eslint-disable-next-line no-empty
-			} catch (e) {
-				// value behält den ursprünglichen Wert
-			}
-		}
-	}
-	if (typeStr !== typeof value) {
-		devHint(`You have used a stringified property value (${oldValue} to ${JSON.stringify(value)}) which type switched from ${typeStr} to ${typeof value}!`);
-	}
-	return value;
 };
 
 export const stringifyJson = (value: unknown): string => {


### PR DESCRIPTION
## What changed?

`KolInputRadio` no longer coerces its `_value` through the `mapString2Unknown` helper before matching it against the configured options. The call was removed from `InputRadioController.validateValue`, and the now-unused `mapString2Unknown` implementation (and its `StencilUnknown` import) was deleted from `schema/utils/prop.validators.ts`. Because the value is no longer implicitly converted (e.g. numeric-looking or JSON-looking strings turned into numbers/objects), a provided `_value` now matches the corresponding option by strict identity for string, number and object values alike. New Playwright e2e tests cover value-to-option matching for all three cases.

## Linked issues

- Refs #5986 — `KolInputRadio` value does not reliably match the selected option

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolInputRadio` wandelt seinen `_value` nicht länger über die Hilfsfunktion `mapString2Unknown` um, bevor er mit den konfigurierten Optionen abgeglichen wird. Der Aufruf wurde aus `InputRadioController.validateValue` entfernt, und die nun ungenutzte `mapString2Unknown`-Implementierung (samt `StencilUnknown`-Import) wurde aus `schema/utils/prop.validators.ts` gelöscht. Da der Wert nicht mehr implizit konvertiert wird (z. B. zahl- oder JSON-artige Strings zu Number/Object), wird ein gesetzter `_value` nun für String-, Number- und Object-Werte gleichermaßen per strikter Identität der passenden Option zugeordnet. Neue Playwright-e2e-Tests decken das Value-zu-Option-Matching für alle drei Fälle ab.

### Verknüpfte Tickets

- Referenziert #5986 — `KolInputRadio`-Wert wird nicht zuverlässig der ausgewählten Option zugeordnet

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-radio/controller.ts` — `mapString2Unknown`-Aufruf aus `validateValue` entfernt
- `packages/components/src/schema/utils/prop.validators.ts` — ungenutzte `mapString2Unknown`-Funktion und Import entfernt
- `packages/components/src/components/input-radio/input-radio.e2e.ts` — e2e-Tests für Value-zu-Option-Matching (String/Number/Object) ergänzt

</details>