### PR TITLE
chore(deps): update adopted-style-sheets to 1.1.8-rc.2 and third-party-web to 0.26.6

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -73,7 +73,7 @@
 	},
 	"dependencies": {
 		"@floating-ui/dom": "1.6.13",
-		"adopted-style-sheets": "1.1.7",
+		"adopted-style-sheets": "1.1.8-rc.2",
 		"clsx": "2.1.1",
 		"color-convert": "2.0.1",
 		"color-rgba": "2.4.0",
@@ -126,7 +126,7 @@
 		"typescript": "5.8.2"
 	},
 	"peerDependencies": {
-		"adopted-style-sheets": "1.1.7"
+		"adopted-style-sheets": "1.1.8-rc.2"
 	},
 	"files": [
 		"assets",

--- a/packages/designer/package.json
+++ b/packages/designer/package.json
@@ -50,7 +50,7 @@
 		"@types/prettier": "2.7.3",
 		"@unocss/preset-mini": "0.58.9",
 		"@unocss/webpack": "0.58.9",
-		"adopted-style-sheets": "1.1.7",
+		"adopted-style-sheets": "1.1.8-rc.2",
 		"ajv": "8.17.1",
 		"chromedriver": "130.0.4",
 		"cpy-cli": "5.0.0",

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -35,7 +35,7 @@
 		"@types/react-dom": "18.3.5",
 		"@unocss/preset-uno": "0.58.9",
 		"@unocss/webpack": "0.58.9",
-		"adopted-style-sheets": "1.1.7",
+		"adopted-style-sheets": "1.1.8-rc.2",
 		"ajv": "8.17.1",
 		"chromedriver": "130.0.4",
 		"cpy-cli": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,8 +374,8 @@ importers:
         specifier: 1.6.13
         version: 1.6.13
       adopted-style-sheets:
-        specifier: 1.1.7
-        version: 1.1.7
+        specifier: 1.1.8-rc.2
+        version: 1.1.8-rc.2
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -571,8 +571,8 @@ importers:
         specifier: 0.58.9
         version: 0.58.9(rollup@4.36.0)(webpack@5.98.0(@swc/core@1.5.28)(esbuild@0.23.0))
       adopted-style-sheets:
-        specifier: 1.1.7
-        version: 1.1.7
+        specifier: 1.1.8-rc.2
+        version: 1.1.8-rc.2
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -719,8 +719,8 @@ importers:
         specifier: 0.58.9
         version: 0.58.9(rollup@4.36.0)(webpack@5.91.0)
       adopted-style-sheets:
-        specifier: 1.1.7
-        version: 1.1.7
+        specifier: 1.1.8-rc.2
+        version: 1.1.8-rc.2
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -4666,8 +4666,8 @@ packages:
     resolution: {integrity: sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==}
     engines: {node: '>=8.9'}
 
-  adopted-style-sheets@1.1.7:
-    resolution: {integrity: sha512-OjAW91PEKxVC53kPcOLLChDpFqgBoqHgHVU9Xs6OtiTtnmVR47+OUtWInDRSZF2WdZYu5UfizKrdPtkIA4/tuA==}
+  adopted-style-sheets@1.1.8-rc.2:
+    resolution: {integrity: sha512-bOz1OPZH7RY1xapR7W7iut1guRxnC0k15jlmmd623bXh6f2FFa2I3womRa3e86KoD7LLvK1maF5Xf5CVlKNfPQ==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -11795,6 +11795,9 @@ packages:
   third-party-web@0.26.5:
     resolution: {integrity: sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==}
 
+  third-party-web@0.26.6:
+    resolution: {integrity: sha512-GsjP92xycMK8qLTcQCacgzvffYzEqe29wyz3zdKVXlfRD5Kz1NatCTOZEeDaSd6uCZXvGd2CNVtQ89RNIhJWvA==}
+
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
@@ -16403,7 +16406,7 @@ snapshots:
 
   '@paulirish/trace_engine@0.0.44':
     dependencies:
-      third-party-web: 0.26.5
+      third-party-web: 0.26.6
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -17593,7 +17596,7 @@ snapshots:
       loader-utils: 2.0.4
       regex-parser: 2.3.0
 
-  adopted-style-sheets@1.1.7:
+  adopted-style-sheets@1.1.8-rc.2:
     dependencies:
       loglevel: 1.9.2
 
@@ -21737,7 +21740,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@22.10.2)(typescript@5.8.2))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -21826,7 +21829,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@22.10.2)(typescript@5.8.2)):
+  jest-jasmine2@26.6.3:
     dependencies:
       '@babel/traverse': 7.25.9
       '@jest/environment': 26.6.2
@@ -21847,11 +21850,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:
@@ -26382,6 +26381,8 @@ snapshots:
       tslib: 2.6.3
 
   third-party-web@0.26.5: {}
+
+  third-party-web@0.26.6: {}
 
   throat@5.0.0: {}
 


### PR DESCRIPTION
## What changed?

A dependency-maintenance update. `adopted-style-sheets` is bumped from `1.1.7` to `1.1.8-rc.2` in `packages/components/package.json`, `packages/designer/package.json` and `packages/samples/react/package.json` (with matching `pnpm-lock.yaml` entries), and `third-party-web` is updated from `0.26.5` to `0.26.6` in the lockfile. Unused transitive peer dependencies for `jest-jasmine2` (`bufferutil`, `canvas`, `ts-node`, `utf-8-validate`) are pruned from `pnpm-lock.yaml` to simplify the dependency tree. No application or component source code changes.

## Linked issues

- Refs #6817 — Dependency/tooling maintenance tracked under this issue.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Eine Abhängigkeits-Pflege. `adopted-style-sheets` wird von `1.1.7` auf `1.1.8-rc.2` angehoben — in `packages/components/package.json`, `packages/designer/package.json` und `packages/samples/react/package.json` (mit passenden Einträgen in `pnpm-lock.yaml`) — und `third-party-web` wird in der Lockdatei von `0.26.5` auf `0.26.6` aktualisiert. Ungenutzte transitive Peer-Abhängigkeiten von `jest-jasmine2` (`bufferutil`, `canvas`, `ts-node`, `utf-8-validate`) werden aus `pnpm-lock.yaml` entfernt, um den Abhängigkeitsbaum zu vereinfachen. Keine Änderung an Anwendungs- oder Komponenten-Quellcode.

### Verknüpfte Tickets

- Referenziert #6817 — Abhängigkeits-/Tooling-Pflege unter diesem Ticket.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/package.json`, `packages/designer/package.json`, `packages/samples/react/package.json` — `adopted-style-sheets` von `1.1.7` auf `1.1.8-rc.2` angehoben.
- `pnpm-lock.yaml` — `third-party-web` auf `0.26.6` aktualisiert und ungenutzte `jest-jasmine2`-Peer-Abhängigkeiten entfernt.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
