### PR TITLE
fix: update publish workflow to include version increment option

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,11 +99,11 @@ jobs:
           git config --local user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git config --local user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
 
-      - name: Bump Versions non-dev
+      - name: Bump versions without dev-tag and with git push
         if: github.event.inputs.increment == 'true' && github.event.inputs.tag != 'dev'
         run: 'HUSKY=0 npx lerna version ${{github.event.inputs.version}} --preid=${{github.event.inputs.label}} --no-private --tag-version-prefix="" -m "chore: release %v" -y --force-publish'
 
-      - name: Bump Versions dev and do not push
+      - name: Bump versions with dev-tag and without git push
         if: github.event.inputs.increment == 'true' && github.event.inputs.tag == 'dev'
         run: 'HUSKY=0 npx lerna version prerelease --preid=$GITHUB_SHA --no-private --tag-version-prefix="" -m "chore: release %v" -y --force-publish --no-push'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ env:
 on:
   workflow_dispatch:
     inputs:
+      increment:
+        type: boolean
+        description: 'Would you like to set the version before publishing? (Else: The current version from the code repository will be used.)'
+        default: true
       tag:
         type: choice
         description: Which NPM tag should be assigned?
@@ -44,7 +48,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -95,115 +99,115 @@ jobs:
           git config --local user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           git config --local user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
 
-      - name: Bump versions without dev-tag and with git push
-        if: github.event.inputs.tag != 'dev'
+      - name: Bump Versions non-dev
+        if: github.event.inputs.increment == 'true' && github.event.inputs.tag != 'dev'
         run: 'HUSKY=0 npx lerna version ${{github.event.inputs.version}} --preid=${{github.event.inputs.label}} --no-private --tag-version-prefix="" -m "chore: release %v" -y --force-publish'
 
-      - name: Bump versions with dev-tag and without git push
-        if: github.event.inputs.tag == 'dev'
+      - name: Bump Versions dev and do not push
+        if: github.event.inputs.increment == 'true' && github.event.inputs.tag == 'dev'
         run: 'HUSKY=0 npx lerna version prerelease --preid=$GITHUB_SHA --no-private --tag-version-prefix="" -m "chore: release %v" -y --force-publish --no-push'
 
       - name: Build
         run: pnpm -r build
 
       - name: Build and publish components
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/components
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter angular v15
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v15
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter angular v16
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v16
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter angular v17
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v17
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter angular v18
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v18
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter react
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/react
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter react-standalone
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/react-standalone
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter solid
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/solid
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter vue
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/vue
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter preact
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/preact
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter hydrate
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/hydrate
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish tools kolibri-cli
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/tools/kolibri-cli
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish theme default
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/themes/default
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
-      - name: Build and publish theme bwst
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
-        working-directory: packages/themes/bwst
+      - name: Build and publish theme ecl
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
+        working-directory: packages/themes/ecl
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish themes
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/themes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish sample react
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/samples/react
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
       - name: Build and publish tools visual-tests
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{env.prefix}}-${{github.event.inputs.tag}}
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/tools/visual-tests
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
@@ -216,13 +220,13 @@ jobs:
           registry-url: '${{env.github-registry}}'
 
       - name: Publish designer
-        run: npm publish --access restricted
+        run: npm publish --access restricted || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/designer
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish sample react
-        run: npm publish --access restricted
+        run: npm publish --access restricted || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/samples/react
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed?

This PR reworks the `.github/workflows/publish.yml` release workflow (on `release/2`). It adds a new boolean `increment` `workflow_dispatch` input that lets the operator choose whether the version is bumped before publishing, or whether the current version in the repository is published as-is; both "Bump versions" steps are now additionally gated on `increment == 'true'`. The npm publish tag is simplified from `${{env.prefix}}-${{github.event.inputs.tag}}` to just `${{github.event.inputs.tag}}`, and every publish step gains an `|| echo "⚠️ Publish skipped – package already exists"` fallback so the pipeline no longer fails when a package version is already present in the registry. The `actions/create-github-app-token` action is bumped from v1 to v2, and the obsolete "theme bwst" publish step is replaced by a "theme ecl" step (`packages/themes/ecl`).

## Linked issues

- Refs #0815 — publish-pipeline adjustments (tracking reference from the branch name)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR überarbeitet den Release-Workflow `.github/workflows/publish.yml` (auf `release/2`). Er fügt einen neuen booleschen `increment`-`workflow_dispatch`-Input hinzu, mit dem gewählt werden kann, ob die Version vor dem Publish erhöht wird oder die aktuelle Version aus dem Repository unverändert veröffentlicht wird; beide "Bump versions"-Steps werden zusätzlich an `increment == 'true'` gebunden. Der npm-Publish-Tag wird von `${{env.prefix}}-${{github.event.inputs.tag}}` auf `${{github.event.inputs.tag}}` vereinfacht, und jeder Publish-Step erhält ein `|| echo "⚠️ Publish skipped – package already exists"`-Fallback, damit die Pipeline nicht mehr fehlschlägt, wenn eine Paketversion bereits in der Registry existiert. Die Action `actions/create-github-app-token` wird von v1 auf v2 angehoben, und der veraltete "theme bwst"-Publish-Step wird durch einen "theme ecl"-Step (`packages/themes/ecl`) ersetzt.

### Verknüpfte Tickets

- Referenziert #0815 — Anpassungen der Publish-Pipeline (Tracking-Referenz aus dem Branchnamen)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/publish.yml` — neuer `increment`-Input, an `increment` gebundene Bump-Steps, vereinfachter Publish-Tag, "already exists"-Fallback pro Publish-Step, `create-github-app-token` v1→v2, "theme bwst"-Step durch "theme ecl" ersetzt

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
