### PR TITLE
fix(preact): move @public-ui/react to peerDependencies

### DIFF
--- a/packages/adapters/preact/package.json
+++ b/packages/adapters/preact/package.json
@@ -47,9 +47,6 @@
 	"scripts": {
 		"build": "unbuild"
 	},
-	"dependencies": {
-		"@public-ui/react": "workspace:*"
-	},
 	"devDependencies": {
 		"@public-ui/components": "workspace:*",
 		"react": "18.3.1",
@@ -58,6 +55,7 @@
 		"unbuild": "1.2.1"
 	},
 	"peerDependencies": {
+		"@public-ui/react": "workspace:*",
 		"preact": ">=10.26.4"
 	},
 	"sideEffects": false,


### PR DESCRIPTION
## What changed?

In `packages/adapters/preact/package.json`, `@public-ui/react` is moved from the `dependencies` section to `peerDependencies` (`workspace:*`). The Preact adapter therefore no longer declares `@public-ui/react` as a direct, bundled dependency; instead the consuming application supplies it as a peer. This avoids pinning/duplicating a second copy of `@public-ui/react` in the dependency tree and prevents version mismatches between the adapter and the React package it builds on. This PR targets the `develop` branch.

## Linked issues

- Refs #7574 — align Preact adapter dependency handling

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/adapters/preact/package.json` wird `@public-ui/react` aus dem Abschnitt `dependencies` in `peerDependencies` (`workspace:*`) verschoben. Der Preact-Adapter deklariert `@public-ui/react` damit nicht mehr als direkte, gebündelte Abhängigkeit, sondern erwartet sie als Peer aus der konsumierenden Anwendung. Dadurch wird eine zweite, gepinnte Kopie von `@public-ui/react` im Abhängigkeitsbaum vermieden und Versionskonflikte zwischen Adapter und React-Paket werden verhindert. Dieser PR zielt auf den `develop`-Branch.

### Verknüpfte Tickets

- Referenziert #7574 — Abhängigkeitsbehandlung des Preact-Adapters angleichen

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/adapters/preact/package.json` — `@public-ui/react` von `dependencies` nach `peerDependencies` verschoben

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
