### PR TITLE
feat(benchmark-tests): enhance hydration benchmarks with batch

### DIFF
--- a/packages/components/src/components/toaster/toaster.tsx
+++ b/packages/components/src/components/toaster/toaster.tsx
@@ -38,7 +38,7 @@ export class ToasterService {
 			this.toastContainerElement = undefined;
 			element.remove();
 		} else {
-			Log.warn('Toaster service is already disposed.', { forceLog: true });
+			Log.warn('Toaster service is already disposed.');
 		}
 	}
 

--- a/packages/components/src/schema/props/color.ts
+++ b/packages/components/src/schema/props/color.ts
@@ -108,7 +108,7 @@ export const handleColorChange = (value: unknown): ColorPair => {
 			break;
 		}
 		case null:
-			Log.warn(`_color was empty or invalid (${JSON.stringify(value)})`, { forceLog: true });
+			Log.warn(`_color was empty or invalid (${JSON.stringify(value)})`);
 			colorContrast = createContrastColorPair({
 				background: '#000',
 				foreground: '#000',

--- a/packages/components/src/utils/unique-nav-labels.ts
+++ b/packages/components/src/utils/unique-nav-labels.ts
@@ -9,7 +9,7 @@ const UNIQUE_LABELS: Set<string> = new Set();
 
 export function addNavLabel(ariaLabel: string): void {
 	if (UNIQUE_LABELS.has(ariaLabel)) {
-		Log.error(`There already is a nav element with the label "${ariaLabel}"`, { forceLog: true });
+		Log.warn(`There already is a nav element with the label "${ariaLabel}"`);
 	} else {
 		UNIQUE_LABELS.add(ariaLabel);
 	}

--- a/packages/tools/benchmark-tests/playwright.config.js
+++ b/packages/tools/benchmark-tests/playwright.config.js
@@ -1,11 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '5000', 10);
+const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '10000', 10);
 
 export default defineConfig({
 	testDir: 'tests',
 	testMatch: '*.playwright.ts',
-	timeout: TEST_TIMEOUT,
+	timeout: 2 * TEST_TIMEOUT,
 	use: {
 		headless: true,
 		viewport: { width: 800, height: 600 },

--- a/packages/tools/benchmark-tests/tests/hydration.playwright.ts
+++ b/packages/tools/benchmark-tests/tests/hydration.playwright.ts
@@ -1,7 +1,10 @@
 import { test } from '@playwright/test';
-import { TAGS, TEST_URL } from './lib/config';
-import { runBenchmark, writeResultFile } from './lib/test';
+import { createResultsMap, TAGS, TEST_URL } from './lib/config';
 import type { Params } from './lib/types';
+import { runBenchmark } from './lib/browser';
+import { writeResultFile } from './lib/after';
+
+const RESULTS = createResultsMap();
 
 test.describe('Hydration Benchmark', () => {
 	test.beforeEach(async ({ page }) => {
@@ -9,8 +12,10 @@ test.describe('Hydration Benchmark', () => {
 	});
 
 	for (const tag of TAGS) {
-		test(`${tag}`, async ({ page }) => await runBenchmark(tag, (fn: any, params: Params) => page.evaluate(fn, params)));
+		test(`${tag}`, async ({ page }) => await runBenchmark(tag, (fn: any, params: Params) => page.evaluate(fn, params), RESULTS));
 	}
 
-	test.afterAll(writeResultFile);
+	test.afterAll(() => {
+		writeResultFile(RESULTS);
+	});
 });

--- a/packages/tools/benchmark-tests/tests/hydration.webdriver.ts
+++ b/packages/tools/benchmark-tests/tests/hydration.webdriver.ts
@@ -1,6 +1,9 @@
-import { TAGS, TEST_URL } from './lib/config';
-import { runBenchmark, writeResultFile } from './lib/test';
+import { writeResultFile } from './lib/after';
+import { runBenchmark } from './lib/browser';
+import { createResultsMap, TAGS, TEST_URL } from './lib/config';
 import type { Params } from './lib/types';
+
+const RESULTS = createResultsMap();
 
 describe('Hydration Benchmark', () => {
 	before(async () => {
@@ -8,8 +11,10 @@ describe('Hydration Benchmark', () => {
 	});
 
 	for (const tag of TAGS) {
-		it(`${tag}`, async () => await runBenchmark(tag, (fn: any, params: Params) => browser.execute(fn, params)));
+		it(`${tag}`, async () => await runBenchmark(tag, (fn: any, params: Params) => browser.execute(fn, params), RESULTS));
 	}
 
-	after(writeResultFile);
+	after(() => {
+		writeResultFile(RESULTS);
+	});
 });

--- a/packages/tools/benchmark-tests/tests/lib/after.ts
+++ b/packages/tools/benchmark-tests/tests/lib/after.ts
@@ -1,0 +1,34 @@
+import { writeFileSync } from 'fs';
+import type { TagType } from './types';
+
+export function writeResultFile(results: Map<TagType, number[]>) {
+	function percentile(sorted: number[], p: number): number {
+		const i = Math.floor(sorted.length * p);
+		return sorted[i] ?? sorted[sorted.length - 1];
+	}
+
+	function stddev(arr: number[]) {
+		const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+		const squared = arr.map((x) => (x - mean) ** 2);
+		return Math.sqrt(squared.reduce((a, b) => a + b, 0) / arr.length);
+	}
+
+	const finalResults = Array.from(results.entries())
+		.filter(([_, values]) => values.length > 0)
+		.map(([tag, values]) => {
+			values.sort((a, b) => a - b);
+			const mid = Math.floor(values.length / 2);
+			return {
+				name: tag,
+				unit: 'ms',
+				value: values[mid],
+				p95: percentile(values, 0.95),
+				p99: percentile(values, 0.99),
+				min: values[0],
+				max: values[values.length - 1],
+				stddev: stddev(values),
+			};
+		});
+
+	writeFileSync('benchmark-result.json', JSON.stringify(finalResults, null, 2));
+}

--- a/packages/tools/benchmark-tests/tests/lib/browser.ts
+++ b/packages/tools/benchmark-tests/tests/lib/browser.ts
@@ -1,0 +1,18 @@
+import { TEST_BATCH_SIZE, TEST_ITERATIONS, TEST_TIMEOUT } from './config';
+import { testRun } from './test';
+import type { TagType } from './types';
+
+export async function runBenchmark(tag: TagType, execFn: any, results: Map<TagType, number[]>) {
+	const durations: number[] = await execFn(testRun, {
+		batchSize: TEST_BATCH_SIZE,
+		iterations: TEST_ITERATIONS,
+		tag,
+		timeout: TEST_TIMEOUT,
+	});
+
+	console.log(`Hydration durations for ${tag}:`, durations);
+	/**
+	 * Cut warmup iterations from the results.
+	 */
+	results.set(tag, durations.splice(1, durations.length - 1));
+}

--- a/packages/tools/benchmark-tests/tests/lib/config.ts
+++ b/packages/tools/benchmark-tests/tests/lib/config.ts
@@ -1,6 +1,8 @@
-export const TEST_ITERATIONS = parseInt(process.env.TEST_ITERATIONS || '25', 10);
-export const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '5000', 10);
-// export const TEST_BATCH_SIZE = parseInt(process.env.TEST_BATCH_SIZE || '10', 10);
+import type { TagType } from './types';
+
+export const TEST_ITERATIONS = parseInt(process.env.TEST_ITERATIONS || '50', 10);
+export const TEST_BATCH_SIZE = parseInt(process.env.TEST_BATCH_SIZE || '100', 10);
+export const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '10000', 10);
 export const TEST_URL = 'http://localhost:3000/test-page.html';
 
 export const TAGS = [
@@ -51,3 +53,7 @@ export const TAGS = [
 	'kol-tree-item',
 	'kol-version',
 ] as const;
+
+export const createResultsMap = (): Map<TagType, number[]> => {
+	return new Map<TagType, number[]>(TAGS.map((tag) => [tag, []]));
+};

--- a/packages/tools/benchmark-tests/tests/lib/test.ts
+++ b/packages/tools/benchmark-tests/tests/lib/test.ts
@@ -1,25 +1,33 @@
-import { writeFileSync } from 'fs';
-import { TEST_ITERATIONS, TEST_TIMEOUT } from './config';
-import type { Measure, Params, TagType } from './types';
+import type { Measure, Params } from './types';
 
-async function testRun({ iterations, tag, timeout }: Params): Promise<number[]> {
+export async function testRun({ batchSize, iterations, tag, timeout }: Params): Promise<number[]> {
 	return new Promise(async (resolve) => {
-		const testResults = new Map<HTMLElement, Measure>();
-		const webComponents = new Set<HTMLElement>();
-		const batches = [];
+		const testResults: Map<Set<HTMLElement>, Measure> = new Map();
+		const batches: Set<Set<HTMLElement>> = new Set();
+		let currentBatch: Set<HTMLElement> = new Set();
+		let batchCounter = 0;
 
 		window.gc?.();
 		await customElements.whenDefined(tag);
 
+		// Fallback for when no elements are hydrated
+		setTimeout(() => {
+			console.warn('⚠️ Timeout: hydration did not finish in time – returning partial or empty results.');
+			returnDurations();
+		}, timeout);
+
 		function startNextHydration() {
-			if (webComponents.size > 0) {
-				const el: HTMLElement = webComponents.values()?.next()?.value!;
-				performance.mark(`mark-append-${el.getAttribute('data-iteration')}`);
-				testResults.set(el, {
+			if (batches.size > 0) {
+				batchCounter++;
+				currentBatch = batches.values()?.next()?.value!;
+				performance.mark(`mark-append-${batchCounter}`);
+				testResults.set(currentBatch, {
 					hydrated: null,
 					themed: null,
 				});
-				document.body.appendChild(el);
+				for (const el of currentBatch) {
+					document.body.appendChild(el);
+				}
 			} else {
 				returnDurations();
 			}
@@ -36,8 +44,12 @@ async function testRun({ iterations, tag, timeout }: Params): Promise<number[]> 
 			resolve(durations);
 		}
 
+		function removeBatch(batch: Set<HTMLElement>) {
+			batches.delete(batch);
+		}
+
 		function removeElement(el: HTMLElement) {
-			webComponents.delete(el);
+			currentBatch.delete(el);
 			try {
 				el.remove();
 			} catch {}
@@ -46,89 +58,37 @@ async function testRun({ iterations, tag, timeout }: Params): Promise<number[]> 
 		const observer = new MutationObserver((mutations) => {
 			for (const mutation of mutations) {
 				const el = mutation.target as HTMLElement;
-				if (!webComponents.has(el) && !el.isConnected) continue;
+				if (!currentBatch.has(el) && !el.isConnected) continue;
 
-				const measure = testResults.get(el);
-				if (!measure) continue;
-
-				const id = el.getAttribute('data-iteration');
-
-				if (!measure.hydrated && el.classList.contains('hydrated')) {
-					performance.mark(`mark-hydrated-${id}`);
-					performance.measure(`hydrated-${id}`, `mark-append-${id}`, `mark-hydrated-${id}`);
-					measure.hydrated = performance.getEntriesByName(`hydrated-${id}`).pop()?.duration!;
-					// } else if (measure.hydrated && el.hasAttribute('data-themed')) {
-					// 	performance.mark(`mark-themed-${id}`);
-					// 	performance.measure(`themed-${id}`, `mark-append-${id}`, `mark-themed-${id}`);
-					// 	measure.themed = performance.getEntriesByName(`themed-${id}`).pop()?.duration!;
-
+				if (el.classList.contains('hydrated')) {
 					removeElement(el);
-					startNextHydration();
+					if (currentBatch.size === 0) {
+						performance.mark(`mark-hydrated-${batchCounter}`);
+						performance.measure(`hydrated-${batchCounter}`, `mark-append-${batchCounter}`, `mark-hydrated-${batchCounter}`);
+
+						const measure = testResults.get(currentBatch)!;
+						measure.hydrated = performance.getEntriesByName(`hydrated-${batchCounter}`).pop()?.duration!;
+
+						removeBatch(currentBatch);
+						setTimeout(startNextHydration);
+					}
 				}
 			}
 		});
 
 		for (let i = 0; i <= iterations; i++) {
-			const el = document.createElement(tag);
-			el.setAttribute('data-iteration', i.toString());
-			webComponents.add(el);
-			observer.observe(el, {
-				attributes: true,
-				attributeFilter: ['class', 'data-themed'],
-			});
+			const batch = new Set<HTMLElement>();
+			for (let j = 0; j < batchSize; j++) {
+				const el = document.createElement(tag);
+				batch.add(el);
+				observer.observe(el, {
+					attributes: true,
+					attributeFilter: ['class', 'data-themed'],
+				});
+			}
+			batches.add(batch);
 		}
-
-		// Fallback for when no elements are hydrated
-		setTimeout(returnDurations, timeout);
 
 		startNextHydration();
 	});
-}
-
-const results = new Map<TagType, number[]>();
-export function writeResultFile() {
-	function percentile(sorted, p) {
-		const i = Math.floor(sorted.length * p);
-		return sorted[i] ?? sorted[sorted.length - 1];
-	}
-
-	function stddev(arr) {
-		const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
-		const squared = arr.map((x) => (x - mean) ** 2);
-		return Math.sqrt(squared.reduce((a, b) => a + b, 0) / arr.length);
-	}
-
-	const finalResults = Array.from(results.entries())
-		.filter(([_, values]) => values.length > 0)
-		.map(([tag, values]) => {
-			values.sort((a, b) => a - b);
-			const mid = Math.floor(values.length / 2);
-			return {
-				name: tag,
-				unit: 'ms',
-				value: values[mid],
-				p95: percentile(values, 0.95),
-				p99: percentile(values, 0.99),
-				min: values[0],
-				max: values[values.length - 1],
-				stddev: stddev(values),
-			};
-		});
-
-	writeFileSync('benchmark-result.json', JSON.stringify(finalResults, null, 2));
-}
-
-export async function runBenchmark(tag: TagType, execFn: any) {
-	const durations: number[] = await execFn(testRun, {
-		iterations: TEST_ITERATIONS,
-		tag,
-		timeout: TEST_TIMEOUT,
-	});
-
-	console.log(`Hydration durations for ${tag}:`, durations);
-	/**
-	 * The network request durations are removed from the test results
-	 * to focus on the hydration performance of the web components itself.
-	 */
-	results.set(tag, durations.splice(1, durations.length - 1));
 }

--- a/packages/tools/benchmark-tests/tests/lib/types.d.ts
+++ b/packages/tools/benchmark-tests/tests/lib/types.d.ts
@@ -8,6 +8,7 @@ export type Measure = {
 };
 
 export type Params = {
+	batchSize: number;
 	iterations: number;
 	tag: TagType;
 	timeout: number;

--- a/packages/tools/benchmark-tests/wdio.conf.cjs
+++ b/packages/tools/benchmark-tests/wdio.conf.cjs
@@ -1,7 +1,7 @@
 const { spawn } = require('child_process');
 const net = require('net');
 
-const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '5000', 10);
+const TEST_TIMEOUT = parseInt(process.env.TEST_TIMEOUT || '10000', 10);
 
 let devServer;
 
@@ -49,7 +49,7 @@ exports.config = {
 	logLevel: 'silent',
 	bail: 0,
 	baseUrl: 'http://localhost:3000',
-	waitforTimeout: TEST_TIMEOUT,
+	timeout: 2 * TEST_TIMEOUT,
 	framework: 'mocha',
 	reporters: ['spec'],
 	mochaOpts: {


### PR DESCRIPTION
## What changed?

The hydration benchmark tooling in `packages/tools/benchmark-tests` now measures hydration in batches instead of a single element at a time. The result-writing logic was extracted from `tests/lib/test.ts` into a dedicated `tests/lib/after.ts` module and the browser-execution helper into `tests/lib/browser.ts`; a `createResultsMap()` factory plus a new `batchSize` parameter (default 100) were added to `tests/lib/config.ts` and `tests/lib/types.d.ts`. The default test timeout was raised from 5000 ms to 10000 ms across the Playwright and WebdriverIO configs and the iteration count increased to 50. Additionally, three `Log.warn`/`Log.error` calls in the components package (`toaster`, `color` schema, `unique-nav-labels`) had their `{ forceLog: true }` flag removed and one `Log.error` was downgraded to `Log.warn`. No public component API changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das Hydration-Benchmark-Tooling in `packages/tools/benchmark-tests` misst die Hydration nun batchweise statt Element für Element. Die Logik zum Schreiben der Ergebnisse wurde aus `tests/lib/test.ts` in ein eigenes Modul `tests/lib/after.ts` ausgelagert und der Browser-Ausführungs-Helper nach `tests/lib/browser.ts`; zusätzlich kamen eine `createResultsMap()`-Factory sowie ein neuer `batchSize`-Parameter (Standard 100) in `tests/lib/config.ts` und `tests/lib/types.d.ts` hinzu. Das Standard-Timeout der Tests wurde von 5000 ms auf 10000 ms angehoben (Playwright- und WebdriverIO-Konfiguration) und die Iterationen auf 50 erhöht. Außerdem wurde in drei `Log.warn`/`Log.error`-Aufrufen des Components-Pakets (`toaster`, `color`-Schema, `unique-nav-labels`) das Flag `{ forceLog: true }` entfernt und ein `Log.error` zu `Log.warn` herabgestuft. Keine Änderung an der öffentlichen Komponenten-API.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/benchmark-tests/tests/lib/test.ts` — Batch-Logik in `testRun`; Ergebnis-/Benchmark-Helper ausgelagert.
- `packages/tools/benchmark-tests/tests/lib/after.ts` — Neues Modul zum Aggregieren/Schreiben der Benchmark-Ergebnisse.
- `packages/tools/benchmark-tests/tests/lib/browser.ts` — Neuer `runBenchmark`-Helper mit `batchSize`.
- `packages/tools/benchmark-tests/tests/lib/config.ts` — `createResultsMap()`, `TEST_BATCH_SIZE`, erhöhte Iterationen/Timeout.
- `packages/tools/benchmark-tests/{playwright.config.js,wdio.conf.cjs}` — Timeout 5000 → 10000 ms.
- `packages/components/src/components/toaster/toaster.tsx`, `src/schema/props/color.ts`, `src/utils/unique-nav-labels.ts` — `{ forceLog: true }` aus Log-Aufrufen entfernt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
