### PR TITLE
fix(span): do not render empty badge text hint

### DIFF
--- a/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
+++ b/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
@@ -16,7 +16,7 @@ const KolSpanCoreHelperFc: FC<{ label: string; hideLabel?: boolean; badgeText?: 
 			<span aria-hidden={hideExpertSlot ? 'true' : undefined} class="kol-span__label" hidden={hideExpertSlot}>
 				{children}
 			</span>
-			{isString(badgeText) && (
+			{isString(badgeText) && badgeText.length > 0 && (
 				<span class="badge-text-hint" aria-hidden="true">
 					{badgeText}
 				</span>


### PR DESCRIPTION
## What changed?

In `SpanCoreHelper.tsx` the render condition for the badge text hint was tightened from `isString(badgeText)` to `isString(badgeText) && badgeText.length > 0`. Previously an empty string passed as `badgeText` still produced an empty `<span class="badge-text-hint">` element. Now the hint span is only rendered when the badge text actually contains characters. This affects all components that render label content through the shared `Span` helper (e.g. buttons, links). No public API changes.

## Linked issues

- Refs #7505 — Empty badge text rendered an empty hint element

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `SpanCoreHelper.tsx` wurde die Render-Bedingung für den Badge-Text-Hinweis von `isString(badgeText)` auf `isString(badgeText) && badgeText.length > 0` verschärft. Bisher erzeugte ein leerer String als `badgeText` trotzdem ein leeres `<span class="badge-text-hint">`-Element. Jetzt wird das Hinweis-Span nur noch gerendert, wenn der Badge-Text tatsächlich Zeichen enthält. Betroffen sind alle Komponenten, die ihren Label-Inhalt über den gemeinsamen `Span`-Helper darstellen (z. B. Buttons, Links). Keine Änderung der öffentlichen API.

### Verknüpfte Tickets

- Referenziert #7505 — Leerer Badge-Text erzeugte ein leeres Hinweis-Element

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/functional-components/Span/SpanCoreHelper.tsx` — Rendert das Badge-Text-Hinweis-Span nur noch bei nicht-leerem Badge-Text.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
