### PR TITLE
ci(deploy): deploy prebuilt sample-react dist to Netlify and remove netlify.toml

### DIFF
--- a/.github/workflows/dod-checker.yml
+++ b/.github/workflows/dod-checker.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   check-dod:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Print Pull Request ID
         run: |

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -48,7 +48,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ vars.NETLIFY_SITE_ID }}
         with:
-          args: deploy --filter=@public-ui/sample-react
+          args: deploy --no-build --filter=@public-ui/sample-react -d packages/samples/react/dist
 
       - name: Find comment
         uses: peter-evans/find-comment@v3

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -49,4 +49,4 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ vars.NETLIFY_SITE_ID }}
         with:
-          args: deploy --filter=@public-ui/sample-react --alias="$GITHUB_REF_NAME" # Netlify conveniently sanitizes the alias for us. E.g. `release/1.7` becomes `release-1-7`
+          args: deploy --no-build --filter=@public-ui/sample-react -d packages/samples/react/dist --alias="$GITHUB_REF_NAME" # Netlify conveniently sanitizes the alias for us. E.g. `release/1.7` becomes `release-1-7`

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,0 @@
-[build]
-	command = "pnpm -r build"
-	publish = "packages/samples/react/dist"


### PR DESCRIPTION
## What changed?

Reworks the Netlify preview/test deployment so the React sample app is deployed from its prebuilt `packages/samples/react/dist` output. The `draft-deploy.yml` and `test-deploy.yml` workflows now call the Netlify action with `deploy --no-build … -d packages/samples/react/dist`, so Netlify no longer rebuilds the monorepo on deploy, and the now-obsolete root `netlify.toml` (which defined `pnpm -r build` and the publish directory) is removed. The `dod-checker.yml` runner is also bumped from `ubuntu-20.04` to `ubuntu-latest`. This is CI/deployment configuration only, on the `release/1` branch.

## Linked issues

- Refs #7651 — Netlify deployment configuration

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Überarbeitet das Netlify-Preview-/Test-Deployment, sodass die React-Sample-App aus dem vorab gebauten Verzeichnis `packages/samples/react/dist` deployt wird. Die Workflows `draft-deploy.yml` und `test-deploy.yml` rufen die Netlify-Action nun mit `deploy --no-build … -d packages/samples/react/dist` auf; Netlify baut das Monorepo beim Deploy also nicht mehr neu, und die dadurch überflüssige Root-Datei `netlify.toml` (mit `pnpm -r build` und Publish-Verzeichnis) wird entfernt. Zusätzlich wird der Runner in `dod-checker.yml` von `ubuntu-20.04` auf `ubuntu-latest` angehoben. Betrifft ausschließlich CI-/Deployment-Konfiguration, auf dem Branch `release/1`.

### Verknüpfte Tickets

- Referenziert #7651 — Netlify-Deployment-Konfiguration

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/draft-deploy.yml` — Netlify-Deploy mit `--no-build` aus `packages/samples/react/dist`.
- `.github/workflows/test-deploy.yml` — dito für Test-Deploy inkl. `--alias`.
- `.github/workflows/dod-checker.yml` — Runner auf `ubuntu-latest` angehoben.
- `netlify.toml` — entfernt (Build-/Publish-Konfiguration nicht mehr benötigt).

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Maturation completed and documented
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue
- [ ] All changes relate to the issue
- [ ] No commented out code in the final commit
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
