### PR TITLE
chore(theme-ecl): add package.json metadata and make package public

### DIFF
--- a/packages/themes/ecl/package.json
+++ b/packages/themes/ecl/package.json
@@ -1,7 +1,45 @@
 {
 	"name": "@public-ui/theme-ecl",
 	"version": "2.1.3",
-	"private": true,
+	"license": "EUPL-1.2",
+	"homepage": "https://public-ui.github.io",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/public-ui/kolibri"
+	},
+	"bugs": {
+		"url": "https://github.com/public-ui/kolibri/issues",
+		"email": "kolibri@itzbund.de"
+	},
+	"author": {
+		"name": "Informationstechnikzentrum Bund",
+		"email": "kolibri@itzbund.de"
+	},
+	"description": "Contains the ECL themes for KoliBri - The accessible HTML-Standard.",
+	"keywords": [
+		"accessibility",
+		"accessible",
+		"bitv",
+		"designsystem",
+		"design",
+		"web components",
+		"webcomponents",
+		"aria",
+		"wai",
+		"axe",
+		"custom elements",
+		"styleguide",
+		"style",
+		"guide",
+		"ui",
+		"html",
+		"css",
+		"web",
+		"a11y",
+		"w3c",
+		"webstandard",
+		"wcag"
+	],
 	"type": "module",
 	"sideEffects": false,
 	"scripts": {


### PR DESCRIPTION
## What changed?

Adds standard npm package metadata to `packages/themes/ecl/package.json` — `license` (`EUPL-1.2`), `homepage`, `repository`, `bugs`, `author`, `description` and `keywords` — and removes `"private": true`, making the ECL theme package publishable. This is packaging/metadata only, part of the v3 theme-package restructuring; no source code or behaviour is affected.

## Linked issues

- Refs #7649 — theme package restructuring (v3)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ergänzt die npm-Paket-Metadaten in `packages/themes/ecl/package.json` — `license` (`EUPL-1.2`), `homepage`, `repository`, `bugs`, `author`, `description` und `keywords` — und entfernt `"private": true`, sodass das ECL-Theme-Paket veröffentlichbar wird. Reine Packaging-/Metadaten-Änderung im Rahmen der v3-Theme-Umstrukturierung; kein Quellcode und kein Verhalten betroffen.

### Verknüpfte Tickets

- Referenziert #7649 — Umstrukturierung der Theme-Pakete (v3)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/themes/ecl/package.json` — Metadatenfelder ergänzt, `private: true` entfernt.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
