### PR TITLE
chore(theme-ecl): bump version to 3.0.0-rc.8

### DIFF
--- a/packages/themes/ecl/package.json
+++ b/packages/themes/ecl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/theme-ecl",
-	"version": "2.1.3",
+	"version": "3.0.0-rc.8",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {


### PR DESCRIPTION
## What changed?

Bumps the `@public-ui/theme-ecl` package version from `2.1.3` to `3.0.0-rc.8` in `packages/themes/ecl/package.json`. This is a version-only change, part of the v3 theme-package restructuring; no source code or behaviour is affected.

## Linked issues

- Refs #7649 — theme package restructuring (v3)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Hebt die Version des Pakets `@public-ui/theme-ecl` in `packages/themes/ecl/package.json` von `2.1.3` auf `3.0.0-rc.8` an. Reine Versionsänderung im Rahmen der v3-Theme-Umstrukturierung; kein Quellcode und kein Verhalten betroffen.

### Verknüpfte Tickets

- Referenziert #7649 — Umstrukturierung der Theme-Pakete (v3)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/themes/ecl/package.json` — Versionsfeld von `2.1.3` auf `3.0.0-rc.8` angehoben.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
