### PR TITLE
fix: underline only the text of a tree item

### DIFF
--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -53,7 +53,7 @@ export class KolTreeItemWc implements TreeItemAPI {
 							) : (
 								<span class="toggle-button-placeholder"></span>
 							)}
-							{_label}
+							<span class="text">{_label}</span>
 						</span>
 					</KolLinkWcTag>
 					<ul hidden={!_hasChildren || !_open} role="group" id={this.groupId}>

--- a/packages/components/src/components/tree-item/style.scss
+++ b/packages/components/src/components/tree-item/style.scss
@@ -33,6 +33,10 @@
 		align-items: center;
 	}
 
+	a {
+		text-decoration: none;
+	}
+
 	a .kol-span-wc {
 		place-items: unset; // unset 'center' style from global layer
 	}
@@ -44,5 +48,9 @@
 		display: inline-flex;
 		justify-content: center;
 		align-items: center;
+	}
+
+	.text {
+		text-decoration: underline;
 	}
 }

--- a/packages/components/src/components/tree-item/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/tree-item/test/__snapshots__/snapshot.spec.tsx.snap
@@ -9,7 +9,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="first-level tree-link">
           <span class="tree-link-inner" slot="expert">
             <span class="toggle-button-placeholder"></span>
-            Label
+            <span class="text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul hidden="" id="tree-group-nonce" role="group">
@@ -30,7 +32,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="0" class="active first-level tree-link">
           <span class="tree-link-inner" slot="expert">
             <span class="toggle-button-placeholder"></span>
-            Label
+            <span class="text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul hidden="" id="tree-group-nonce" role="group">
@@ -51,7 +55,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="first-level tree-link">
           <span class="tree-link-inner" slot="expert">
             <span class="toggle-button-placeholder"></span>
-            Label
+            <span class="text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul hidden="" id="tree-group-nonce" role="group">
@@ -72,7 +78,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="first-level tree-link">
           <span class="tree-link-inner" slot="expert">
             <span class="toggle-button-placeholder"></span>
-            Label
+            <span class="text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul hidden="" id="tree-group-nonce" role="group">
@@ -93,7 +101,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="first-level tree-link">
           <span class="tree-link-inner" slot="expert">
             <span class="toggle-button-placeholder"></span>
-            Label
+            <span class="text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul hidden="" id="tree-group-nonce" role="group">

--- a/packages/themes/bwst/src/components/tree-item.scss
+++ b/packages/themes/bwst/src/components/tree-item.scss
@@ -31,13 +31,16 @@
 
 		a {
 			color: var(--color-text);
-			text-decoration: none;
 			text-align: left;
 
 			.toggle-button:hover {
 				.toggle-button-icon::part(icon) {
 					transform: scale(1.6);
 				}
+			}
+
+			.text {
+				text-decoration: none;
 			}
 		}
 	}

--- a/packages/themes/default/src/components/tree-item.scss
+++ b/packages/themes/default/src/components/tree-item.scss
@@ -35,13 +35,16 @@
 
 		a {
 			color: var(--color-text);
-			text-decoration: none;
 			text-align: left;
 
 			.toggle-button:hover {
 				.toggle-button-icon::part(icon) {
 					transform: scale(1.6);
 				}
+			}
+
+			.text {
+				text-decoration: none;
 			}
 		}
 	}

--- a/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
@@ -33,7 +33,6 @@
 
 		a {
 			color: var(--color-black);
-			text-decoration: none;
 			text-align: left;
 
 			.toggle-button:hover {
@@ -44,6 +43,10 @@
 
 			&:focus {
 				color: var(--color-black);
+			}
+
+			.text {
+				text-decoration: none;
 			}
 		}
 	}

--- a/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
@@ -33,7 +33,6 @@
 
 		a {
 			color: var(--color-black);
-			text-decoration: none;
 			text-align: left;
 
 			.toggle-button {
@@ -46,6 +45,10 @@
 
 			&:focus {
 				color: var(--color-black);
+			}
+
+			.text {
+				text-decoration: none;
 			}
 		}
 	}

--- a/packages/themes/itzbund/src/components/tree-item.scss
+++ b/packages/themes/itzbund/src/components/tree-item.scss
@@ -32,7 +32,6 @@
 
 		a {
 			color: var(--color-black);
-			text-decoration: none;
 			text-align: left;
 
 			.toggle-button {
@@ -45,6 +44,10 @@
 
 			&:focus {
 				color: var(--color-petrol);
+			}
+
+			.text {
+				text-decoration: none;
 			}
 		}
 	}


### PR DESCRIPTION
## What changed?

Fixes the underline styling of tree items so that only the item's text label is underlined, instead of the whole link area (which also contains the expand/collapse toggle and its placeholder). In `tree-item/component.tsx` the `_label` is now wrapped in a dedicated `<span class="text">`. The component stylesheet sets `text-decoration: none` on the `a` link and `text-decoration: underline` on `.text`, and the `bwst`, `default`, `ecl-ec`, `ecl-eu` and `itzbund` themes are updated to move their `text-decoration: none` onto the new text span. Component snapshots are updated accordingly. This targets `release/2`; a sibling PR (#7597) applies the same fix to `develop`.

## Linked issues

- Refs #7593 — Tree item underline should not span the expand/collapse arrow

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Korrigiert die Unterstreichung von Tree-Items, sodass nur der Text des Eintrags unterstrichen wird und nicht der gesamte Link-Bereich (der auch den Aufklapp-/Zuklapp-Button und dessen Platzhalter enthält). In `tree-item/component.tsx` wird das `_label` nun in ein eigenes `<span class="text">` gehüllt. Im Komponenten-Stylesheet erhält der `a`-Link `text-decoration: none` und `.text` `text-decoration: underline`; die Themes `bwst`, `default`, `ecl-ec`, `ecl-eu` und `itzbund` werden angepasst, indem ihr `text-decoration: none` auf das neue Text-Span verschoben wird. Die Komponenten-Snapshots werden entsprechend aktualisiert. Zielbranch ist `release/2`; ein Schwester-PR (#7597) überträgt dieselbe Korrektur auf `develop`.

### Verknüpfte Tickets

- Referenziert #7593 — Unterstreichung des Tree-Items soll nicht den Aufklapp-Pfeil umfassen

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tree-item/component.tsx` — `_label` in `<span class="text">` gekapselt.
- `packages/components/src/components/tree-item/style.scss` — `text-decoration: none` auf den Link, Unterstreichung auf `.text`.
- `packages/themes/{bwst,default,itzbund}/src/components/tree-item.scss`, `ecl/src/ecl-ec/components/tree-item.scss`, `ecl/src/ecl-eu/components/tree-item.scss` — `text-decoration: none` auf das Text-Span verschoben.
- `.../tree-item/test/__snapshots__/snapshot.spec.tsx.snap` — Aktualisierte Snapshots.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
