### PR TITLE
fix(samples): make git revision parsing fail-safe when no git repository is present

### DIFF
--- a/packages/samples/react/src/components/Sidebar.tsx
+++ b/packages/samples/react/src/components/Sidebar.tsx
@@ -7,6 +7,34 @@ import { THEME_OPTIONS } from '../shares/theme';
 
 import type { Routes } from '../shares/types';
 import Navigation from './Navigation';
+
+type BuildInformationProps = {
+	buildDate?: string | null;
+	commitHash?: string | null;
+};
+const BuildInformation: FC<BuildInformationProps> = ({ buildDate, commitHash }) => {
+	if (!buildDate && !commitHash) {
+		return '';
+	}
+
+	return (
+		<div className="text-sm font-mono color-gray-5 m-t-2">
+			{buildDate && commitHash ? ( // date and hash provided
+				<>
+					Build: {commitHash}
+					<br />
+					at {buildDate}
+				</>
+			) : commitHash ? ( // hash only
+				`Build: ${commitHash}`
+			) : (
+				// date only
+				`Build date: ${buildDate}`
+			)}
+		</div>
+	);
+};
+
 type Props = {
 	version: string;
 	theme: string;
@@ -47,16 +75,8 @@ export const Sidebar: FC<Props> = ({ version, theme, routes, routeList, sample, 
 					<KolHeading _label="KoliBri React"></KolHeading>
 					<KolVersion _label={version}></KolVersion>
 				</div>
-				{(buildDate || commitHash) && (
-					<div className="text-sm font-mono color-gray-5 m-t-2">
-						{commitHash ? `Build: ${commitHash}` : ''}
-						<br />
-						{buildDate ? `at ${buildDate}` : ''}
-					</div>
-				)}
-
+				<BuildInformation buildDate={buildDate} commitHash={commitHash} />
 				<KolSelect _label="Theme" _options={THEME_OPTIONS} _on={{ onChange: handleThemeSelectChange }} _value={[theme]} class="mt"></KolSelect>
-
 				<KolHeading _label="Components" _level={2} className="block mt"></KolHeading>
 				<div className="flex flex-justify-between flex-items-center mt">
 					<KolButton _icons="codicon codicon-arrow-left" _hideLabel _label="Previous component" _on={{ onClick: handlePreviousClick }} />
@@ -65,7 +85,6 @@ export const Sidebar: FC<Props> = ({ version, theme, routes, routeList, sample, 
 					</span>
 					<KolButton _icons="codicon codicon-arrow-right" _hideLabel _label="Next component" _on={{ onClick: handleNextClick }} />
 				</div>
-
 				<Navigation routes={routes} />
 			</div>
 		</aside>

--- a/packages/samples/react/webpack.config.js
+++ b/packages/samples/react/webpack.config.js
@@ -2,10 +2,21 @@ const webpack = require('webpack');
 
 const OPTIONAL_THEME_PACKAGE = '@public-ui-/theme-ecl';
 
+/**
+ * @returns {null|string}
+ */
+function getGitCommitHash() {
+	try {
+		return require('child_process').execSync('git rev-parse --short HEAD 2>/dev/null').toString().trim();
+	} catch (e) {
+		return null;
+	}
+}
+
 module.exports = (...args) => {
 	const config = require('@leanup/stack-react/webpack.config')(...args);
 	const UnoCSS = require('@unocss/webpack').default;
-	const commitHash = require('child_process').execSync('git rev-parse --short HEAD').toString().trim();
+
 	config.plugins.push(UnoCSS());
 	config.plugins.push(
 		new webpack.EnvironmentPlugin({
@@ -15,7 +26,7 @@ module.exports = (...args) => {
 			ENABLE_TAG_NAME_TRANSFORMER: '',
 			ENABLE_THEME_PATCHING: '',
 			BUILD_DATE: new Date().toISOString(),
-			COMMIT_HASH: commitHash,
+			COMMIT_HASH: getGitCommitHash(),
 		}),
 	);
 	delete config.devServer.proxy;


### PR DESCRIPTION
## What changed?

The React sample app's webpack config (`packages/samples/react/webpack.config.js`) previously called `git rev-parse --short HEAD` unconditionally at build time, which threw and aborted the build when the sources were built outside a git repository (e.g. from an extracted archive). The call is now wrapped in a `getGitCommitHash()` helper that runs `git rev-parse --short HEAD 2>/dev/null` inside a `try/catch` and returns `null` on failure, so the build succeeds without a repo. Correspondingly, `Sidebar.tsx` extracts the build-info rendering into a dedicated `BuildInformation` component that gracefully handles all combinations of a present/absent build date and commit hash (both, hash only, date only, or nothing). Only the demo/sample application is affected — no library component or public API changes.

## Linked issues

- Refs #7616 — sample app fails to build when no git repository is present.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Webpack-Konfiguration der React-Sample-App (`packages/samples/react/webpack.config.js`) rief bisher zur Build-Zeit bedingungslos `git rev-parse --short HEAD` auf, was den Build abbrach, wenn außerhalb eines Git-Repositories gebaut wurde (z. B. aus einem extrahierten Archiv). Der Aufruf ist jetzt in eine Hilfsfunktion `getGitCommitHash()` gekapselt, die `git rev-parse --short HEAD 2>/dev/null` in einem `try/catch` ausführt und bei Fehler `null` zurückgibt, sodass der Build auch ohne Repo gelingt. Passend dazu lagert `Sidebar.tsx` die Build-Info-Darstellung in eine eigene `BuildInformation`-Komponente aus, die alle Kombinationen aus vorhandenem/fehlendem Build-Datum und Commit-Hash sauber behandelt. Betroffen ist ausschließlich die Demo-/Sample-Anwendung — keine Änderung an Bibliothekskomponenten oder der öffentlichen API.

### Verknüpfte Tickets

- Referenziert #7616 — Sample-App lässt sich ohne Git-Repository nicht bauen.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/webpack.config.js` — `git rev-parse` in `getGitCommitHash()` mit `try/catch` gekapselt (gibt bei Fehler `null` zurück).
- `packages/samples/react/src/components/Sidebar.tsx` — Build-Info in eine eigene `BuildInformation`-Komponente ausgelagert, die fehlende Datums-/Hash-Werte robust behandelt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
