### PR TITLE
fix(TableStateful): prevent in-place sorting of _data (backport to release/2)

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -452,9 +452,9 @@ export class KolTableStateful implements TableAPI {
 			return;
 		}
 
-		let sortedData: KoliBriTableDataType[] = this.state._data;
+		let sortedData: KoliBriTableDataType[] = [...this.state._data];
 		if (this.sortData.length > 0) {
-			sortedData = this.state._data.sort((a: KoliBriTableDataType, b: KoliBriTableDataType) => {
+			sortedData.sort((a: KoliBriTableDataType, b: KoliBriTableDataType) => {
 				for (let index = 0; index < this.sortData.length; index++) {
 					const data = this.sortData[index];
 					const result = data.compareFn(a, b);
@@ -476,7 +476,6 @@ export class KolTableStateful implements TableAPI {
 					break;
 				case 'NOS':
 				default:
-					sortedData = [...this.state._data];
 					this.sortedColumnHead = { label: '', key: '', sortDirection: 'NOS' };
 			}
 		}


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/table-stateful/shadow.tsx`, the sorting logic of `KolTableStateful` no longer mutates the original data array. Previously `this.state._data.sort(...)` sorted the array in place, which permanently reordered the source data and made it impossible to return to the unsorted ("no sort" / NOS) state. The fix copies the array first (`sortedData = [...this.state._data]`) and sorts the copy, so the original `_data` order is preserved and toggling back to NOS restores the initial order. This is a backport of #7715 to the `release/2` branch.

## Linked issues

- Closes #7634 — Table sorting could not be reset correctly (returning to the unsorted "no sort" state) because the data array was mutated in place.
- Refs #7715 — Original fix on the development line that this PR backports.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/table-stateful/shadow.tsx` verändert die Sortierlogik von `KolTableStateful` das ursprüngliche Datenarray nicht mehr. Zuvor sortierte `this.state._data.sort(...)` das Array direkt (in-place), wodurch die Quelldaten dauerhaft umgeordnet wurden und eine Rückkehr in den unsortierten Zustand ("no sort" / NOS) nicht mehr möglich war. Der Fix kopiert das Array zunächst (`sortedData = [...this.state._data]`) und sortiert die Kopie, sodass die ursprüngliche `_data`-Reihenfolge erhalten bleibt und das Zurückschalten auf NOS die Ausgangsreihenfolge wiederherstellt. Dies ist ein Backport von #7715 auf den `release/2`-Branch.

### Verknüpfte Tickets

- Schließt #7634 — Die Tabellensortierung ließ sich nicht korrekt zurücksetzen (Rückkehr in den unsortierten "no sort"-Zustand), da das Datenarray in-place verändert wurde.
- Referenziert #7715 — Ursprünglicher Fix auf der Entwicklungslinie, der hier zurückportiert wird.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/table-stateful/shadow.tsx` — `_data` wird vor dem Sortieren kopiert, statt in-place sortiert; NOS-Reset stellt die Ausgangsreihenfolge wieder her.

</details>