### PR TITLE
refactor: simplify loadJson function and update benchmark result stru…

### DIFF
--- a/packages/tools/benchmark-tests/scripts/compare-benchmark.mjs
+++ b/packages/tools/benchmark-tests/scripts/compare-benchmark.mjs
@@ -1,8 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-const loadJson = (path) => {
-	return existsSync(path) ? JSON.parse(readFileSync(path, 'utf-8')) : [];
-};
+const loadJson = (path) => (existsSync(path) ? JSON.parse(readFileSync(path, 'utf-8')) : []);
 
 const current = loadJson('benchmark-result.json');
 const baseline = loadJson('benchmark-baseline.json');
@@ -41,21 +39,21 @@ for (const entry of current) {
 	});
 }
 
-const top5 = rows
-	.filter((r) => r.percent !== null)
-	.sort((a, b) => Math.abs(b.percent) - Math.abs(a.percent))
+const flop5 = rows
+	.filter((r) => typeof r.percent === 'number' && r.percent > 0)
+	.sort((a, b) => b.percent - a.percent)
 	.slice(0, 5);
 
-const rest = rows.filter((r) => !top5.includes(r)).sort((a, b) => a.name.localeCompare(b.name));
+const rest = rows.filter((r) => !flop5.includes(r)).sort((a, b) => a.name.localeCompare(b.name));
 
 let markdown = `## Hydration Benchmark Report (vs Baseline)\n\n`;
 
-markdown += `### 📊 Top 5 Änderungen\n\n`;
+markdown += `### 📊 Flop 5 Regressions\n\n`;
 markdown += `| Component | Current | Baseline | Δ% | Result |\n`;
 markdown += `|-----------|---------|----------|-----|--------|\n`;
-markdown += top5.map((r) => r.markdown).join('\n') + '\n\n';
+markdown += flop5.map((r) => r.markdown).join('\n') + '\n\n';
 
-markdown += `<details>\n<summary>📋 Alle Ergebnisse anzeigen</summary>\n\n`;
+markdown += `<details>\n<summary>📋 Show all results</summary>\n\n`;
 markdown += `| Component | Current | Baseline | Δ% | Result |\n`;
 markdown += `|-----------|---------|----------|-----|--------|\n`;
 markdown += rest.map((r) => r.markdown).join('\n') + '\n';

--- a/packages/tools/benchmark-tests/tests/benchmark.test.ts
+++ b/packages/tools/benchmark-tests/tests/benchmark.test.ts
@@ -52,13 +52,15 @@ const TAGS = [
 
 type TagType = (typeof TAGS)[number];
 
-const results: {
+type ResultEntry = {
 	name: TagType;
-	value: number;
+	values: number[];
 	unit: 'ms';
-}[] = [];
+};
 
-const TEST_ITERATIONS = parseInt(process.env.TEST_ITERATIONS || '1', 10);
+const results: Map<TagType, ResultEntry> = new Map();
+
+const TEST_ITERATIONS = Math.max(parseInt(process.env.TEST_ITERATIONS || '1', 10), !!process.env.CI ? 5 : 1);
 const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '5000', 10);
 
 test.beforeEach(async ({ page }) => {
@@ -66,10 +68,8 @@ test.beforeEach(async ({ page }) => {
 });
 
 for (const tag of TAGS) {
-	test(`${tag} hydrates`, async ({ page }) => {
-		const durations: number[] = [];
-
-		for (let idx = 0; idx < TEST_ITERATIONS; idx++) {
+	for (let idx = 0; idx < TEST_ITERATIONS; idx++) {
+		test(`${tag} hydration iteration ${idx + 1}`, async ({ page }) => {
 			await page.evaluate(() => window.gc?.());
 
 			const duration = await page.evaluate(
@@ -92,7 +92,6 @@ for (const tag of TAGS) {
 						function cleanup() {
 							if (cleaned) return;
 							cleaned = true;
-
 							clearTimeout(timeoutId);
 							observer.disconnect();
 							if (el.parentNode) el.remove();
@@ -111,20 +110,30 @@ for (const tag of TAGS) {
 				{ tag, timeout: TEST_TIMEOUT, idx },
 			);
 
-			durations.push(duration);
-		}
-
-		durations.sort((a, b) => a - b);
-		const median = durations[Math.floor(durations.length / 2)];
-
-		results.push({
-			name: tag,
-			value: Math.round(median),
-			unit: 'ms',
+			if (!results.has(tag)) {
+				results.set(tag, {
+					name: tag,
+					values: [],
+					unit: 'ms',
+				});
+			}
+			results.get(tag)!.values.push(Math.round(duration));
 		});
-	});
+	}
 }
 
 test.afterAll(() => {
-	writeFileSync('benchmark-result.json', JSON.stringify(results, null, 2));
+	const finalResults = Array.from(results.values()).map(({ name, values, unit }) => {
+		values.sort((a, b) => a - b);
+		const mid = Math.floor(values.length / 2);
+		const median = values.length % 2 === 0 ? Math.round((values[mid - 1] + values[mid]) / 2) : values[mid];
+
+		return {
+			name,
+			value: median,
+			unit,
+		};
+	});
+
+	writeFileSync('benchmark-result.json', JSON.stringify(finalResults, null, 2));
 });


### PR DESCRIPTION
## What changed?

This PR refactors the benchmark tooling. In `compare-benchmark.mjs`, the `loadJson` helper becomes a single-expression arrow function, the "Top 5 Änderungen" section is replaced by a "Flop 5 Regressions" list that filters to positive regressions only and sorts them descending, and the report headings are translated to English. In `benchmark.test.ts`, the results store changes from a flat array to a `Map` of `values[]` per component, each iteration becomes its own Playwright test, CI now enforces at least 5 iterations, and the median is computed once in `afterAll` (including correct averaging for an even number of samples). Only the benchmark-tests package is touched — no component source or public API changes.

## Linked issues

- Refs #7778 — typed BEM work (issue number derived from the `7778-add-typed-bem` branch)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR überarbeitet das Benchmark-Tooling. In `compare-benchmark.mjs` wird der `loadJson`-Helper zu einer einzeiligen Arrow-Funktion, der Abschnitt „Top 5 Änderungen" wird durch eine „Flop 5 Regressions"-Liste ersetzt, die nur positive Regressionen absteigend filtert, und die Report-Überschriften werden ins Englische übersetzt. In `benchmark.test.ts` wird der Ergebnisspeicher von einem flachen Array auf eine `Map` mit Werteliste je Komponente umgestellt, jede Iteration wird zu einem eigenen Playwright-Test, in CI werden mindestens 5 Iterationen erzwungen und der Median wird einmalig in `afterAll` berechnet (inklusive korrekter Mittelung bei gerader Anzahl von Messwerten). Betroffen ist ausschließlich das benchmark-tests-Paket — es gibt keine Änderung an Komponenten oder öffentlichen APIs.

### Verknüpfte Tickets

- Referenziert #7778 — Typed-BEM-Arbeit (Issue-Nummer aus dem Branch `7778-add-typed-bem` abgeleitet)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/benchmark-tests/scripts/compare-benchmark.mjs` — vereinfacht `loadJson`, ersetzt „Top 5" durch „Flop 5 Regressions" und übersetzt die Report-Überschriften ins Englische
- `packages/tools/benchmark-tests/tests/benchmark.test.ts` — speichert Ergebnisse als `Map` mit Werteliste, ein Test pro Iteration, mind. 5 Iterationen in CI und Median-Berechnung in `afterAll`

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
