### PR TITLE
docs: remove draft warning from combobox

### DIFF
--- a/packages/components/src/components/combobox/readme.md
+++ b/packages/components/src/components/combobox/readme.md
@@ -2,10 +2,6 @@
 
 Synonyme: Autocomplete, Select, Dropdown
 
-<kol-alert _type="warning" _variant="card">
-  <kol-badge _color="#476af5" _label="Preview"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da die Barrierefreiheitstests noch ausstehen. Die verschiedenen Tests können aufgrund der Modularität bei neuen Komponenten und Funktionalitäten meist erst nach einem Release erfolgen. Wir empfehlen daher, die Komponente noch nicht in Produktion zu verwenden.
-</kol-alert>
-
 Die **Combobox**-Komponente erzeugt eine Auswahlliste, die ein Eingabefeld mit einer darunter angezeigten Liste von auswählbaren Optionen kombiniert.
 
 ## Konstruktion


### PR DESCRIPTION
## What changed?

This PR removes the "Preview / untested" warning `<kol-alert>` from the Combobox component's `readme.md`. The removed notice previously advised against using the component in production while its accessibility tests were still pending. Only documentation is affected — no component code, styling, or public API is changed.

## Linked issues

- Closes #7815 — remove the draft/preview warning from the Combobox documentation

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR entfernt den „Preview/ungetestet"-Warnhinweis (`<kol-alert>`) aus der `readme.md` der Combobox-Komponente. Der entfernte Hinweis riet bislang davon ab, die Komponente produktiv einzusetzen, solange die Barrierefreiheitstests noch ausstehen. Betroffen ist ausschließlich die Dokumentation — es werden weder Komponenten-Code noch Styling oder öffentliche API geändert.

### Verknüpfte Tickets

- Schließt #7815 — Entfernen des Entwurfs-/Preview-Warnhinweises aus der Combobox-Dokumentation

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/combobox/readme.md` — entfernt den „Preview/ungetestet"-Warnhinweis aus der Combobox-Dokumentation

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
