### PR TITLE
ci(draft-deploy): re-enable Netlify draft deploys for draft PRs

### DIFF
--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -3,7 +3,7 @@ name: Netlify Draft Deploy
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
@@ -11,11 +11,8 @@ concurrency:
 
 jobs:
   deploy:
-    # Skip this job for draft pull requests as they are considered works in progress
-    # or the base clone URL may be different than the head clone URL.
-    if: |
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.fork == false
+    # Skip this job when the base clone URL may be different from the head clone URL.
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What changed?

The `Netlify Draft Deploy` workflow (`.github/workflows/draft-deploy.yml`) no longer skips pull requests that are in draft state. The `github.event.pull_request.draft == false` guard was removed from the job condition, leaving only the fork check (`github.event.pull_request.head.repo.fork == false`), and the `ready_for_review` trigger type was dropped since deploys now run while the PR is still a draft. This is a CI-only change with no impact on the published component library.

## Linked issues

- Refs #7764 — Draft PRs should get Netlify preview deployments again

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Workflow `Netlify Draft Deploy` (`.github/workflows/draft-deploy.yml`) überspringt Pull Requests im Entwurfsstatus nicht mehr. Die Bedingung `github.event.pull_request.draft == false` wurde aus der Job-Bedingung entfernt, sodass nur noch die Fork-Prüfung (`github.event.pull_request.head.repo.fork == false`) verbleibt; der Trigger-Typ `ready_for_review` wurde entfernt, da Deployments jetzt bereits im Draft-Zustand laufen. Reine CI-Änderung ohne Auswirkung auf die veröffentlichte Komponentenbibliothek.

### Verknüpfte Tickets

- Referenziert #7764 — Draft-PRs sollen wieder Netlify-Preview-Deployments erhalten

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/draft-deploy.yml` — Entfernt die Draft-Ausschlussbedingung und den `ready_for_review`-Trigger, sodass Draft-PRs wieder deployt werden.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
