### PR TITLE
fix(single-select): read value prop directly instead of syncing with state

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -50,7 +50,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<StencilUnknown | undefined> {
-		return this.state._value;
+		return this._value;
 	}
 
 	@Method()
@@ -80,9 +80,14 @@ export class KolSingleSelect implements SingleSelectAPI {
 		}
 	};
 
+	/**
+	 * If there are options and the current input value doesn't match any option's label,
+	 * resets the input value to match the label of the currently selected option.
+	 * Closes the dropdown and resets the opened state.
+	 */
 	private onBlur() {
 		if (Array.isArray(this.state._options) && this.state._options.length > 0 && !this.state._options.some((option) => option.label === this._inputValue)) {
-			this._inputValue = this.state._options.find((option) => (option as Option<string>).value === this.state._value)?.label as string;
+			this._inputValue = this.state._options.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];
 		}
 		this._isOpen = false;
@@ -110,7 +115,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 		this.controller.onFacade.onChange(new CustomEvent('change', { bubbles: true, detail: { name: this.state._name, value: option.value } }), option.value);
 		this._filteredOptions = [...this.state._options];
 
-		this.controller.setFormAssociatedValue(this.state._value);
+		this.controller.setFormAssociatedValue(this._value);
 	}
 
 	private onInput(event: Event) {
@@ -281,7 +286,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 												}}
 												tabIndex={-1}
 												role="option"
-												aria-selected={this.state._value === (option as Option<string>).value ? 'true' : undefined}
+												aria-selected={this._value === (option as Option<string>).value ? 'true' : undefined}
 												onClick={(event: Event) => {
 													this.selectOption(option as Option<string>);
 													this.refInput?.focus();
@@ -313,7 +318,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 													name="options"
 													id={`option-radio-${index}`}
 													value={(option as Option<string>).value}
-													checked={this.state._value === (option as Option<string>).value || index === this._focusedOptionIndex}
+													checked={this._value === (option as Option<string>).value || index === this._focusedOptionIndex}
 												/>
 
 												<label htmlFor={`option-radio-${index}`} class="radio-label">
@@ -571,7 +576,6 @@ export class KolSingleSelect implements SingleSelectAPI {
 		_id: `id-${nonce()}`,
 		_label: '', // ⚠ required
 		_options: [],
-		_value: '',
 		_hideClearButton: false,
 	};
 


### PR DESCRIPTION
## What changed?

The `single-select` component (`packages/components/src/components/single-select/shadow.tsx`) no longer keeps the reflective `_value` prop and the internal `state._value` in sync, which was redundant and a source of desynchronization bugs. All read sites now use the `_value` prop directly instead of `this.state._value`: `getValue()`, the `onBlur` handler that resets the input value to the selected option's label, `selectOption()`'s `setFormAssociatedValue` call, the `aria-selected` attribute, and the radio `checked` state. The `_value: ''` entry is also removed from the component's initial state. This mirrors the approach already used in the V3 component and fixes the selected value getting out of sync. A doc comment is added to `onBlur`. No public API change.

## Linked issues

- Refs #7557 — single-select value prop/state synchronization.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `single-select`-Komponente (`packages/components/src/components/single-select/shadow.tsx`) synchronisiert die reflektierende `_value`-Prop nicht mehr mit dem internen `state._value` — diese Synchronisierung war redundant und fehleranfällig. Alle Lesezugriffe verwenden nun direkt die `_value`-Prop statt `this.state._value`: `getValue()`, der `onBlur`-Handler (setzt den Eingabewert auf das Label der gewählten Option zurück), der `setFormAssociatedValue`-Aufruf in `selectOption()`, das `aria-selected`-Attribut sowie der `checked`-Zustand des Radio-Buttons. Zusätzlich wird der `_value: ''`-Eintrag aus dem Initial-State entfernt. Dies entspricht dem bereits in der V3-Komponente genutzten Ansatz und behebt das Auseinanderlaufen des gewählten Werts. Ein Doku-Kommentar für `onBlur` wurde ergänzt. Keine Änderung der öffentlichen API.

### Verknüpfte Tickets

- Referenziert #7557 — Prop/State-Synchronisierung des Single-Select-Werts.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/single-select/shadow.tsx` — Zugriffe von `state._value` auf die `_value`-Prop umgestellt, `_value`-Default aus dem Initial-State entfernt, Doku-Kommentar für `onBlur` ergänzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
