### PR TITLE
feat(input-file): add modifier class when a file is selected

### DIFF
--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -95,7 +95,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 		return (
 			<KolFormFieldStateWrapperFc {...this.getFormFieldProps()}>
 				<KolInputContainerFc state={this.state}>
-					<span class="kol-input-container__filename">{this.filename}</span>
+					<span class={clsx('kol-input-container__filename', { 'kol-input-container__filename--has-file': this.hasFileSelected })}>{this.filename}</span>
 					<KolInputStateWrapperFc {...this.getInputProps()} />
 					<KolButtonWcTag class="kol-input-container__button" _label={translate('kol-data-browse-text')} _variant="primary" _disabled={this._disabled} />
 				</KolInputContainerFc>
@@ -209,6 +209,8 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	@State() private filename: string = translate('kol-filename-text');
+	@State() private hasFileSelected: boolean = false;
+
 	@State() public state: InputFileStates = {
 		_hideMsg: false,
 		_id: `id-${nonce()}`,
@@ -350,6 +352,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	private onChange = (event: Event): void => {
 		if (this.inputRef instanceof HTMLInputElement && this.inputRef.type === 'file') {
 			const value = this.inputRef.files;
+			this.hasFileSelected = !!value?.length;
 			this.filename = value?.length
 				? Array.from(value)
 						.map((file) => file.name)

--- a/packages/themes/default/src/components/input-file.scss
+++ b/packages/themes/default/src/components/input-file.scss
@@ -8,6 +8,7 @@
 
 	.kol-input-container {
 		gap: initial;
+		padding: 0 0 0 rem(8);
 
 		&__filename {
 			color: var(--color-subtle);


### PR DESCRIPTION
## What changed?

`KolInputFile` now exposes whether a file is currently selected as a CSS hook. A new `hasFileSelected` `@State()` is set in the `onChange` handler (`!!value?.length`), and the filename `<span>` gets an additional `kol-input-container__filename--has-file` modifier class (composed via `clsx`) whenever a file has been chosen. The default theme (`themes/default/src/components/input-file.scss`) also adds `padding: 0 0 0 rem(8)` to the input container. This lets themes/consumers style the filename differently in the empty vs. selected state.

## Linked issues

- No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolInputFile` stellt jetzt als CSS-Hook bereit, ob aktuell eine Datei ausgewählt ist. Ein neues `hasFileSelected`-`@State()` wird im `onChange`-Handler gesetzt (`!!value?.length`), und das Dateinamen-`<span>` erhält zusätzlich die Modifier-Klasse `kol-input-container__filename--has-file` (per `clsx` zusammengesetzt), sobald eine Datei gewählt wurde. Das Default-Theme (`themes/default/src/components/input-file.scss`) ergänzt außerdem `padding: 0 0 0 rem(8)` am Input-Container. Dadurch lässt sich der Dateiname im leeren gegenüber dem ausgewählten Zustand unterschiedlich stylen.

### Verknüpfte Tickets

- Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/input-file/shadow.tsx` — Ergänzt `hasFileSelected`-State und die Modifier-Klasse `--has-file` am Dateinamen.
- `packages/themes/default/src/components/input-file.scss` — Fügt Padding am Input-Container hinzu.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
