### PR TITLE
fix: keep dropdown open when clicking combobox and single-select inputs

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -65,9 +65,10 @@ export class KolCombobox implements ComboboxAPI {
 		if (this.state._disabled === true) {
 			this._isOpen = false;
 		} else {
-			this._isOpen = !this._isOpen;
 			this.refInput?.focus();
-			if (this._isOpen && Array.isArray(this._filteredSuggestions) && this._filteredSuggestions.length > 0) {
+			if (!this._hasOpened && Array.isArray(this._filteredSuggestions) && this._filteredSuggestions.length > 0) {
+				this._isOpen = true;
+				this._hasOpened = true;
 				const selectedIndex = this._filteredSuggestions.findIndex((option) => option === this.state._value);
 				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : 0;
 				this.focusOption(this._focusedOptionIndex);
@@ -293,6 +294,8 @@ export class KolCombobox implements ComboboxAPI {
 				break;
 			case 'Esc':
 			case 'Escape': {
+				this._hasOpened = false;
+				this._isOpen = false;
 				handleEvent(false);
 				this.refInput?.focus();
 				break;
@@ -340,6 +343,8 @@ export class KolCombobox implements ComboboxAPI {
 	private _isOpen: boolean = false;
 	@State()
 	private _filteredSuggestions?: SuggestionsPropType;
+	@State()
+	private _hasOpened = false;
 
 	@Listen('click', { target: 'window' })
 	handleWindowClick(event: MouseEvent) {
@@ -590,6 +595,7 @@ export class KolCombobox implements ComboboxAPI {
 	}
 
 	private onBlur() {
+		this._hasOpened = false;
 		if (this._isOpen) {
 			this._isOpen = !this._isOpen;
 			this.refInput?.focus();

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -73,8 +73,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 		if (this.state._disabled) {
 			return;
 		} else {
-			this._isOpen = !this._isOpen;
-			if (this._isOpen) {
+			if (!this._hasOpened) {
+				this._isOpen = true;
+				this._hasOpened = true;
 				this.refInput?.focus();
 				const selectedIndex = Array.isArray(this._filteredOptions) ? this._filteredOptions.findIndex((option) => option.label === this._inputValue) : -1;
 				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : 0;
@@ -89,6 +90,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 			this._filteredOptions = [...this.state._options];
 		}
 		this._isOpen = false;
+		this._hasOpened = false;
 	}
 
 	private clearSelection() {
@@ -359,6 +361,8 @@ export class KolSingleSelect implements SingleSelectAPI {
 				break;
 			case 'Esc':
 			case 'Escape': {
+				this._hasOpened = false;
+				this._isOpen = false;
 				handleEvent(false);
 				break;
 			}
@@ -422,6 +426,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 	private _inputValue: string = '';
 	@State()
 	private blockSuggestionMouseOver: boolean = false;
+	@State()
+	private _hasOpened = false;
+
 	/**
 	 * Defines which key combination can be used to trigger or focus the interactive element of the component.
 	 */


### PR DESCRIPTION
## What changed?

This fixes the dropdown toggle behavior of the `combobox` and `single-select` components when the input is clicked. A new `_hasOpened` state flag is introduced in both components: the click handler now opens the dropdown exactly once and guards against re-toggling, instead of flipping `_isOpen` on every click (which could immediately close a freshly opened list). The `_hasOpened` flag is reset on `blur`, on `Escape`, and after a selection, so the dropdown can be reopened normally afterwards. Changes are limited to the two component controllers; no public API changed.

## Linked issues

- Refs #7529 — Fix dropdown toggle behavior for combobox and single-select

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt das Toggle-Verhalten des Dropdowns der Komponenten `combobox` und `single-select` beim Klick auf das Eingabefeld. In beiden Komponenten wird ein neues Status-Flag `_hasOpened` eingeführt: Der Klick-Handler öffnet das Dropdown nun genau einmal und verhindert ein erneutes Umschalten, anstatt `_isOpen` bei jedem Klick zu invertieren (wodurch eine gerade geöffnete Liste sofort wieder geschlossen werden konnte). Das Flag `_hasOpened` wird bei `blur`, bei `Escape` und nach einer Auswahl zurückgesetzt, sodass das Dropdown danach wieder normal geöffnet werden kann. Es wurde keine öffentliche API geändert.

### Verknüpfte Tickets

- Referenziert #7529 — Fehlerhaftes Toggle-Verhalten des Dropdowns bei Combobox und Single-Select

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/combobox/shadow.tsx` — Neues `_hasOpened`-Flag und angepasste Klick-, Escape- und Blur-Logik, damit das Dropdown beim Input-Klick geöffnet bleibt.
- `packages/components/src/components/single-select/shadow.tsx` — Analoge Umstellung der Toggle-Logik auf `_hasOpened` inklusive Reset bei Auswahl, Escape und Blur.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
