### PR TITLE
fix(table-stateless): reinitialize table settings only when header values change

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -542,8 +542,8 @@ export class KolTableStateful implements TableAPI {
 		const paginationBottom = this._paginationPosition === 'bottom' || this._paginationPosition === 'both' ? this.renderPagination('bottom') : null;
 
 		const headerCells: TableHeaderCells = {
-			horizontal: this.state._headers.horizontal?.map((row) => row.map((cell) => ({ ...cell, sortDirection: this.getHeaderCellSortState(cell) }))),
-			vertical: this.state._headers.vertical?.map((column) => column.map((cell) => ({ ...cell, sortDirection: this.getHeaderCellSortState(cell) }))),
+			horizontal: this.state._headers.horizontal?.map((row) => row.map((cell) => ({ ...cell, sortDirection: this.getHeaderCellSortState(cell) }))) ?? [],
+			vertical: this.state._headers.vertical?.map((column) => column.map((cell) => ({ ...cell, sortDirection: this.getHeaderCellSortState(cell) }))) ?? [],
 		};
 		return (
 			<Host class="kol-table-stateful">

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import { KolButtonWcTag, KolIconTag, KolTableSettingsWcTag, KolTooltipWcTag } from '../../core/component-names';
 import type { TranslationKey } from '../../i18n';
 import { translate } from '../../i18n';
+import { isEqual } from 'lodash-es';
 import type {
 	KoliBriTableCell,
 	KoliBriTableDataType,
@@ -73,6 +74,12 @@ export class KolTableStateless implements TableStatelessAPI {
 	private tableDivElementHasScrollbar = false;
 
 	/**
+	 * Store previous value to allow change detection by value-comparison
+	 */
+	@State()
+	private previousHeaderCells?: TableHeaderCellsPropType;
+
+	/**
 	 * Defines the primary table data.
 	 */
 	@Prop() public _data!: TableDataPropType;
@@ -129,7 +136,13 @@ export class KolTableStateless implements TableStatelessAPI {
 	@Watch('_headerCells')
 	public validateHeaderCells(value?: TableHeaderCellsPropType) {
 		validateTableHeaderCells(this, value);
-		this.initializeTableSettings();
+
+		/* The reference changes on every render. Only reinitialize settings when headers actually changed */
+		if (!isEqual(this.previousHeaderCells, this.state._headerCells)) {
+			this.initializeTableSettings();
+		}
+
+		this.previousHeaderCells = this.state._headerCells;
 	}
 
 	@Watch('_label')


### PR DESCRIPTION
## What changed?

`KolTableStateless` now stores the previous `_headerCells` value and compares it by value (via lodash-es `isEqual`) inside the `_headerCells` watcher, calling `initializeTableSettings()` only when the header cells actually changed. Because Stencil hands the component a new array reference on every render, the previous implementation reinitialized the table settings on each render and thereby discarded the user's current table settings (for example when paginating). In addition, `KolTableStateful` now falls back to empty arrays for the horizontal and vertical header cells instead of leaving them `undefined`. The change touches `table-stateless/component.tsx` and `table-stateful/shadow.tsx`.

## Linked issues

- Refs #7716 — Table settings should be preserved on pagination

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolTableStateless` speichert nun den vorherigen `_headerCells`-Wert und vergleicht ihn wertbasiert (über lodash-es `isEqual`) im `_headerCells`-Watcher. `initializeTableSettings()` wird nur noch aufgerufen, wenn sich die Header-Zellen tatsächlich geändert haben. Da Stencil bei jedem Render eine neue Array-Referenz übergibt, hat die bisherige Implementierung die Tabelleneinstellungen bei jedem Render neu initialisiert und dabei die aktuellen Einstellungen der Nutzer:innen verworfen (z. B. beim Blättern/Paginieren). Zusätzlich verwendet `KolTableStateful` nun leere Arrays als Fallback für die horizontalen und vertikalen Header-Zellen, statt `undefined` zu belassen.

### Verknüpfte Tickets

- Referenziert #7716 — Tabelleneinstellungen sollen bei der Paginierung erhalten bleiben

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/table-stateless/component.tsx` — Wertvergleich der Header-Zellen, bevor die Tabelleneinstellungen neu initialisiert werden
- `packages/components/src/components/table-stateful/shadow.tsx` — Fallback auf leere Arrays für die Header-Zellen

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
