### PR TITLE
feat(popover-button)!: wire aria-haspopup and manage aria-expanded internally

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -52,6 +52,7 @@ import { propagateResetEventToForm, propagateSubmitEventToForm } from '../form/c
 import { AssociatedInputController } from '../input-adapter-leanup/associated.controller';
 import { KolTooltipWcTag } from '../../core/component-names';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
+import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 import { KolSpanFc } from '../../functional-components';
 import clsx from 'clsx';
 
@@ -125,6 +126,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 					aria-controls={this.state._ariaControls}
 					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
 					aria-expanded={mapBoolean2String(this.state._ariaExpanded)}
+					aria-haspopup={this._ariaHasPopup}
 					aria-label={this.state._hideLabel && typeof this.state._label === 'string' ? this.state._label : undefined}
 					aria-selected={mapStringOrBoolean2String(this.state._ariaSelected)}
 					class={clsx('kol-button', {
@@ -195,6 +197,12 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 	 * Defines whether the interactive element of the component expanded something. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
 	 */
 	@Prop() public _ariaExpanded?: boolean;
+
+	/**
+	 * Defines the aria-haspopup attribute. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup)
+	 * @internal
+	 */
+	@Prop() public _ariaHasPopup?: AriaHasPopupPropType;
 
 	/**
 	 * Defines whether the interactive element of the component is selected (e.g. role=tab). (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -39,6 +39,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 		_popoverAlign: 'bottom',
 	};
 	@State() private justClosed = false;
+	@State() private popoverOpen = false;
 
 	/**
 	 * Hides the popover programmatically by calling the native hidePopover method.
@@ -67,7 +68,9 @@ export class KolPopoverButton implements PopoverButtonProps {
 	}
 
 	private handleToggle(event: Event) {
-		if ((event as ToggleEvent).newState === 'open' && this.refPopover && this.refButton) {
+		this.popoverOpen = (event as ToggleEvent).newState === 'open';
+
+		if (this.popoverOpen && this.refPopover && this.refButton) {
 			void alignFloatingElements({
 				align: this.state._popoverAlign,
 				floatingElement: this.refPopover,
@@ -98,9 +101,11 @@ export class KolPopoverButton implements PopoverButtonProps {
 			<div class="kol-popover-button">
 				<KolButtonWcTag
 					_accessKey={this._accessKey}
+					_aria-controls="popover"
 					_ariaControls={this._ariaControls}
 					_ariaDescription={this._ariaDescription}
-					_ariaExpanded={this._ariaExpanded}
+					_ariaExpanded={this.popoverOpen}
+					_ariaHasPopup={'dialog'}
 					_ariaSelected={this._ariaSelected}
 					_customClass={this._customClass}
 					_disabled={this._disabled}
@@ -147,11 +152,6 @@ export class KolPopoverButton implements PopoverButtonProps {
 	 * Defines the value for the aria-description attribute.
 	 */
 	@Prop() public _ariaDescription?: AriaDescriptionPropType;
-
-	/**
-	 * Defines whether the interactive element of the component expanded something. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
-	 */
-	@Prop() public _ariaExpanded?: boolean;
 
 	/**
 	 * Defines whether the interactive element of the component is selected (e.g. role=tab). (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -49,7 +49,6 @@ export class KolPopoverButton implements PopoverButtonProps {
 				_accessKey={this._accessKey}
 				_ariaControls={this._ariaControls}
 				_ariaDescription={this._ariaDescription}
-				_ariaExpanded={this._ariaExpanded}
 				_ariaSelected={this._ariaSelected}
 				_customClass={this._customClass}
 				_disabled={this._disabled}
@@ -89,11 +88,6 @@ export class KolPopoverButton implements PopoverButtonProps {
 	 * Defines the value for the aria-description attribute.
 	 */
 	@Prop() public _ariaDescription?: AriaDescriptionPropType;
-
-	/**
-	 * Defines whether the interactive element of the component expanded something. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
-	 */
-	@Prop() public _ariaExpanded?: boolean;
 
 	/**
 	 * Defines whether the interactive element of the component is selected (e.g. role=tab). (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected)

--- a/packages/components/src/schema/props/aria-has-popup.ts
+++ b/packages/components/src/schema/props/aria-has-popup.ts
@@ -1,0 +1,26 @@
+/* types */
+
+// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup#values
+const ariaHasPopupOptions = ['false', 'true', 'menu', 'listbox', 'tree', 'grid', 'dialog'] as const;
+export type AriaHasPopupPropType = (typeof ariaHasPopupOptions)[number];
+
+/**
+ * Defines the aria-haspopup attribute.
+ */
+// export type PropAriaHasPopup = {
+// 	ariaHasPopup: AriaHasPopupPropType;
+// };
+
+/* validator */
+// export const validateAriaHasPopup = (component: Generic.Element.Component, value?: AriaHasPopupPropType): void => {
+// 	watchValidator(
+// 		component,
+// 		'_ariaHasPopup',
+// 		(value) => typeof value === 'string' && ariaHasPopupOptions.includes(value),
+// 		new Set([`KoliBriAriaHasPopup {${ariaHasPopupOptions.join(', ')}`]),
+// 		value,
+// 		{
+// 			defaultValue: 'false',
+// 		},
+// 	);
+// };


### PR DESCRIPTION
## What changed?

This adds correct ARIA semantics to `KolPopoverButton` and its underlying button:

- A new internal `_ariaHasPopup` prop (`AriaHasPopupPropType`, values `false | true | menu | listbox | tree | grid | dialog`) was added to `KolButtonWc`, rendering the `aria-haspopup` attribute. A new schema type file `schema/props/aria-has-popup.ts` was introduced.
- `KolPopoverButton` now tracks its open state in a `popoverOpen` `@State()` and passes `_ariaExpanded={this.popoverOpen}`, `_ariaHasPopup="dialog"` and `aria-controls="popover"` down to the button, so `aria-expanded` reflects the real popover state and screen readers announce that the button opens a dialog.
- The consumer-facing `_ariaExpanded` / `_aria-expanded` prop was removed from `KolPopoverButton` (both `component.tsx` and `shadow.tsx`), because the component now controls this value itself.

Consumers that previously set `_aria-expanded` on `kol-popover-button` must remove it; the correct value is now derived automatically from the popover's open state.

## Linked issues

- Refs #7749 — Implement ARIA properties for the popover-button

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [x] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung ergänzt korrekte ARIA-Semantik für `KolPopoverButton` und den zugrunde liegenden Button:

- Eine neue interne Prop `_ariaHasPopup` (`AriaHasPopupPropType`, Werte `false | true | menu | listbox | tree | grid | dialog`) wurde `KolButtonWc` hinzugefügt und rendert das `aria-haspopup`-Attribut. Neu ist die Schema-Typdatei `schema/props/aria-has-popup.ts`.
- `KolPopoverButton` verwaltet seinen Öffnungszustand jetzt in einem `popoverOpen`-`@State()` und übergibt `_ariaExpanded={this.popoverOpen}`, `_ariaHasPopup="dialog"` sowie `aria-controls="popover"` an den Button. Dadurch spiegelt `aria-expanded` den tatsächlichen Popover-Zustand wider, und Screenreader kündigen an, dass der Button einen Dialog öffnet.
- Die konsumentenseitige Prop `_ariaExpanded` / `_aria-expanded` wurde aus `KolPopoverButton` entfernt (`component.tsx` und `shadow.tsx`), da die Komponente diesen Wert nun selbst steuert.

Anwendungen, die zuvor `_aria-expanded` an `kol-popover-button` gesetzt haben, müssen dieses Attribut entfernen; der korrekte Wert wird jetzt automatisch aus dem Öffnungszustand des Popovers abgeleitet.

### Verknüpfte Tickets

- Referenziert #7749 — ARIA-Eigenschaften für den Popover-Button implementieren

### Art der Änderung

💥 Breaking Change

### Geänderte Dateien

- `packages/components/src/components/button/component.tsx` — Ergänzt die interne Prop `_ariaHasPopup` und rendert `aria-haspopup`.
- `packages/components/src/components/popover-button/component.tsx` — Verwaltet den Öffnungszustand, setzt `aria-expanded`/`aria-haspopup`/`aria-controls` und entfernt die öffentliche `_ariaExpanded`-Prop.
- `packages/components/src/components/popover-button/shadow.tsx` — Entfernt die öffentliche `_ariaExpanded`-Prop.
- `packages/components/src/schema/props/aria-has-popup.ts` — Neuer Schema-Typ für `aria-haspopup`.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
