### PR TITLE
feat(popover-button): auto-update popover position while open

### DIFF
--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -22,6 +22,7 @@ import type {
 } from '../../schema';
 import { validatePopoverAlign } from '../../schema';
 import clsx from 'clsx';
+import { autoUpdate } from '@floating-ui/dom';
 
 /**
  * @slot - The popover content.
@@ -37,6 +38,7 @@ import clsx from 'clsx';
 export class KolPopoverButton implements PopoverButtonProps {
 	private refButton?: HTMLKolButtonWcElement;
 	private refPopover?: HTMLDivElement;
+	private cleanupAutoPositioning?: () => void;
 
 	@State() public state: PopoverButtonStates = {
 		_label: '',
@@ -62,15 +64,28 @@ export class KolPopoverButton implements PopoverButtonProps {
 		}
 	}
 
-	private handleToggle(event: Event) {
-		this.popoverOpen = (event as ToggleEvent).newState === 'open';
-
-		if (this.popoverOpen && this.refPopover && this.refButton) {
+	private alignPopover() {
+		if (this.refPopover && this.refButton) {
 			void alignFloatingElements({
 				align: this.state._popoverAlign,
 				floatingElement: this.refPopover,
 				referenceElement: this.refButton,
 			});
+		}
+	}
+
+	private handleToggle(event: Event) {
+		this.popoverOpen = (event as ToggleEvent).newState === 'open';
+
+		if (this.popoverOpen) {
+			if (this.refPopover && this.refButton) {
+				this.cleanupAutoPositioning = autoUpdate(this.refButton, this.refPopover, () => {
+					this.alignPopover();
+				});
+			}
+		} else if (this.cleanupAutoPositioning) {
+			this.cleanupAutoPositioning();
+			this.cleanupAutoPositioning = undefined;
 		}
 	}
 
@@ -89,6 +104,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	public disconnectedCallback() {
 		this.refPopover?.removeEventListener('toggle', this.handleToggle.bind(this));
 		this.refPopover?.removeEventListener('beforetoggle', this.handleBeforeToggle.bind(this));
+		this.cleanupAutoPositioning?.();
 	}
 
 	public render(): JSX.Element {


### PR DESCRIPTION
## What changed?

`KolPopoverButton` (`popover-button/shadow.tsx`) now keeps the popover correctly aligned for as long as it is open, not just at the moment it opens. The alignment logic was extracted into a dedicated `alignPopover()` method, and `handleToggle()` now registers `autoUpdate` from `@floating-ui/dom` when the popover opens. `autoUpdate` re-runs the alignment on scroll, resize and layout shifts. A `cleanupAutoPositioning` teardown function is stored and invoked when the popover closes and in `disconnectedCallback()` to avoid leaking listeners.

## Linked issues

- Refs #7614 — Popover position should follow the trigger while open

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolPopoverButton` (`popover-button/shadow.tsx`) hält das Popover jetzt so lange korrekt ausgerichtet, wie es geöffnet ist — nicht mehr nur im Moment des Öffnens. Die Ausrichtungslogik wurde in eine eigene Methode `alignPopover()` ausgelagert, und `handleToggle()` registriert beim Öffnen `autoUpdate` aus `@floating-ui/dom`. `autoUpdate` führt die Ausrichtung bei Scrollen, Größenänderung und Layout-Verschiebungen erneut aus. Eine `cleanupAutoPositioning`-Aufräumfunktion wird gespeichert und beim Schließen des Popovers sowie im `disconnectedCallback()` aufgerufen, um Listener-Lecks zu vermeiden.

### Verknüpfte Tickets

- Referenziert #7614 — Popover-Position soll dem Trigger folgen, solange es geöffnet ist

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/popover-button/shadow.tsx` — Registriert `autoUpdate` beim Öffnen des Popovers, lagert die Ausrichtung in `alignPopover()` aus und räumt die Auto-Positionierung beim Schließen bzw. Entfernen auf.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
