### PR TITLE
fix(ci): guard upload-reports steps with failure() at the workflow level

### DIFF
--- a/.github/actions/upload-reports/action.yml
+++ b/.github/actions/upload-reports/action.yml
@@ -8,7 +8,6 @@ runs:
   steps:
     - name: Upload test reports
       uses: actions/upload-artifact@v4
-      if: failure()
       with:
         name: ${{ inputs.name }}
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: E2E Test
         run: pnpm --filter @public-ui/components test:e2e
       - uses: ./.github/actions/upload-reports
+        if: failure()
         with:
           name: report-e2e
 
@@ -75,6 +76,7 @@ jobs:
       - name: Visual Tests
         run: pnpm --filter=@public-ui/${{ matrix.package }} test
       - uses: ./.github/actions/upload-reports
+        if: failure()
         with:
           name: report-${{ matrix.package }}
 


### PR DESCRIPTION
## What changed?

Moved the `if: failure()` condition out of the reusable `upload-reports` composite action (`.github/actions/upload-reports/action.yml`) and onto the two steps in `.github/workflows/ci.yml` that invoke it (the E2E and Visual Tests report uploads). A step-level `if: failure()` placed inside a composite action does not evaluate against the overall job status as intended, so test reports were not being uploaded reliably. Guarding the `uses: ./.github/actions/upload-reports` steps at the workflow level makes the upload run exactly when a job fails. Only CI configuration is affected.

## Linked issues

- Refs #7787 — upload-reports fix

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Bedingung `if: failure()` wurde aus der wiederverwendbaren Composite-Action `upload-reports` (`.github/actions/upload-reports/action.yml`) entfernt und stattdessen an den beiden aufrufenden Schritten in `.github/workflows/ci.yml` (Upload der E2E- und Visual-Tests-Reports) gesetzt. Ein `if: failure()` innerhalb eines Schritts einer Composite-Action wird nicht wie erwartet gegen den Gesamt-Job-Status ausgewertet, weshalb Test-Reports nicht zuverlässig hochgeladen wurden. Durch das Absichern der `uses: ./.github/actions/upload-reports`-Schritte auf Workflow-Ebene wird der Upload genau dann ausgeführt, wenn ein Job fehlschlägt. Betroffen ist ausschließlich die CI-Konfiguration.

### Verknüpfte Tickets

- Referenziert #7787 — Fix für upload-reports

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/actions/upload-reports/action.yml` — `if: failure()` vom Upload-Schritt der Composite-Action entfernt.
- `.github/workflows/ci.yml` — `if: failure()` an den beiden Aufrufen von `upload-reports` (E2E- und Visual-Tests-Reports) ergänzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
