### PR TITLE
fix(tree): ignore modifier keys in type-ahead shortcut handling

### DIFF
--- a/packages/components/src/components/tree/component.tsx
+++ b/packages/components/src/components/tree/component.tsx
@@ -121,6 +121,7 @@ export class KolTreeWc implements TreeAPI {
 	public async handleKeyDown(event: KeyboardEvent) {
 		const openItems = await this.getOpenTreeItemElements();
 		const currentTreeItem: HTMLKolTreeItemElement | undefined | null = document.activeElement?.closest(KolTreeItemTag);
+		const hasModifierKeyPressed = event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
 
 		if (!openItems || !currentTreeItem) {
 			return;
@@ -172,16 +173,19 @@ export class KolTreeWc implements TreeAPI {
 				break;
 			}
 			case event.key.match(/[a-zA-Z0-9]/)?.input: {
-				const char = event.key.toLowerCase();
-				const startIndex = openItems.indexOf(currentTreeItem) + 1;
-				const wrapAroundItems = openItems.concat(openItems);
-				const matchIndex = wrapAroundItems
-					.slice(startIndex, startIndex + openItems.length)
-					.findIndex((item) => item.getAttribute('_label')?.trim().toLowerCase().startsWith(char));
+				/* Ignore events with any modifier key to avoid breaking native browser or OS shortcuts such as ⌘+L */
+				if (!hasModifierKeyPressed) {
+					const char = event.key.toLowerCase();
+					const startIndex = openItems.indexOf(currentTreeItem) + 1;
+					const wrapAroundItems = openItems.concat(openItems);
+					const matchIndex = wrapAroundItems
+						.slice(startIndex, startIndex + openItems.length)
+						.findIndex((item) => item.getAttribute('_label')?.trim().toLowerCase().startsWith(char));
 
-				if (matchIndex !== -1) {
-					await wrapAroundItems[startIndex + matchIndex].focusLink();
-					event.preventDefault();
+					if (matchIndex !== -1) {
+						await wrapAroundItems[startIndex + matchIndex].focusLink();
+						event.preventDefault();
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
## What changed?

This fixes the Tree component's type-ahead keyboard navigation swallowing key presses that carry a modifier. In `packages/components/src/components/tree/component.tsx`, `handleKeyDown` now computes `hasModifierKeyPressed` (`metaKey || altKey || ctrlKey || shiftKey`) and only runs the alphanumeric first-character focus logic when no modifier is held. As a result, native browser and OS shortcuts such as ⌘+L are no longer intercepted and broken by the tree while an item is focused. This PR targets the `develop` branch.

## Linked issues

- Refs #7128 — Tree type-ahead navigation intercepts modifier shortcuts (e.g. ⌘+L), breaking native browser/OS behaviour.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt, dass die Type-Ahead-Tastaturnavigation der Tree-Komponente Tastendrücke mit Modifier-Taste abfängt. In `packages/components/src/components/tree/component.tsx` ermittelt `handleKeyDown` nun `hasModifierKeyPressed` (`metaKey || altKey || ctrlKey || shiftKey`) und führt die alphanumerische Fokus-Logik nur noch aus, wenn keine Modifier-Taste gedrückt ist. Dadurch werden native Browser- und OS-Shortcuts wie ⌘+L nicht mehr vom Baum abgefangen und außer Kraft gesetzt, während ein Element fokussiert ist. Dieser PR zielt auf den `develop`-Branch.

### Verknüpfte Tickets

- Referenziert #7128 — Tree-Type-Ahead-Navigation fängt Modifier-Shortcuts (z. B. ⌘+L) ab und stört natives Browser-/OS-Verhalten.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tree/component.tsx` — Type-Ahead-Navigation ignoriert Tastendrücke mit Modifier-Taste.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
