### PR TITLE
fix(input-range): allow number field to receive focus on click

### DIFF
--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -133,7 +133,6 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 			state: this.state,
 			class: clsx('kol-input-range', 'range'),
 			tooltipAlign: this._tooltipAlign,
-			onClick: () => this.refInputRange?.focus(),
 			alert: this.showAsAlert(),
 		};
 	}
@@ -181,6 +180,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 			name: this.state._name ? `${this.state._name}-number` : undefined,
 			list: this.hasSuggestions ? `${this.state._id}-list` : undefined,
 			type: 'number',
+			id: undefined,
 			ref: this.catchInputNumberRef,
 			onKeyDown: this.onKeyDown,
 		};

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -180,7 +180,6 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 			name: this.state._name ? `${this.state._name}-number` : undefined,
 			list: this.hasSuggestions ? `${this.state._id}-list` : undefined,
 			type: 'number',
-			id: undefined,
 			ref: this.catchInputNumberRef,
 			onKeyDown: this.onKeyDown,
 		};

--- a/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input accesskey="V" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -43,7 +43,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -69,7 +69,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--range" disabled="" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -95,7 +95,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-hint" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -127,7 +127,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
@@ -159,7 +159,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end"></div>
@@ -187,7 +187,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
@@ -216,7 +216,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -242,7 +242,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -268,7 +268,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -295,7 +295,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -322,7 +322,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input accesskey="V" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -360,7 +360,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -398,7 +398,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--range" disabled="" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -436,7 +436,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-hint" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -480,7 +480,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -524,7 +524,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -564,7 +564,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -605,7 +605,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -643,7 +643,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -681,7 +681,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -720,7 +720,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -758,7 +758,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -796,7 +796,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -834,7 +834,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -860,7 +860,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>

--- a/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input accesskey="V" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -43,7 +43,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -69,7 +69,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--range" disabled="" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -95,7 +95,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-hint" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -127,7 +127,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
@@ -159,7 +159,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end"></div>
@@ -187,7 +187,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
@@ -216,7 +216,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -242,7 +242,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -268,7 +268,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -295,7 +295,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -322,7 +322,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input accesskey="V" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input accesskey="V" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -360,7 +360,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -398,7 +398,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--range" disabled="" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-range__input kol-input-range__input--number" disabled="" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -436,7 +436,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-hint" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -480,7 +480,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -524,7 +524,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -564,7 +564,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -605,7 +605,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -643,7 +643,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-describedby="id-nonce-msg" aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -681,7 +681,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -720,7 +720,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -758,7 +758,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -796,7 +796,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" list="id-nonce-list" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" list="id-nonce-list" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
             <datalist id="id-nonce-list">
               <option value="1"></option>
@@ -834,7 +834,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input--touched kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>
@@ -860,7 +860,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 1.5em);">
               <input aria-hidden="true" autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--range" max="10" min="1" name="field-range" step="1" tabindex="-1" type="range" value="5">
-              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" max="10" min="1" name="field-number" step="1" type="number" value="5">
+              <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input kol-input-range__input kol-input-range__input--number" id="id-nonce" max="10" min="1" name="field-number" step="1" type="number" value="5">
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What changed?

The `kol-input-range` component had an `onClick` handler on its range slider element that unconditionally called `.focus()` on the range input whenever any part of the wrapping control was clicked. This meant that clicking directly on the numeric input field next to the slider moved focus to the range slider instead of the number field. The fix removes this erroneous `onClick` handler in `packages/components/src/components/input-range/shadow.tsx`, so each sub-control (range slider and number field) now correctly receives focus based on where the user actually clicks.

## Linked issues

- Closes #7796 — "kol-input-range: technische Fokus für Nummerneingabefeld nicht fokussierbar"

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Komponente `kol-input-range` besaß einen `onClick`-Handler auf dem Range-Slider, der bei jedem Klick auf den Bereich unbedingt `.focus()` auf das Range-Element aufgerufen hat. Dadurch wurde beim Klick auf das Nummernfeld stattdessen der Slider fokussiert. Der Fix entfernt diesen fehlerhaften `onClick`-Handler, sodass Nummernfeld und Slider nun jeweils korrekt per Mausklick fokussiert werden können.

### Verknüpfte Tickets

- Schließt #7796 — "kol-input-range: technische Fokus für Nummerneingabefeld nicht fokussierbar"

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-range/shadow.tsx`: Entfernt den `onClick`-Handler, der den Fokus fälschlicherweise immer auf den Range-Slider gesetzt hat.

</details>