### PR TITLE
refactor(nav): replace compact toggle button with KolButtonWc

### DIFF
--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -28,7 +28,7 @@ import { Component, h, Host, Prop, State, Watch } from '@stencil/core';
 import { translate } from '../../i18n';
 import { addNavLabel, removeNavLabel } from '../../utils/unique-nav-labels';
 import { watchNavLinks } from './validation';
-import { KolButtonTag, KolButtonWcTag, KolLinkWcTag } from '../../core/component-names';
+import { KolButtonWcTag, KolLinkWcTag } from '../../core/component-names';
 import type { StencilUnknown } from '../../schema';
 
 const linkValidator = (link: ButtonOrLinkOrTextWithChildrenProps): boolean => {
@@ -230,7 +230,7 @@ export class KolNav implements NavAPI {
 					</nav>
 					{hasCompactButton && (
 						<div class="compact">
-							<KolButtonTag
+							<KolButtonWcTag
 								_ariaControls="nav"
 								_ariaExpanded={!hideLabel}
 								_icons={hideLabel ? 'codicon codicon-chevron-right' : 'codicon codicon-chevron-left'}
@@ -246,7 +246,7 @@ export class KolNav implements NavAPI {
 								}}
 								_tooltipAlign="right"
 								_variant="ghost"
-							></KolButtonTag>
+							></KolButtonWcTag>
 						</div>
 					)}
 				</div>

--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -231,6 +231,7 @@ export class KolNav implements NavAPI {
 					{hasCompactButton && (
 						<div class="compact">
 							<KolButtonWcTag
+								class="toggle-button"
 								_ariaControls="nav"
 								_ariaExpanded={!hideLabel}
 								_icons={hideLabel ? 'codicon codicon-chevron-right' : 'codicon codicon-chevron-left'}

--- a/packages/components/src/components/nav/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/nav/test/__snapshots__/snapshot.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
         </ul>
       </nav>
       <div class="compact">
-        <kol-button-wc _ariacontrols="nav" _ariaexpanded="" _hidelabel="" _icons="codicon codicon-chevron-left" _label="kol-nav-minimize" _tooltipalign="right" _variant="ghost"></kol-button-wc>
+        <kol-button-wc _ariacontrols="nav" _ariaexpanded="" _hidelabel="" _icons="codicon codicon-chevron-left" _label="kol-nav-minimize" _tooltipalign="right" _variant="ghost" class="toggle-button"></kol-button-wc>
       </div>
     </div>
   </template>

--- a/packages/components/src/components/nav/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/nav/test/__snapshots__/snapshot.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
         </ul>
       </nav>
       <div class="compact">
-        <kol-button _ariacontrols="nav" _ariaexpanded="" _hidelabel="" _icons="codicon codicon-chevron-left" _label="kol-nav-minimize" _tooltipalign="right" _variant="ghost"></kol-button>
+        <kol-button-wc _ariacontrols="nav" _ariaexpanded="" _hidelabel="" _icons="codicon codicon-chevron-left" _label="kol-nav-minimize" _tooltipalign="right" _variant="ghost"></kol-button-wc>
       </div>
     </div>
   </template>

--- a/packages/themes/bwst/src/components/nav.scss
+++ b/packages/themes/bwst/src/components/nav.scss
@@ -83,4 +83,36 @@
 			justify-content: center;
 		}
 	}
+
+	.toggle-button :is(a, button) > .kol-span-wc,
+	.toggle-button :is(a, button):disabled:hover > .kol-span-wc {
+		border-color: var(--color-light);
+		background-color: var(--color-light);
+		box-shadow: none;
+		color: var(--color-primary);
+		font-weight: 400;
+		border-radius: var(--border-radius);
+		border-style: solid;
+		border-width: var(--border-width);
+		min-height: var(--a11y-min-size);
+		min-width: var(--a11y-min-size);
+		padding: rem(8) rem(14);
+		text-align: center;
+		transition-duration: 0.2s;
+		transition-property: background-color, color, border-color;
+	}
+
+	.toggle-button :is(a, button):active > .kol-span-wc,
+	.toggle-button :is(a, button):hover > .kol-span-wc {
+		background-color: var(--color-primary-variant);
+		border-color: var(--color-primary-variant);
+		box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
+		color: var(--color-light);
+	}
+
+	.toggle-button :is(a, button):active > .kol-span-wc {
+		border-color: var(--color-light);
+		box-shadow: none;
+		outline: none;
+	}
 }

--- a/packages/themes/default/src/components/nav.scss
+++ b/packages/themes/default/src/components/nav.scss
@@ -1,5 +1,6 @@
 @use '../mixins/rem' as *;
 @use '../mixins/focus-outline' as *;
+@use '../mixins/button' as *;
 
 @layer kol-theme-component {
 	:host {
@@ -82,5 +83,26 @@
 		.button-inner {
 			justify-content: center;
 		}
+	}
+
+	.toggle-button :is(a, button) > .kol-span-wc,
+	.toggle-button :is(a, button):disabled:hover > .kol-span-wc {
+		color: var(--color-primary);
+		font-weight: 700;
+		min-height: var(--a11y-min-size);
+		min-width: var(--a11y-min-size);
+		border-color: var(--color-light);
+		background-color: var(--color-light);
+		border-radius: var(--border-radius);
+		border-style: solid;
+		box-shadow: none;
+	}
+
+	.toggle-button :is(a, button):active > .kol-span-wc,
+	.toggle-button :is(a, button):hover > .kol-span-wc {
+		background-color: var(--color-primary-variant);
+		border-color: var(--color-primary-variant);
+		box-shadow: 0 2px 8px 2px rgba(8, 35, 48, 0.24);
+		color: var(--color-light);
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/nav.scss
@@ -82,4 +82,25 @@
 	.expanded > div > .expand-button kol-icon::part(icon)::before {
 		content: '\eab4';
 	}
+
+	button.toggle-button :focus .kol-span-wc {
+		outline-offset: -2px;
+	}
+
+	.toggle-button a .kol-span-wc,
+	.toggle-button button .kol-span-wc {
+		background-color: transparent;
+		border-color: transparent;
+		color: var(--color-blue);
+	}
+
+	.toggle-button a:focus .kol-span-wc,
+	.toggle-button button:focus .kol-span-wc {
+		outline-color: var(--color-blue);
+	}
+
+	.toggle-button a:hover .kol-span-wc,
+	.toggle-button button:hover .kol-span-wc {
+		color: var(--color-blue-130);
+	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/nav.scss
@@ -82,4 +82,19 @@
 	.expanded > div > .expand-button kol-icon::part(icon)::before {
 		content: '\eab4';
 	}
+
+	.toggle-button a > .kol-span-wc,
+	.toggle-button button > .kol-span-wc {
+		color: #0e47cb;
+	}
+
+	.toggle-button a:focus-visible > .kol-span-wc,
+	.toggle-button button:focus-visible > .kol-span-wc {
+		outline-color: #0e47cb;
+	}
+
+	.toggle-button a:hover > .kol-span-wc,
+	.toggle-button button:hover > .kol-span-wc {
+		color: #0e47cb;
+	}
 }

--- a/packages/themes/itzbund/src/components/nav.scss
+++ b/packages/themes/itzbund/src/components/nav.scss
@@ -82,7 +82,6 @@
 	/* compact button */
 	:host > div > div:last-child {
 		margin-top: 0.5em;
-		width: 100%;
 		text-align: center;
 	}
 
@@ -103,5 +102,28 @@
 
 	.kol-span-wc {
 		justify-items: baseline;
+	}
+
+	.toggle-button :is(a, button) > .kol-span-wc,
+	.toggle-button :is(a, button):disabled:hover > .kol-span-wc {
+		background-color: var(--color-ghost);
+		color: var(--color-anthrazit);
+		display: grid;
+		place-items: center;
+		border-radius: 32px;
+		border-style: solid;
+		min-width: var(--a11y-min-size);
+		min-height: var(--a11y-min-size);
+		border-width: var(--spacing);
+		font-size: inherit;
+		padding: 0 rem(8);
+		border-color: transparent;
+	}
+
+	.toggle-button :is(a, button):hover > .kol-span-wc,
+	.toggle-button :is(a, button):focus > .kol-span-wc {
+		background-color: var(--color-ghost);
+		border-color: var(--color-ghost);
+		color: var(--color-anthrazit);
 	}
 }


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/nav/shadow.tsx`, the nav's compact collapse/expand toggle button is switched from the light-DOM `KolButtonTag` (`kol-button`) to the web-component `KolButtonWcTag` (`kol-button-wc`) and tagged with a `toggle-button` class; the now-unused `KolButtonTag` import is removed. The Jest snapshot is updated for the new `kol-button-wc` markup, and `.toggle-button` styling is added to five theme stylesheets — `bwst`, `default`, ECL `ecl-ec`/`ecl-eu`, and `itzbund` `nav.scss` — targeting the `.kol-span-wc` inside the web component so the button retains its ghost look, hover/active/focus states and accessible minimum size (the `itzbund` theme also drops an obsolete `width: 100%` rule on the compact container). No public API or behaviour change — this is part of the ongoing migration of internal building blocks to the `*-wc` web components. (Earlier iteration of the same work as #7591.)

## Linked issues

- Refs #7583 — Nav toggle-button migration to KolButtonWc.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/nav/shadow.tsx` wird der kompakte Ein-/Ausklapp-Button der Navigation vom Light-DOM-`KolButtonTag` (`kol-button`) auf das Webkomponenten-Tag `KolButtonWcTag` (`kol-button-wc`) umgestellt und mit der Klasse `toggle-button` versehen; der nicht mehr benötigte `KolButtonTag`-Import wird entfernt. Der Jest-Snapshot wird an das neue `kol-button-wc`-Markup angepasst, und in fünf Theme-Stylesheets — `bwst`, `default`, ECL `ecl-ec`/`ecl-eu` und `itzbund` `nav.scss` — werden `.toggle-button`-Stilregeln ergänzt, die auf das `.kol-span-wc` innerhalb der Webkomponente zielen, damit der Button sein Ghost-Aussehen, die Hover-/Active-/Focus-Zustände und die barrierefreie Mindestgröße behält (im `itzbund`-Theme wird zusätzlich eine überflüssige `width: 100%`-Regel am Compact-Container entfernt). Keine Änderung an öffentlicher API oder Verhalten — Teil der laufenden Migration interner Bausteine auf die `*-wc`-Webkomponenten. (Frühere Iteration derselben Arbeit wie #7591.)

### Verknüpfte Tickets

- Referenziert #7583 — Migration des Nav-Toggle-Buttons auf KolButtonWc.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/nav/shadow.tsx` — Compact-Toggle-Button von `kol-button` auf `kol-button-wc` umgestellt, Klasse `toggle-button` ergänzt, ungenutzter Import entfernt.
- `packages/components/src/components/nav/test/__snapshots__/snapshot.spec.tsx.snap` — Jest-Snapshot an das neue `kol-button-wc`-Markup angepasst.
- `packages/themes/bwst/…/nav.scss`, `packages/themes/default/…/nav.scss`, `packages/themes/ecl/src/ecl-ec/…/nav.scss`, `packages/themes/ecl/src/ecl-eu/…/nav.scss`, `packages/themes/itzbund/…/nav.scss` — `.toggle-button`-Stilregeln ergänzt (itzbund: überflüssige `width: 100%`-Regel entfernt), um das bisherige Erscheinungsbild zu erhalten.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
