### PR TITLE
refactor(samples): use useLocation in SampleDescription and point doc links to v2

### DIFF
--- a/packages/samples/react/src/components/SampleDescription.tsx
+++ b/packages/samples/react/src/components/SampleDescription.tsx
@@ -6,36 +6,48 @@ import { PUBLIC_CODE_COMPONENT_URL, PUBLIC_DOC_COMPONENT_URL } from '../shares/c
 import { KolLink } from '@public-ui/react';
 
 import { HideMenusContext } from '../shares/HideMenusContext';
-
-const getLocationPaths = () => {
-	return location.hash.split('/').slice(1);
-};
+import { useLocation } from 'react-router';
 
 export const SampleDescription: FC<PropsWithChildren> = (props) => {
 	const hideMenus = useContext(HideMenusContext);
+	const location = useLocation();
+	const paths = location.pathname.split('/').slice(1);
 
 	const docLink = useMemo(() => {
-		const paths = getLocationPaths();
 		return paths[0] === 'scenarios'
 			? null // Scenarios are not a component and hence have no documentation.
 			: `${PUBLIC_DOC_COMPONENT_URL}/${paths[0]}`;
 	}, [location.hash]);
 
 	const codeLink = useMemo(() => {
-		const paths = getLocationPaths();
 		return paths[0] === 'scenarios'
 			? null // Scenarios are not a component and hence have no documentation.
 			: `${PUBLIC_CODE_COMPONENT_URL}/${paths[0]}/${paths[1]}.tsx`;
 	}, [location.hash]);
 
-	return hideMenus ? null : (
-		<div className="flex justify-between mb-sm">
-			<div className="indented-text">{props.children}</div>
-			<div className="flex flex-wrap gap-2 shrink-0 ml">
-				{codeLink && <KolLink _href={codeLink} _label="Code" _target="_blank" />}
-				{docLink && <KolLink _href={docLink} _label="Documentation" _target="_blank" />}
-				<KolLink _href={`${location.href}?hideMenus`} _label="Standalone example" _target="_blank" />
-			</div>
-		</div>
+	return (
+		<>
+			<h1 className="visually-hidden">{location.pathname.replace(/\//g, ' ')}</h1>
+			{hideMenus ? null : (
+				<div className="grid sm:flex gap-4 justify-between pb-sm border-b-1 border-b-solid border-gray">
+					<div className="indented-text">{props.children}</div>
+					<ul className="flex flex-wrap gap-2 list-none m-0 p-0">
+						{codeLink && (
+							<li>
+								<KolLink _href={codeLink} _label="Code" _target="_blank" />
+							</li>
+						)}
+						{docLink && (
+							<li>
+								<KolLink _href={docLink} _label="Documentation" _target="_blank" />
+							</li>
+						)}
+						<li>
+							<KolLink _href={`#${location.pathname}?hideMenus`} _label="Standalone example" _target="_blank" />
+						</li>
+					</ul>
+				</div>
+			)}
+		</>
 	);
 };

--- a/packages/samples/react/src/react.main.tsx
+++ b/packages/samples/react/src/react.main.tsx
@@ -68,12 +68,12 @@ void (async () => {
 					? new Set([
 							(t) =>
 								t('en', {
-									// https://github.com/public-ui/kolibri/blob/develop/packages/components/src/locales/en.ts
+									// https://github.com/public-ui/kolibri/blob/release/2/packages/components/src/locales/en.ts
 									'kol-error': 'Tiny error!',
 								}),
 							(t) =>
 								t('de', {
-									// https://github.com/public-ui/kolibri/blob/develop/packages/components/src/locales/de.ts
+									// https://github.com/public-ui/kolibri/blob/release/2/packages/components/src/locales/de.ts
 									'kol-error': 'Kleiner Fehler!',
 								}),
 						])

--- a/packages/samples/react/src/shares/constants.ts
+++ b/packages/samples/react/src/shares/constants.ts
@@ -1,4 +1,4 @@
-export const PUBLIC_DOC_COMPONENT_URL = 'https://public-ui.github.io/docs/components';
-export const PUBLIC_CODE_COMPONENT_URL = 'https://github.com/public-ui/kolibri/blob/develop/packages/samples/react/src/components';
+export const PUBLIC_DOC_COMPONENT_URL = 'https://public-ui.github.io/v2/docs/components';
+export const PUBLIC_CODE_COMPONENT_URL = 'https://github.com/public-ui/kolibri/blob/release/2/packages/samples/react/src/components';
 export const ERROR_MSG = 'I am an error message!';
 export const HINT_MSG = 'I am a hint.';

--- a/packages/samples/react/src/style.scss
+++ b/packages/samples/react/src/style.scss
@@ -30,6 +30,16 @@ hr {
 	}
 }
 
+.visually-hidden {
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
 .black-background {
 	background-color: black;
 	display: flex;


### PR DESCRIPTION
## What changed?

This is the `release/2` variant of the `SampleDescription` refactor in the React samples app. The component now reads the current route via the `useLocation` hook from `react-router` instead of the custom `getLocationPaths()` helper, adds a visually-hidden `<h1>` reflecting the current path, and renders the link row as a semantic `<ul>`/`<li>` list. A `.visually-hidden` utility class was added to `style.scss`. Additionally, the public documentation/code URLs in `shares/constants.ts` were repointed to the v2 structure (`public-ui.github.io/v2/docs/components` and `blob/release/2/...`), and the locale-reference comments in `react.main.tsx` were updated from `develop` to `release/2`. Only the demo/sample application is affected — no library component or public API changes.

## Linked issues

- Refs #7621 — sample app description / missing `<h1>` heading.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies ist die `release/2`-Variante des `SampleDescription`-Refactorings in der React-Samples-App. Die Komponente liest die aktuelle Route jetzt über den `useLocation`-Hook aus `react-router` statt über die eigene Hilfsfunktion `getLocationPaths()`, ergänzt eine visuell versteckte `<h1>` mit dem aktuellen Pfad und rendert die Linkzeile als semantische `<ul>`/`<li>`-Liste. Eine `.visually-hidden`-Utility-Klasse wurde in `style.scss` ergänzt. Zusätzlich wurden die öffentlichen Dokumentations-/Code-URLs in `shares/constants.ts` auf die v2-Struktur umgestellt (`public-ui.github.io/v2/docs/components` bzw. `blob/release/2/...`), und die Locale-Referenz-Kommentare in `react.main.tsx` wurden von `develop` auf `release/2` aktualisiert. Betroffen ist ausschließlich die Demo-/Sample-Anwendung — keine Änderung an Bibliothekskomponenten oder der öffentlichen API.

### Verknüpfte Tickets

- Referenziert #7621 — Sample-App-Beschreibung / fehlende `<h1>`-Überschrift.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/SampleDescription.tsx` — auf `useLocation` umgestellt; visuell versteckte `<h1>`; Links als semantische `<ul>`/`<li>`-Liste.
- `packages/samples/react/src/shares/constants.ts` — Doku-/Code-URLs auf v2-Struktur umgestellt.
- `packages/samples/react/src/react.main.tsx` — Locale-Referenz-Kommentare von `develop` auf `release/2` aktualisiert.
- `packages/samples/react/src/style.scss` — `.visually-hidden`-Utility-Klasse ergänzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
