### PR TITLE
Add batch execution to benchmark tests

### DIFF
--- a/packages/tools/benchmark-tests/tests/lib/config.ts
+++ b/packages/tools/benchmark-tests/tests/lib/config.ts
@@ -1,6 +1,6 @@
 export const TEST_ITERATIONS = parseInt(process.env.TEST_ITERATIONS || '25', 10);
 export const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '5000', 10);
-// export const TEST_BATCH_SIZE = parseInt(process.env.TEST_BATCH_SIZE || '10', 10);
+export const TEST_BATCH_SIZE = parseInt(process.env.TEST_BATCH_SIZE || '10', 10);
 export const TEST_URL = 'http://localhost:3000/test-page.html';
 
 export const TAGS = [

--- a/packages/tools/benchmark-tests/tests/lib/test.ts
+++ b/packages/tools/benchmark-tests/tests/lib/test.ts
@@ -1,25 +1,35 @@
 import { writeFileSync } from 'fs';
-import { TEST_ITERATIONS, TEST_TIMEOUT } from './config';
+import { TEST_BATCH_SIZE, TEST_ITERATIONS, TEST_TIMEOUT } from './config';
 import type { Measure, Params, TagType } from './types';
 
 async function testRun({ iterations, tag, timeout }: Params): Promise<number[]> {
 	return new Promise(async (resolve) => {
 		const testResults = new Map<HTMLElement, Measure>();
-		const webComponents = new Set<HTMLElement>();
-		const batches = [];
+		const batches: Set<HTMLElement>[] = [];
+		let batchIndex = 0;
+		let webComponents: Set<HTMLElement>;
 
 		window.gc?.();
 		await customElements.whenDefined(tag);
 
 		function startNextHydration() {
 			if (webComponents.size > 0) {
-				const el: HTMLElement = webComponents.values()?.next()?.value!;
+				const el: HTMLElement = webComponents.values().next().value!;
 				performance.mark(`mark-append-${el.getAttribute('data-iteration')}`);
 				testResults.set(el, {
 					hydrated: null,
 					themed: null,
 				});
 				document.body.appendChild(el);
+			} else if (++batchIndex < batches.length) {
+				webComponents = batches[batchIndex];
+				for (const el of webComponents) {
+					observer.observe(el, {
+						attributes: true,
+						attributeFilter: ['class', 'data-themed'],
+					});
+				}
+				startNextHydration();
 			} else {
 				returnDurations();
 			}
@@ -69,9 +79,15 @@ async function testRun({ iterations, tag, timeout }: Params): Promise<number[]> 
 		});
 
 		for (let i = 0; i <= iterations; i++) {
+			const batch = Math.floor(i / TEST_BATCH_SIZE);
+			if (!batches[batch]) batches[batch] = new Set();
 			const el = document.createElement(tag);
 			el.setAttribute('data-iteration', i.toString());
-			webComponents.add(el);
+			batches[batch].add(el);
+		}
+
+		webComponents = batches[0] ?? new Set();
+		for (const el of webComponents) {
 			observer.observe(el, {
 				attributes: true,
 				attributeFilter: ['class', 'data-themed'],


### PR DESCRIPTION
## Summary
- add TEST_BATCH_SIZE config for benchmark tests
- execute hydration benchmark in batches of 10 web components

## Testing
- `pnpm --filter @public-ui/benchmark-tests test-with-playwright` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481f14fa74832b837739bf175f6a79

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
