### PR TITLE
ci: add ready_for_review trigger and skip drafts in DoD workflow

### DIFF
--- a/.github/workflows/dod-checker.yml
+++ b/.github/workflows/dod-checker.yml
@@ -1,7 +1,8 @@
 name: Definition of Done
+
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, synchronize, ready_for_review]
 
 concurrency:
   group: 'pr-${{ github.event.pull_request.number }}'
@@ -9,6 +10,8 @@ concurrency:
 
 jobs:
   check-dod:
+    # Skip this job for draft pull requests as they are considered works in progress
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - name: Print Pull Request ID


### PR DESCRIPTION
## What changed?

This change updates the "Definition of Done" GitHub Actions workflow (`.github/workflows/dod-checker.yml`). The workflow now also runs on the `ready_for_review` pull-request event and skips draft pull requests via a `github.event.pull_request.draft == false` condition, so the DoD check runs only once a PR is actually ready for review.

## Linked issues

- Refs #7675 — Enhance the Definition of Done workflow

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung aktualisiert den "Definition of Done"-GitHub-Actions-Workflow (`.github/workflows/dod-checker.yml`). Der Workflow läuft nun zusätzlich beim Pull-Request-Ereignis `ready_for_review` und überspringt Entwurf-Pull-Requests über die Bedingung `github.event.pull_request.draft == false`, sodass die DoD-Prüfung erst bei tatsächlich review-bereiten PRs greift.

### Verknüpfte Tickets

- Referenziert #7675 — Erweiterung des Definition-of-Done-Workflows

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/dod-checker.yml` — `ready_for_review`-Trigger und Draft-Skip-Bedingung ergänzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
