### PR TITLE
fix: enable persist-credentials in benchmark PR check workflow

### DIFF
--- a/.github/workflows/benchmark.pr-check.yml
+++ b/.github/workflows/benchmark.pr-check.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Install and execute benchmark
         uses: ./.github/actions/benchmark

--- a/packages/tools/benchmark-tests/scripts/compare-benchmark.mjs
+++ b/packages/tools/benchmark-tests/scripts/compare-benchmark.mjs
@@ -1,20 +1,27 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-const current = JSON.parse(readFileSync('benchmark-result.json', 'utf-8'));
-const baseline = existsSync('benchmark-baseline.json') ? JSON.parse(readFileSync('benchmark-baseline.json', 'utf-8')) : [];
+const loadJson = (path) => {
+	return existsSync(path) ? JSON.parse(readFileSync(path, 'utf-8')) : [];
+};
 
+const current = loadJson('benchmark-result.json');
+const baseline = loadJson('benchmark-baseline.json');
+
+const rows = [];
 let hasRegression = false;
-
-let markdown = `## Hydration Benchmark Report (vs Baseline)\n\n`;
-markdown += `| Component | Current | Baseline | Δ% | Result |\n`;
-markdown += `|-----------|---------|----------|-----|--------|\n`;
 
 for (const entry of current) {
 	const prev = baseline.find((b) => b.name === entry.name);
 	const now = entry.value;
 
 	if (!prev) {
-		markdown += `| \`${entry.name}\` | ${now}ms | – | – | 🆕 |\n`;
+		rows.push({
+			name: entry.name,
+			current: now,
+			baseline: null,
+			percent: null,
+			markdown: `| \`${entry.name}\` | ${now}ms | – | – | 🆕 |`,
+		});
 		continue;
 	}
 
@@ -25,8 +32,34 @@ for (const entry of current) {
 
 	if (percent > 5) hasRegression = true;
 
-	markdown += `| \`${entry.name}\` | ${now}ms | ${old}ms | ${diffStr} | ${emoji} |\n`;
+	rows.push({
+		name: entry.name,
+		current: now,
+		baseline: old,
+		percent,
+		markdown: `| \`${entry.name}\` | ${now}ms | ${old}ms | ${diffStr} | ${emoji} |`,
+	});
 }
+
+const top5 = rows
+	.filter((r) => r.percent !== null)
+	.sort((a, b) => Math.abs(b.percent) - Math.abs(a.percent))
+	.slice(0, 5);
+
+const rest = rows.filter((r) => !top5.includes(r)).sort((a, b) => a.name.localeCompare(b.name));
+
+let markdown = `## Hydration Benchmark Report (vs Baseline)\n\n`;
+
+markdown += `### 📊 Top 5 Änderungen\n\n`;
+markdown += `| Component | Current | Baseline | Δ% | Result |\n`;
+markdown += `|-----------|---------|----------|-----|--------|\n`;
+markdown += top5.map((r) => r.markdown).join('\n') + '\n\n';
+
+markdown += `<details>\n<summary>📋 Alle Ergebnisse anzeigen</summary>\n\n`;
+markdown += `| Component | Current | Baseline | Δ% | Result |\n`;
+markdown += `|-----------|---------|----------|-----|--------|\n`;
+markdown += rest.map((r) => r.markdown).join('\n') + '\n';
+markdown += `</details>\n`;
 
 writeFileSync('benchmark-report.md', markdown);
 


### PR DESCRIPTION
## What changed?

This PR switches the `actions/checkout` step in `.github/workflows/benchmark.pr-check.yml` from `persist-credentials: false` to `persist-credentials: true`, so the git credentials remain available for the later steps of the benchmark PR-check workflow. It also refactors the benchmark comparison script `compare-benchmark.mjs`: it introduces a `loadJson` helper, builds a structured `rows` array from the current and baseline results, and renders a "Top 5 Änderungen" summary followed by a collapsible full-results table, while switching the `fs` import to the `node:` protocol. Only CI configuration and benchmark tooling are touched — no component source or public API changes.

## Linked issues

- Refs #7656 — optimize theming and add benchmark

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR stellt den `actions/checkout`-Schritt in `.github/workflows/benchmark.pr-check.yml` von `persist-credentials: false` auf `persist-credentials: true` um, sodass die Git-Zugangsdaten für die folgenden Schritte des Benchmark-PR-Check-Workflows verfügbar bleiben. Außerdem wird das Vergleichsskript `compare-benchmark.mjs` überarbeitet: Es führt einen `loadJson`-Helper ein, baut aus den aktuellen und Baseline-Ergebnissen ein strukturiertes `rows`-Array und rendert eine „Top 5 Änderungen"-Übersicht gefolgt von einer ausklappbaren Gesamttabelle; der `fs`-Import wird auf das `node:`-Protokoll umgestellt. Betroffen sind ausschließlich CI-Konfiguration und Benchmark-Tooling — keine Änderung an Komponenten oder öffentlichen APIs.

### Verknüpfte Tickets

- Referenziert #7656 — Optimierung des Themings und Ergänzung der Benchmarks

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/benchmark.pr-check.yml` — setzt `persist-credentials` beim Checkout von `false` auf `true`
- `packages/tools/benchmark-tests/scripts/compare-benchmark.mjs` — führt `loadJson` ein und baut strukturierte Report-Zeilen mit Top-5-Übersicht und ausklappbarer Gesamtliste

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
