### PR TITLE
ci(benchmark): store benchmark results in the public-ui.github.io repository

### DIFF
--- a/.github/workflows/benchmark.monitoring.yml
+++ b/.github/workflows/benchmark.monitoring.yml
@@ -43,10 +43,9 @@ jobs:
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1
         with:
-          alert-threshold: 10%
           auto-push: true
-          fail-threshold: 25%
-          gh-pages-branch: benchmarks
+          gh-pages-branch: main
+          gh-repository: https://github.com/public-ui/public-ui.github.io
           github-token: ${{ secrets.GITHUB_TOKEN }}
           output-file-path: packages/tools/benchmark-tests/benchmark-result.json
           tool: customSmallerIsBetter


### PR DESCRIPTION
## What changed?

The benchmark monitoring workflow (`.github/workflows/benchmark.monitoring.yml`) was reconfigured to publish benchmark results to the `main` branch of the external `public-ui/public-ui.github.io` repository instead of a local `benchmarks` branch, via the new `gh-repository` input. The `alert-threshold` (10%) and `fail-threshold` (25%) options were also removed, so the workflow no longer fails or comments on regressions automatically. This is a pure CI configuration adjustment for the benchmark result storage pipeline introduced in the related benchmark workflow work (issue #7799) and has no impact on the published library or its consumers.

## Linked issues

- #7799 (branch name `7799-v3`; issue tracks "Create a benchmark workflow", closed by this and related PRs)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Benchmark-Monitoring-Workflow (`.github/workflows/benchmark.monitoring.yml`) wurde so angepasst, dass die Benchmark-Ergebnisse künftig im `main`-Branch des externen Repositories `public-ui/public-ui.github.io` gespeichert werden, anstatt im lokalen `benchmarks`-Branch. Zusätzlich wurden die Schwellenwerte `alert-threshold` (10%) und `fail-threshold` (25%) entfernt, sodass der Workflow bei Regressionen nicht mehr automatisch fehlschlägt oder kommentiert. Es handelt sich um eine reine CI-Konfigurationsänderung ohne Auswirkung auf die veröffentlichte Bibliothek.

### Verknüpfte Tickets

- #7799 (Branchname `7799-v3`; Issue „Create a benchmark workflow")

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/benchmark.monitoring.yml`: Speicherziel für Benchmark-Ergebnisse auf das externe Repository `public-ui.github.io` (Branch `main`) umgestellt und Schwellenwert-Optionen entfernt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
