### PR TITLE
fix: missing icon fonts in snapshot tests

### DIFF
--- a/packages/samples/react/public/index.html
+++ b/packages/samples/react/public/index.html
@@ -6,7 +6,16 @@
 		<meta name="description" content="Webapp demonstrating KolBri-components with React." />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="shortcut icon" type="image/x-icon" href="assets/kolibri.ico" />
+		<link rel="stylesheet" href="assets/bundes/style.css" />
 		<link rel="stylesheet" href="assets/codicons/codicon.css" />
+		<link rel="stylesheet" href="assets/fontawesome-free/css/all.min.css" />
+		<link rel="stylesheet" href="assets/icofont/icofont.min.css" />
+		<link rel="stylesheet" href="assets/kreon/style.css" />
+		<link rel="stylesheet" href="assets/noto-sans/noto-sans.css" />
+		<link rel="stylesheet" href="assets/material-icons/iconfont/material-icons.css" />
+		<link rel="stylesheet" href="assets/material-symbols/index.css" />
+		<link rel="stylesheet" href="assets/roboto/roboto.css" />
+		<link rel="stylesheet" href="assets/tabler-icons/tabler-icons.css" />
 		<link rel="stylesheet" href="main.css" />
 		<meta name="robots" content="noindex" />
 		<meta name="kolibri" content="dev-mode=false;experimental-mode=true;" />

--- a/packages/samples/react/public/index.html
+++ b/packages/samples/react/public/index.html
@@ -6,6 +6,7 @@
 		<meta name="description" content="Webapp demonstrating KolBri-components with React." />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="shortcut icon" type="image/x-icon" href="assets/kolibri.ico" />
+		<!-- We include all the important fonts in the index.html here so that they are available for the theme tests. -->
 		<link rel="stylesheet" href="assets/bundes/style.css" />
 		<link rel="stylesheet" href="assets/codicons/codicon.css" />
 		<link rel="stylesheet" href="assets/fontawesome-free/css/all.min.css" />


### PR DESCRIPTION
## What changed?

This PR adds stylesheet `<link>` tags for the icon and web fonts to the React sample's `packages/samples/react/public/index.html`, so those fonts (Bundes, Codicons, FontAwesome Free, IcoFont, Kreon, Noto Sans, Material Icons, Material Symbols, Roboto, Tabler Icons) are loaded and available when the visual/snapshot theme tests render. Previously the fonts were not linked during snapshot rendering, so icons were missing in the generated snapshots. An explanatory comment is added noting that the fonts are included here specifically so they are available for the theme tests. This is the `develop` (v3) fix; #7706 applies the equivalent change on `release/2`.

## Linked issues

- Refs #7704 — icon fonts missing in the theme snapshot tests

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ergänzt in der `index.html` des React-Beispiels (`packages/samples/react/public/index.html`) Stylesheet-`<link>`-Tags für die Icon- und Web-Fonts, damit diese Fonts (Bundes, Codicons, FontAwesome Free, IcoFont, Kreon, Noto Sans, Material Icons, Material Symbols, Roboto, Tabler Icons) beim Rendern der visuellen/Snapshot-Theme-Tests geladen und verfügbar sind. Zuvor waren die Fonts beim Snapshot-Rendering nicht eingebunden, sodass Icons in den erzeugten Snapshots fehlten. Ein erläuternder Kommentar weist darauf hin, dass die Fonts hier bewusst eingebunden werden, damit sie für die Theme-Tests verfügbar sind. Dies ist der Fix für `develop` (v3); #7706 wendet die entsprechende Änderung auf `release/2` an.

### Verknüpfte Tickets

- Referenziert #7704 — fehlende Icon-Fonts in den Theme-Snapshot-Tests

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/public/index.html` — Stylesheet-`<link>`-Tags für Icon-/Web-Fonts ergänzt, damit die Fonts in den Snapshot-Tests verfügbar sind

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
