### PR TITLE
feat: highlight matching search term in single-select and combobox suggestions

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -228,6 +228,7 @@ export class KolCombobox implements ComboboxAPI {
 									<CustomSuggestionsOptionFc
 										index={index}
 										option={option}
+										searchTerm={this.state._value}
 										ref={(el) => {
 											if (el) this.refSuggestions[index] = el;
 										}}

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -280,6 +280,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 									<CustomSuggestionsOptionFc
 										index={index}
 										option={option.label}
+										searchTerm={this._inputValue}
 										ref={(el) => {
 											if (el) this.refOptions[index] = el;
 										}}

--- a/packages/components/src/functional-components/CustomSuggestionsOption/CustomSuggestionsOption.tsx
+++ b/packages/components/src/functional-components/CustomSuggestionsOption/CustomSuggestionsOption.tsx
@@ -6,10 +6,20 @@ export type CustomSuggestionsProps = JSXBase.HTMLAttributes<HTMLLIElement> & {
 	index: number;
 	option: W3CInputValue;
 	selected: boolean;
+	searchTerm?: string;
 	ref?: ((elm?: HTMLLIElement | undefined) => void) | undefined;
 };
 
-const CustomSuggestionsOptionFc: FC<CustomSuggestionsProps> = ({ index, ref, selected, onClick, onMouseOver, onFocus, onKeyDown, option }) => {
+const CustomSuggestionsOptionFc: FC<CustomSuggestionsProps> = ({ index, ref, selected, onClick, onMouseOver, onFocus, onKeyDown, option, searchTerm }) => {
+	const highlightSearchTerm = (text: string, searchTerm: string) => {
+		if (!searchTerm?.trim()) return text;
+
+		const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+		const parts = text.split(regex);
+
+		return parts.map((part, partIndex) => (regex.test(part) ? <mark key={partIndex}>{part}</mark> : part));
+	};
+
 	return (
 		<li
 			id={`option-${index}`}
@@ -25,7 +35,7 @@ const CustomSuggestionsOptionFc: FC<CustomSuggestionsProps> = ({ index, ref, sel
 			class="kol-custom-suggestions-option"
 			onKeyDown={onKeyDown}
 		>
-			{option}
+			{highlightSearchTerm(String(option), searchTerm || '')}
 		</li>
 	);
 };


### PR DESCRIPTION
## What changed?

This PR highlights the active search term within the suggestion options of the Single-Select and Combobox components. A new optional `searchTerm` prop is passed from `single-select/shadow.tsx` and `combobox/shadow.tsx` into the shared `CustomSuggestionsOption` functional component. That component now wraps every case-insensitive occurrence of the search term in a `<mark>` element, escaping the term before building the `RegExp` so special characters are treated literally. When no search term is present the option text renders unchanged, so existing behaviour is preserved. No public API surface changes for consumers.

## Linked issues

- Refs #7732 — Single-Select and Combobox: highlight the search words in the suggestion list

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR hebt den aktuellen Suchbegriff innerhalb der Vorschlagsoptionen der Komponenten Single-Select und Combobox hervor. Ein neues optionales `searchTerm`-Prop wird von `single-select/shadow.tsx` und `combobox/shadow.tsx` an die gemeinsam genutzte funktionale Komponente `CustomSuggestionsOption` übergeben. Diese umschließt nun jedes case-insensitive Vorkommen des Suchbegriffs mit einem `<mark>`-Element und maskiert den Begriff vor dem Erstellen des `RegExp`, sodass Sonderzeichen wörtlich behandelt werden. Ist kein Suchbegriff vorhanden, wird der Optionstext unverändert dargestellt; das bisherige Verhalten bleibt damit erhalten. Für Verbraucher der Bibliothek ändert sich die öffentliche API nicht.

### Verknüpfte Tickets

- Referenziert #7732 — Single-Select und Combobox: Hervorhebung der Suchworte in der Vorschlagsliste

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/functional-components/CustomSuggestionsOption/CustomSuggestionsOption.tsx` — fügt das `searchTerm`-Prop hinzu und hebt Treffer im Optionstext per `<mark>` hervor
- `packages/components/src/components/single-select/shadow.tsx` — übergibt den aktuellen Suchbegriff an die Vorschlagsoption
- `packages/components/src/components/combobox/shadow.tsx` — übergibt den aktuellen Suchbegriff an die Vorschlagsoption

</details>