### PR TITLE
fix(alert): correct icon screen reader output when referenced via aria-describedby

### DIFF
--- a/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,7 +7,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -30,7 +33,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -53,7 +59,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -76,7 +85,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -99,7 +111,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -122,7 +137,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -145,7 +163,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -168,7 +189,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -191,7 +215,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -214,7 +241,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -237,7 +267,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -260,7 +293,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -283,7 +319,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -306,7 +345,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -329,7 +371,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -352,7 +397,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -375,7 +423,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -398,7 +449,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -421,7 +475,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -444,7 +501,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -467,7 +527,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -490,7 +553,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -513,7 +579,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -536,7 +605,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -559,7 +631,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -582,7 +657,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -605,7 +683,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -628,7 +709,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -651,7 +735,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -674,7 +761,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -697,7 +787,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -720,7 +813,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -743,7 +839,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -766,7 +865,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -789,7 +891,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-headline kol-headline--h1 kol-headline--single">
               Überschrift
@@ -812,7 +917,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -835,7 +943,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -858,7 +969,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -881,7 +995,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -904,7 +1021,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-headline kol-headline--h2 kol-headline--single">
               Überschrift
@@ -927,7 +1047,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -950,7 +1073,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -973,7 +1099,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -996,7 +1125,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -1019,7 +1151,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-headline kol-headline--h3 kol-headline--single">
               Überschrift
@@ -1042,7 +1177,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -1065,7 +1203,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -1088,7 +1229,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -1111,7 +1255,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -1134,7 +1281,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-headline kol-headline--h4 kol-headline--single">
               Überschrift
@@ -1157,7 +1307,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -1180,7 +1333,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -1203,7 +1359,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -1226,7 +1385,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -1249,7 +1411,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-headline kol-headline--h5 kol-headline--single">
               Überschrift
@@ -1272,7 +1437,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
       <!---->
       <div class="kol-alert kol-alert--default kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -1295,7 +1463,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
       <!---->
       <div class="kol-alert kol-alert--error kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -1318,7 +1489,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
       <!---->
       <div class="kol-alert kol-alert--info kol-alert--msg" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -1341,7 +1515,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--success" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-pass" _label="kol-success" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift
@@ -1364,7 +1541,10 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
       <!---->
       <div class="kol-alert kol-alert--msg kol-alert--warning" role="alert">
         <div class="kol-alert__container">
-          <kol-icon _icons="codicon codicon-warning" _label="kol-warning" class="kol-alert__heading-icon"></kol-icon>
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__heading-icon"></kol-icon>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-headline kol-headline--h6 kol-headline--single">
               Überschrift

--- a/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
@@ -3,7 +3,10 @@
 exports[`KolAlertFc should render 1`] = `
 <div class="kol-alert kol-alert--default kol-alert--msg">
   <div class="kol-alert__container">
-    <kol-icon _icons="codicon codicon-comment" _label="kol-message" class="kol-alert__heading-icon"></kol-icon>
+    <span class="visually-hidden">
+      kol-message
+    </span>
+    <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__heading-icon"></kol-icon>
     <div class="kol-alert__container-content">
       <div class="kol-alert__content"></div>
     </div>

--- a/packages/components/src/functional-components/AlertIcon/AlertIcon.tsx
+++ b/packages/components/src/functional-components/AlertIcon/AlertIcon.tsx
@@ -1,10 +1,20 @@
-import { h, type FunctionalComponent as FC } from '@stencil/core';
+import { Fragment, type FunctionalComponent as FC, h } from '@stencil/core';
 import { KolIconTag } from '../../core/component-names';
 import type { AlertType } from '../../schema';
 import { translate } from '../../i18n';
 
+/**
+ * The icon uses a visually-hidden span instead of an aria-label because the Alert might be referenced as content for aria-describedby.
+ * In this scenario, Firefox with NVDA does not properly read the aria-label, so the visually-hidden span ensures correct screen reader behavior.
+ * @see https://github.com/public-ui/kolibri/issues/7119
+ */
 const Icon: FC<{ ariaLabel: string; icon: string; label?: string }> = ({ ariaLabel, icon }) => {
-	return <KolIconTag class="kol-alert__heading-icon" _label={ariaLabel} _icons={icon} />;
+	return (
+		<>
+			<span class="visually-hidden">{ariaLabel}</span>
+			<KolIconTag class="kol-alert__heading-icon" _label="" _icons={icon} />
+		</>
+	);
 };
 
 const AlertIcon: FC<{ label?: string; type?: AlertType }> = ({ type, label }) => {

--- a/packages/components/src/functional-components/FormField/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/FormField/tests/__snapshots__/snapshot.test.tsx.snap
@@ -89,7 +89,10 @@ exports[`KolFormFieldFc should render with error message 1`] = `
   <div class="kol-form-field__input"></div>
   <div aria-hidden="true" class="kol-alert kol-alert--error kol-alert--msg kol-form-field__msg" description="Error message" id="test-id-msg">
     <div class="kol-alert__container">
-      <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+      <span class="visually-hidden">
+        kol-error
+      </span>
+      <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
       <div class="kol-alert__container-content">
         <div class="kol-alert__content">
           Error message

--- a/packages/components/src/functional-components/FormFieldMsg/tests/__snapshots__/snapshort.test.tsx.snap
+++ b/packages/components/src/functional-components/FormFieldMsg/tests/__snapshots__/snapshort.test.tsx.snap
@@ -3,7 +3,10 @@
 exports[`FormFieldMsgFc should render with all props 1`] = `
 <div aria-hidden="true" class="custom-class kol-alert kol-alert--error kol-alert--msg kol-form-field__msg" description="This is an error message" id="test-id-msg" role="alert">
   <div class="kol-alert__container">
-    <kol-icon _icons="codicon codicon-error" _label="kol-error" class="kol-alert__heading-icon"></kol-icon>
+    <span class="visually-hidden">
+      kol-error
+    </span>
+    <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__heading-icon"></kol-icon>
     <div class="kol-alert__container-content">
       <div class="kol-alert__content">
         This is an error message

--- a/packages/components/src/functional-components/FormFieldMsg/tests/snapshort.test.tsx
+++ b/packages/components/src/functional-components/FormFieldMsg/tests/snapshort.test.tsx
@@ -38,7 +38,8 @@ describe('FormFieldMsgFc', () => {
 	it('should render the message correctly', async () => {
 		const msg: InternMsgPropType = { description: 'This is an error message' };
 		const page = await renderFunctionalComponentToSpecPage(() => <FormFieldMsgFc id="test-id" msg={msg} />);
+		const ICON_LABEL = 'kol-error';
 
-		expect(page.root?.textContent).toBe(msg.description);
+		expect(page.root?.textContent).toBe(`${ICON_LABEL}${msg.description}`);
 	});
 });

--- a/packages/components/src/functional-components/ToastItem/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/ToastItem/tests/__snapshots__/snapshot.test.tsx.snap
@@ -4,7 +4,10 @@ exports[`ToastItemFc should render with basic props and status 1`] = `
 <div class="kol-toast-item kol-toast-item--settled">
   <div class="kol-alert kol-alert--card kol-alert--hasCloser kol-alert--info kol-toast-item__alert" role="alert">
     <div class="kol-alert__container">
-      <kol-icon _icons="codicon codicon-info" _label="kol-info" class="kol-alert__heading-icon"></kol-icon>
+      <span class="visually-hidden">
+        kol-info
+      </span>
+      <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__heading-icon"></kol-icon>
       <div class="kol-alert__container-content">
         <strong class="kol-alert__heading kol-headline kol-headline--single kol-headline--strong">
           Test Toast


### PR DESCRIPTION
## What changed?

This fixes the screen reader output of the Alert heading icon, particularly when the Alert is referenced by another element via `aria-describedby`. Instead of passing the semantic type text (e.g. `kol-message`, `kol-error`) as the icon's `_label` — which was announced as part of the icon and produced confusing output — the Alert now renders that text in a separate `<span class="visually-hidden">` and sets the icon's `_label` to an empty string, so the icon itself is no longer announced. Alert component snapshots and tests were updated to reflect the new markup. This PR targets the `develop` branch.

## Linked issues

- Refs #7119 — Alert icon produces incorrect/duplicated screen reader output when the Alert is referenced as `aria-describedby`.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt die Screenreader-Ausgabe des Alert-Überschriften-Icons, insbesondere wenn der Alert per `aria-describedby` von einem anderen Element referenziert wird. Statt den semantischen Typ-Text (z. B. `kol-message`, `kol-error`) als `_label` des Icons zu übergeben — was als Teil des Icons vorgelesen wurde und verwirrende Ausgaben erzeugte — rendert der Alert diesen Text nun in einem separaten `<span class="visually-hidden">` und setzt das `_label` des Icons auf einen leeren String, sodass das Icon selbst nicht mehr angesagt wird. Alert-Snapshots und -Tests wurden an das neue Markup angepasst. Dieser PR zielt auf den `develop`-Branch.

### Verknüpfte Tickets

- Referenziert #7119 — Alert-Icon erzeugt falsche/doppelte Screenreader-Ausgabe, wenn der Alert per `aria-describedby` referenziert wird.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/alert/**` — Icon-Label in eine visuell verborgene Span verschoben, `_label` des Icons geleert.
- `packages/components/src/components/alert/test/__snapshots__/**` — Snapshots an das neue Markup angepasst.

</details>