### PR TITLE
refactor(components): remove E2E environment option and dist-e2e output

### DIFF
--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -1,5 +1,4 @@
 /dist/
-/dist-e2e/
 /doc/**
 /loader/
 /public/

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -68,7 +68,7 @@
 		"test": "pnpm test:unit",
 		"test:unit": "cross-env NODE_ENV=test stencil test --spec --json --outputFile dist/jest-test-results.json",
 		"test:watch": "cross-env NODE_ENV=test stencil test --spec --watchAll",
-		"test:e2e": "cross-env E2E=1 playwright test",
+		"test:e2e": "playwright test",
 		"postpack": "mv package.bak.json package.json",
 		"prepack": "npm run build && cp package.json package.bak.json && rimraf dist/collection dist/kolibri/assets/@leanup dist/types/assets/@leanup && node scripts/anonymous.js && node scripts/minify.js",
 		"xunused": "knip"

--- a/packages/components/playwright.config.ts
+++ b/packages/components/playwright.config.ts
@@ -38,6 +38,6 @@ export default createConfig({
 		url: TEST_URL,
 		reuseExistingServer: false,
 		/* The builtin Stencil server sometimes fails to serve some assets which leads to intermittent test failures. Use a more stable server (without watcher) for CI: */
-		...(process.env.CI ? { command: `stencil build --dev && mv dist-e2e/kolibri dist-e2e/build && npx serve dist-e2e -p ${TEST_PORT} -L` } : {}),
+		...(process.env.CI ? { command: `stencil build --dev && mv dist/kolibri dist/build && npx serve dist -p ${TEST_PORT} -L` } : {}),
 	},
 });

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -152,9 +152,6 @@ async function generateCustomElementsJson(docsData: JsonDocs) {
 let outputTargets: OutputTarget[] = [
 	{
 		type: 'dist',
-
-		/* Prevent E2E tests from overriding the existing components build. This avoids conflicts when running the Sample App at the same time. */
-		dir: process.env.E2E === '1' ? 'dist-e2e' : undefined,
 		copy: [
 			{
 				src: 'assets',


### PR DESCRIPTION
## What changed?

Removed the dedicated E2E build environment from the `@public-ui/components` package. The Stencil `dist` output target no longer switches its directory to `dist-e2e` when `E2E=1` (`stencil.config.ts`), the `test:e2e` script drops the `E2E=1` prefix and runs `playwright test` directly (`package.json`), the Playwright CI web-server command now builds and serves from `dist` instead of `dist-e2e` (`playwright.config.ts`), and the obsolete `/dist-e2e/` entry was removed from `.gitignore`. E2E tests now run against the regular `dist` build, simplifying the build configuration. Only build/test tooling is affected — no component, API, or theme code.

## Linked issues

- Refs #7746 — remove E2E environment option

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die dedizierte E2E-Build-Umgebung wurde aus dem Paket `@public-ui/components` entfernt. Das Stencil-`dist`-Output-Target wechselt sein Verzeichnis nicht mehr auf `dist-e2e`, wenn `E2E=1` gesetzt ist (`stencil.config.ts`), das Skript `test:e2e` verzichtet auf das `E2E=1`-Präfix und ruft direkt `playwright test` auf (`package.json`), der Playwright-Webserver-Befehl in CI baut und serviert nun aus `dist` statt `dist-e2e` (`playwright.config.ts`), und der veraltete Eintrag `/dist-e2e/` wurde aus der `.gitignore` entfernt. E2E-Tests laufen nun gegen den regulären `dist`-Build, was die Build-Konfiguration vereinfacht. Betroffen ist ausschließlich Build-/Test-Tooling — kein Komponenten-, API- oder Theme-Code.

### Verknüpfte Tickets

- Referenziert #7746 — E2E-Umgebungsoption entfernen

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/stencil.config.ts` — `dist`-Output-Target nutzt nicht mehr `dist-e2e` bei `E2E=1`.
- `packages/components/package.json` — `test:e2e` ohne `E2E=1`, ruft direkt `playwright test`.
- `packages/components/playwright.config.ts` — CI-Webserver baut/serviert aus `dist` statt `dist-e2e`.
- `packages/components/.gitignore` — veralteten Eintrag `/dist-e2e/` entfernt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
