### PR TITLE
sample: add DocxPreview scenario to showcase .docx file previews

### DIFF
--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -45,6 +45,7 @@
 		"cpy-cli": "5.0.0",
 		"cross-env": "7.0.3",
 		"css-loader": "7.1.2",
+		"docx-preview": "0.3.5",
 		"esbuild-loader": "4.3.0",
 		"eslint": "^8",
 		"eslint-plugin-html": "8.1.2",

--- a/packages/samples/react/src/scenarios/docx-preview.tsx
+++ b/packages/samples/react/src/scenarios/docx-preview.tsx
@@ -1,0 +1,61 @@
+import { ToasterService } from '@public-ui/components';
+import { KolInputFile } from '@public-ui/react';
+import { renderAsync } from 'docx-preview';
+import React, { useRef, useState } from 'react';
+import { SampleDescription } from '../components/SampleDescription';
+
+const DOCX_PREVIEW_ERROR = 'The file could not be displayed. It may be damaged or not a valid .docx document.';
+
+export const DocxPreview = () => {
+	const [files, setFiles] = useState<File[]>([]);
+	const previewRef = useRef<HTMLDivElement>(null);
+	const toaster = ToasterService.getInstance(document);
+
+	const errorToast = (msg: string) => {
+		void toaster.enqueue({
+			description: msg,
+			label: `Error occurred`,
+			type: 'warning',
+		});
+	};
+
+	const onChange = {
+		onChange: async (_e: Event, v: unknown) => {
+			const fileList = v as FileList;
+			if (Array.isArray(fileList) || fileList.length === 1) {
+				setFiles(Array.from(fileList));
+				const file = fileList[0];
+				if (previewRef.current) {
+					previewRef.current.innerHTML = '';
+					try {
+						await renderAsync(await file.arrayBuffer(), previewRef.current);
+					} catch (e) {
+						previewRef.current.innerHTML = `<p class="text-red-600 text-center">${DOCX_PREVIEW_ERROR}</p>`;
+						errorToast(DOCX_PREVIEW_ERROR);
+					}
+				}
+			}
+		},
+	};
+
+	return (
+		<>
+			<SampleDescription>
+				<p>This component showcases how to preview `.docx` files directly in the browser using the `docx-preview` library.</p>
+			</SampleDescription>
+			<KolInputFile _label="Select file" _accept=".docx,.odt,.pdf" _on={onChange} />
+			<ul>
+				{files.map((file) => (
+					<li key={`file-${file.name}-${file.size}`}>
+						{file.name} – {(file.size / 1024).toFixed(1)} KB
+					</li>
+				))}
+			</ul>
+			{/* The preview area is not usable and visible for users with screenreader. */}
+			<div aria-hidden="true" onClick={(event) => event.preventDefault()}>
+				<div className="docx-preview border-dashed border bg-gray-1 p-4 overflow-scroll h-300px rounded" ref={previewRef} />
+				<p className="text-xs px-2">Note: The preview is not interactive. You can only scroll and select text.</p>
+			</div>
+		</>
+	);
+};

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -7,6 +7,7 @@ import { FocusElements } from './focus-elements';
 import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
 import { InputGroupWithError } from './input-group-with-error';
 import { ChangeTabindex } from './change-tabindex';
+import { DocxPreview } from './docx-preview';
 
 export const SCENARIO_ROUTES: Routes = {
 	scenarios: {
@@ -18,5 +19,6 @@ export const SCENARIO_ROUTES: Routes = {
 		'static-form': StaticForm,
 		'table-horizontal-scrollbar-advanced': TableHorizontalScrollAdvanced,
 		'change-tabindex': ChangeTabindex,
+		'docx-preview': DocxPreview,
 	},
 };

--- a/packages/samples/react/src/style.scss
+++ b/packages/samples/react/src/style.scss
@@ -71,6 +71,10 @@ hr {
 	}
 }
 
+.docx-preview * {
+	cursor: text !important;
+}
+
 @media print {
 
 	.no-print,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,6 +669,9 @@ importers:
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(webpack@5.98.0)
+      docx-preview:
+        specifier: 0.3.5
+        version: 0.3.5
       esbuild-loader:
         specifier: 4.3.0
         version: 4.3.0(webpack@5.98.0)
@@ -6157,6 +6160,9 @@ packages:
 
   doctypes@1.1.0:
     resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
+
+  docx-preview@0.3.5:
+    resolution: {integrity: sha512-nod1jG5PkvzDIiZAcgAY4gSFQzgmAAChcuZH4Hj9dj7oCzscY3Hn8NfbUv7X7Jk4xL1lfKO113JLDhWKOt6fYw==}
 
   dom-serialize@2.2.1:
     resolution: {integrity: sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==}
@@ -18649,6 +18655,10 @@ snapshots:
       esutils: 2.0.3
 
   doctypes@1.1.0: {}
+
+  docx-preview@0.3.5:
+    dependencies:
+      jszip: 3.10.1
 
   dom-serialize@2.2.1:
     dependencies:


### PR DESCRIPTION
This pull request adds a new feature to preview `.docx` files directly in the browser using the `docx-preview` library. The changes include updates to dependencies, new component creation, and integration into the existing routes.

### New Feature: `.docx` File Preview

* **Dependency Addition:**
  * Added `docx-preview` version `0.3.5` to `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-ed3152191d96cecda1937e0c6ef89f87668cf18d86265a97696ad30cf29dcd45R48) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR672-R674) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6164-R6166) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR18659-R18662)

* **Component Creation:**
  * Created a new component `DocxPreview` in `docx-preview.tsx` that allows users to select and preview `.docx` files.

* **Route Integration:**
  * Imported and added the new `DocxPreview` component to the scenario routes in `routes.ts`. [[1]](diffhunk://#diff-474fe0e7b94968827bf2407950d10e5572f874b36d4e00361b9724211fc9673fR10) [[2]](diffhunk://#diff-474fe0e7b94968827bf2407950d10e5572f874b36d4e00361b9724211fc9673fR22)

* **Styling Update:**
  * Updated `style.scss` to ensure the text cursor is displayed for all elements within the `.docx-preview` class.Refs: #0815

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [x] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [x] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [x] Documentation or migration has been updated (if applicable)
