### PR TITLE
fix: correct cursor and hover states for disabled form controls

### DIFF
--- a/packages/components/src/components/input-checkbox/style.scss
+++ b/packages/components/src/components/input-checkbox/style.scss
@@ -16,29 +16,27 @@
 	}
 
 	#{$root} {
-		position: relative;
-		display: flex;
 		align-items: center;
+		cursor: pointer;
+		display: flex;
+		position: relative;
+
+		&--disabled {
+			cursor: not-allowed;
+		}
 
 		.kol-input {
-			font-size: rem(16);
-
 			appearance: none;
 			background-color: #fff;
-			cursor: pointer;
-			transition: 0.5s;
-
-			margin: 0;
 			border-style: solid;
 			border-width: 2px;
+			cursor: inherit;
+			font-size: rem(16);
+			margin: 0;
+			transition: 0.5s;
 
 			&:before {
 				content: '';
-				cursor: pointer;
-			}
-
-			&:disabled:before {
-				cursor: not-allowed;
 			}
 		}
 	}
@@ -110,7 +108,6 @@
 		}
 
 		.kol-icon {
-			cursor: pointer;
 			display: flex;
 			align-items: center;
 			justify-content: center;

--- a/packages/components/src/components/input-color/style.scss
+++ b/packages/components/src/components/input-color/style.scss
@@ -13,7 +13,6 @@
 .kol-input-color {
 	&__input {
 		&--color {
-			cursor: pointer;
 			flex-grow: 1;
 		}
 
@@ -27,5 +26,13 @@
 		display: flex;
 		flex-direction: row;
 		gap: rem(6) !important;
+	}
+}
+
+.kol-input {
+	cursor: pointer;
+
+	&:disabled {
+		cursor: not-allowed;
 	}
 }

--- a/packages/components/src/components/input-file/style.scss
+++ b/packages/components/src/components/input-file/style.scss
@@ -19,6 +19,10 @@
 		height: 100%;
 		opacity: 0;
 		cursor: pointer;
+
+		&:disabled {
+			cursor: not-allowed;
+		}
 	}
 
 	.kol-input-container {

--- a/packages/components/src/components/input-range/style.scss
+++ b/packages/components/src/components/input-range/style.scss
@@ -20,6 +20,8 @@
 		}
 
 		&__input {
+			$input: &;
+
 			&--number {
 				width: var(--kolibri-input-range--input-number--width);
 			}
@@ -43,8 +45,11 @@
 					height: rem(20);
 					width: rem(20);
 					border-radius: 20px;
-					cursor: pointer;
 					-webkit-appearance: none;
+
+					@at-root #{$input}:not(:disabled)#{&} {
+						cursor: pointer;
+					}
 
 					@media (prefers-contrast: more) or (forced-colors: active) {
 						outline: 1px solid currentColor;
@@ -57,8 +62,11 @@
 					height: rem(20);
 					width: rem(20);
 					border-radius: 20px;
-					cursor: pointer;
 					-moz-appearance: none;
+
+					@at-root #{$input}:not(:disabled)#{&} {
+						cursor: pointer;
+					}
 				}
 			}
 		}

--- a/packages/components/src/components/select/style.scss
+++ b/packages/components/src/components/select/style.scss
@@ -12,8 +12,11 @@
 @layer kol-component {
 	.kol-select {
 		font-size: rem(16);
-		cursor: pointer;
 		width: 100%;
+
+		&:not(:disabled) {
+			cursor: pointer;
+		}
 
 		&:not([multiple], [size]) {
 			height: 2.75em;

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -31,7 +31,8 @@ import CustomSuggestionsToggleFc from '../../functional-components/CustomSuggest
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper';
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper';
 import KolInputStateWrapperFc from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
-import { EventDetail } from '../../schema/interfaces/EventDetail';
+import type { EventDetail } from '../../schema/interfaces/EventDetail';
+import clsx from 'clsx';
 
 /**
  * @slot - The input field label.
@@ -256,7 +257,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 									this.clearSelection();
 									this.refInput?.focus();
 								}}
-								class="kol-single-select__delete"
+								class={clsx('kol-single-select__delete', {
+									'kol-single-select__delete--disabled': this.state._disabled,
+								})}
 							/>
 						)}
 

--- a/packages/components/src/components/single-select/style.scss
+++ b/packages/components/src/components/single-select/style.scss
@@ -18,6 +18,14 @@
 
 @layer kol-component {
 	.kol-single-select {
+		&__delete {
+			cursor: pointer;
+
+			&--disabled {
+				cursor: not-allowed;
+			}
+		}
+
 		&__no-results-message {
 			cursor: default;
 			display: flex;

--- a/packages/components/src/styles/_kol-custom-suggestions-toggle.scss
+++ b/packages/components/src/styles/_kol-custom-suggestions-toggle.scss
@@ -2,10 +2,13 @@
 	@layer kol-component {
 		.kol-custom-suggestions-toggle {
 			align-items: center;
-			cursor: pointer;
 			display: flex;
 			height: var(--a11y-min-size);
 			width: var(--a11y-min-size);
+
+			&:not(:disabled) {
+				cursor: pointer;
+			}
 		}
 	}
 }

--- a/packages/components/src/styles/_kol-input-container-mixin.scss
+++ b/packages/components/src/styles/_kol-input-container-mixin.scss
@@ -5,7 +5,6 @@
 
 			align-items: center;
 			background-color: white;
-			cursor: pointer;
 			display: grid;
 			grid-template-columns: 1fr;
 			min-height: var(--a11y-min-size);

--- a/packages/themes/default/src/@shared/input-text.scss
+++ b/packages/themes/default/src/@shared/input-text.scss
@@ -8,9 +8,5 @@
 		&::placeholder {
 			color: var(--color-subtle);
 		}
-
-		&:disabled {
-			cursor: not-allowed;
-		}
 	}
 }

--- a/packages/themes/default/src/components/input-checkbox.scss
+++ b/packages/themes/default/src/components/input-checkbox.scss
@@ -12,11 +12,6 @@
 		&--disabled {
 			#{$root}__input {
 				outline: none;
-				cursor: not-allowed;
-			}
-
-			#{$root}__label {
-				cursor: not-allowed;
 			}
 		}
 	}
@@ -24,13 +19,22 @@
 	@include kol-field-control-theme;
 
 	.kol-field-control {
-		gap: rem(6.4);
+		$root: &;
+
+		&__label {
+			@at-root #{$root}--label-align-left & {
+				padding-right: rem(6.4);
+			}
+
+			@at-root #{$root}--label-align-right & {
+				padding-left: rem(6.4);
+			}
+		}
 	}
 
 	.kol-checkbox {
 		.kol-input {
 			@include kol-typography-body;
-			cursor: pointer;
 			order: 1;
 			width: 100%;
 			border-color: var(--color-subtle);
@@ -48,10 +52,6 @@
 				border-color: var(--color-primary);
 			}
 
-			&:disabled {
-				cursor: not-allowed;
-			}
-
 			&:focus {
 				@include focus-outline;
 			}
@@ -64,7 +64,7 @@
 				box-shadow: none;
 			}
 
-			&:hover {
+			&:not(:disabled):hover {
 				border-color: var(--color-primary);
 				box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 			}
@@ -283,11 +283,6 @@
 						&__input {
 							opacity: 0.5;
 							outline: none;
-							cursor: not-allowed;
-						}
-
-						&__label {
-							cursor: not-allowed;
 						}
 					}
 				}

--- a/packages/themes/default/src/components/input-checkbox.scss
+++ b/packages/themes/default/src/components/input-checkbox.scss
@@ -21,14 +21,11 @@
 	.kol-field-control {
 		$root: &;
 
-		&__label {
-			@at-root #{$root}--label-align-left & {
-				padding-right: rem(6.4);
-			}
-
-			@at-root #{$root}--label-align-right & {
-				padding-left: rem(6.4);
-			}
+		&--label-align-left:not(.kol-input-checkbox__field-control--variant-button) &__label {
+			padding-right: rem(6.4);
+		}
+		&--label-align-right:not(.kol-input-checkbox__field-control--variant-button) &__label {
+			padding-left: rem(6.4);
 		}
 	}
 
@@ -150,9 +147,7 @@
 		$root: &;
 
 		&--variant-button {
-			gap: unset;
-
-			& .kol-field-control {
+			.kol-field-control {
 				&__input,
 				&__label {
 					border-color: var(--color-primary);

--- a/packages/themes/default/src/components/input-radio.scss
+++ b/packages/themes/default/src/components/input-radio.scss
@@ -40,17 +40,13 @@
 	}
 
 	.kol-field-control {
-		&__wrapper {
-			gap: rem(8);
-		}
-
 		&__label {
 			padding-top: 0.1em;
+			padding-left: rem(8);
 		}
 	}
 
 	.kol-input-radio {
-		cursor: pointer;
 		width: 100%;
 		border-color: var(--color-subtle);
 		border-width: 2px;
@@ -58,7 +54,7 @@
 		border-radius: 50%;
 		line-height: 1.5;
 
-		&:hover {
+		&:not(:disabled):hover {
 			border-color: var(--color-primary);
 			box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
 		}
@@ -80,7 +76,6 @@
 		}
 
 		&:disabled {
-			cursor: not-allowed;
 			background-color: var(--color-mute-variant);
 		}
 	}

--- a/packages/themes/default/src/components/select.scss
+++ b/packages/themes/default/src/components/select.scss
@@ -12,11 +12,6 @@
 		&__option {
 			margin: rem(1) 0;
 			border-radius: var(--border-radius);
-			cursor: pointer;
-
-			&:disabled {
-				cursor: not-allowed;
-			}
 
 			&:active:not(:disabled),
 			&:checked:not(:disabled),

--- a/packages/themes/default/src/components/textarea.scss
+++ b/packages/themes/default/src/components/textarea.scss
@@ -13,10 +13,6 @@
 		display: block;
 		overflow: auto;
 
-		&:disabled {
-			cursor: not-allowed;
-		}
-
 		&::placeholder {
 			color: var(--color-subtle);
 		}

--- a/packages/themes/default/src/mixins/field-control.scss
+++ b/packages/themes/default/src/mixins/field-control.scss
@@ -2,8 +2,6 @@
 
 @mixin kol-field-control-theme {
 	.kol-field-control {
-		column-gap: rem(8);
-
 		&--required & {
 			&__label-text {
 				&::after {

--- a/packages/themes/default/src/mixins/input.scss
+++ b/packages/themes/default/src/mixins/input.scss
@@ -33,6 +33,7 @@
 			background-color: var(--color-mute);
 			border-color: var(--color-mute-variant);
 			color: var(--color-text);
+			cursor: not-allowed;
 		}
 
 		&:not(&--disabled) {

--- a/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
@@ -26,7 +26,17 @@
 	}
 
 	.kol-field-control {
-		gap: rem(8);
+		$root: &;
+
+		&__label {
+			@at-root #{$root}--label-align-left & {
+				padding-right: rem(8);
+			}
+
+			@at-root #{$root}--label-align-right & {
+				padding-left: rem(8);
+			}
+		}
 
 		&__label {
 			&-text::after {
@@ -57,12 +67,12 @@
 				border-color: var(--color-blue);
 			}
 
-			&:hover {
+			&:not(:disabled):hover {
 				border-color: var(--color-blue);
 			}
 
 			&:checked {
-				&:hover {
+				&:not(:disabled):hover {
 					background-color: var(--color-blue-130);
 					border-color: var(--color-blue-130);
 				}
@@ -76,12 +86,12 @@
 					border-color: var(--color-red);
 				}
 
-				&:hover {
+				&:not(:disabled):hover {
 					border-color: var(--color-red);
 				}
 
 				&:checked {
-					&:hover {
+					&:not(:disabled):hover {
 						background-color: var(--color-red-120);
 						border-color: var(--color-red-120);
 					}
@@ -118,7 +128,7 @@
 		}
 
 		&:hover {
-			.kol-input::before {
+			.kol-input:not(:disabled)::before {
 				background-color: var(--color-blue);
 			}
 		}
@@ -139,7 +149,7 @@
 			}
 
 			&:hover {
-				.kol-input::before {
+				.kol-input:not(:disabled)::before {
 					background-color: var(--color-red);
 				}
 			}

--- a/packages/themes/ecl/src/ecl-ec/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/single-select.scss
@@ -51,7 +51,6 @@ $visible-options: 5;
 		&__button {
 			display: grid;
 			place-items: center;
-			cursor: pointer;
 			padding-left: 1em;
 
 			&:focus {

--- a/packages/themes/ecl/src/ecl-ec/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/button.scss
@@ -26,7 +26,7 @@
 				--text-focus-outline-color: var(--color-white);
 			}
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-background-color: var(--color-blue-130);
 				--text-border-color: var(--color-blue-130);
 			}
@@ -41,7 +41,7 @@
 				--text-focus-outline-color: var(--color-blue);
 			}
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-border-color: var(--color-blue-130);
 				--text-color: var(--color-blue-130);
 			}
@@ -52,7 +52,7 @@
 			--text-border-color: var(--color-yellow);
 			--text-color: var(--color-black);
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-background-color: var(--color-yellow-120);
 				--text-border-color: var(--color-yellow-120);
 			}
@@ -67,7 +67,7 @@
 				--text-focus-outline-color: var(--color-white);
 			}
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-background-color: var(--color-red);
 				--text-border-color: var(--color-red);
 			}
@@ -82,7 +82,7 @@
 				--text-focus-outline-color: var(--color-blue);
 			}
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-background-color: unset;
 				--text-border-color: transparent;
 				--text-color: var(--color-blue-130);

--- a/packages/themes/ecl/src/ecl-ec/mixins/input-container.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/input-container.scss
@@ -17,8 +17,12 @@
 		}
 
 		&:focus-within,
-		&:hover {
+		&:not(&--disabled):hover {
 			border-color: var(--color-blue);
+		}
+
+		&--disabled {
+			cursor: not-allowed;
 		}
 
 		&#{&}--error {

--- a/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
@@ -26,7 +26,17 @@
 	}
 
 	.kol-field-control {
-		gap: rem(8);
+		$root: &;
+
+		&__label {
+			@at-root #{$root}--label-align-left & {
+				padding-right: rem(8);
+			}
+
+			@at-root #{$root}--label-align-right & {
+				padding-left: rem(8);
+			}
+		}
 
 		&__label {
 			&-text::after {
@@ -57,12 +67,12 @@
 				border-color: var(--color-blue);
 			}
 
-			&:hover {
+			&:not(:disabled):hover {
 				border-color: var(--color-blue);
 			}
 
 			&:checked {
-				&:hover {
+				&:not(:disabled):hover {
 					background-color: var(--color-blue-130);
 					border-color: var(--color-blue-130);
 				}
@@ -76,12 +86,12 @@
 					border-color: var(--color-red);
 				}
 
-				&:hover {
+				&:not(:disabled):hover {
 					border-color: var(--color-red);
 				}
 
 				&:checked {
-					&:hover {
+					&:not(:disabled):hover {
 						background-color: var(--color-red-120);
 						border-color: var(--color-red-120);
 					}
@@ -113,7 +123,7 @@
 		}
 
 		&:hover {
-			.kol-input::before {
+			.kol-input:not(:disabled)::before {
 				background-color: var(--color-blue);
 			}
 		}
@@ -134,7 +144,7 @@
 			}
 
 			&:hover {
-				.kol-input::before {
+				.kol-input:not(:disabled)::before {
 					background-color: var(--color-red);
 				}
 			}

--- a/packages/themes/ecl/src/ecl-eu/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/single-select.scss
@@ -49,7 +49,6 @@ $visible-options: 5;
 		&__button {
 			display: grid;
 			place-items: center;
-			cursor: pointer;
 			padding-left: 1em;
 
 			&:focus {

--- a/packages/themes/ecl/src/ecl-eu/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/button.scss
@@ -16,7 +16,7 @@
 			--text-color: #fff;
 			--text-focus-outline-color: #fff;
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-background-color: #3e6cd5;
 			}
 		}
@@ -27,7 +27,7 @@
 			--text-border-color: #0e47cb;
 			--text-focus-outline-color: #fff;
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-color: #0e47cb;
 			}
 		}
@@ -38,7 +38,7 @@
 			--text-focus-outline-color: #000;
 			--text-border-color: #fc0;
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-background-color: #fc0;
 			}
 		}
@@ -48,7 +48,7 @@
 			--text-border-color: var(--color-red);
 			--text-color: var(--color-white);
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-background-color: var(--color-red);
 				--text-border-color: var(--color-red);
 			}
@@ -58,7 +58,7 @@
 			--text-color: #0e47cb;
 			--text-focus-outline-color: #0e47cb;
 
-			&:hover {
+			&:not(:disabled):hover {
 				--text-color: #0e47cb;
 			}
 		}
@@ -84,7 +84,7 @@
 			color: var(--text-color);
 
 			&:active,
-			&:hover {
+			&:not(:disabled):hover {
 				box-shadow:
 					0 rem(2) rem(4) rgb(9 49 142 / 8%),
 					0 0 rem(10) rgb(9 49 142 / 4%),

--- a/packages/themes/ecl/src/ecl-eu/mixins/input-container.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/input-container.scss
@@ -17,8 +17,12 @@
 		}
 
 		&:focus-within,
-		&:hover {
+		&:not(&--disabled):hover {
 			border-color: var(--color-blue);
+		}
+
+		&--disabled {
+			cursor: not-allowed;
 		}
 
 		&#{&}--error {


### PR DESCRIPTION
## What changed?

Corrects `cursor` and `:hover` styling for form controls across the base component styles and the bundled themes. Disabled controls now consistently show a `not-allowed` cursor while enabled ones show `pointer`, and hover effects are gated behind `:not(:disabled)` so disabled checkboxes, radios, selects, ranges, buttons, single-select delete buttons and input containers no longer react to hover. Duplicated/conflicting `cursor` rules were consolidated (e.g. moved onto the shared `.kol-input` / input mixin), and `single-select/shadow.tsx` now applies a `kol-single-select__delete--disabled` class via `clsx` so the delete button reflects the disabled state. Touches base SCSS for `input-checkbox`, `input-color`, `input-file`, `input-range`, `select`, `single-select`, custom-suggestions-toggle and the input-container mixin, plus the `default` and `ecl` (ec/eu) themes.

## Linked issues

- Refs #7528 — inconsistent cursor and hover states on form controls

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Korrigiert `cursor`- und `:hover`-Styles für Formular-Steuerelemente sowohl in den Basis-Komponenten-Styles als auch in den mitgelieferten Themes. Deaktivierte Steuerelemente zeigen nun konsistent einen `not-allowed`-Cursor, aktivierte einen `pointer`, und Hover-Effekte werden mit `:not(:disabled)` abgesichert, sodass deaktivierte Checkboxen, Radios, Selects, Ranges, Buttons, Single-Select-Löschbuttons und Input-Container nicht mehr auf Hover reagieren. Doppelte/kollidierende `cursor`-Regeln wurden konsolidiert (z. B. auf `.kol-input` bzw. das Input-Mixin verschoben), und `single-select/shadow.tsx` setzt jetzt per `clsx` die Klasse `kol-single-select__delete--disabled`, sodass der Löschbutton den Disabled-Zustand widerspiegelt. Betrifft die Basis-SCSS von `input-checkbox`, `input-color`, `input-file`, `input-range`, `select`, `single-select`, Custom-Suggestions-Toggle und das Input-Container-Mixin sowie die Themes `default` und `ecl` (ec/eu).

### Verknüpfte Tickets

- Referenziert #7528 — inkonsistente Cursor- und Hover-Zustände bei Formular-Steuerelementen

### Art der Änderung

🐛 Fehlerbehebung (UX)

### Geänderte Dateien

- `packages/components/src/components/{input-checkbox,input-color,input-file,input-range,select,single-select}/style.scss` — Cursor-/Hover-Regeln korrigiert und konsolidiert
- `packages/components/src/components/single-select/shadow.tsx` — `--disabled`-Modifier für den Löschbutton via `clsx`
- `packages/components/src/styles/{_kol-custom-suggestions-toggle,_kol-input-container-mixin}.scss` — Cursor nur noch für aktive Elemente
- `packages/themes/default/src/**` und `packages/themes/ecl/src/ecl-ec|ecl-eu/**` — Hover nur bei `:not(:disabled)`, Disabled-Cursor vereinheitlicht

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
