### PR TITLE
feat(popover-button): auto-reposition popover while open via floating-ui autoUpdate

### DIFF
--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from '@stencil/core';
 import { Component, h, Method, Prop, State, Watch } from '@stencil/core';
+import { autoUpdate } from '@floating-ui/dom';
 import { KolButtonWcTag } from '../../core/component-names';
 import { alignFloatingElements } from '../../utils/align-floating-elements';
 import type { PopoverButtonProps, PopoverButtonStates } from '../../schema/components/popover-button';
@@ -33,6 +34,7 @@ import { validatePopoverAlign } from '../../schema';
 export class KolPopoverButton implements PopoverButtonProps {
 	private refButton?: HTMLKolButtonWcElement;
 	private refPopover?: HTMLDivElement;
+	private cleanupAutoPositioning?: () => void;
 
 	@State() public state: PopoverButtonStates = {
 		_label: '',
@@ -67,15 +69,28 @@ export class KolPopoverButton implements PopoverButtonProps {
 		}
 	}
 
-	private handleToggle(event: Event) {
-		this.popoverOpen = (event as ToggleEvent).newState === 'open';
-
-		if (this.popoverOpen && this.refPopover && this.refButton) {
+	private alignPopover() {
+		if (this.refPopover && this.refButton) {
 			void alignFloatingElements({
 				align: this.state._popoverAlign,
 				floatingElement: this.refPopover,
 				referenceElement: this.refButton,
 			});
+		}
+	}
+
+	private handleToggle(event: Event) {
+		this.popoverOpen = (event as ToggleEvent).newState === 'open';
+
+		if (this.popoverOpen) {
+			if (this.refPopover && this.refButton) {
+				this.cleanupAutoPositioning = autoUpdate(this.refButton, this.refPopover, () => {
+					this.alignPopover();
+				});
+			}
+		} else if (this.cleanupAutoPositioning) {
+			this.cleanupAutoPositioning();
+			this.cleanupAutoPositioning = undefined;
 		}
 	}
 
@@ -94,6 +109,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	public disconnectedCallback() {
 		this.refPopover?.removeEventListener('toggle', this.handleToggle.bind(this));
 		this.refPopover?.removeEventListener('beforetoggle', this.handleBeforeToggle.bind(this));
+		this.cleanupAutoPositioning?.();
 	}
 
 	public render(): JSX.Element {


### PR DESCRIPTION
## What changed?

Added automatic repositioning to `kol-popover-button` using `autoUpdate` from `@floating-ui/dom` (`packages/components/src/components/popover-button/component.tsx`). The alignment logic was extracted into a private `alignPopover()` method; when the popover opens, `autoUpdate` is registered to keep it aligned to its trigger button as the page scrolls or resizes, and the returned cleanup function is invoked when the popover closes and in `disconnectedCallback`. Previously the popover was aligned only once at open time and could drift out of position. Only the popover-button component is affected; its public API is unchanged.

## Linked issues

- Refs #7614 — auto positioning for kol-popover-button

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`kol-popover-button` erhält automatische Neupositionierung über `autoUpdate` aus `@floating-ui/dom` (`packages/components/src/components/popover-button/component.tsx`). Die Ausrichtungslogik wurde in eine private Methode `alignPopover()` ausgelagert; beim Öffnen des Popovers wird `autoUpdate` registriert, um es beim Scrollen oder bei Größenänderungen der Seite an seinem Auslöser-Button ausgerichtet zu halten, und die zurückgegebene Cleanup-Funktion wird beim Schließen sowie in `disconnectedCallback` aufgerufen. Zuvor wurde das Popover nur einmal beim Öffnen ausgerichtet und konnte aus der Position rutschen. Betroffen ist ausschließlich die Popover-Button-Komponente; ihre öffentliche API bleibt unverändert.

### Verknüpfte Tickets

- Referenziert #7614 — Auto-Positionierung für kol-popover-button

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/popover-button/component.tsx` — Ausrichtung in `alignPopover()` ausgelagert, `autoUpdate` beim Öffnen registriert, Cleanup beim Schließen und in `disconnectedCallback`.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
