### PR TITLE
chore: build only necessary project when visual testing

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -1,24 +1,16 @@
 name: pnpm Setup
 runs:
   using: 'composite'
-  steps:
-    - name: Install Node.js
+  steps: # https://pnpm.io/continuous-integration#github-actions
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
+    - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 22
-
-    - name: Cache PNPM store + node_modules
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.pnpm-store
-          **/node_modules
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-
-
-    - name: Install PNPM
-      uses: pnpm/action-setup@v2
-      with:
-        version: 10
-        run_install: true
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+      shell: bash

--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -1,21 +1,24 @@
-# References:
-# - https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data
-# - https://github.com/pnpm/action-setup
-
 name: pnpm Setup
-description: Install Node and pnpm, install dependencies
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    - name: Cache PNPM store + node_modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.pnpm-store
+          **/node_modules
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
+    - name: Install PNPM
+      uses: pnpm/action-setup@v2
       with:
         version: 10
-        run_install: false
-
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'pnpm'
-
-    - run: pnpm install
-      shell: bash
+        run_install: true

--- a/.github/actions/upload-reports/action.yml
+++ b/.github/actions/upload-reports/action.yml
@@ -1,0 +1,16 @@
+name: Upload Reports
+inputs:
+  name:
+    default: 'reports'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload test reports
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: ${{ inputs.name }}
+        path: |
+          packages/**/playwright-report/
+          packages/**/test-results/**/*.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: pnpm --filter @public-ui/components exec playwright install --with-deps
 
       - name: Build
-        run: pnpm -r build
+        run: pnpm --filter @public-ui/theme-* --filter @public-ui/sample-react^... build
 
       - name: Visual Tests
         run: pnpm --filter=${{ matrix.package }} test:visual

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,90 +9,85 @@ on:
       - 'release/*'
   workflow_dispatch:
 
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build-and-check:
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
-
       - name: Build
         run: pnpm -r build
-
+      - name: Format
+        run: pnpm -r --parallel format
+      - name: Lint
+        run: pnpm -r --parallel lint
+      - name: Unit Tests
+        run: pnpm -r --parallel test:unit
       - name: Unused
         run: pnpm -r --parallel unused
 
-      - name: Lint
-        run: pnpm -r --parallel lint
-
-      - name: Format
-        run: pnpm -r --parallel format
-
-  test:
+  e2e-tests:
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
-
-      - name: Install Playwright Browsers
-        run: pnpm --filter @public-ui/components exec playwright install --with-deps
-
-      - name: Build
-        run: pnpm --filter @public-ui/sample-react^... build
-
-      - name: Unit Tests
-        run: pnpm -r test:unit
-
-        # Tests in sample app are currently failing and hence disabled.
-        # Remove `--filter @public-ui/components` after tests have been fixed in #7003.
+      - name: Install Playwright and Browsers
+        run: pnpm --filter @public-ui/components exec playwright install --with-deps chromium firefox webkit
+      # Tests in sample app are currently failing and hence disabled.
+      # Remove `--filter @public-ui/components` after tests have been fixed in #7003.
       - name: E2E Test
         run: pnpm --filter @public-ui/components test:e2e
-
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        name: Upload test reports
+      - uses: ./.github/actions/upload-reports
         with:
-          name: reports
-          path: |
-            packages/themes/**/test-results/**/*.png
-            packages/test-tag-name-transformer/test-results/**/*.png
-            packages/components/playwright-report/
-            !**/node_modules
+          name: report-e2e
 
-  test-visual:
-    runs-on: ubuntu-latest
+  visual-tests:
+    continue-on-error: true
     strategy:
       matrix:
-        package: ['@public-ui/test-tag-name-transformer', '@public-ui/theme-default']
+        package: ['test-tag-name-transformer', 'theme-default']
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
-
-      - name: Install Playwright Browsers
-        run: pnpm --filter @public-ui/components exec playwright install --with-deps
-
+      - name: Install Playwright and Firefox
+        run: pnpm --filter @public-ui/components exec playwright install --with-deps firefox
       - name: Build
-        run: pnpm --filter @public-ui/theme-* --filter @public-ui/sample-react^... build
-
+        run: pnpm --filter @public-ui/sample-react^... build
       - name: Visual Tests
-        run: pnpm --filter=${{ matrix.package }} test:visual
-
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        name: Upload test reports
+        run: pnpm --filter=@public-ui/${{ matrix.package }} test
+      - uses: ./.github/actions/upload-reports
         with:
-          name: reports
-          path: |
-            packages/themes/**/test-results/**/*.png
-            packages/test-tag-name-transformer/test-results/**/*.png
-            packages/components/playwright-report/
-            !**/node_modules
+          name: report-${{ matrix.package }}
+
+  check-results:
+    runs-on: ubuntu-latest
+    needs: [build-and-check, e2e-tests, visual-tests]
+    if: always()
+    steps:
+      - name: Fail if any job failed
+        run: |
+          if [[ "${{ needs.build-and-check.result }}" == "failure" || \
+                "${{ needs.e2e-tests.result }}" == "failure" || \
+                "${{ needs.visual-tests.result }}" == "failure" ]]; then
+            echo "At least one job failed"
+            exit 1
+          fi

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   cla:
     if: github.repository == 'public-ui/kolibri'
@@ -17,7 +21,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-          repositories: "kolibri,.github-private"
+          repositories: 'kolibri,.github-private'
 
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,16 +9,20 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ "develop", "main", "release/*" ]
+    branches: ['develop', 'main', 'release/*']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "develop" ]
+    branches: ['develop']
   schedule:
     - cron: '23 1 * * 6'
+
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   analyze:
@@ -39,45 +43,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript' ]
+        language: ['javascript-typescript']
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'

--- a/.github/workflows/dod-checker.yml
+++ b/.github/workflows/dod-checker.yml
@@ -14,7 +14,7 @@ jobs:
     # or the base clone URL may be different than the head clone URL.
     if: |
       github.event.pull_request.draft == false &&
-      github.event.pull_request.base.repo.clone_url == github.event.pull_request.head.repo.clone_url
+      github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/dod-checker.yml
+++ b/.github/workflows/dod-checker.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize, ready_for_review]
 
 concurrency:
-  group: 'pr-${{ github.event.pull_request.number }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true
 
 jobs:
@@ -17,13 +17,8 @@ jobs:
       github.event.pull_request.base.repo.clone_url == github.event.pull_request.head.repo.clone_url
     runs-on: ubuntu-latest
     steps:
-      - name: Print Pull Request ID
-        run: |
-          echo "Pull Request Number: ${{ github.event.pull_request.number }}"
-      - name: Clone Repo
-        uses: actions/checkout@v3
-      - name: Check DoD
-        uses: platisd/definition-of-done@master
+      - uses: actions/checkout@v3
+      - uses: platisd/definition-of-done@master
         with:
           dod_yaml: '.github/dod.yml'
           message_header: 'The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:'

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -3,6 +3,7 @@ name: Netlify Draft Deploy
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
@@ -14,7 +15,7 @@ jobs:
     # or the base clone URL may be different than the head clone URL.
     if: |
       github.event.pull_request.draft == false &&
-      github.event.pull_request.base.repo.clone_url == github.event.pull_request.head.repo.clone_url
+      github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -4,8 +4,17 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   deploy:
+    # Skip this job for draft pull requests as they are considered works in progress
+    # or the base clone URL may be different than the head clone URL.
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.base.repo.clone_url == github.event.pull_request.head.repo.clone_url
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -6,6 +6,10 @@ on:
       - 'develop'
       - 'release/*'
 
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -62,7 +62,7 @@ jobs:
         run: pnpm i --no-frozen-lockfile
 
       - name: Build
-        run: pnpm -r build
+        run: pnpm --filter @public-ui/theme-* --filter @public-ui/sample-react^... build
 
       - name: Purge existing snapshots (optional)
         if: inputs.delete_snapshots == true

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -9,6 +9,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   update-snapshots:
     runs-on: ubuntu-latest
@@ -62,7 +66,7 @@ jobs:
         run: pnpm i --no-frozen-lockfile
 
       - name: Build
-        run: pnpm --filter @public-ui/theme-* --filter @public-ui/sample-react^... build
+        run: pnpm --filter @public-ui/sample-react^... build
 
       - name: Purge existing snapshots (optional)
         if: inputs.delete_snapshots == true

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,7 +69,6 @@
 		"test:unit": "cross-env NODE_ENV=test stencil test --spec --json --outputFile dist/jest-test-results.json",
 		"test:watch": "cross-env NODE_ENV=test stencil test --spec --watchAll",
 		"test:e2e": "cross-env E2E=1 playwright test",
-		"postinstall": "pnpm exec playwright install",
 		"postpack": "mv package.bak.json package.json",
 		"prepack": "npm run build && cp package.json package.bak.json && rimraf dist/collection dist/kolibri/assets/@leanup dist/types/assets/@leanup && node scripts/anonymous.js && node scripts/minify.js",
 		"xunused": "knip"

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -16,7 +16,6 @@
 		"lint:eslint": "eslint src",
 		"lint:stylelint": "stylelint \"src/**/*.{css,scss}\"",
 		"lint:tsc": "tsc --noemit",
-		"postinstall": "pnpm exec playwright install",
 		"prepare": "npm-run-all prepare:*",
 		"prepare:components-assets": "cpy \"node_modules/@public-ui/components/assets/**/*\" public/assets --dot",
 		"prepare:themes-assets": "cpy \"node_modules/@public-ui/themes/assets/**/*\" public/assets --dot",

--- a/packages/test-tag-name-transformer/package.json
+++ b/packages/test-tag-name-transformer/package.json
@@ -1,16 +1,15 @@
 {
-  "name": "@public-ui/test-tag-name-transformer",
+	"name": "@public-ui/test-tag-name-transformer",
 	"private": true,
 	"version": "1.0.0",
 	"license": "EUPL-1.2",
-  "description": "Performs snapshot testing on the default theme with a tag name transformer enabled.",
-  "scripts": {
-		"test": "pnpm test:visual",
-		"test:visual": "THEME_MODULE=theme ENABLE_TAG_NAME_TRANSFORMER=true kolibri-visual-test",
-    "test-update": "THEME_MODULE=theme ENABLE_TAG_NAME_TRANSFORMER=true kolibri-visual-test --update-snapshots theme-snapshots.spec.js"
-  },
-  "devDependencies": {
-    "@public-ui/theme-default": "workspace:*",
-    "@public-ui/visual-tests": "workspace:*"
-  }
+	"description": "Performs snapshot testing on the default theme with a tag name transformer enabled.",
+	"scripts": {
+		"test": "THEME_MODULE=theme ENABLE_TAG_NAME_TRANSFORMER=true kolibri-visual-test",
+		"test-update": "THEME_MODULE=theme ENABLE_TAG_NAME_TRANSFORMER=true kolibri-visual-test --update-snapshots theme-snapshots.spec.js"
+	},
+	"devDependencies": {
+		"@public-ui/themes": "workspace:*",
+		"@public-ui/visual-tests": "workspace:*"
+	}
 }

--- a/packages/test-tag-name-transformer/theme.js
+++ b/packages/test-tag-name-transformer/theme.js
@@ -1,2 +1,2 @@
-import { DEFAULT } from '@public-ui/theme-default';
+import { DEFAULT } from '@public-ui/themes';
 export default DEFAULT;

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -53,8 +53,7 @@
 		"prepare": "cpy \"node_modules/@public-ui/components/assets/**/*\" assets --dot",
 		"start": "npm-run-all --parallel dev serve",
 		"serve": "sh serve.sh DEFAULT",
-		"test": "pnpm test:visual",
-		"test:visual": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test",
+		"test": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test",
 		"test-update": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test --update-snapshots theme-snapshots.spec.js",
 		"pretest": "pnpm build",
 		"pretest-update": "pnpm build"

--- a/packages/tools/visual-tests/.knip.json
+++ b/packages/tools/visual-tests/.knip.json
@@ -2,7 +2,7 @@
 	"$schema": "https://unpkg.com/knip@5/schema.json",
 	"entry": ["src/index.ts"],
 	"ignoreBinaries": [],
-	"ignoreDependencies": ["@public-ui/sample-react", "serve", "axe-playwright"],
+	"ignoreDependencies": ["@playwright/test", "@public-ui/sample-react", "serve", "axe-playwright"],
 	"project": ["src/**/*.ts"],
 	"rules": {
 		"classMembers": "warn"

--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -25,8 +25,7 @@
 		"format": "prettier --check src",
 		"lint": "pnpm lint:eslint",
 		"lint:eslint": "eslint src",
-		"unused": "knip",
-		"postinstall": "pnpm exec playwright install"
+		"unused": "knip"
 	},
 	"bin": {
 		"kolibri-visual-test": "src/index.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,9 +783,9 @@ importers:
 
   packages/test-tag-name-transformer:
     devDependencies:
-      '@public-ui/theme-default':
+      '@public-ui/themes':
         specifier: workspace:*
-        version: link:../themes/default
+        version: link:../themes
       '@public-ui/visual-tests':
         specifier: workspace:*
         version: link:../tools/visual-tests
@@ -20747,7 +20747,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@22.14.1)(typescript@5.8.2))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -20836,7 +20836,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.5.28)(@types/node@22.14.1)(typescript@5.8.2)):
+  jest-jasmine2@26.6.3:
     dependencies:
       '@babel/traverse': 7.27.0
       '@jest/environment': 26.6.2
@@ -20857,11 +20857,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:


### PR DESCRIPTION
## What changed?

This is a CI/tooling change that speeds up the visual-test builds and reworks the GitHub Actions pipeline. Instead of building every workspace project (`pnpm -r build`), the visual-test and snapshot jobs now build only the projects required for the React sample app (`pnpm --filter @public-ui/sample-react^... build`). The `ci.yml` workflow is restructured: the previous `test`/`test-visual` jobs become `e2e-tests` and `visual-tests`, unit tests move into `build-and-check`, all jobs get `continue-on-error: true` plus a final `check-results` gate, and a shared `upload-reports` composite action replaces the duplicated artifact-upload steps. Playwright browser installation is narrowed to the needed browsers and the `postinstall: playwright install` hooks are removed from several packages. `pnpm-setup` bumps Node to 22, and the `test-tag-name-transformer` package now depends on `@public-ui/themes` instead of `@public-ui/theme-default`. `concurrency` groups are added to several workflows. No library or component source code is affected.

## Linked issues

- Closes #7738 — Speed up the build for visual tests (only build the projects that are actually needed).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies ist eine CI-/Tooling-Änderung, die die Builds für die visuellen Tests beschleunigt und die GitHub-Actions-Pipeline überarbeitet. Statt alle Workspace-Projekte zu bauen (`pnpm -r build`), bauen die Visual-Test- und Snapshot-Jobs nur noch die für die React-Sample-App benötigten Projekte (`pnpm --filter @public-ui/sample-react^... build`). Der `ci.yml`-Workflow wird umstrukturiert: Die bisherigen Jobs `test`/`test-visual` werden zu `e2e-tests` und `visual-tests`, Unit-Tests wandern in `build-and-check`, alle Jobs erhalten `continue-on-error: true` sowie einen abschließenden `check-results`-Gate, und eine gemeinsame `upload-reports`-Composite-Action ersetzt die duplizierten Artefakt-Upload-Schritte. Die Playwright-Browserinstallation wird auf die benötigten Browser eingegrenzt und die `postinstall: playwright install`-Hooks werden aus mehreren Paketen entfernt. `pnpm-setup` hebt Node auf 22 an, und das Paket `test-tag-name-transformer` hängt nun von `@public-ui/themes` statt `@public-ui/theme-default` ab. Mehreren Workflows werden `concurrency`-Gruppen hinzugefügt. Es ist kein Bibliotheks- oder Komponenten-Quellcode betroffen.

### Verknüpfte Tickets

- Schließt #7738 — Build für visuelle Tests beschleunigen (nur die tatsächlich benötigten Projekte bauen).

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/ci.yml` — Jobs umstrukturiert (`e2e-tests`, `visual-tests`, `check-results`), scoped Builds, `continue-on-error`.
- `.github/actions/pnpm-setup/action.yml` — Node auf 22 angehoben, Schritte benannt.
- `.github/actions/upload-reports/action.yml` — neue gemeinsame Composite-Action für Report-Uploads.
- `.github/workflows/{cla,codeql,dod-checker,draft-deploy,test-deploy,update-snapshots}.yml` — `concurrency`-Gruppen und kleinere Anpassungen.
- `packages/**/package.json`, `packages/test-tag-name-transformer/theme.js` — `postinstall`-Playwright-Hooks entfernt, Test-Skripte vereinheitlicht, `@public-ui/themes`-Abhängigkeit.
- `pnpm-lock.yaml` — Lockfile aktualisiert.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
