### PR TITLE
refactor(visual-tests): make sample-app module resolution more robust

### DIFF
--- a/packages/tools/visual-tests/src/index.js
+++ b/packages/tools/visual-tests/src/index.js
@@ -19,15 +19,8 @@ if (!tempDir) {
 process.env.THEME_MODULE = path.join(process.cwd(), process.env.THEME_MODULE); // Use current working directory (i.e. the theme folder) to complete module path
 const visualsTestModulePath = fileURLToPath(new URL('..', import.meta.url));
 const binaryPath = fileURLToPath(new URL('../node_modules/.bin', import.meta.url));
-
-let sampleReactPath = '../node_modules/@public-ui/visual-tests/node_modules/@public-ui/sample-react';
-let backSteps = ``;
-let workingDir = null;
-do {
-	const url = new URL(backSteps + sampleReactPath, import.meta.url);
-	workingDir = fileURLToPath(url);
-	backSteps += `../`;
-} while (!fs.existsSync(workingDir) && path.resolve(process.cwd(), backSteps) !== '/');
+const sampleReactPackageJsonPath = import.meta.resolve('@public-ui/sample-react/package.json');
+const workingDir = fileURLToPath(path.dirname(sampleReactPackageJsonPath));
 
 if (!fs.existsSync(workingDir)) {
 	throw new Error('Could not find React Sample App package. Please install it with "npm install @public-ui/sample-react".');


### PR DESCRIPTION
## What changed?

In `packages/tools/visual-tests/src/index.js`, the way the visual-tests runner locates the `@public-ui/sample-react` package is rewritten. The previous implementation hard-coded a relative path (`../node_modules/@public-ui/visual-tests/node_modules/@public-ui/sample-react`) and walked up the directory tree one `../` at a time until the folder happened to exist. That loop is replaced by a single `import.meta.resolve('@public-ui/sample-react/package.json')` call, deriving the working directory from the resolved package.json path. This removes the dependency on a specific `node_modules` nesting/hoisting layout and makes the tool resilient to different package-manager install structures. Purely test-infrastructure tooling; no shipped package is affected.

## Linked issues

- Refs #7570 — Robustness of the visual-tests tooling.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/tools/visual-tests/src/index.js` wird die Auflösung des `@public-ui/sample-react`-Pakets durch den Visual-Tests-Runner neu geschrieben. Die bisherige Implementierung nutzte einen fest verdrahteten relativen Pfad (`../node_modules/@public-ui/visual-tests/node_modules/@public-ui/sample-react`) und lief den Verzeichnisbaum Schritt für Schritt (`../`) nach oben, bis der Ordner existierte. Diese Schleife wird durch einen einzigen Aufruf von `import.meta.resolve('@public-ui/sample-react/package.json')` ersetzt; das Arbeitsverzeichnis wird aus dem aufgelösten package.json-Pfad abgeleitet. Das entfernt die Abhängigkeit von einer bestimmten `node_modules`-Verschachtelung bzw. -Hoisting-Struktur und macht das Werkzeug robust gegenüber unterschiedlichen Installationslayouts der Paketmanager. Reines Test-Infrastruktur-Tooling; kein ausgeliefertes Paket ist betroffen.

### Verknüpfte Tickets

- Referenziert #7570 — Robustheit des Visual-Tests-Tools.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/src/index.js` — Manuelle `../`-Suchschleife zur Auflösung von `@public-ui/sample-react` durch `import.meta.resolve('@public-ui/sample-react/package.json')` ersetzt.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
