### PR TITLE
fix: update grid classes for responsive design

### DIFF
--- a/packages/samples/react/src/components/SampleDescription.tsx
+++ b/packages/samples/react/src/components/SampleDescription.tsx
@@ -29,7 +29,7 @@ export const SampleDescription: FC<PropsWithChildren> = (props) => {
 		<>
 			<h1 className="visually-hidden">{location.pathname.replace(/\//g, ' ')}</h1>
 			{hideMenus ? null : (
-				<div className="grid sm:flex gap-4 justify-between pb-sm border-b-1 border-b-solid border-gray">
+				<div className="grid sm:flex gap-4 justify-between pb-sm border-b-1 border-b-solid border-gray mb-2">
 					<div className="indented-text">{props.children}</div>
 					<ul className="flex flex-wrap gap-2 list-none m-0 p-0">
 						{codeLink && (

--- a/packages/samples/react/src/components/handout/basic.tsx
+++ b/packages/samples/react/src/components/handout/basic.tsx
@@ -190,7 +190,7 @@ export const HandoutBasic: FC = () => {
 
 	return (
 		<div className="grid gap-4">
-			<div className="grid gap-4 grid-cols-[auto_1fr_1fr] items-center">
+			<div className="grid gap-4 md:grid-cols-[auto_1fr_1fr] items-center">
 				<KolKolibri className="block w-75px" _labeled={false}></KolKolibri>
 				<KolHeading _label="" _level={1}>
 					<span slot="expert">
@@ -441,7 +441,7 @@ export const HandoutBasic: FC = () => {
 				</KolCard>
 				<KolCard className="col-span-6 sm:col-span-6 md:col-span-4 xl:col-span-5" _label="Input" _level={2}>
 					<KolForm slot="">
-						<div className="grid gap-4 grid-cols-3 p-2">
+						<div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 p-2">
 							<KolInputColor _label={`Color`} />
 							<KolInputFile _label={`Upload file`} />
 							<KolInputNumber _label={`Number input`} />

--- a/packages/samples/react/src/components/handout/basic.tsx
+++ b/packages/samples/react/src/components/handout/basic.tsx
@@ -460,7 +460,9 @@ export const HandoutBasic: FC = () => {
 							<div className="grid gap-4">
 								<KolInputRadio _orientation="horizontal" _options="[{'label':'Mr.','value':0},{'label':'Mrs.','value':1}]" _value="0" _label={`Salutation`} />
 								<KolInputCheckbox _label="">
-									I accept the <KolAbbr _label="General Terms and Conditions">AGB</KolAbbr>.
+									<span slot="expert">
+										I accept the <KolAbbr _label="General Terms and Conditions">AGB</KolAbbr>.
+									</span>
 								</KolInputCheckbox>
 							</div>
 							<KolTextarea _rows={4} _label={`Textarea`} />


### PR DESCRIPTION
## What changed?

Two files in the React samples package received responsive-layout refinements. `packages/samples/react/src/components/SampleDescription.tsx` gained a bottom margin (`mb-2`) on the header container for more spacing. `packages/samples/react/src/components/handout/basic.tsx` made two grids responsive — the header grid changed from a fixed `grid-cols-[auto_1fr_1fr]` to `md:grid-cols-[auto_1fr_1fr]`, and the input form grid changed from `grid-cols-3` to `sm:grid-cols-2 md:grid-cols-3`; the terms-and-conditions checkbox label was also wrapped in a `<span slot="expert">`. Only the demo/sample application is affected — no library component or public API changes.

## Linked issues

- Refs #7627 — responsiveness of the handout/sample layout (issue derived from the branch name `7627-v3`).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Zwei Dateien im React-Samples-Paket wurden responsiv verfeinert. In `packages/samples/react/src/components/SampleDescription.tsx` erhielt der Kopf-Container einen unteren Abstand (`mb-2`). In `packages/samples/react/src/components/handout/basic.tsx` wurden zwei Grids responsiv gemacht — das Kopf-Grid von festem `grid-cols-[auto_1fr_1fr]` auf `md:grid-cols-[auto_1fr_1fr]`, das Eingabeformular-Grid von `grid-cols-3` auf `sm:grid-cols-2 md:grid-cols-3`; zusätzlich wurde das Label der AGB-Checkbox in ein `<span slot="expert">` gewickelt. Betroffen ist ausschließlich die Demo-/Sample-Anwendung — keine Änderung an Bibliothekskomponenten oder der öffentlichen API.

### Verknüpfte Tickets

- Referenziert #7627 — Responsiveness des Handout-/Sample-Layouts (aus dem Branchnamen `7627-v3` abgeleitet).

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/SampleDescription.tsx` — unterer Abstand (`mb-2`) am Kopf-Container ergänzt.
- `packages/samples/react/src/components/handout/basic.tsx` — Grids responsiv gemacht (`md:grid-cols-…`, `sm:grid-cols-2 md:grid-cols-3`); AGB-Checkbox-Label in `<span slot="expert">` gewickelt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
