### PR TITLE
fix(table): disambiguate duplicate pagination aria-labels by position

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -419,7 +419,12 @@ export class KolTableStateful implements TableAPI {
 	 *
 	 * @returns {JSX.Element} The rendered pagination controls including page range and navigation.
 	 */
-	private renderPagination(): JSX.Element {
+	private renderPagination(position: 'top' | 'bottom'): JSX.Element {
+		const label = translate('kol-table-pagination-label', {
+			placeholders: {
+				label: `${this.state._label} (${translate(`kol-pagination-position-${position}`)})`,
+			},
+		});
 		return (
 			<div class={`kol-table-stateful__pagination kol-table-stateful__pagination--${this.state._paginationPosition}`}>
 				<span>
@@ -448,7 +453,7 @@ export class KolTableStateful implements TableAPI {
 						_siblingCount={this.state._pagination._siblingCount}
 						_tooltipAlign="bottom"
 						_max={this.state._pagination._max || this.state._pagination._max || this.state._data.length}
-						_label={translate('kol-table-pagination-label', { placeholders: { label: this.state._label } })}
+						_label={label}
 					></KolPaginationTag>
 				</div>
 			</div>
@@ -520,8 +525,8 @@ export class KolTableStateful implements TableAPI {
 			this.showPagination ? (this.state._pagination?._pageSize ?? 10) : this.state._sortedData.length,
 			this.state._pagination._page || 1,
 		);
-		const paginationTop = this._paginationPosition === 'top' || this._paginationPosition === 'both' ? this.renderPagination() : null;
-		const paginationBottom = this._paginationPosition === 'bottom' || this._paginationPosition === 'both' ? this.renderPagination() : null;
+		const paginationTop = this._paginationPosition === 'top' || this._paginationPosition === 'both' ? this.renderPagination('top') : null;
+		const paginationBottom = this._paginationPosition === 'bottom' || this._paginationPosition === 'both' ? this.renderPagination('bottom') : null;
 
 		const headerCells: TableHeaderCells = {
 			horizontal: this.state._headers.horizontal?.map((row) => row.map((cell) => ({ ...cell, sortDirection: this.getHeaderCellSortState(cell) }))),

--- a/packages/components/src/locales/de.ts
+++ b/packages/components/src/locales/de.ts
@@ -50,4 +50,6 @@ export default {
 	'delete-selection': 'Auswahl entfernen',
 	'filename-text': 'Datei auswählen oder hier ablegen...',
 	'data-browse-text': 'Datei auswählen',
+	'pagination-position-top': 'oben',
+	'pagination-position-bottom': 'unten',
 };

--- a/packages/components/src/locales/en.ts
+++ b/packages/components/src/locales/en.ts
@@ -50,4 +50,6 @@ export default {
 	'delete-selection': 'Delete selection',
 	'filename-text': 'Choose a file or drop it here...',
 	'data-browse-text': 'Browse',
+	'pagination-position-top': 'top',
+	'pagination-position-bottom': 'bottom',
 };


### PR DESCRIPTION
## What changed?

`KolTableStateful` renders pagination controls at the top and/or bottom of a table. Previously both controls were produced by a parameterless `renderPagination()` and therefore received an identical accessible name (`_label`), producing duplicate `aria-label`s when pagination is shown at both positions. `renderPagination()` now takes a `position: 'top' | 'bottom'` argument and builds the pagination `_label` with the translated position appended (e.g. `"<table label> (top)"`), so the two controls have distinct accessible names. Two new locale keys — `pagination-position-top` / `pagination-position-bottom` — were added to `de.ts` (`oben`/`unten`) and `en.ts` (`top`/`bottom`).

## Linked issues

- Refs #7218 — duplicate aria-labels on table pagination.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolTableStateful` rendert Pagination-Steuerelemente oben und/oder unten an der Tabelle. Bisher wurden beide über ein parameterloses `renderPagination()` erzeugt und erhielten denselben zugänglichen Namen (`_label`), was bei Pagination an beiden Positionen zu doppelten `aria-label`s führte. `renderPagination()` erhält jetzt ein Argument `position: 'top' | 'bottom'` und baut das `_label` mit der übersetzten Position auf (z. B. `"<Tabellen-Label> (oben)"`), sodass beide Steuerelemente eindeutige zugängliche Namen haben. Zwei neue Locale-Schlüssel — `pagination-position-top` / `pagination-position-bottom` — wurden in `de.ts` (`oben`/`unten`) und `en.ts` (`top`/`bottom`) ergänzt.

### Verknüpfte Tickets

- Referenziert #7218 — doppelte aria-labels bei der Tabellen-Pagination.

### Art der Änderung

🐛 Fehlerbehebung (Barrierefreiheit)

### Geänderte Dateien

- `packages/components/src/components/table-stateful/shadow.tsx` — `renderPagination(position)` erzeugt positionsabhängige, eindeutige Pagination-Labels.
- `packages/components/src/locales/de.ts` — Locale-Schlüssel `pagination-position-top`/`-bottom` (oben/unten) ergänzt.
- `packages/components/src/locales/en.ts` — Locale-Schlüssel `pagination-position-top`/`-bottom` (top/bottom) ergänzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
