### PR TITLE
test: add accessibility snapshot tests using Playwright and Axe

### DIFF
--- a/packages/tools/visual-tests/tests/axe-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/axe-snapshots.spec.js
@@ -36,21 +36,31 @@ test.use({
 	},
 });
 
-const blocklist = [];
-
 ROUTES.forEach((options, route) => {
-	if (blocklist.includes(route)) {
+	// Skip unnecessary axe tests
+	if (options?.axe?.skip === true) {
 		return;
 	}
 	test(`snapshot for ${route}`, async ({ page }, testInfo) => {
 		const outputPath = rename(testInfo.outputDir);
-		await page.goto(`/#${route}?hideMenus`, { waitUntil: 'networkidle' });
-		if (options?.viewportSize) {
-			await page.setViewportSize(options.viewportSize);
+		const hideMenusParam = `${route.includes('?') ? '&' : '?'}hideMenus`;
+		await page.goto(`/#${route}${hideMenusParam}`);
+		await page.waitForLoadState('networkidle');
+		await page.addStyleTag({
+			content: `
+				* {
+					transition: none !important;
+					animation: none !important;
+				}
+			`,
+		});
+		if (options?.snapshot?.viewportSize) {
+			await page.setViewportSize(options?.snapshot?.viewportSize);
 		}
-		if (options?.waitForTimeout) {
-			await page.waitForTimeout(options.waitForTimeout);
+		if (options?.snapshot?.waitForTimeout) {
+			await page.waitForTimeout(options?.snapshot?.waitForTimeout);
 		}
+
 		await injectAxe(page);
 		await checkA11y(
 			page,
@@ -67,7 +77,7 @@ ROUTES.forEach((options, route) => {
 					html: true,
 				},
 			},
-			options?.axe?.skipFailures ?? true,
+			options?.axe?.skipFailures ?? false,
 			'html',
 			{
 				outputDirPath: outputPath.replace(/\/[^/]+$/, ''),

--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -84,9 +84,21 @@ ROUTES.set('heading/basic');
 ROUTES.set('heading/paragraph');
 ROUTES.set('icon/basic');
 ROUTES.set('image/basic');
-ROUTES.set('input-checkbox/basic?noColumns');
-ROUTES.set('input-checkbox/button?noColumns');
-ROUTES.set('input-checkbox/switch?noColumns');
+ROUTES.set('input-checkbox/basic?noColumns', {
+	axe: {
+		skipFailures: true,
+	},
+});
+ROUTES.set('input-checkbox/button?noColumns', {
+	axe: {
+		skipFailures: true,
+	},
+});
+ROUTES.set('input-checkbox/switch?noColumns', {
+	axe: {
+		skipFailures: true,
+	},
+});
 ROUTES.set('input-color/basic?noColumns');
 ROUTES.set('input-date/basic?noColumns');
 ROUTES.set('input-email/basic?noColumns');
@@ -94,7 +106,11 @@ ROUTES.set('input-file/basic?noColumns');
 ROUTES.set('input-number/basic?noColumns');
 ROUTES.set('input-password/basic?noColumns');
 ROUTES.set('input-password/show-password?noColumns');
-ROUTES.set('input-radio/basic?noColumns');
+ROUTES.set('input-radio/basic?noColumns', {
+	axe: {
+		skipFailures: true,
+	},
+});
 ROUTES.set('input-radio/horizontal?noColumns');
 ROUTES.set('input-radio/object?noColumns');
 ROUTES.set('input-range/basic?noColumns');
@@ -132,7 +148,11 @@ ROUTES.set('quote/block');
 ROUTES.set('select/basic?noColumns');
 ROUTES.set('skip-nav/basic');
 ROUTES.set('spin/basic');
-ROUTES.set('single-select/basic?noColumns');
+ROUTES.set('single-select/basic?noColumns', {
+	axe: {
+		skipFailures: true,
+	},
+});
 ROUTES.set('spin/custom');
 ROUTES.set('spin/cycle');
 ROUTES.set('split-button/basic');
@@ -247,12 +267,27 @@ ROUTES.set('toast/basic?type=error&variant=msg', {
 
 ROUTES.set('toolbar/basic');
 ROUTES.set('toolbar/disabled');
-ROUTES.set('tree/basic/home');
+ROUTES.set('tree/basic/home', {
+	axe: {
+		skipFailures: true,
+	},
+});
 ROUTES.set('version/basic');
 ROUTES.set('version/context');
-ROUTES.set('scenarios/static-form');
-ROUTES.set('scenarios/disabled-interactive-scenario');
+ROUTES.set('scenarios/static-form', {
+	axe: {
+		skipFailures: true,
+	},
+});
+ROUTES.set('scenarios/disabled-interactive-scenario', {
+	axe: {
+		skipFailures: true,
+	},
+});
 ROUTES.set('scenarios/same-height-of-all-interactive-elements', {
+	axe: {
+		skipFailures: true,
+	},
 	snapshot: {
 		viewportSize: {
 			width: 4000,
@@ -282,5 +317,9 @@ ROUTES.set('scenarios/focus-elements?component=link');
 ROUTES.set('scenarios/focus-elements?component=linkButton');
 ROUTES.set('scenarios/focus-elements?component=select');
 ROUTES.set('scenarios/focus-elements?component=selectMultiple');
-ROUTES.set('scenarios/focus-elements?component=singleSelect');
+ROUTES.set('scenarios/focus-elements?component=singleSelect', {
+	axe: {
+		skipFailures: true,
+	},
+});
 ROUTES.set('scenarios/focus-elements?component=textarea');


### PR DESCRIPTION
## What changed?

This change reworks the Playwright/Axe accessibility snapshot test setup. The blocklist array in `axe-snapshots.spec.js` is replaced by a per-route `axe.skip` option, the `hideMenus` query parameter is now appended dynamically depending on whether the route already contains query parameters, and animations/transitions are disabled via an injected style tag for more stable results. `viewportSize` and `waitForTimeout` are read from the route's `snapshot` scope, and the default of `axe.skipFailures` is changed from `true` to `false` so accessibility violations fail the test unless a route explicitly opts out via `axe.skipFailures: true` in `sample-app.routes.js`. The spec file was also renamed from `.spec.js.bak` to `.spec.js`.

## Linked issues

- Refs #7452 — Accessibility snapshot testing with Playwright and Axe

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung überarbeitet das Playwright/Axe-Setup für Barrierefreiheits-Snapshot-Tests. Die Blocklist in `axe-snapshots.spec.js` wird durch eine routenbezogene Option `axe.skip` ersetzt, der Parameter `hideMenus` wird abhängig von bereits vorhandenen Query-Parametern dynamisch angehängt, und Animationen/Übergänge werden per injiziertem Style-Tag für stabilere Ergebnisse deaktiviert. `viewportSize` und `waitForTimeout` werden aus dem `snapshot`-Bereich der Route gelesen, und der Standard von `axe.skipFailures` wird von `true` auf `false` geändert, sodass Barrierefreiheits-Verstöße den Test fehlschlagen lassen, sofern eine Route nicht explizit über `axe.skipFailures: true` in `sample-app.routes.js` ausgenommen wird.

### Verknüpfte Tickets

- Referenziert #7452 — Barrierefreiheits-Snapshot-Tests mit Playwright und Axe

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/tests/axe-snapshots.spec.js` — Blocklist durch `axe.skip` ersetzt, dynamischer `hideMenus`-Parameter, deaktivierte Animationen, `skipFailures`-Standard auf `false`.
- `packages/tools/visual-tests/tests/sample-app.routes.js` — Routen mit bekannten Verstößen über `axe.skipFailures: true` ausgenommen.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
