### PR TITLE
ci(dod-checker): upgrade runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/dod-checker.yml
+++ b/.github/workflows/dod-checker.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   check-dod:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Print Pull Request ID
         run: |


### PR DESCRIPTION
## What changed?

This upgrades the runner image of the `check-dod` job in `.github/workflows/dod-checker.yml` from the retired `ubuntu-20.04` to `ubuntu-24.04` (a single one-line change). It keeps the Definition-of-Done checker running on a supported GitHub Actions runner. There is no impact on the shipped component library. This PR is the backport targeting the `release/2` branch.

## Linked issues

- Refs #7559 — dod-checker workflow fails on the deprecated `ubuntu-20.04` runner.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Aktualisiert das Runner-Image des `check-dod`-Jobs in `.github/workflows/dod-checker.yml` vom eingestellten `ubuntu-20.04` auf `ubuntu-24.04` (einzeilige Änderung). Damit läuft der Definition-of-Done-Checker weiterhin auf einem unterstützten GitHub-Actions-Runner. Kein Einfluss auf die ausgelieferte Komponentenbibliothek. Dieser PR ist der Backport auf den `release/2`-Branch.

### Verknüpfte Tickets

- Referenziert #7559 — dod-checker-Workflow schlägt auf dem veralteten `ubuntu-20.04`-Runner fehl.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/dod-checker.yml` — Runner von `ubuntu-20.04` auf `ubuntu-24.04` angehoben.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
