### PR TITLE
docs(table): document sticky headers as a known issue

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -111,3 +111,8 @@ This is a limitation in Firefox’s ARIA implementation. Until it is resolved, a
 
 It has been observed that on a system with German locale, NVDA spells out certain English words such as "selection", instead of reading them properly.  
 References: <https://github.com/public-ui/kolibri/issues/6898>, <https://stackoverflow.com/questions/69091167/nvda-spells-words-where-it-shouldnt>
+
+## Table — Sticky headers
+
+Sticky headers in tables are not supported at the moment, because `position: sticky` doesn't work together with `overflow: auto` on the table container, without introducing other drawbacks.
+References: <https://github.com/public-ui/kolibri/issues/7490>, <https://github.com/w3c/csswg-drafts/issues/865>

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -115,4 +115,4 @@ References: <https://github.com/public-ui/kolibri/issues/6898>, <https://stackov
 ## Table — Sticky headers
 
 Sticky headers in tables are not supported at the moment, because `position: sticky` doesn't work together with `overflow: auto` on the table container, without introducing other drawbacks.
-References: <https://github.com/public-ui/kolibri/issues/7490>, <https://github.com/w3c/csswg-drafts/issues/865>
+References: <https://github.com/public-ui/kolibri/issues/7490>, <https://github.com/w3c/csswg-drafts/issues/865>, [Code-Sample (StackBlitz)](https://stackblitz.com/edit/stackblitz-starters-umfg2y7m)


### PR DESCRIPTION
## What changed?

Adds a "Table — Sticky headers" section to `KNOWN_ISSUES.md` documenting that sticky table headers are currently unsupported, because `position: sticky` does not work together with `overflow: auto` on the table container without introducing other drawbacks. The entry links the tracking issue (#7490), the relevant CSSWG draft discussion, and a StackBlitz reproduction. Documentation only — no code or component behaviour changes.

## Linked issues

- Refs #7490 — Table sticky headers known issue

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Fügt der Datei `KNOWN_ISSUES.md` einen Abschnitt „Table — Sticky headers" hinzu, der dokumentiert, dass fixierte (sticky) Tabellenköpfe derzeit nicht unterstützt werden, weil `position: sticky` nicht mit `overflow: auto` am Tabellen-Container zusammenarbeitet, ohne andere Nachteile einzuführen. Der Eintrag verlinkt das Tracking-Issue (#7490), die relevante CSSWG-Draft-Diskussion und eine StackBlitz-Reproduktion. Reine Dokumentation — keine Code- oder Verhaltensänderung.

### Verknüpfte Tickets

- Referenziert #7490 — Known Issue zu fixierten Tabellenköpfen

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `KNOWN_ISSUES.md` — neuer Abschnitt „Table — Sticky headers" mit Begründung und Referenzen.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
