### PR TITLE
feat(input): add classnames to adornments and remove redundant tabindex

### DIFF
--- a/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -130,7 +130,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-combobox__group">
@@ -141,7 +141,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -164,7 +164,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-combobox__group">
@@ -205,7 +205,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
@@ -122,7 +122,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -131,7 +131,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -154,7 +154,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -191,7 +191,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -326,7 +326,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>
@@ -457,7 +457,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -466,7 +466,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -489,7 +489,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -526,7 +526,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -661,7 +661,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,13 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="9999-12-31" name="field" type="date" value="2025-01-01">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -139,7 +139,7 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="9999-12-31" name="field" type="date" value="2025-01-01">
@@ -170,7 +170,7 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="9999-12-31" name="field" type="date" value="2025-01-01">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,13 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -139,7 +139,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
@@ -170,7 +170,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -290,7 +290,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>
@@ -429,7 +429,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
@@ -440,7 +440,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -463,7 +463,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
@@ -504,7 +504,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -649,7 +649,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
@@ -126,7 +126,7 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <span class="kol-input-container__filename">
@@ -136,7 +136,7 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
             <kol-button-wc _label="kol-data-browse-text" _variant="primary" class="kol-input-container__button"></kol-button-wc>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -159,7 +159,7 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <span class="kol-input-container__filename">
@@ -198,7 +198,7 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
             <kol-button-wc _label="kol-data-browse-text" _variant="primary" class="kol-input-container__button"></kol-button-wc>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -338,7 +338,7 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
             <kol-button-wc _label="kol-data-browse-text" _variant="primary" class="kol-input-container__button"></kol-button-wc>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,13 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="" min="" name="field" placeholder="Hier steht ein Platzhaltertext" type="number" value="">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -139,7 +139,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="" min="" name="field" placeholder="Hier steht ein Platzhaltertext" type="number" value="">
@@ -170,7 +170,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="" min="" name="field" placeholder="Hier steht ein Platzhaltertext" type="number" value="">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -290,7 +290,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="" min="" name="field" placeholder="Hier steht ein Platzhaltertext" type="number" value="">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>
@@ -429,7 +429,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" max="" min="" name="field" placeholder="Hier steht ein Platzhaltertext" type="number" value="">
@@ -440,7 +440,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -463,7 +463,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" max="" min="" name="field" placeholder="Hier steht ein Platzhaltertext" type="number" value="">
@@ -504,7 +504,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -649,7 +649,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,13 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="password" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -139,7 +139,7 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="password" value="Value">
@@ -170,7 +170,7 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="password" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -290,7 +290,7 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="password" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
@@ -122,7 +122,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
@@ -131,7 +131,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -154,7 +154,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
@@ -191,7 +191,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -475,7 +475,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
@@ -496,7 +496,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -519,7 +519,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
@@ -580,7 +580,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,13 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" spellcheck="" type="text" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -139,7 +139,7 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" spellcheck="" type="text" value="Value">
@@ -170,7 +170,7 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" spellcheck="" type="text" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -290,7 +290,7 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" spellcheck="" type="text" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-button-wc _hidelabel="" _label="einblenden" tabindex="0"></kol-button-wc>
+            <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -162,7 +162,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <form>
@@ -181,7 +181,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             </form>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -204,7 +204,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <form>
@@ -261,7 +261,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             </form>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -504,7 +504,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <form>
@@ -523,7 +523,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             </form>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -546,7 +546,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <form>
@@ -603,7 +603,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             </form>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -130,7 +130,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
@@ -141,7 +141,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -164,7 +164,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
@@ -205,7 +205,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
@@ -106,12 +106,12 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container"><textarea autocapitalize="off" autocorrect="off" class="kol-textarea" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" rows="5" value="Value" style="resize: vertical;"></textarea>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>
@@ -134,7 +134,7 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
           <div class="kol-input-container__container"><textarea autocapitalize="off" autocorrect="off" class="kol-textarea" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" rows="5" value="Value" style="resize: vertical;"></textarea>
           </div>
@@ -163,7 +163,7 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
           <div class="kol-input-container__container"><textarea autocapitalize="off" autocorrect="off" class="kol-textarea" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" rows="5" value="Value" style="resize: vertical;"></textarea>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label=""></kol-icon>
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
           </div>
         </div>
       </div>

--- a/packages/components/src/functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper.tsx
+++ b/packages/components/src/functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper.tsx
@@ -87,15 +87,17 @@ const InputContainerStateWrapperFc: FC<InputContainerStateWrapperProps> = ({ sta
 	}
 
 	if (leftIconProps) {
-		startAdornment.push(<KolIconButtonFc componentName="icon" {...(isObject(leftIconProps) ? leftIconProps : {})} />);
+		startAdornment.push(<KolIconButtonFc componentName="icon" class="kol-input-container__icon" {...(isObject(leftIconProps) ? leftIconProps : {})} />);
 	}
 
 	if (isObject(smartButton)) {
-		endAdornment.push(<KolIconButtonFc componentName="button" {...smartButton} hideLabel={true} disabled={disabled} />);
+		endAdornment.push(
+			<KolIconButtonFc componentName="button" class="kol-input-container__smart-button" {...smartButton} hideLabel={true} disabled={disabled} />,
+		);
 	}
 
 	if (rightIconProps) {
-		endAdornment.push(<KolIconButtonFc componentName="icon" {...(isObject(rightIconProps) ? rightIconProps : {})} />);
+		endAdornment.push(<KolIconButtonFc componentName="icon" class="kol-input-container__icon" {...(isObject(rightIconProps) ? rightIconProps : {})} />);
 	}
 
 	return (

--- a/packages/components/src/functional-components/Button/Button.tsx
+++ b/packages/components/src/functional-components/Button/Button.tsx
@@ -11,7 +11,7 @@ export type ButtonProps = Partial<InternalButtonProps> & {
 const KolButtonFc: FC<ButtonProps> = (props) => {
 	const { label, icons, hideLabel, disabled, onClick, ...other } = props;
 
-	return <KolButtonWcTag tabindex={0} _label={label} _disabled={disabled} _icons={icons} _hideLabel={hideLabel} _on={{ onClick }} {...other} />;
+	return <KolButtonWcTag _label={label} _disabled={disabled} _icons={icons} _hideLabel={hideLabel} _on={{ onClick }} {...other} />;
 };
 
 export default KolButtonFc;

--- a/packages/components/src/functional-components/Button/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Button/tests/__snapshots__/snapshot.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`KolButtonFc should handle click event 1`] = `
 <kol-button-wc
   _label="Test Button"
-  tabindex="0"
 />
 `;
 
@@ -11,14 +10,12 @@ exports[`KolButtonFc should hide label when hideLabel is true 1`] = `
 <kol-button-wc
   _hidelabel=""
   _label="Test Button"
-  tabindex="0"
 />
 `;
 
 exports[`KolButtonFc should render correctly 1`] = `
 <kol-button-wc
   _label="Test Button"
-  tabindex="0"
 />
 `;
 
@@ -26,13 +23,11 @@ exports[`KolButtonFc should render with custom class 1`] = `
 <kol-button-wc
   _label="Test Button"
   class="custom-class"
-  tabindex="0"
 />
 `;
 
 exports[`KolButtonFc should render with icons 1`] = `
 <kol-button-wc
   _label="Test Button"
-  tabindex="0"
 />
 `;

--- a/packages/components/src/functional-components/IconButton/IconButton.tsx
+++ b/packages/components/src/functional-components/IconButton/IconButton.tsx
@@ -5,7 +5,7 @@ import KolIconFc, { type IconProps } from '../Icon';
 type IconType = Partial<Omit<IconProps, 'icons'>> & {
 	componentName: 'icon';
 	icon?: string;
-	class?: never;
+	class?: string;
 
 	onClick?: (event: MouseEvent) => void;
 };

--- a/packages/components/src/functional-components/IconButton/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/IconButton/tests/__snapshots__/snapshot.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`KolIconButtonFc should render button component correctly 1`] = `
   _hidelabel=""
   _icons="codicon codicon-test-icon"
   _label="Test Button"
-  tabindex="0"
 />
 `;
 
@@ -22,6 +21,5 @@ exports[`KolIconButtonFc should render with additional props 1`] = `
   _icons="codicon codicon-test-icon"
   _label="Test Button"
   class="custom-class"
-  tabindex="0"
 />
 `;


### PR DESCRIPTION
## What changed?

Adds a stable BEM class (`kol-input-container__icon`) to the start/end adornment icons rendered by the shared input container, so that themes and consumers can reliably target adornment/ornament icons via CSS instead of relying on element structure. A redundant `tabindex` property was also removed from the affected markup. The change touches the input-container rendering used across form components (combobox, input-text and friends) and updates the corresponding Stencil DOM snapshots to include the new `class` attribute.

## Linked issues

- Refs #7305 — expose classnames on input adornments/ornaments

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Fügt den Start-/End-Adornment-Icons des geteilten Input-Containers eine stabile BEM-Klasse (`kol-input-container__icon`) hinzu, sodass Themes und Konsumenten die Adornment-/Ornament-Icons zuverlässig per CSS ansprechen können, statt sich auf die Elementstruktur zu verlassen. Zusätzlich wurde eine redundante `tabindex`-Eigenschaft aus dem Markup entfernt. Die Änderung betrifft das Input-Container-Rendering, das von mehreren Formular-Komponenten (Combobox, Input-Text u. a.) genutzt wird, und aktualisiert die zugehörigen Stencil-DOM-Snapshots um das neue `class`-Attribut.

### Verknüpfte Tickets

- Referenziert #7305 — Klassennamen an Input-Adornments/Ornamenten bereitstellen

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/functional-component-wrappers/**` / Input-Container-Rendering — `kol-input-container__icon`-Klasse an Adornment-Icons ergänzt, redundantes `tabindex` entfernt
- `packages/components/src/components/**/test/__snapshots__/*.snap` — DOM-Snapshots um das neue `class`-Attribut aktualisiert

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
