### PR TITLE
refactor: enhance conditions for DoD job execution in workflows

### DIFF
--- a/.github/workflows/dod-checker.yml
+++ b/.github/workflows/dod-checker.yml
@@ -11,8 +11,11 @@ concurrency:
 jobs:
   check-dod:
     # Skip this job for draft pull requests as they are considered works in progress
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    # or the base clone URL may be different than the head clone URL.
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.base.repo.clone_url == github.event.pull_request.head.repo.clone_url
+    runs-on: ubuntu-latest
     steps:
       - name: Print Pull Request ID
         run: |

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event.pull_request.base.repo.clone_url == github.event.pull_request.head.repo.clone_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What changed?

This PR adjusts the GitHub Actions workflow conditions so that the Definition-of-Done (DoD) check and the draft deployment behave correctly for pull requests opened from external forks. In `.github/workflows/dod-checker.yml`, the `check-dod` job now runs only when the PR is **not** a draft **and** the base and head repositories share the same clone URL (i.e. the PR does not originate from a fork), and the runner is switched from the pinned `ubuntu-24.04` to `ubuntu-latest`. In `.github/workflows/draft-deploy.yml`, the now-redundant same-clone-URL guard is removed from the `deploy` job. Together these changes stop the DoD/deploy jobs from erroring on fork-based PRs that cannot access repository secrets. This is the `develop` change; #7718 backports the same fix to `release/2`.

## Linked issues

- Refs #0815 — skip DoD and draft deploy for external (fork) PRs

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR passt die GitHub-Actions-Workflow-Bedingungen so an, dass der Definition-of-Done-(DoD-)Check und das Draft-Deployment für Pull Requests aus externen Forks korrekt funktionieren. In `.github/workflows/dod-checker.yml` läuft der `check-dod`-Job nun nur noch, wenn der PR **kein** Draft ist **und** Basis- und Head-Repository dieselbe Clone-URL haben (der PR also nicht aus einem Fork stammt); der Runner wird vom festgesetzten `ubuntu-24.04` auf `ubuntu-latest` umgestellt. In `.github/workflows/draft-deploy.yml` wird die nun redundante Clone-URL-Bedingung aus dem `deploy`-Job entfernt. Zusammen verhindern diese Änderungen, dass die DoD-/Deploy-Jobs bei Fork-basierten PRs fehlschlagen, die keinen Zugriff auf Repository-Secrets haben. Dies ist die Änderung auf `develop`; #7718 portiert denselben Fix nach `release/2`.

### Verknüpfte Tickets

- Referenziert #0815 — DoD und Draft-Deploy für externe (Fork-)PRs überspringen

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/dod-checker.yml` — `check-dod`-Job läuft nur noch für Nicht-Fork-PRs; Runner auf `ubuntu-latest`
- `.github/workflows/draft-deploy.yml` — redundante Clone-URL-Bedingung aus dem `deploy`-Job entfernt

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
