### PR TITLE
fix(toolbar): apply button role and styling to link items

### DIFF
--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -38,7 +38,7 @@ export class KolToolbar implements ToolbarAPI {
 		};
 
 		return '_href' in element ? (
-			<KolLinkWcTag {...element} {...props} ref={catchRef}></KolLinkWcTag>
+			<KolLinkWcTag {...element} {...props} ref={catchRef} _role="button"></KolLinkWcTag>
 		) : (
 			<KolButtonWcTag {...element} {...props} ref={catchRef}></KolButtonWcTag>
 		);

--- a/packages/components/src/components/toolbar/style.scss
+++ b/packages/components/src/components/toolbar/style.scss
@@ -1,6 +1,9 @@
 @use '../@shared/mixins' as *;
 @use '../style' as *;
 @use '../tooltip/style.scss' as *;
+@use '../@shared/kol-button-mixin' as *;
+
+@include kol-button-styles('kol-link');
 
 @layer kol-component {
 	.toolbar {

--- a/packages/components/src/components/toolbar/style.scss
+++ b/packages/components/src/components/toolbar/style.scss
@@ -1,9 +1,7 @@
 @use '../@shared/mixins' as *;
 @use '../style' as *;
 @use '../tooltip/style.scss' as *;
-@use '../@shared/kol-button-mixin' as *;
-
-@include kol-button-styles('kol-link');
+@use '../button' as *;
 
 @layer kol-component {
 	.toolbar {

--- a/packages/components/src/components/toolbar/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/toolbar/test/__snapshots__/snapshot.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`kol-toolbar should render with _label="Text" _items=[{"_label":"Button"
   <template shadowrootmode="open">
     <div aria-label="Text" class="toolbar" role="toolbar">
       <kol-button-wc _label="Button" _tabindex="0" class="button kol-toolbar-item normal"></kol-button-wc>
-      <kol-link-wc _href="#" _label="Link" _tabindex="-1" class="button kol-toolbar-item normal"></kol-link-wc>
+      <kol-link-wc _href="#" _label="Link" _role="button" _tabindex="-1" class="button kol-toolbar-item normal"></kol-link-wc>
     </div>
   </template>
 </kol-toolbar>


### PR DESCRIPTION
## What changed?

Toolbar items that render as links (elements with an `_href`) are now given `_role="button"` in the toolbar renderer (`packages/components/src/components/toolbar/shadow.tsx`), and the toolbar stylesheet (`toolbar/style.scss`) imports the button styles so link items are styled like the other toolbar buttons. This fixes the focus/appearance of link buttons inside the toolbar so they behave consistently with regular button items. The test snapshot is updated to include the new `_role="button"` attribute. This PR targets `release/2`. No public API change.

## Linked issues

- Refs #7487 — toolbar link button focus/appearance.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Toolbar-Einträge, die als Link gerendert werden (Elemente mit `_href`), erhalten im Toolbar-Renderer (`packages/components/src/components/toolbar/shadow.tsx`) nun `_role="button"`, und das Toolbar-Stylesheet (`toolbar/style.scss`) importiert die Button-Styles, sodass Link-Einträge wie die übrigen Toolbar-Buttons gestaltet werden. Damit wird der Fokus bzw. die Darstellung von Link-Buttons in der Toolbar korrigiert, sodass sie sich konsistent zu regulären Button-Einträgen verhalten. Der Test-Snapshot wird um das neue `_role="button"`-Attribut ergänzt. Dieser PR zielt auf `release/2`. Keine Änderung der öffentlichen API.

### Verknüpfte Tickets

- Referenziert #7487 — Fokus/Darstellung von Link-Buttons in der Toolbar.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/toolbar/shadow.tsx` — `_role="button"` für Link-Einträge (`KolLinkWcTag`) gesetzt.
- `packages/components/src/components/toolbar/style.scss` — Button-Styles importiert, damit Link-Einträge wie Buttons dargestellt werden.
- `packages/components/src/components/toolbar/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshot um `_role="button"` aktualisiert.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
