### PR TITLE
fix: underline only the text of a tree item

### DIFF
--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -56,7 +56,7 @@ export class KolTreeItemWc implements TreeItemAPI {
 							) : (
 								<span class="kol-tree-item__toggle-button-placeholder"></span>
 							)}
-							{_label}
+							<span class="kol-tree-item__text">{_label}</span>
 						</span>
 					</KolLinkWcTag>
 					<ul class="kol-tree-item__children" hidden={!_hasChildren || !_open} role="group" id={this.groupId}>

--- a/packages/components/src/components/tree-item/style.scss
+++ b/packages/components/src/components/tree-item/style.scss
@@ -16,6 +16,7 @@
 				min-height: var(--a11y-min-size);
 				padding-left: max(calc((var(--indentation) * var(--level)) + $base-horizontal-padding), $base-horizontal-padding);
 				padding-right: rem(6);
+				text-decoration: none;
 			}
 
 			&--first-level .kol-link {
@@ -45,6 +46,10 @@
 			display: inline-flex;
 			justify-content: center;
 			align-items: center;
+		}
+
+		&__text {
+			text-decoration: underline;
 		}
 	}
 }

--- a/packages/components/src/components/tree-item/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/tree-item/test/__snapshots__/snapshot.spec.tsx.snap
@@ -9,7 +9,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="kol-tree-item__link kol-tree-item__link--first-level">
           <span class="kol-tree-item__link-inner" slot="expert">
             <span class="kol-tree-item__toggle-button-placeholder"></span>
-            Label
+            <span class="kol-tree-item__text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul class="kol-tree-item__children" hidden="" id="tree-group-nonce" role="group">
@@ -30,7 +32,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="0" class="kol-tree-item__link kol-tree-item__link--active kol-tree-item__link--first-level">
           <span class="kol-tree-item__link-inner" slot="expert">
             <span class="kol-tree-item__toggle-button-placeholder"></span>
-            Label
+            <span class="kol-tree-item__text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul class="kol-tree-item__children" hidden="" id="tree-group-nonce" role="group">
@@ -51,7 +55,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="kol-tree-item__link kol-tree-item__link--first-level">
           <span class="kol-tree-item__link-inner" slot="expert">
             <span class="kol-tree-item__toggle-button-placeholder"></span>
-            Label
+            <span class="kol-tree-item__text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul class="kol-tree-item__children" hidden="" id="tree-group-nonce" role="group">
@@ -72,7 +78,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="kol-tree-item__link kol-tree-item__link--first-level">
           <span class="kol-tree-item__link-inner" slot="expert">
             <span class="kol-tree-item__toggle-button-placeholder"></span>
-            Label
+            <span class="kol-tree-item__text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul class="kol-tree-item__children" hidden="" id="tree-group-nonce" role="group">
@@ -93,7 +101,9 @@ exports[`kol-tree-item should render with _label="Label" _href="https://example.
         <kol-link-wc _href="https://example.com" _label="" _role="treeitem" _tabindex="-1" class="kol-tree-item__link kol-tree-item__link--first-level">
           <span class="kol-tree-item__link-inner" slot="expert">
             <span class="kol-tree-item__toggle-button-placeholder"></span>
-            Label
+            <span class="kol-tree-item__text">
+              Label
+            </span>
           </span>
         </kol-link-wc>
         <ul class="kol-tree-item__children" hidden="" id="tree-group-nonce" role="group">

--- a/packages/themes/default/src/components/tree-item.scss
+++ b/packages/themes/default/src/components/tree-item.scss
@@ -11,7 +11,6 @@
 
 			.kol-link {
 				color: var(--color-text);
-				text-decoration: none;
 				text-align: left;
 			}
 
@@ -37,6 +36,10 @@
 
 		&__toggle-button:hover &__toggle-button-icon::part(icon) {
 			transform: scale(1.6);
+		}
+
+		&__text {
+			text-decoration: none;
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
@@ -35,7 +35,6 @@
 
 			.kol-link {
 				color: var(--color-black);
-				text-decoration: none;
 				text-align: left;
 
 				&:focus {
@@ -46,6 +45,10 @@
 
 		&__toggle-button:hover &__toggle-button-icon::part(icon) {
 			transform: scale(1.3);
+		}
+
+		&__text {
+			text-decoration: none;
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
@@ -35,7 +35,6 @@
 
 			.kol-link {
 				color: var(--color-black);
-				text-decoration: none;
 				text-align: left;
 
 				&:focus {
@@ -50,6 +49,10 @@
 
 		&__toggle-button:hover &__toggle-button-icon::part(icon) {
 			transform: scale(1.3);
+		}
+
+		&__text {
+			text-decoration: none;
 		}
 	}
 }


### PR DESCRIPTION
## What changed?

Fixes the underline styling of tree items so that only the item's text label is underlined, instead of the whole link area (which also contains the expand/collapse toggle and its placeholder). In `tree-item/component.tsx` the `_label` is now wrapped in a dedicated `<span class="kol-tree-item__text">`. The component stylesheet sets `text-decoration: none` on the link and `text-decoration: underline` on `&__text`, and the `default`, `ecl-ec` and `ecl-eu` themes are updated to move their `text-decoration: none` onto the new text span. Component snapshots are updated accordingly. This targets `develop`; a sibling PR (#7595) applies the same fix to `release/2`.

## Linked issues

- Refs #7593 — Tree item underline should not span the expand/collapse arrow

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Korrigiert die Unterstreichung von Tree-Items, sodass nur der Text des Eintrags unterstrichen wird und nicht der gesamte Link-Bereich (der auch den Aufklapp-/Zuklapp-Button und dessen Platzhalter enthält). In `tree-item/component.tsx` wird das `_label` nun in ein eigenes `<span class="kol-tree-item__text">` gehüllt. Im Komponenten-Stylesheet erhält der Link `text-decoration: none` und `&__text` `text-decoration: underline`; die Themes `default`, `ecl-ec` und `ecl-eu` werden angepasst, indem ihr `text-decoration: none` auf das neue Text-Span verschoben wird. Die Komponenten-Snapshots werden entsprechend aktualisiert. Zielbranch ist `develop`; ein Schwester-PR (#7595) überträgt dieselbe Korrektur auf `release/2`.

### Verknüpfte Tickets

- Referenziert #7593 — Unterstreichung des Tree-Items soll nicht den Aufklapp-Pfeil umfassen

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tree-item/component.tsx` — `_label` in `<span class="kol-tree-item__text">` gekapselt.
- `packages/components/src/components/tree-item/style.scss` — Unterstreichung vom Link auf das Text-Span verschoben.
- `packages/themes/default/src/components/tree-item.scss`, `ecl/src/ecl-ec/components/tree-item.scss`, `ecl/src/ecl-eu/components/tree-item.scss` — `text-decoration: none` auf das Text-Span verschoben.
- `.../tree-item/test/__snapshots__/snapshot.spec.tsx.snap` — Aktualisierte Snapshots.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
