### PR TITLE
chore: update adopted-style-sheets dependency to version 1.1.9-rc.18 …

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,7 +76,7 @@
 	},
 	"dependencies": {
 		"@floating-ui/dom": "1.6.13",
-		"adopted-style-sheets": "1.1.9-rc.17",
+		"adopted-style-sheets": "1.1.9-rc.18",
 		"clsx": "2.1.1",
 		"color-convert": "2.0.1",
 		"color-rgba": "2.4.0",
@@ -136,7 +136,7 @@
 		"typescript": "5.8.2"
 	},
 	"peerDependencies": {
-		"adopted-style-sheets": "1.1.9-rc.17"
+		"adopted-style-sheets": "1.1.9-rc.18"
 	},
 	"files": [
 		"assets",

--- a/packages/samples/angular/package.json
+++ b/packages/samples/angular/package.json
@@ -30,7 +30,7 @@
 		"@angular/compiler-cli": "17.3.12",
 		"@types/jasmine": "5.1.8",
 		"@tailwindcss/postcss": "4.1.8",
-		"adopted-style-sheets": "1.1.9-rc.17",
+		"adopted-style-sheets": "1.1.9-rc.18",
 		"cpy-cli": "5.0.0",
 		"karma-jasmine": "5.1.0",
 		"karma-chrome-launcher": "3.2.0",

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -40,7 +40,7 @@
 		"@typescript-eslint/parser": "8.27.0",
 		"@unocss/preset-uno": "0.58.9",
 		"@unocss/webpack": "0.58.9",
-		"adopted-style-sheets": "1.1.9-rc.17",
+		"adopted-style-sheets": "1.1.9-rc.18",
 		"ajv": "8.17.1",
 		"chromedriver": "130.0.4",
 		"cpy-cli": "5.0.0",

--- a/packages/tools/benchmark-tests/package.json
+++ b/packages/tools/benchmark-tests/package.json
@@ -35,7 +35,7 @@
 		"@playwright/test": "1.49.1",
 		"@public-ui/components": "workspace:*",
 		"@public-ui/theme-default": "workspace:*",
-		"adopted-style-sheets": "1.1.9-rc.17",
+		"adopted-style-sheets": "1.1.9-rc.18",
 		"cpy-cli": "5.0.0",
 		"knip": "5.46.0",
 		"npm-run-all2": "8.0.4",

--- a/packages/tools/benchmark-tests/scripts/compare-benchmark.mjs
+++ b/packages/tools/benchmark-tests/scripts/compare-benchmark.mjs
@@ -2,8 +2,8 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 const loadJson = (path) => (existsSync(path) ? JSON.parse(readFileSync(path, 'utf-8')) : []);
 
-const current = loadJson('benchmark-result.json');
-const baseline = loadJson('benchmark-baseline.json');
+const current = loadJson(`benchmark-result.json`);
+const baseline = loadJson(`benchmark-baseline.json`);
 
 const rows = [];
 let hasRegression = false;
@@ -59,10 +59,10 @@ markdown += `|-----------|---------|----------|-----|--------|\n`;
 markdown += rest.map((r) => r.markdown).join('\n') + '\n';
 markdown += `</details>\n`;
 
-writeFileSync('benchmark-report.md', markdown);
+writeFileSync(`benchmark-report.md`, markdown);
 
 if (hasRegression) {
-	console.error('❌ Performance regression detected.');
+	console.warn(`❌ Performance regression detected.`);
 } else {
-	console.log('✅ No significant regression.');
+	console.log(`✅ No significant regression.`);
 }

--- a/packages/tools/benchmark-tests/tests/benchmark.test.ts
+++ b/packages/tools/benchmark-tests/tests/benchmark.test.ts
@@ -65,28 +65,35 @@ const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '5000', 10);
 
 test.beforeEach(async ({ page }) => {
 	await page.goto('http://localhost:3000/test-page.html');
+	await page.waitForLoadState('networkidle');
 });
 
 for (const tag of TAGS) {
 	for (let idx = 0; idx < TEST_ITERATIONS; idx++) {
-		test(`${tag} hydration iteration ${idx + 1}`, async ({ page }) => {
-			await page.evaluate(() => window.gc?.());
-
-			const duration = await page.evaluate(
-				async ({ tag, timeout, idx }) => {
+		test(`${tag} hydration (${idx + 1})`, async ({ page }) => {
+			const { hydratedTime } = await page.evaluate(
+				async ({ tag, timeout }) => {
+					window.gc?.();
 					await customElements.whenDefined(tag);
-
 					const el = document.createElement(tag);
-					el.setAttribute('data-test', `hydration-${idx}`);
-					const start = performance.now();
 					document.body.appendChild(el);
+					const start = performance.now();
+					let hydratedTime: number | null = null;
+					let themedTime: number | null = null;
 
 					await new Promise<void>((resolve) => {
 						let cleaned = false;
 
 						const timeoutId = setTimeout(cleanup, timeout);
+
 						const observer = new MutationObserver(() => {
-							if (el.classList.contains('hydrated')) cleanup();
+							if (!hydratedTime && el.classList.contains('hydrated')) {
+								hydratedTime = performance.now() - start;
+							}
+							if (hydratedTime && el.hasAttribute('data-themed')) {
+								themedTime = performance.now() - hydratedTime;
+								cleanup();
+							}
 						});
 
 						function cleanup() {
@@ -100,24 +107,28 @@ for (const tag of TAGS) {
 
 						observer.observe(el, {
 							attributes: true,
-							attributeFilter: ['class'],
+							attributeFilter: ['class', 'data-themed'],
 						});
 					});
 
-					const end = performance.now();
-					return end - start;
+					return {
+						hydratedTime,
+						themedTime,
+					};
 				},
-				{ tag, timeout: TEST_TIMEOUT, idx },
+				{ tag, timeout: TEST_TIMEOUT },
 			);
 
-			if (!results.has(tag)) {
-				results.set(tag, {
-					name: tag,
-					values: [],
-					unit: 'ms',
-				});
+			if (hydratedTime !== null) {
+				if (!results.has(tag)) {
+					results.set(tag, {
+						name: tag,
+						values: [],
+						unit: 'ms',
+					});
+				}
+				results.get(tag)!.values.push(Math.round(hydratedTime));
 			}
-			results.get(tag)!.values.push(Math.round(duration));
 		});
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,8 +371,8 @@ importers:
         specifier: 1.6.13
         version: 1.6.13
       adopted-style-sheets:
-        specifier: 1.1.9-rc.17
-        version: 1.1.9-rc.17
+        specifier: 1.1.9-rc.18
+        version: 1.1.9-rc.18
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -598,8 +598,8 @@ importers:
         specifier: 5.1.8
         version: 5.1.8
       adopted-style-sheets:
-        specifier: 1.1.9-rc.17
-        version: 1.1.9-rc.17
+        specifier: 1.1.9-rc.18
+        version: 1.1.9-rc.18
       cpy-cli:
         specifier: 5.0.0
         version: 5.0.0
@@ -682,8 +682,8 @@ importers:
         specifier: 0.58.9
         version: 0.58.9(rollup@4.36.0)(webpack@5.98.0)
       adopted-style-sheets:
-        specifier: 1.1.9-rc.17
-        version: 1.1.9-rc.17
+        specifier: 1.1.9-rc.18
+        version: 1.1.9-rc.18
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -994,8 +994,8 @@ importers:
         specifier: workspace:*
         version: link:../../themes/default
       adopted-style-sheets:
-        specifier: 1.1.9-rc.17
-        version: 1.1.9-rc.17
+        specifier: 1.1.9-rc.18
+        version: 1.1.9-rc.18
       cpy-cli:
         specifier: 5.0.0
         version: 5.0.0
@@ -4689,8 +4689,8 @@ packages:
     resolution: {integrity: sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==}
     engines: {node: '>=8.9'}
 
-  adopted-style-sheets@1.1.9-rc.17:
-    resolution: {integrity: sha512-1tZf+93AP6x3DrUIc2vIHSH0aFdnmEVWQol/2Z/FvIHyyybhL61qMhae7hKWf46e6cKppxVV89wZga+97oEdTw==}
+  adopted-style-sheets@1.1.9-rc.18:
+    resolution: {integrity: sha512-x6ZSo3s6tw9LLmYKsMjdqO+EERPwsaKmLN8ahJ1dwGRI+oxyt+kBlY+yuTr7381Nm7/E10wcEtN6ZE2g1kDS2A==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -16784,7 +16784,7 @@ snapshots:
       loader-utils: 2.0.4
       regex-parser: 2.3.1
 
-  adopted-style-sheets@1.1.9-rc.17:
+  adopted-style-sheets@1.1.9-rc.18:
     dependencies:
       loglevel: 1.9.2
 


### PR DESCRIPTION
## What changed?

This PR bumps the `adopted-style-sheets` dependency from `1.1.9-rc.17` to `1.1.9-rc.18` everywhere it is referenced: the components package (both `dependencies` and `peerDependencies`), the Angular and React sample apps, the benchmark-tests package, and the resolved versions in `pnpm-lock.yaml`. Alongside the bump it refines the benchmark Playwright test (`benchmark.test.ts`) to wait for network idle and to measure hydration and theming timings separately via a `data-themed` attribute observer, and tidies string literals in `compare-benchmark.mjs`. No component source logic or public API is changed.

## Linked issues

- Refs #7778 — typed BEM work (issue number derived from the `7778-add-typed-bem` branch)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR hebt die Abhängigkeit `adopted-style-sheets` überall von `1.1.9-rc.17` auf `1.1.9-rc.18` an: im components-Paket (sowohl `dependencies` als auch `peerDependencies`), in den Angular- und React-Beispiel-Apps, im benchmark-tests-Paket sowie in den aufgelösten Versionen der `pnpm-lock.yaml`. Zusätzlich wird der Benchmark-Playwright-Test (`benchmark.test.ts`) überarbeitet, sodass er auf Network-Idle wartet und Hydration- und Theming-Zeiten getrennt über einen `data-themed`-Attribut-Observer misst; außerdem werden String-Literale in `compare-benchmark.mjs` bereinigt. Es werden weder Komponenten-Quelllogik noch öffentliche APIs geändert.

### Verknüpfte Tickets

- Referenziert #7778 — Typed-BEM-Arbeit (Issue-Nummer aus dem Branch `7778-add-typed-bem` abgeleitet)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/package.json` — Bump von `adopted-style-sheets` in `dependencies` und `peerDependencies`
- `packages/samples/angular/package.json`, `packages/samples/react/package.json`, `packages/tools/benchmark-tests/package.json`, `pnpm-lock.yaml` — derselbe Versions-Bump
- `packages/tools/benchmark-tests/tests/benchmark.test.ts` — misst Hydration- und Theming-Zeiten getrennt und wartet auf Network-Idle
- `packages/tools/benchmark-tests/scripts/compare-benchmark.mjs` — kleinere String-Literal-Bereinigung

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
