### PR TITLE
fix(collapsible): force GPU compositing layer to prevent layout issues

### DIFF
--- a/packages/components/src/functional-components/Collapsible/collapsible.scss
+++ b/packages/components/src/functional-components/Collapsible/collapsible.scss
@@ -9,6 +9,8 @@
 			grid-template-rows: 0fr;
 			overflow: hidden;
 			transition: grid-template-rows 0.3s;
+			/* Forces the element into its own GPU compositing layer (via 3D transform). Helps prevent rendering/layout bugs (e.g. #7511) and may improve animation performance. */
+			transform: translateZ(0);
 		}
 
 		&__wrapper-animation {


### PR DESCRIPTION
## What changed?

Added `transform: translateZ(0)` to the Collapsible functional component's styles (`packages/components/src/functional-components/Collapsible/collapsible.scss`). The 3D transform promotes the collapsible content into its own GPU compositing layer, which prevents rendering/layout glitches during the `grid-template-rows` open/close animation (issue #7511) and can improve animation performance. A code comment documents the rationale. Only the Collapsible stylesheet is affected.

## Linked issues

- Refs #7511 — collapsible layout/rendering issues

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Den Styles der Collapsible-Functional-Component (`packages/components/src/functional-components/Collapsible/collapsible.scss`) wurde `transform: translateZ(0)` hinzugefügt. Der 3D-Transform verschiebt den einklappbaren Inhalt in eine eigene GPU-Compositing-Ebene, wodurch Rendering-/Layout-Fehler während der `grid-template-rows`-Auf-/Zuklapp-Animation verhindert werden (Issue #7511) und die Animationsleistung verbessert werden kann. Ein Code-Kommentar dokumentiert die Begründung. Betroffen ist ausschließlich das Collapsible-Stylesheet.

### Verknüpfte Tickets

- Referenziert #7511 — Layout-/Rendering-Probleme bei Collapsible

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/functional-components/Collapsible/collapsible.scss` — `transform: translateZ(0)` erzwingt eine eigene GPU-Compositing-Ebene und verhindert Layout-Fehler beim Auf-/Zuklappen.

</details>