### PR TITLE
test: refactor snapshot tests to conditionally skip based on options

### DIFF
--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -3,500 +3,261 @@ export const ROUTES = new Map();
 /**
  * Actually we support the following options:
  *
- * Details: https://playwright.dev/docs/api/class-pageassertions#page-assertions-to-have-screenshot-1
- * - fullPage: boolean (Default: true)
- * - maxDiffPixelRatio: number (Default: undefined)
- * - maxDiffPixels: number (Default: undefined)
- * - threshold: number (Default: undefined)
- * - timeout: number (Default: 0)
+ * Axe options:
+ * - axe:
+ *   - skip: boolean (Default: false)
+ *   - skipFailures: boolean (Default: false)
  *
- * To set the viewport size, use the following options:
- * - viewportSize: { width, height } (Default: 800x600)
- *
+ * Snapshot options:
+ * - snapshot:
+ *   - options:
+ *     - maxDiffPixelRatio: number (Default: 0)
+ *   - skip: boolean (Default: false)
+ *   - viewportSize:
+ *     - width (Default: 800)
+ *     - height (Default: 600)
+ *   - waitForTimeout: number (Default: 15000)
+ *   - zoom:
+ *     - options:
+ *       - maxDiffPixelRatio: number (Default: 0)
+ *     - skip: boolean (Default: false)
  */
 
-ROUTES.set('abbr/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('accordion/basic', null);
-ROUTES.set('accordion/headlines', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('alert/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('alert/card-msg', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('alert/html', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('avatar/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('badge/basic', null);
-ROUTES.set('badge/button', null);
-ROUTES.set('breadcrumb/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button-link/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button-link/icons', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button-link/image', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button/icons', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button/width', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button/access-key', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button/baselined', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('button/short-key', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('card/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('combobox/basic?noColumns', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('details/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
+ROUTES.set('abbr/basic');
+ROUTES.set('accordion/basic');
+ROUTES.set('accordion/headlines');
+ROUTES.set('alert/basic');
+ROUTES.set('alert/card-msg');
+ROUTES.set('alert/html');
+ROUTES.set('avatar/basic');
+ROUTES.set('badge/basic');
+ROUTES.set('badge/button');
+ROUTES.set('breadcrumb/basic');
+ROUTES.set('button-link/basic');
+ROUTES.set('button-link/icons');
+ROUTES.set('button-link/image');
+ROUTES.set('button/basic');
+ROUTES.set('button/icons');
+ROUTES.set('button/width');
+ROUTES.set('button/access-key');
+ROUTES.set('button/baselined');
+ROUTES.set('button/short-key');
+ROUTES.set('card/basic');
+ROUTES.set('combobox/basic?noColumns');
+ROUTES.set('details/basic');
 ROUTES.set('drawer/basic?align=left', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('drawer/basic?align=top', {
-	viewportSize: {
-		width: 800,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 800,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('drawer/basic?align=right', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('drawer/basic?align=bottom', {
-	viewportSize: {
-		width: 800,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 800,
+			height: 600,
+		},
 	},
 });
-ROUTES.set('form/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('form/error-list', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('heading/badge', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('heading/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('heading/paragraph', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('icon/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('image/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('input-checkbox/basic?noColumns', null);
-ROUTES.set('input-checkbox/button?noColumns', null);
-ROUTES.set('input-checkbox/switch?noColumns', null);
-ROUTES.set('input-color/basic?noColumns', null);
-ROUTES.set('input-date/basic?noColumns', null);
-ROUTES.set('input-email/basic?noColumns', null);
-ROUTES.set('input-file/basic?noColumns', null);
-ROUTES.set('input-number/basic?noColumns', null);
-ROUTES.set('input-password/basic?noColumns', null);
-ROUTES.set('input-password/show-password?noColumns', null);
-ROUTES.set('input-radio/basic?noColumns', null);
-ROUTES.set('input-radio/horizontal?noColumns', null);
-ROUTES.set('input-radio/object?noColumns', null);
-ROUTES.set('input-range/basic?noColumns', null);
-ROUTES.set('input-text/basic?noColumns', null);
-ROUTES.set('kolibri/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('link-button/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('link/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('link/icons', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('link/image', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('link/target', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('modal/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
+ROUTES.set('form/basic');
+ROUTES.set('form/error-list');
+ROUTES.set('heading/badge');
+ROUTES.set('heading/basic');
+ROUTES.set('heading/paragraph');
+ROUTES.set('icon/basic');
+ROUTES.set('image/basic');
+ROUTES.set('input-checkbox/basic?noColumns');
+ROUTES.set('input-checkbox/button?noColumns');
+ROUTES.set('input-checkbox/switch?noColumns');
+ROUTES.set('input-color/basic?noColumns');
+ROUTES.set('input-date/basic?noColumns');
+ROUTES.set('input-email/basic?noColumns');
+ROUTES.set('input-file/basic?noColumns');
+ROUTES.set('input-number/basic?noColumns');
+ROUTES.set('input-password/basic?noColumns');
+ROUTES.set('input-password/show-password?noColumns');
+ROUTES.set('input-radio/basic?noColumns');
+ROUTES.set('input-radio/horizontal?noColumns');
+ROUTES.set('input-radio/object?noColumns');
+ROUTES.set('input-range/basic?noColumns');
+ROUTES.set('input-text/basic?noColumns');
+ROUTES.set('kolibri/basic');
+ROUTES.set('link-button/basic');
+ROUTES.set('link/basic');
+ROUTES.set('link/icons');
+ROUTES.set('link/image');
+ROUTES.set('link/target');
+ROUTES.set('modal/basic');
 ROUTES.set('modal/basic?show-modal=true', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('modal/basic?show-modal=true&variant=card', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
-ROUTES.set('nav/aria-current', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('nav/basic', null);
-ROUTES.set('nav/horizontal', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('pagination/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('progress/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('quote/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('quote/block', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('select/basic?noColumns', null);
-ROUTES.set('skip-nav/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('spin/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('single-select/basic?noColumns', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('spin/custom', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('spin/cycle', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('split-button/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/column-alignment', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/sort-data', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/with-footer', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/with-pagination', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/pagination-position', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/complex-headers', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/stateful-with-selection', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/stateful-with-single-selection', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/stateless-with-single-selection', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/stateless-with-selection', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('table/stateless', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('tabs/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('tabs/icons-only', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('textarea/adjust-height', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('textarea/basic?noColumns', null);
-ROUTES.set('textarea/resize', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('textarea/rows', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('textarea/with-counter', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('toast/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
+ROUTES.set('nav/aria-current');
+ROUTES.set('nav/basic');
+ROUTES.set('nav/horizontal');
+ROUTES.set('pagination/basic');
+ROUTES.set('progress/basic');
+ROUTES.set('quote/basic');
+ROUTES.set('quote/block');
+ROUTES.set('select/basic?noColumns');
+ROUTES.set('skip-nav/basic');
+ROUTES.set('spin/basic');
+ROUTES.set('single-select/basic?noColumns');
+ROUTES.set('spin/custom');
+ROUTES.set('spin/cycle');
+ROUTES.set('split-button/basic');
+ROUTES.set('table/column-alignment');
+ROUTES.set('table/sort-data');
+ROUTES.set('table/with-footer');
+ROUTES.set('table/with-pagination');
+ROUTES.set('table/pagination-position');
+ROUTES.set('table/complex-headers');
+ROUTES.set('table/stateful-with-selection');
+ROUTES.set('table/stateful-with-single-selection');
+ROUTES.set('table/stateless-with-single-selection');
+ROUTES.set('table/stateless-with-selection');
+ROUTES.set('table/stateless');
+ROUTES.set('tabs/basic');
+ROUTES.set('tabs/icons-only');
+ROUTES.set('textarea/adjust-height');
+ROUTES.set('textarea/basic?noColumns');
+ROUTES.set('textarea/resize');
+ROUTES.set('textarea/rows');
+ROUTES.set('textarea/with-counter');
+ROUTES.set('toast/basic');
 ROUTES.set('toast/basic?type=info', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?type=success', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?type=warning', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?type=error', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?variant=msg', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?variant=card', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 
 ROUTES.set('toast/basic?type=default&variant=msg', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?type=info&variant=msg', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?type=success&variant=msg', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?type=warning&variant=msg', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 ROUTES.set('toast/basic?type=error&variant=msg', {
-	viewportSize: {
-		width: 1920,
-		height: 600,
+	snapshot: {
+		viewportSize: {
+			width: 1920,
+			height: 600,
+		},
 	},
 });
 
-ROUTES.set('toolbar/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('toolbar/disabled', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('tree/basic/home', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('version/basic', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('version/context', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('scenarios/static-form', {
-	axe: {
-		skipFailures: false,
-	},
-});
-ROUTES.set('scenarios/disabled-interactive-scenario', {
-	axe: {
-		skipFailures: false,
-	},
-});
+ROUTES.set('toolbar/basic');
+ROUTES.set('toolbar/disabled');
+ROUTES.set('tree/basic/home');
+ROUTES.set('version/basic');
+ROUTES.set('version/context');
+ROUTES.set('scenarios/static-form');
+ROUTES.set('scenarios/disabled-interactive-scenario');
 ROUTES.set('scenarios/same-height-of-all-interactive-elements', {
-	axe: {
-		skipFailures: false,
-	},
-	viewportSize: {
-		width: 4000,
-		height: 0,
+	snapshot: {
+		viewportSize: {
+			width: 4000,
+			height: 0,
+		},
 	},
 });
 

--- a/packages/tools/visual-tests/tests/theme-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/theme-snapshots.spec.js
@@ -22,6 +22,10 @@ const DEFAULT_SNAPSHOT_OPTIONS = {
 };
 
 ROUTES.forEach((options, route) => {
+	// Skip unnecessary snapshot tests
+	if (options?.snapshot?.skip === true && options?.snapshot?.zoom?.skip === true) {
+		return;
+	}
 	test(`snapshot for ${route}`, async ({ page }) => {
 		const hideMenusParam = `${route.includes('?') ? '&' : '?'}hideMenus`;
 		await page.goto(`/#${route}${hideMenusParam}`);
@@ -34,11 +38,11 @@ ROUTES.forEach((options, route) => {
 				}
 			`,
 		});
-		if (options?.viewportSize) {
-			await page.setViewportSize(options.viewportSize);
+		if (options?.snapshot?.viewportSize) {
+			await page.setViewportSize(options?.snapshot?.viewportSize);
 		}
-		if (options?.waitForTimeout) {
-			await page.waitForTimeout(options.waitForTimeout);
+		if (options?.snapshot?.waitForTimeout) {
+			await page.waitForTimeout(options?.snapshot?.waitForTimeout);
 		}
 
 		/**
@@ -46,20 +50,29 @@ ROUTES.forEach((options, route) => {
 		 */
 		const snapshotName = `snapshot-for-${route.replace(/(\/|\?|&|=)/g, '-')}`;
 
-		await expect(page).toHaveScreenshot(`${snapshotName}.png`, {
+		const SNAPSHOT_OPTIONS = {
 			...DEFAULT_SNAPSHOT_OPTIONS,
-			...options,
-		});
-		await page.evaluate(() => {
-			// eslint-disable-next-line no-undef
-			document.body.style.zoom = '400%';
-			// document.body.style.transform = 'scale(4)';
-			// document.body.style.transformOrigin = 'top left';
-			// document.body.style.width = '25vw';
-		});
-		await expect(page).toHaveScreenshot(`${snapshotName}-zoom.png`, {
-			...DEFAULT_SNAPSHOT_OPTIONS,
-			...options,
-		});
+			...options?.snapshot?.options,
+		};
+
+		// Skip unnecessary normal tests
+		if (options?.snapshot?.skip !== true) {
+			await expect(page).toHaveScreenshot(`${snapshotName}.png`, SNAPSHOT_OPTIONS);
+		}
+
+		// Skip unnecessary zoom tests
+		if (options?.snapshot?.zoom?.skip !== true) {
+			await page.evaluate(() => {
+				// eslint-disable-next-line no-undef
+				document.body.style.zoom = '400%';
+				// document.body.style.transform = 'scale(4)';
+				// document.body.style.transformOrigin = 'top left';
+				// document.body.style.width = '25vw';
+			});
+			await expect(page).toHaveScreenshot(`${snapshotName}-zoom.png`, {
+				...SNAPSHOT_OPTIONS,
+				...options?.snapshot?.zoom?.options,
+			});
+		}
 	});
 });


### PR DESCRIPTION
## What changed?

This change refines the visual snapshot testing logic in `theme-snapshots.spec.js` by moving all snapshot-related settings under a dedicated `snapshot` object and adding granular skip control. A test is skipped entirely when both `snapshot.skip` and `snapshot.zoom.skip` are set; `viewportSize` and `waitForTimeout` are read from the `snapshot` scope; a new `SNAPSHOT_OPTIONS` object merges `DEFAULT_SNAPSHOT_OPTIONS` with route-specific `snapshot.options`; and zoom snapshots can receive additional `snapshot.zoom.options`. The route definitions in `sample-app.routes.js` were migrated to the new `snapshot`-scoped structure.

## Linked issues

- Refs #7251 — Make visual snapshot tests conditionally skippable

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung verfeinert die Logik der visuellen Snapshot-Tests in `theme-snapshots.spec.js`, indem alle snapshot-bezogenen Einstellungen unter einem eigenen `snapshot`-Objekt zusammengefasst und eine feingranulare Skip-Steuerung ergänzt werden. Ein Test wird vollständig übersprungen, wenn sowohl `snapshot.skip` als auch `snapshot.zoom.skip` gesetzt sind; `viewportSize` und `waitForTimeout` werden aus dem `snapshot`-Bereich gelesen; ein neues `SNAPSHOT_OPTIONS`-Objekt führt `DEFAULT_SNAPSHOT_OPTIONS` mit routenspezifischen `snapshot.options` zusammen; und Zoom-Snapshots können zusätzliche `snapshot.zoom.options` erhalten. Die Routen-Definitionen in `sample-app.routes.js` wurden auf die neue `snapshot`-Struktur migriert.

### Verknüpfte Tickets

- Referenziert #7251 — Visuelle Snapshot-Tests bedingt überspringbar machen

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/tests/theme-snapshots.spec.js` — Bedingtes Überspringen und `SNAPSHOT_OPTIONS`-Zusammenführung eingeführt.
- `packages/tools/visual-tests/tests/sample-app.routes.js` — Routen auf die neue `snapshot`-scoped-Optionsstruktur migriert.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
