### PR TITLE
feat(popover-button): expose aria-haspopup and live aria-expanded state

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -52,6 +52,7 @@ import { propagateResetEventToForm, propagateSubmitEventToForm } from '../form/c
 import { AssociatedInputController } from '../input-adapter-leanup/associated.controller';
 import { KolSpanWcTag, KolTooltipWcTag } from '../../core/component-names';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
+import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 
 /**
  * @internal
@@ -116,6 +117,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 					aria-controls={this.state._ariaControls}
 					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
 					aria-expanded={mapBoolean2String(this.state._ariaExpanded)}
+					aria-haspopup={this._ariaHasPopup}
 					aria-label={this.state._hideLabel && typeof this.state._label === 'string' ? this.state._label : undefined}
 					aria-selected={mapStringOrBoolean2String(this.state._ariaSelected)}
 					class={{
@@ -186,6 +188,12 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 	 * Defines whether the interactive element of the component expanded something. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
 	 */
 	@Prop() public _ariaExpanded?: boolean;
+
+	/**
+	 * Defines the aria-haspopup attribute. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup)
+	 * @internal
+	 */
+	@Prop() public _ariaHasPopup?: AriaHasPopupPropType;
 
 	/**
 	 * Defines whether the interactive element of the component is selected (e.g. role=tab). (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -43,6 +43,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 		_popoverAlign: 'bottom',
 	};
 	@State() private justClosed = false;
+	@State() private popoverOpen = false;
 
 	/* Regarding type issue see https://github.com/microsoft/TypeScript/issues/54864 */
 	private handleBeforeToggle(event: Event) {
@@ -62,7 +63,9 @@ export class KolPopoverButton implements PopoverButtonProps {
 	}
 
 	private handleToggle(event: Event) {
-		if ((event as ToggleEvent).newState === 'open' && this.refPopover && this.refButton) {
+		this.popoverOpen = (event as ToggleEvent).newState === 'open';
+
+		if (this.popoverOpen && this.refPopover && this.refButton) {
 			void alignFloatingElements({
 				align: this.state._popoverAlign,
 				floatingElement: this.refPopover,
@@ -93,9 +96,11 @@ export class KolPopoverButton implements PopoverButtonProps {
 			<div class="kol-popover-button">
 				<KolButtonWcTag
 					_accessKey={this._accessKey}
+					_aria-controls="popover"
 					_ariaControls={this._ariaControls}
 					_ariaDescription={this._ariaDescription}
-					_ariaExpanded={this._ariaExpanded}
+					_ariaExpanded={this.popoverOpen}
+					_ariaHasPopup={'dialog'}
 					_ariaSelected={this._ariaSelected}
 					_customClass={this._customClass}
 					_disabled={this._disabled}

--- a/packages/components/src/components/popover-button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/popover-button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`kol-popover-button should render with _label="Click to toggle" 1`] = `
 <kol-popover-button>
   <template shadowrootmode="open">
     <div class="kol-popover-button">
-      <kol-button-wc _label="Click to toggle" _tooltipalign="top" _type="button" _variant="normal" class="kol-popover-button__button" data-testid="popover-button">
+      <kol-button-wc _aria-controls="popover" _ariahaspopup="dialog" _label="Click to toggle" _tooltipalign="top" _type="button" _variant="normal" class="kol-popover-button__button" data-testid="popover-button">
         <slot name="expert" slot="expert"></slot>
       </kol-button-wc>
       <div class="kol-popover-button__popover" data-testid="popover-content" id="popover" popover="auto">

--- a/packages/components/src/schema/props/aria-has-popup.ts
+++ b/packages/components/src/schema/props/aria-has-popup.ts
@@ -1,0 +1,26 @@
+/* types */
+
+// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup#values
+const ariaHasPopupOptions = ['false', 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog'] as const;
+export type AriaHasPopupPropType = (typeof ariaHasPopupOptions)[number];
+
+/**
+ * Defines the aria-haspopup attribute.
+ */
+// export type PropAriaHasPopup = {
+// 	ariaHasPopup: AriaHasPopupPropType;
+// };
+
+/* validator */
+// export const validateAriaHasPopup = (component: Generic.Element.Component, value?: AriaHasPopupPropType): void => {
+// 	watchValidator(
+// 		component,
+// 		'_ariaHasPopup',
+// 		(value) => typeof value === 'string' && ariaHasPopupOptions.includes(value),
+// 		new Set([`KoliBriAriaHasPopup {${ariaHasPopupOptions.join(', ')}`]),
+// 		value,
+// 		{
+// 			defaultValue: 'false',
+// 		},
+// 	);
+// };


### PR DESCRIPTION
## What changed?

Improves the accessibility semantics of `KolPopoverButton` (shadow variant):

- A new internal `_ariaHasPopup` prop (`AriaHasPopupPropType`, values `false | true | menu | listbox | tree | grid | dialog`) was added to `KolButtonWc` and renders the `aria-haspopup` attribute. A new schema type file `schema/props/aria-has-popup.ts` was introduced.
- `KolPopoverButton` now tracks its open state in a `popoverOpen` `@State()`. The trigger button receives `_ariaExpanded={this.popoverOpen}` (instead of the pass-through consumer value), `_ariaHasPopup="dialog"` and `aria-controls="popover"`, so `aria-expanded` reflects the real popover state and screen readers announce that the button opens a dialog.
- The component snapshot was updated to include the new `aria-haspopup="dialog"` / `aria-controls` attributes.

Note: the `_ariaExpanded` value is now derived from the popover's open state rather than the consumer-supplied prop.

## Linked issues

- Refs #7749 — Implement ARIA properties for the popover-button

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Verbessert die Accessibility-Semantik von `KolPopoverButton` (Shadow-Variante):

- Eine neue interne Prop `_ariaHasPopup` (`AriaHasPopupPropType`, Werte `false | true | menu | listbox | tree | grid | dialog`) wurde `KolButtonWc` hinzugefügt und rendert das `aria-haspopup`-Attribut. Neu ist die Schema-Typdatei `schema/props/aria-has-popup.ts`.
- `KolPopoverButton` verwaltet seinen Öffnungszustand jetzt in einem `popoverOpen`-`@State()`. Der Trigger-Button erhält `_ariaExpanded={this.popoverOpen}` (statt des durchgereichten Konsumentenwerts), `_ariaHasPopup="dialog"` sowie `aria-controls="popover"`, sodass `aria-expanded` den tatsächlichen Popover-Zustand widerspiegelt und Screenreader ankündigen, dass der Button einen Dialog öffnet.
- Der Komponenten-Snapshot wurde um die neuen Attribute `aria-haspopup="dialog"` / `aria-controls` ergänzt.

Hinweis: Der Wert von `_ariaExpanded` wird jetzt aus dem Öffnungszustand des Popovers abgeleitet statt aus der vom Konsumenten gesetzten Prop.

### Verknüpfte Tickets

- Referenziert #7749 — ARIA-Eigenschaften für den Popover-Button implementieren

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/button/component.tsx` — Ergänzt die interne Prop `_ariaHasPopup` und rendert `aria-haspopup`.
- `packages/components/src/components/popover-button/shadow.tsx` — Verwaltet den Öffnungszustand und setzt `aria-expanded`/`aria-haspopup`/`aria-controls` am Button.
- `packages/components/src/components/popover-button/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshot an die neuen ARIA-Attribute angepasst.
- `packages/components/src/schema/props/aria-has-popup.ts` — Neuer Schema-Typ für `aria-haspopup`.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
