### PR TITLE
refactor: update package.json import to use fs for better compatibility

### DIFF
--- a/scripts/update-publiccode.mjs
+++ b/scripts/update-publiccode.mjs
@@ -3,7 +3,9 @@
 import yaml from 'js-yaml';
 import fs from 'fs';
 import * as prettier from 'prettier';
-import packageJson from '../packages/components/package.json' assert { type: 'json' };
+
+const packageJsonPath = new URL('../packages/components/package.json', import.meta.url);
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
 const filePath = new URL('../publiccode.yml', import.meta.url);
 const doc = yaml.load(fs.readFileSync(filePath, 'utf8'));


### PR DESCRIPTION
## What changed?

Replaces the JSON import assertion in `scripts/update-publiccode.mjs`. Instead of `import packageJson from '../packages/components/package.json' assert { type: 'json' }`, the script now resolves the path with `new URL('../packages/components/package.json', import.meta.url)` and reads it at runtime via `JSON.parse(fs.readFileSync(...))`. This avoids depending on the experimental/version-sensitive import-assertions syntax and improves Node.js compatibility. Build/tooling script only — no shipped code, runtime, or public API changes.

## Linked issues

- Refs #7540 — publiccode/publishing tooling.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ersetzt die JSON-Import-Assertion in `scripts/update-publiccode.mjs`. Statt `import packageJson from '../packages/components/package.json' assert { type: 'json' }` löst das Skript den Pfad nun mit `new URL('../packages/components/package.json', import.meta.url)` auf und liest die Datei zur Laufzeit via `JSON.parse(fs.readFileSync(...))`. Das vermeidet die Abhängigkeit von der experimentellen/versionsabhängigen Import-Assertions-Syntax und verbessert die Node.js-Kompatibilität. Reines Build-/Tooling-Skript — keine ausgelieferten Code-, Laufzeit- oder API-Änderungen.

### Verknüpfte Tickets

- Referenziert #7540 — publiccode-/Publishing-Tooling.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `scripts/update-publiccode.mjs` — JSON-Import-Assertion durch `new URL(...)` + `JSON.parse(fs.readFileSync(...))` ersetzt.

</details>