### PR TITLE
feat(theme): change button hierarchy and introduce secondary colour variable

### DIFF
--- a/packages/samples/react/src/components/button/partials/cases.tsx
+++ b/packages/samples/react/src/components/button/partials/cases.tsx
@@ -20,10 +20,10 @@ export const ButtonCases: React.FC<ButtonSampleProps> = (props) => {
 			<KolButton _icons="codicon codicon-heart" _label="Secondary" _variant="secondary" _on={dummyEventHandler} {...other}>
 				{children}
 			</KolButton>
-			<KolButton _icons="codicon codicon-hubot" _label="Normal" _variant="normal" _on={dummyEventHandler} {...other}>
+			<KolButton _icons="codicon codicon-hubot" _label="Tertiary" _variant="tertiary" _on={dummyEventHandler} {...other}>
 				{children}
 			</KolButton>
-			<KolButton _icons="codicon codicon-hubot" _label="Tertiary" _variant="tertiary" _on={dummyEventHandler} {...other}>
+			<KolButton _icons="codicon codicon-hubot" _label="Normal" _variant="normal" _on={dummyEventHandler} {...other}>
 				{children}
 			</KolButton>
 			<KolButton _icons="codicon codicon-trash" _label="Danger" _variant="danger" _on={dummyEventHandler} {...other}>

--- a/packages/themes/default/README.md
+++ b/packages/themes/default/README.md
@@ -46,6 +46,7 @@ Das Default-Theme ist ein _Token-Based_ Theme, das mit minimalen Anpassungen sof
 | `--kolibri-border-width`          | `1px`                                            | Allgemeine Rahmen-Breite                           |
 | `--kolibri-color-primary`         | `#004b76`                                        | Primärfarbe                                        |
 | `--kolibri-color-primary-variant` | `#0077b6`                                        | Alternative Variante der Primärfarbe               |
+| `--kolibri-color-secondary`       | `#99c9e2`                                        | Sekundärfarbe                                      |
 | `--kolibri-color-danger`          | `#c0003c`                                        | Farbe für Fehlermeldungen und gefährliche Aktionen |
 | `--kolibri-color-warning`         | `#c44931`                                        | Farbe für Warnungen                                |
 | `--kolibri-color-success`         | `#005c45`                                        | Farbe für Erfolgsmeldungen                         |

--- a/packages/themes/default/README.md
+++ b/packages/themes/default/README.md
@@ -46,7 +46,7 @@ Das Default-Theme ist ein _Token-Based_ Theme, das mit minimalen Anpassungen sof
 | `--kolibri-border-width`          | `1px`                                            | Allgemeine Rahmen-Breite                           |
 | `--kolibri-color-primary`         | `#004b76`                                        | Primärfarbe                                        |
 | `--kolibri-color-primary-variant` | `#0077b6`                                        | Alternative Variante der Primärfarbe               |
-| `--kolibri-color-secondary`       | `#99c9e2`                                        | Sekundärfarbe                                      |
+| `--kolibri-color-secondary`       | `#ccebf7`                                        | Sekundärfarbe                                      |
 | `--kolibri-color-danger`          | `#c0003c`                                        | Farbe für Fehlermeldungen und gefährliche Aktionen |
 | `--kolibri-color-warning`         | `#c44931`                                        | Farbe für Warnungen                                |
 | `--kolibri-color-success`         | `#005c45`                                        | Farbe für Erfolgsmeldungen                         |

--- a/packages/themes/default/src/global.scss
+++ b/packages/themes/default/src/global.scss
@@ -9,7 +9,7 @@
 		--border-width: var(--kolibri-border-width, 1px);
 		--color-primary: var(--kolibri-color-primary, #004b76);
 		--color-primary-variant: var(--kolibri-color-primary-variant, #0077b6);
-		--color-secondary: var(--kolibri-color-secondary, #99c9e2);
+		--color-secondary: var(--kolibri-color-secondary, #ccebf7);
 		--color-danger: var(--kolibri-color-danger, #b4003c);
 		--color-warning: var(--kolibri-color-warning, #c44931);
 		--color-success: var(--kolibri-color-success, #005c45);

--- a/packages/themes/default/src/global.scss
+++ b/packages/themes/default/src/global.scss
@@ -9,6 +9,7 @@
 		--border-width: var(--kolibri-border-width, 1px);
 		--color-primary: var(--kolibri-color-primary, #004b76);
 		--color-primary-variant: var(--kolibri-color-primary-variant, #0077b6);
+		--color-secondary: var(--kolibri-color-secondary, #99c9e2);
 		--color-danger: var(--kolibri-color-danger, #b4003c);
 		--color-warning: var(--kolibri-color-warning, #c44931);
 		--color-success: var(--kolibri-color-success, #005c45);

--- a/packages/themes/default/src/mixins/button.scss
+++ b/packages/themes/default/src/mixins/button.scss
@@ -26,7 +26,7 @@
 
 		&--secondary {
 			--text-background-color: var(--color-secondary);
-			--text-border-color: var(--color-secondary);
+			--text-border-color: var(--color-primary);
 			--text-color: var(--color-primary);
 		}
 

--- a/packages/themes/default/src/mixins/button.scss
+++ b/packages/themes/default/src/mixins/button.scss
@@ -24,8 +24,13 @@
 			--text-color: var(--color-light);
 		}
 
-		&--secondary,
-		&--normal {
+		&--secondary {
+			--text-background-color: var(--color-secondary);
+			--text-border-color: var(--color-secondary);
+			--text-color: var(--color-primary);
+		}
+
+		&--tertiary {
 			--text-background-color: var(--color-light);
 			--text-border-color: var(--color-primary);
 			--text-color: var(--color-primary);
@@ -46,7 +51,7 @@
 
 		&--primary,
 		&--secondary,
-		&--normal,
+		&--tertiary,
 		&--danger,
 		&--ghost {
 			&:not([disabled]):hover {


### PR DESCRIPTION
## What changed?

This change adjusts the button hierarchy of the default theme and introduces a new `--kolibri-color-secondary` design token (`#ccebf7`). The `secondary` button variant now uses the new secondary background colour, and the styling previously used by the `normal` variant has been moved into a dedicated `tertiary` variant. The new token is registered in `global.scss`, documented in the theme README, wired up in the `button` mixin, and the React button sample was reordered accordingly.

## Linked issues

- Refs #7669 — Adjust the button hierarchy in the default theme

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung passt die Button-Hierarchie des Default-Themes an und führt ein neues Design-Token `--kolibri-color-secondary` (`#ccebf7`) ein. Die Button-Variante `secondary` verwendet nun die neue Sekundärfarbe, während das zuvor von der Variante `normal` genutzte Styling in eine eigene Variante `tertiary` verschoben wurde. Das neue Token wird in `global.scss` registriert, im Theme-README dokumentiert, im `button`-Mixin verwendet und das React-Button-Beispiel entsprechend umsortiert.

### Verknüpfte Tickets

- Referenziert #7669 — Anpassung der Button-Hierarchie im Default-Theme

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/themes/default/src/global.scss` — Neues Design-Token `--color-secondary` (Fallback `#ccebf7`) ergänzt.
- `packages/themes/default/README.md` — Neue CSS-Custom-Property `--kolibri-color-secondary` dokumentiert.
- `packages/themes/default/src/mixins/button.scss` — `secondary`-Variante mit Sekundärfarbe und neue `tertiary`-Variante definiert.
- `packages/samples/react/src/components/button/partials/cases.tsx` — Reihenfolge/Bezeichnung der Button-Varianten (normal/tertiary) im Beispiel angepasst.

</details>