### PR TITLE
fix: prevent auto-focusing the first option when opening combobox and single-select, add E2E tests

### DIFF
--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -1,10 +1,71 @@
 import { test } from '@stencil/playwright';
 import { testInputCallbacksAndEvents, testInputValueReflection } from '../../e2e';
+import { expect } from '@playwright/test';
 
 const COMPONENT_NAME = 'kol-combobox';
 const TEST_VALUE = 'Hello World';
+const OPTIONS = ['North', 'South', 'West', 'East'];
 
 test.describe(COMPONENT_NAME, () => {
 	testInputValueReflection<HTMLKolComboboxElement>(COMPONENT_NAME, TEST_VALUE);
 	testInputCallbacksAndEvents<HTMLKolComboboxElement>(COMPONENT_NAME, TEST_VALUE);
+
+	test('should fire input and change events', async ({ page }) => {
+		await page.setContent(`<kol-combobox _label="Input" _suggestions=${JSON.stringify(OPTIONS)}></kol-combobox>`);
+		const input = page.locator('input.kol-combobox__input');
+
+		await input.fill(TEST_VALUE);
+		await expect(input).toHaveValue(TEST_VALUE);
+	});
+
+	test('should open listbox when button is clicked', async ({ page }) => {
+		await page.setContent(`<kol-combobox _label="Input" _suggestions=${JSON.stringify(OPTIONS)}></kol-combobox>`);
+		await page.getByRole('button').click();
+		const listbox = page.locator('ul[role="listbox"]');
+		await expect(listbox).toBeVisible();
+	});
+
+	test('should close listbox when pressing Escape', async ({ page }) => {
+		await page.setContent(`<kol-combobox _label="Input" _suggestions=${JSON.stringify(OPTIONS)}></kol-combobox>`);
+		await page.getByRole('button').click();
+		const input = page.locator('input.kol-combobox__input');
+		await input.press('Escape');
+		const listbox = page.locator('ul[role="listbox"]');
+		await expect(listbox).toHaveCount(0);
+	});
+
+	test('should select option with Enter key', async ({ page }) => {
+		await page.setContent(`<kol-combobox _label="Input" _suggestions=${JSON.stringify(OPTIONS)}></kol-combobox>`);
+		await page.getByRole('button').click();
+		const input = page.locator('input.kol-combobox__input');
+		await input.focus();
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('Enter');
+
+		await expect(input).toHaveValue('North');
+	});
+
+	test('should filter suggestions based on input', async ({ page }) => {
+		await page.setContent(`<kol-combobox _label="Input"></kol-combobox>`);
+		await page.evaluate(() => {
+			const combobox = document.querySelector('kol-combobox');
+			if (combobox) combobox._suggestions = ['North', 'South', 'West', 'East'];
+		});
+		const input = page.locator('input.kol-combobox__input');
+		await input.focus();
+		await input.fill('SOU');
+
+		await page.waitForChanges();
+		await page.waitForTimeout(300);
+		const suggestions = page.locator('ul[role="listbox"] li');
+		await expect(suggestions).toHaveCount(1);
+		await expect(suggestions.first()).toHaveText('South');
+	});
+
+	test('should disable interaction when _disabled is true', async ({ page }) => {
+		await page.setContent(`<kol-combobox _label="Input" _disabled _suggestions=${JSON.stringify(OPTIONS)}></kol-combobox>`);
+		await page.getByRole('button').click({ force: true });
+		const listbox = page.locator('ul[role="listbox"]');
+		await expect(listbox).toHaveCount(0);
+	});
 });

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -70,7 +70,7 @@ export class KolCombobox implements ComboboxAPI {
 				this._isOpen = true;
 				this._hasOpened = true;
 				const selectedIndex = this._filteredSuggestions.findIndex((option) => option === this.state._value);
-				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : 0;
+				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : -1;
 				this.focusOption(this._focusedOptionIndex);
 			}
 		}

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -78,7 +78,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 				this._hasOpened = true;
 				this.refInput?.focus();
 				const selectedIndex = Array.isArray(this._filteredOptions) ? this._filteredOptions.findIndex((option) => option.label === this._inputValue) : -1;
-				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : 0;
+				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : -1;
 				this.focusOption(this._focusedOptionIndex);
 			}
 		}
@@ -254,6 +254,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 						{this._inputValue && !this.state._hideClearButton && (
 							<KolIconTag
 								_icons="codicon codicon-close"
+								data-testid="single-select-delete"
 								_label={translate('kol-delete-selection')}
 								onClick={() => {
 									this.clearSelection();

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -1,6 +1,7 @@
 import { test } from '@stencil/playwright';
 import { testInputCallbacksAndEvents, testInputValueReflection } from '../../e2e';
 import type { FillAction } from '../../e2e/utils/FillAction';
+import { expect } from '@playwright/test';
 
 const COMPONENT_NAME = 'kol-single-select';
 const TEST_VALUE = 'E';
@@ -20,4 +21,108 @@ const fillAction: FillAction = async (page) => {
 test.describe(COMPONENT_NAME, () => {
 	testInputValueReflection<HTMLKolSingleSelectElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OPTIONS_ATTRIBUTE);
 	testInputCallbacksAndEvents<HTMLKolSingleSelectElement>(COMPONENT_NAME, TEST_VALUE, fillAction, undefined, OPTIONS_ATTRIBUTE);
+
+	test.describe('kol-single-select additional interactions', () => {
+		test('should open listbox on button click and close on ESC', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
+
+			await page.getByRole('button').click();
+
+			await expect(page.getByRole('listbox')).toBeVisible();
+
+			await page.keyboard.press('Escape');
+
+			await expect(page.getByRole('listbox')).toHaveCount(0);
+		});
+
+		test('should move focus with arrow keys and select with Enter', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
+
+			await page.getByRole('button').click();
+
+			await page.keyboard.press('ArrowDown');
+			await page.keyboard.press('ArrowDown');
+			await page.keyboard.press('Enter');
+
+			const value = await page.locator('kol-single-select').evaluate((el: HTMLKolInputDateElement) => el._value);
+			expect(value).toBe('S');
+		});
+
+		test('should filter options when typing and select the filtered one', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
+			await page.getByRole('button').click();
+
+			await page.locator('input.kol-single-select__input').focus();
+			await page.locator('input.kol-single-select__input').fill('We');
+
+			await expect(page.getByText('West')).toBeVisible();
+			await expect(page.getByText('North')).toHaveCount(0);
+
+			await page.keyboard.press('ArrowDown');
+			await page.keyboard.press('Enter');
+
+			const value = await page.locator('kol-single-select').evaluate((el: HTMLKolInputDateElement) => el._value);
+			expect(value).toBe('W');
+		});
+
+		test('should clear the selection when clear button is clicked', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
+			await page.getByRole('button').click();
+
+			const input = page.locator('input.kol-single-select__input');
+
+			await page.getByRole('listbox').getByText(TEST_LABEL).click({ force: true });
+
+			await expect(input).toHaveValue(TEST_LABEL);
+			await page.waitForChanges();
+			await page.waitForTimeout(500);
+
+			const clearButton = page.getByTestId('single-select-delete');
+			await expect(clearButton).toHaveCount(1);
+			await clearButton.click({ force: true });
+
+			await expect(input).toHaveValue('');
+		});
+
+		test('should not render clear button when _hideClearButton is true', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _hideClearButton="true" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
+
+			await page.getByRole('button').click();
+			await page.getByRole('listbox').getByText(TEST_LABEL).click({ force: true });
+
+			if (page.locator('input.kol-single-select__input')) await expect(page.locator('input.kol-single-select__input')).toHaveValue(TEST_LABEL);
+			const clearButton = page.getByTestId('single-select-delete');
+			await expect(clearButton).not.toBeVisible();
+		});
+
+		test('should select option with SPACE key', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
+			await page.getByRole('button').click();
+
+			const input = page.locator('input.kol-single-select__input');
+
+			await input.click();
+			await input.press('ArrowDown');
+			await input.press('Space');
+
+			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', 'N');
+		});
+
+		test('should disable interaction when _disabled is true', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _disabled="true" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
+
+			await expect(page.locator('input.kol-single-select__input')).toBeDisabled();
+
+			const listbox = page.locator('ul[role="listbox"]');
+			await expect(listbox).toHaveCount(0);
+		});
+
+		test('should display no results message when input does not match', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Test" _options='[{"label":"North","value":"N"}]'></kol-single-select>`);
+			const input = page.locator('input.kol-single-select__input');
+			await input.fill('Something');
+			const noResult = page.getByText('Keine Ergebnisse gefunden.');
+			await expect(noResult).toBeVisible();
+		});
+	});
 });


### PR DESCRIPTION
## What changed?

This PR adds Playwright E2E coverage for `kol-combobox` and `kol-single-select` and, alongside it, changes the initial-focus behaviour of both components. In `combobox/shadow.tsx` and `single-select/shadow.tsx`, when the listbox is opened and no value is currently selected, `_focusedOptionIndex` is now set to `-1` instead of `0` — so no option is auto-focused/highlighted on open unless a matching value already exists. A `data-testid="single-select-delete"` hook was added to the single-select clear-button icon to make it addressable in tests. The new E2E tests cover opening/closing the listbox (button click, Escape), keyboard selection (ArrowDown + Enter/Space), suggestion filtering, the clear button (including `_hideClearButton`), the disabled state, and the "no results" message.

## Linked issues

- Refs #7531 — E2E tests for combobox and single-select.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ergänzt Playwright-E2E-Tests für `kol-combobox` und `kol-single-select` und ändert dabei zusätzlich das anfängliche Fokusverhalten beider Komponenten. In `combobox/shadow.tsx` und `single-select/shadow.tsx` wird `_focusedOptionIndex` beim Öffnen der Listbox — wenn kein Wert ausgewählt ist — jetzt auf `-1` statt `0` gesetzt. Dadurch wird beim Öffnen keine Option automatisch fokussiert/hervorgehoben, solange kein passender Wert existiert. Am Icon des Single-Select-Clear-Buttons wurde ein `data-testid="single-select-delete"` ergänzt, um ihn in Tests adressierbar zu machen. Die neuen E2E-Tests decken u. a. Öffnen/Schließen der Listbox (Button-Klick, Escape), Tastaturauswahl (ArrowDown + Enter/Space), Vorschlagsfilterung, den Clear-Button (inkl. `_hideClearButton`), den Disabled-Zustand und die „Keine Ergebnisse"-Meldung ab.

### Verknüpfte Tickets

- Referenziert #7531 — E2E-Tests für Combobox und Single-Select.

### Art der Änderung

🐛 Fehlerbehebung (Fokusverhalten) + Testabdeckung

### Geänderte Dateien

- `packages/components/src/components/combobox/shadow.tsx` — beim Öffnen ohne Auswahl kein Auto-Fokus der ersten Option mehr (`_focusedOptionIndex = -1`).
- `packages/components/src/components/single-select/shadow.tsx` — gleiches Fokusverhalten; `data-testid="single-select-delete"` am Clear-Button ergänzt.
- `packages/components/src/components/combobox/combobox.e2e.ts` — neue E2E-Tests für die Combobox.
- `packages/components/src/components/single-select/single-select.e2e.ts` — neue E2E-Tests für das Single-Select.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
