### PR TITLE
chore: fix serve default theme on windows

### DIFF
--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -49,7 +49,7 @@
 		"lint": "tsc --noemit && eslint src",
 		"prepare": "cpy \"node_modules/@public-ui/components/assets/**/*\" assets --dot",
 		"start": "npm-run-all --parallel dev serve",
-		"serve": "cross-env THEME_MODULE=\"`pwd`/dist\" THEME_EXPORT=DEFAULT npm --prefix \"node_modules/@public-ui/visual-tests/node_modules/@public-ui/sample-react/\" start",
+		"serve": "sh serve.sh DEFAULT",
 		"test": "pnpm test:visual",
 		"test:visual": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test",
 		"test-update": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test --update-snapshots theme-snapshots.spec.js",

--- a/packages/themes/default/serve.sh
+++ b/packages/themes/default/serve.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+export THEME_MODULE="`pwd`/dist"
+export THEME_EXPORT=$1
+cd ../../../node_modules/@public-ui/sample-react/
+echo "`pwd`"
+npm start


### PR DESCRIPTION
## What changed?

This change fixes the `serve` developer script of the default theme package so it also works on Windows. The previous inline `cross-env` command (which relied on POSIX shell substitution and a deep `node_modules/@public-ui/visual-tests/node_modules/@public-ui/sample-react/` path) was extracted into a small `serve.sh` wrapper. The `serve` npm script now calls `sh serve.sh DEFAULT`; the script exports `THEME_MODULE`/`THEME_EXPORT`, changes into the `sample-react` package and starts it. This is a local developer-tooling change with no impact on the shipped components or themes.

## Linked issues

- Refs #7506 — fix serving the default theme on Windows

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das `serve`-Entwicklerskript des Default-Theme-Pakets wurde so korrigiert, dass es auch unter Windows funktioniert. Der bisherige Inline-`cross-env`-Aufruf (der auf POSIX-Shell-Substitution und einen tiefen `node_modules/@public-ui/visual-tests/node_modules/@public-ui/sample-react/`-Pfad angewiesen war) wurde in ein kleines `serve.sh`-Wrapper-Skript ausgelagert. Das `serve`-npm-Skript ruft nun `sh serve.sh DEFAULT` auf; das Skript exportiert `THEME_MODULE`/`THEME_EXPORT`, wechselt in das `sample-react`-Paket und startet es. Reine lokale Tooling-Änderung ohne Auswirkung auf ausgelieferte Komponenten oder Themes.

### Verknüpfte Tickets

- Referenziert #7506 — Serven des Default-Themes unter Windows reparieren

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/themes/default/serve.sh` — neues Wrapper-Skript, das `THEME_MODULE`/`THEME_EXPORT` setzt und die Sample-App startet
- `packages/themes/default/package.json` — `serve`-Skript auf `sh serve.sh DEFAULT` umgestellt

</details>