### PR TITLE
docs: add known issue for text inputs not receiving focus in Chrome

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -60,6 +60,12 @@ avoiding Toasts in Modals and giving feedback within the modal directly.
 The `search` of this component is highly browser-dependent. For example, the close button is either shown or hidden depending on the browser. Accessibility is therefore not achieved.
 [🐞 GitHub issue #6307](https://github.com/public-ui/kolibri/issues/6307)
 
+## All text inputs
+
+In Chrome on Windows, clicking outside an HTML input but inside a WebComponent does not give focus to the input when it is empty. This issue sometimes does not occur if the input already contains a value. We suspect a focus propagation problem related to WebComponent behavior.
+
+[🐞 GitHub issue #7713](https://github.com/public-ui/kolibri/issues/7713)
+
 ## Screen reader only reads last selected in Select
 
 KolSelect is using native HTML `<select>`.


### PR DESCRIPTION
## What changed?

Added a new entry to `KNOWN_ISSUES.md` under an "All text inputs" heading, documenting that in Chrome on Windows, clicking outside a native HTML input but inside a web component does not focus the input while it is empty (the problem is intermittent when the input already has a value). The entry links to the tracking issue #7713. This is a documentation-only change; no component, API, or theme code is affected.

## Linked issues

- Refs #7713 — inputs in Chrome not receiving focus when empty

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `KNOWN_ISSUES.md` wurde unter der Überschrift „All text inputs" ein neuer Eintrag ergänzt. Er dokumentiert, dass in Chrome unter Windows ein Klick außerhalb eines nativen HTML-Inputs, aber innerhalb einer Web-Komponente, dem Input keinen Fokus gibt, solange dieser leer ist (bei bereits vorhandenem Wert tritt das Problem seltener auf). Der Eintrag verweist auf das Tracking-Issue #7713. Es handelt sich um eine reine Dokumentationsänderung; Komponenten-, API- oder Theme-Code ist nicht betroffen.

### Verknüpfte Tickets

- Referenziert #7713 — Inputs erhalten in Chrome bei leerem Feld keinen Fokus

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `KNOWN_ISSUES.md` — Neuer Abschnitt „All text inputs" dokumentiert das Chrome-Fokusproblem und verlinkt Issue #7713.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
