### PR TITLE
fix(tree): only match single-character keys during type-ahead navigation

### DIFF
--- a/packages/components/src/components/tree/component.tsx
+++ b/packages/components/src/components/tree/component.tsx
@@ -172,7 +172,7 @@ export class KolTreeWc implements TreeAPI {
 				event.preventDefault();
 				break;
 			}
-			case event.key.match(/[a-zA-Z0-9]/)?.input: {
+			case event.key.match(/^[a-zA-Z0-9]$/)?.input: {
 				/* Ignore events with any modifier key to avoid breaking native browser or OS shortcuts such as ⌘+L */
 				if (!hasModifierKeyPressed) {
 					const char = event.key.toLowerCase();


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/tree/component.tsx`, the key-matching branch of the tree's keyboard handler was tightened from the regular expression `/[a-zA-Z0-9]/` to `/^[a-zA-Z0-9]$/`. The old pattern matched any `event.key` value that merely *contained* an alphanumeric character, so composite key names such as `ArrowDown`, `Enter` or `Home` were incorrectly treated as printable characters and triggered the type-ahead ("jump to the next node starting with this letter") logic. The anchored pattern now matches only keys whose entire value is a single alphanumeric character, so navigation and action keys are no longer swallowed by the type-ahead branch. (Companion PR to #7580, applied on a separate branch.)

## Linked issues

- Refs #7568 — Tree keyboard navigation issue this fix belongs to.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/tree/component.tsx` wurde der Zweig zur Tastenerkennung im Keyboard-Handler des Trees vom regulären Ausdruck `/[a-zA-Z0-9]/` auf `/^[a-zA-Z0-9]$/` verschärft. Das alte Muster passte auf jeden `event.key`-Wert, der *irgendein* alphanumerisches Zeichen enthielt, sodass zusammengesetzte Tastennamen wie `ArrowDown`, `Enter` oder `Home` fälschlich als druckbare Zeichen behandelt wurden und die Type-Ahead-Logik (Sprung zum nächsten Knoten mit diesem Anfangsbuchstaben) auslösten. Das verankerte Muster passt nun nur noch auf Tasten, deren gesamter Wert ein einzelnes alphanumerisches Zeichen ist. (Begleit-PR zu #7580, auf einem separaten Branch angewendet.)

### Verknüpfte Tickets

- Referenziert #7568 — Ticket zur Tastaturnavigation des Trees, zu dem dieser Fix gehört.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tree/component.tsx` — Regex zur Tastenerkennung von `/[a-zA-Z0-9]/` auf `/^[a-zA-Z0-9]$/` verankert, damit nur Einzelzeichen-Tasten das Type-Ahead auslösen.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
