### PR TITLE
ci: trigger benchmark monitoring workflow on release/2 instead of develop

### DIFF
--- a/.github/workflows/benchmark.monitoring.yml
+++ b/.github/workflows/benchmark.monitoring.yml
@@ -3,7 +3,7 @@ name: Benchmark-Monitoring
 on:
   push:
     branches:
-      - develop
+      - release/2
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What changed?

This PR updates the push trigger of the `.github/workflows/benchmark.monitoring.yml` GitHub Actions workflow, changing the watched branch from `develop` to `release/2`. As a result, the Benchmark-Monitoring workflow now runs against the v2 release line rather than `develop`. It is a single-line CI configuration change with no impact on any component or public API.

## Linked issues

- Refs #7799 — benchmark monitoring pipeline for the v2 release line

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ändert den Push-Trigger des GitHub-Actions-Workflows `.github/workflows/benchmark.monitoring.yml` und ersetzt den überwachten Branch `develop` durch `release/2`. Dadurch läuft der Benchmark-Monitoring-Workflow nun gegen die v2-Release-Linie statt gegen `develop`. Es handelt sich um eine einzeilige CI-Konfigurationsänderung ohne Auswirkungen auf Komponenten oder öffentliche APIs.

### Verknüpfte Tickets

- Referenziert #7799 — Benchmark-Monitoring-Pipeline für die v2-Release-Linie

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/benchmark.monitoring.yml` — ändert den Push-Trigger-Branch von `develop` auf `release/2`

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
