### PR TITLE
fix(table-stateful): prevent in-place sorting so the initial order is restored when sorting is cleared

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -410,9 +410,9 @@ export class KolTableStateful implements TableAPI {
 			return;
 		}
 
-		let sortedData: KoliBriTableDataType[] = this.state._data;
+		const sortedData: KoliBriTableDataType[] = [...this.state._data];
 		if (this.sortData.length > 0) {
-			sortedData = this.state._data.sort((a: KoliBriTableDataType, b: KoliBriTableDataType) => {
+			sortedData.sort((a: KoliBriTableDataType, b: KoliBriTableDataType) => {
 				for (let index = 0; index < this.sortData.length; index++) {
 					const data = this.sortData[index];
 					const result = data.compareFn(a, b);


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/table-stateful/shadow.tsx`, the sort routine no longer mutates the component's original `_data` state array. Previously `sortedData` was assigned by reference (`let sortedData = this.state._data`) and `Array.prototype.sort()` was called on that reference, mutating the pristine data in place and discarding the original row order. Now a shallow copy is taken (`const sortedData = [...this.state._data]`) and sorting is applied to that copy. Because the source array stays untouched, clearing the sorting (returning to the "no sort" / NOS state) restores the table's initial order instead of leaving it in the last-sorted order.

## Linked issues

- Closes #7634 — `TableStateful` does not return to the initial order after sorting is deselected

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/table-stateful/shadow.tsx` verändert die Sortier-Routine das ursprüngliche `_data`-State-Array der Komponente nicht mehr direkt. Zuvor wurde `sortedData` per Referenz zugewiesen (`let sortedData = this.state._data`) und `Array.prototype.sort()` auf dieser Referenz aufgerufen, wodurch die ursprünglichen Daten in-place mutiert und die initiale Reihenfolge verloren gingen. Jetzt wird eine flache Kopie erstellt (`const sortedData = [...this.state._data]`) und die Sortierung auf dieser Kopie ausgeführt. Da das Quell-Array unangetastet bleibt, stellt das Zurücksetzen der Sortierung (Rückkehr zum "no sort"-/NOS-Zustand) die ursprüngliche Reihenfolge der Tabelle wieder her, statt die zuletzt angewandte Sortierung beizubehalten.

### Verknüpfte Tickets

- Schließt #7634 — `TableStateful` kehrt nach dem Abwählen der Sortierung nicht zur Ausgangsreihenfolge zurück

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/table-stateful/shadow.tsx` — Sortierung auf einer Kopie von `_data` statt in-place, damit die Ausgangsreihenfolge erhalten bleibt

</details>