### PR TITLE
docs: removed outdated warning and enhanced tree component documentation

### DIFF
--- a/packages/components/src/components/tree/readme.md
+++ b/packages/components/src/components/tree/readme.md
@@ -2,11 +2,7 @@
 
 Synonyme: List, Navigation
 
-<kol-alert _type="warning" _variant="card">
-  <kol-badge _color="#476af5" _label="Preview"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da die Barrierefreiheitstests noch ausstehen. Die verschiedenen Tests können aufgrund der Modularität bei neuen Komponenten und Funktionalitäten meist erst nach einem Release erfolgen. Wir empfehlen daher, die Komponente noch nicht in Produktion zu verwenden.
-</kol-alert>
-
-Die Komponente **Tree** stellt eine hierarchische Liste dar. Jedes Element in der Hierarchie kann Kindelemente haben, und Elemente, die Kinder haben, können erweitert oder reduziert werden, um die Kinder anzuzeigen oder zu verbergen.
+Die **Tree**-Komponente stellt eine hierarchische Liste dar, in der jedes Element untergeordnete Einträge enthalten kann. Elemente mit Kindelementen lassen sich ein- oder ausklappen, um die untergeordnete Ebene anzuzeigen oder auszublenden.
 
 ### Code
 
@@ -48,21 +44,25 @@ Die Komponente **Tree** stellt eine hierarchische Liste dar. Jedes Element in de
 
 ## Verwendung
 
-Eine **Tree**-Komponente wird verwendet, um komplexe, hierarchische Datenstrukturen visuell darzustellen und zu navigieren. Sie ermöglicht es Benutzern, sich effizient durch verschachtelte Informationen zu bewegen und bietet eine klare Übersicht über die Beziehungen zwischen den verschiedenen Elementen. Solche Komponenten sind nützlich in Anwendungen wie Navigatoren, Organisationsdiagrammen, Produktkatalogen und überall dort, wo eine strukturierte Darstellung von Daten erforderlich ist.
-Das **`_label`**-Attribut wird für den Text und das **`_href`**-Attribut für den Link des Navigationspunkts genutzt. Zusätzlich lässt sich das aktive Element über das Attribut **`_active`** steuern, sowie im Standardzustand über das **`_open`** Attribut öffnen.
+Die Tree-Komponente wird verwendet, um komplexe, hierarchisch aufgebaute Daten visuell darzustellen und benutzerfreundlich navigierbar zu machen. Sie ermöglicht es Nutzerinnen und Nutzern, sich effizient durch verschachtelte Strukturen zu bewegen und liefert dabei eine klare Übersicht über die Beziehungen zwischen über- und untergeordneten Elementen.
+
+Typische Einsatzbereiche sind z. B. Navigationsleisten, Organisationsstrukturen, Dateiverzeichnisse oder Produktkataloge – überall dort, wo Inhalte strukturiert und mehrstufig angezeigt werden sollen.
+
+Jeder Navigationspunkt wird über das Attribut `_label` beschriftet und kann optional über `_href` mit einem Ziel verlinkt werden. Mit dem Attribut `_active` lässt sich ein Element als aktuell aktiv markieren, während `_open` steuert, ob ein Element beim initialen Laden aufgeklappt ist.
 
 ### Tastatursteuerung
 
-| Taste          | Funktion                                                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Tab`          | Der Tree lässt sich zudem mittels Tabulator-Taste fokussieren.                                                                                                                                                                                                                                                                                                   |
-| `Pfeil-Tasten` | Die Pfeiltasten können für die Navigation der Elemente im Tree verwendet werden, um das Untermenü zu öffnen oder zu schließen sowie zwischen den Navigationspunkten zu springen. Dabei wird die linke/rechte Pfeiltaste für das Öffnen oder Schließen des Untermenüs und die oben/unten Pfeiltaste für das Wechseln zwischen den Navigationselementen verwendet. |
-| `Enter`        | Selektiert das derzeitig fokussierte Element und navigiert, falls das **`_href`**-Attribut gesetzt wurde.                                                                                                                                                                                                                                                        |
-| `Home`         | Fokussiert das erste Element in der Tree-Komponenten                                                                                                                                                                                                                                                                                                             |
-| `End`          | Fokussiert das letzte Element in der Tree-Komponenten                                                                                                                                                                                                                                                                                                            |
-| `*`            | Öffnet, alle Geschwister-Elemente der derzeitig fokussierten Ebene                                                                                                                                                                                                                                                                                               |
-
-Zusätzlich können Elemente in der **Tree**-Komponente mit Alphanumerischen-Tasten gesucht und fokussiert werden. In dem oben gennanten Beispiel, würde durch die Taste `S` das Element mit dem **`_label`** `Subpage 1` fokussiert werden und bei wiederholten Drücken der selben Taste die `Subpage 2`, etc.
+| Taste          | Funktion                                                                                                                                                                                                                      |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab`          | Fokussiert die Tree-Komponente, sodass sie per Tastatur bedient werden kann.                                                                                                                                                  |
+| `↑ / ↓`        | Navigiert zwischen sichtbaren Elementen auf derselben Ebene.                                                                                                                                                                  |
+| `→`            | Öffnet das Untermenü des aktuell fokussierten Elements (sofern vorhanden).                                                                                                                                                    |
+| `←`            | Schließt das Untermenü (sofern geöffnet) oder verschiebt den Fokus auf das übergeordnete Element.                                                                                                                             |
+| `Enter`        | Aktiviert das aktuell fokussierte Element. Wenn ein `_href`-Attribut vorhanden ist, erfolgt eine Navigation zum Ziel.                                                                                                         |
+| `Pos1`         | Fokussiert das erste Element der Tree-Komponente.                                                                                                                                                                             |
+| `Ende`         | Fokussiert das letzte Element der Tree-Komponente.                                                                                                                                                                            |
+| `*`            | Öffnet alle geschlossenen Geschwisterelemente auf der aktuell fokussierten Ebene.                                                                                                                                             |
+| Alphanumerisch | Durch Eingabe eines Buchstabens wird das nächste Element fokussiert, dessen `_label` mit diesem Zeichen beginnt. Bei wiederholtem Drücken desselben Buchstabens wird zum jeweils nächsten passenden Element weitergesprungen. |
 
 ## Links und Referenzen
 


### PR DESCRIPTION
## What changed?

This PR is a documentation-only update to the Tree component's `readme.md`. It removes the "Preview / untested" warning `<kol-alert>`, rephrases the component description and usage section for clarity and consistency, and fully reworks the keyboard-navigation table: the combined arrow-key row is split into individual `↑ / ↓`, `→` and `←` rows, the `Home`/`End` keys are renamed to the German `Pos1`/`Ende`, and an alphanumeric type-ahead row is added. No component code, styling, or public API is changed.

## Linked issues

- Closes #7813 — improve and modernise the Tree component documentation

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ist eine reine Dokumentationsänderung an der `readme.md` der Tree-Komponente. Der „Preview/ungetestet"-Warnhinweis (`<kol-alert>`) wird entfernt, die Beschreibung und der Verwendungsabschnitt werden zur besseren Klarheit und Konsistenz umformuliert, und die Tabelle zur Tastatursteuerung wird vollständig überarbeitet: Die kombinierte Pfeiltasten-Zeile wird in einzelne Zeilen für `↑ / ↓`, `→` und `←` aufgeteilt, die Tasten `Home`/`End` werden zu `Pos1`/`Ende` umbenannt und eine Zeile für die alphanumerische Sprungnavigation wird ergänzt. Es werden weder Komponenten-Code noch Styling oder öffentliche API geändert.

### Verknüpfte Tickets

- Schließt #7813 — Verbesserung und Modernisierung der Tree-Komponenten-Dokumentation

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/tree/readme.md` — entfernt den Preview-Warnhinweis und überarbeitet Beschreibung, Verwendungsabschnitt und Tastatursteuerungs-Tabelle der Tree-Komponente

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
