### PR TITLE
feat(bootstrap)!: toggle input value reflection via new reflectInputValues option

### DIFF
--- a/docs/BREAKING_CHANGES.v3.md
+++ b/docs/BREAKING_CHANGES.v3.md
@@ -61,6 +61,7 @@ The public `focus`-methods have been removed from all components. Use `kolFocus`
 
 ## All Input Components
 
+- Input value reflection ("associated form fields") is now toggled using the 'reflectInputValues' option set in the bootstrap function, no longer using the experimental mode.
 - The property `_alert` has been removed. It's now being handled automatically based on `_msg` and the touched state. See #6138.
 - The property `_error` has been removed. Use `_msg` instead.
 - The property `_hideError` has bee renamed to `_hideMsg`.

--- a/packages/components/src/components/input-adapter-leanup/associated.controller.ts
+++ b/packages/components/src/components/input-adapter-leanup/associated.controller.ts
@@ -2,6 +2,7 @@ import type { NamePropType, PropSyncValueBySelector, StencilUnknown, SyncValueBy
 import { devHint, devWarning, getExperimentalMode, validateName } from '../../schema';
 
 import type { Generic } from 'adopted-style-sheets';
+import { getOptions } from '../../core/bootstrap';
 
 type RequiredProps = NonNullable<unknown>;
 type OptionalProps = {
@@ -46,7 +47,7 @@ export class AssociatedInputController implements Watches {
 		this.host = this.findHostWithShadowRoot(host);
 		this.type = type;
 
-		if (this.experimentalMode && isAssociatedTagName(this.host?.tagName) && component._name) {
+		if (getOptions()?.reflectInputValues && isAssociatedTagName(this.host?.tagName) && component._name) {
 			this.host?.querySelectorAll('input,select,textarea').forEach((el) => {
 				this.host?.removeChild(el);
 			});

--- a/packages/components/src/core/bootstrap.ts
+++ b/packages/components/src/core/bootstrap.ts
@@ -15,9 +15,15 @@ type KoliBriOptions = RegisterOptions & {
 	 * This option allows you to transform the component tag names.
 	 */
 	transformTagName?: (tagName: string) => string;
+
+	/**
+	 * When enabled, all input fields will reflect their current value to the host element, making it accessible outside the shadow DOM.
+	 */
+	reflectInputValues?: boolean;
 };
 
 let initialized = false;
+let options: KoliBriOptions | undefined;
 
 export const bootstrap = async (
 	themes:
@@ -25,19 +31,21 @@ export const bootstrap = async (
 		| Generic.Theming.RegisterPatch<string, string, string>[]
 		| Set<Generic.Theming.RegisterPatch<string, string, string>>,
 	loaders: LoaderCallback | LoaderCallback[] | Set<LoaderCallback>,
-	options?: KoliBriOptions,
+	koliBriOptions?: KoliBriOptions,
 ): Promise<void[]> => {
-	setDevMode(options?.environment === 'development');
+	setDevMode(koliBriOptions?.environment === 'development');
 
-	initializeI18n(options?.translation?.name ?? 'de', options?.translations);
-	if (options?.transformTagName) {
-		setCustomTagNames(options?.transformTagName);
+	initializeI18n(koliBriOptions?.translation?.name ?? 'de', koliBriOptions?.translations);
+	if (koliBriOptions?.transformTagName) {
+		setCustomTagNames(koliBriOptions?.transformTagName);
 	}
-	const coreRegisterReturnValue = await coreRegister(themes, loaders, options);
+	const coreRegisterReturnValue = await coreRegister(themes, loaders, koliBriOptions);
 	initialized = true;
+	options = koliBriOptions;
 
 	return coreRegisterReturnValue;
 };
 
 export const register = bootstrap;
 export const isInitialized = () => initialized;
+export const getOptions = () => options;

--- a/packages/samples/react/src/react.main.tsx
+++ b/packages/samples/react/src/react.main.tsx
@@ -77,6 +77,7 @@ void (async () => {
 					: undefined,
 				transformTagName: ENABLE_TAG_NAME_TRANSFORMER ? tagNameTransformer : undefined,
 				environment: process.env.NODE_ENV === 'development' ? 'development' : 'production',
+				reflectInputValues: true,
 			},
 		);
 


### PR DESCRIPTION
## What changed?

Introduced a dedicated `reflectInputValues` boolean option to the `bootstrap`/`register` function (`packages/components/src/core/bootstrap.ts`) and exposed the stored options through a new `getOptions()` export. The `AssociatedInputController` (`packages/components/src/components/input-adapter-leanup/associated.controller.ts`) now gates input-value reflection — the "associated form fields" behaviour that mirrors input values onto the host element outside the shadow DOM — on `getOptions()?.reflectInputValues` instead of the global experimental mode. The React sample enables the new option, and the migration is documented in `docs/BREAKING_CHANGES.v3.md`. Consumers who previously relied on experimental mode to reflect input values must now explicitly set `reflectInputValues: true`.

## Linked issues

- Refs #7781 — replace experimental-mode toggle for associated input value reflection

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [x] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Eine dedizierte boolesche Option `reflectInputValues` wurde zur `bootstrap`/`register`-Funktion (`packages/components/src/core/bootstrap.ts`) hinzugefügt und die gespeicherten Optionen über einen neuen Export `getOptions()` verfügbar gemacht. Der `AssociatedInputController` (`packages/components/src/components/input-adapter-leanup/associated.controller.ts`) steuert die Spiegelung von Eingabewerten — das Verhalten der „associated form fields", das Eingabewerte außerhalb des Shadow DOM auf das Host-Element spiegelt — nun über `getOptions()?.reflectInputValues` statt über den globalen Experimental-Modus. Das React-Sample aktiviert die neue Option, und die Migration ist in `docs/BREAKING_CHANGES.v3.md` dokumentiert. Verbraucher, die sich zuvor auf den Experimental-Modus verlassen haben, müssen nun explizit `reflectInputValues: true` setzen.

### Verknüpfte Tickets

- Referenziert #7781 — Experimental-Modus-Umschaltung für die Spiegelung von Eingabewerten ersetzen

### Art der Änderung

💥 Breaking Change

### Geänderte Dateien

- `packages/components/src/core/bootstrap.ts` — Neue Option `reflectInputValues` und Export `getOptions()` zum Auslesen der gesetzten Optionen.
- `packages/components/src/components/input-adapter-leanup/associated.controller.ts` — Spiegelung der Eingabewerte wird über `reflectInputValues` statt über den Experimental-Modus aktiviert.
- `packages/samples/react/src/react.main.tsx` — Aktiviert `reflectInputValues: true` im React-Sample.
- `docs/BREAKING_CHANGES.v3.md` — Dokumentiert die Migration von Experimental-Modus zu `reflectInputValues`.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
