### PR TITLE
docs(heading): deprecate _variant prop, to be removed in v3

### DIFF
--- a/packages/components/src/components/heading/shadow.tsx
+++ b/packages/components/src/components/heading/shadow.tsx
@@ -39,6 +39,7 @@ export class KolHeading implements HeadingProps {
 
 	/**
 	 * Defines which variant should be used for presentation.
+	 * @deprecated Removed in v3. Use CSS custom properties instead.
 	 */
 	@Prop() public _variant?: HeadingVariantPropType;
 }

--- a/packages/components/src/schema/props/heading-variant.ts
+++ b/packages/components/src/schema/props/heading-variant.ts
@@ -7,6 +7,7 @@ export type HeadingVariantPropType = (typeof headingVariantPropTypeOptions)[numb
 
 /**
  * Defines which variant should be used for presentation.
+ * @deprecated Removed in v3. Use CSS custom properties instead.
  */
 export type PropHeadingVariant = {
 	variant: HeadingVariantPropType;


### PR DESCRIPTION
## What changed?

An `@deprecated` JSDoc annotation was added to the `_variant` property of `KolHeading` in `packages/components/src/components/heading/shadow.tsx`, and to the corresponding `PropHeadingVariant` type in `packages/components/src/schema/props/heading-variant.ts`. Both annotations state that the property is "Removed in v3. Use CSS custom properties instead." No runtime logic, rendering, or prop behavior was changed — the `_variant` prop continues to work exactly as before. The change is purely a documentation/typing signal that surfaces as a deprecation warning in IDE tooltips, generated API docs, and Storybook, informing consumers to migrate to CSS custom properties ahead of the v3 major release.

## Linked issues

- Refs #7735 — Deprecate kol-heading _variant property

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [ ] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

An der Eigenschaft `_variant` von `KolHeading` in `packages/components/src/components/heading/shadow.tsx` sowie am zugehörigen Typ `PropHeadingVariant` in `packages/components/src/schema/props/heading-variant.ts` wurde jeweils ein `@deprecated`-JSDoc-Kommentar ergänzt. Beide Kommentare weisen darauf hin, dass die Eigenschaft "Removed in v3. Use CSS custom properties instead." ist. Es wurde keine Laufzeitlogik, kein Rendering und kein Prop-Verhalten verändert — die Eigenschaft `_variant` funktioniert weiterhin unverändert. Die Änderung ist rein ein Dokumentations-/Typisierungshinweis, der als Deprecation-Warnung in IDE-Tooltips, generierter API-Dokumentation und Storybook sichtbar wird und Nutzende auf die bevorstehende Migration zu CSS Custom Properties vor dem v3-Major-Release hinweist.

### Verknüpfte Tickets

- Bezug: #7735 — Deprecate kol-heading _variant property

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/heading/shadow.tsx` — `@deprecated`-Hinweis am `_variant`-Prop von `KolHeading` ergänzt.
- `packages/components/src/schema/props/heading-variant.ts` — `@deprecated`-Hinweis am Typ `PropHeadingVariant` ergänzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
