### PR TITLE
fix: improve environment variable handling in Playwright config

### DIFF
--- a/packages/tools/visual-tests/playwright.config.js
+++ b/packages/tools/visual-tests/playwright.config.js
@@ -2,19 +2,24 @@ import { defineConfig, devices } from '@playwright/test';
 import * as path from 'path';
 import * as process from 'process';
 
-const PORT = Number(process.env.KOLIBRI_VISUAL_TEST_PORT);
-const URL = `http://localhost:${PORT}`;
+// Validate and set ENVs
+const PORT = parseInt(process.env.KOLIBRI_VISUAL_TEST_PORT || '', 10);
+const BASE_URL = `http://localhost:${PORT}`;
 
-console.log('Serving React Sample app:', URL);
+const CWD = process.env.KOLIBRI_CWD ?? '';
+const TIMEOUT = parseInt(process.env.KOLIBRI_VISUAL_TESTS_TIMEOUT || '15000', 10);
+const EXPECT_TIMEOUT = parseInt(process.env.KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT || '5000', 10);
+const BUILD_PATH = process.env.KOLIBRI_VISUAL_TESTS_BUILD_PATH ?? '';
+const THEME = (process.env.THEME_EXPORT || 'default').toLocaleLowerCase();
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
 	testDir: './tests',
-	snapshotDir: path.join(process.env.KOLIBRI_CWD ?? '', 'snapshots'),
+	snapshotDir: path.join(CWD, 'snapshots'),
 	// snapshotPathTemplate: '',
-	outputDir: path.join(process.env.KOLIBRI_CWD ?? '', 'test-results'),
+	outputDir: path.join(CWD, 'test-results'),
 	/* Run tests in files in parallel */
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -24,20 +29,20 @@ export default defineConfig({
 	/* Opt out of parallel tests on CI. */
 	workers: process.env.CI ? 1 : undefined,
 	/* Allow to override the expectation timeout for slow environments */
-	timeout: process.env.KOLIBRI_VISUAL_TESTS_TIMEOUT ? Number(process.env.KOLIBRI_VISUAL_TESTS_TIMEOUT) : undefined,
+	timeout: TIMEOUT,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: 'line',
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
-		baseURL: URL,
+		baseURL: BASE_URL,
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
 	},
 
 	expect: {
-		timeout: process.env.KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT ? Number(process.env.KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT) : undefined,
+		timeout: EXPECT_TIMEOUT,
 	},
 
 	/* Configure projects for major browsers */
@@ -59,9 +64,9 @@ export default defineConfig({
 	/* Run your local dev server before starting the tests */
 	webServer: {
 		command: `npx serve -p ${PORT}`,
-		cwd: path.resolve(process.env.KOLIBRI_VISUAL_TESTS_BUILD_PATH),
-		url: URL,
+		cwd: path.resolve(BUILD_PATH),
+		url: BASE_URL,
 		reuseExistingServer: false,
 	},
-	snapshotPathTemplate: `{snapshotDir}/theme-${(process.env.THEME_EXPORT || 'default').toLocaleLowerCase()}/{arg}-{projectName}-{platform}{ext}`,
+	snapshotPathTemplate: `{snapshotDir}/theme-${THEME}/{arg}-{projectName}-{platform}{ext}`,
 });


### PR DESCRIPTION
## What changed?

Refactors the Playwright visual-tests configuration (`packages/tools/visual-tests/playwright.config.js`) to centralize and validate environment-variable handling. The environment variables `KOLIBRI_VISUAL_TEST_PORT`, `KOLIBRI_CWD`, `KOLIBRI_VISUAL_TESTS_TIMEOUT`, `KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT`, `KOLIBRI_VISUAL_TESTS_BUILD_PATH` and `THEME_EXPORT` are now parsed once into named constants (`PORT`, `BASE_URL`, `CWD`, `TIMEOUT`, `EXPECT_TIMEOUT`, `BUILD_PATH`, `THEME`) with fallback defaults (e.g. 15000 ms timeout, 5000 ms expect timeout, `default` theme) and reused consistently across `timeout`, `expect.timeout`, `baseURL`, `snapshotDir`, `outputDir`, the `webServer` block and `snapshotPathTemplate`. This affects only the internal visual-test tooling; there are no library code or public API changes. This PR targets the `develop` branch (a sibling of #7605 which targets `release/2`).

## Linked issues

- Closes #7603 — Improve environment variable handling in the visual-tests Playwright config

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Überarbeitet die Playwright-Konfiguration der Visual-Tests (`packages/tools/visual-tests/playwright.config.js`), um die Behandlung von Umgebungsvariablen zu zentralisieren und zu validieren. Die Umgebungsvariablen `KOLIBRI_VISUAL_TEST_PORT`, `KOLIBRI_CWD`, `KOLIBRI_VISUAL_TESTS_TIMEOUT`, `KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT`, `KOLIBRI_VISUAL_TESTS_BUILD_PATH` und `THEME_EXPORT` werden nun einmalig in benannte Konstanten (`PORT`, `BASE_URL`, `CWD`, `TIMEOUT`, `EXPECT_TIMEOUT`, `BUILD_PATH`, `THEME`) mit Fallback-Standardwerten geparst (z. B. 15000 ms Timeout, 5000 ms Expect-Timeout, Theme `default`) und einheitlich in `timeout`, `expect.timeout`, `baseURL`, `snapshotDir`, `outputDir`, `webServer` und `snapshotPathTemplate` verwendet. Betroffen ist ausschließlich das interne Visual-Test-Tooling; es gibt keine Änderungen an Bibliothekscode oder öffentlicher API. Dieser PR zielt auf den Branch `develop` (Pendant zu #7605 auf `release/2`).

### Verknüpfte Tickets

- Schließt #7603 — Verbesserte Behandlung von Umgebungsvariablen in der Visual-Tests-Playwright-Konfiguration

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/playwright.config.js` — Zentralisierte, validierte Umgebungsvariablen mit Standardwerten und einheitliche Verwendung in der gesamten Konfiguration.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
