### PR TITLE
fix(table): render focus outline on the scroll container

### DIFF
--- a/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
@@ -8,6 +8,8 @@
 
 	@layer kol-component {
 		.kol-table {
+			$root: &;
+
 			display: block;
 			font-size: rem(16);
 			max-width: 100%;
@@ -16,6 +18,13 @@
 			&__scroll-container {
 				overflow-x: auto;
 				overflow-y: hidden;
+
+				@at-root #{$root}:has(#{$root}__focus-element:focus) & {
+					/* @see https://remysharp.com/til/css/focus-ring-default-styles */
+					outline: 5px auto Highlight;
+					outline: 5px auto -webkit-focus-ring-color;
+					outline-offset: 2px;
+				}
 			}
 
 			&__table {
@@ -30,14 +39,6 @@
 
 			&__focus-element {
 				font-size: 0;
-
-				&:focus {
-					outline: 0 !important;
-					/* @see https://remysharp.com/til/css/focus-ring-default-styles */
-					outline: 5px auto Highlight;
-					outline: 5px auto -webkit-focus-ring-color;
-					outline-offset: 2px;
-				}
 			}
 
 			&__sort-button {

--- a/packages/samples/react/src/components/table/horizontal-scrollbar.tsx
+++ b/packages/samples/react/src/components/table/horizontal-scrollbar.tsx
@@ -36,7 +36,7 @@ export const TableHorizontalScrollbar: FC = () => {
 
 				<KolTableStateful
 					_label="Table for demonstration purposes with horizontal scrollbar."
-					_minWidth={hasWidthRestriction ? '600px' : 'auto'}
+					_minWidth={hasWidthRestriction ? '600px' : '300px'}
 					_headers={HEADERS}
 					_data={DATA}
 					className="block"
@@ -47,7 +47,7 @@ export const TableHorizontalScrollbar: FC = () => {
 
 				<KolTableStateful
 					_label="Table for demonstration purposes with horizontal scrollbar with auto minWidth."
-					_minWidth={hasWidthRestriction ? '600px' : 'auto'}
+					_minWidth={hasWidthRestriction ? '600px' : '300px'}
 					_headers={HEADERS}
 					_data={[]}
 					className="block"

--- a/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
@@ -35,14 +35,18 @@
 			min-height: calc(var(--a11y-min-size) + 2px); // leave some extra space so the settings button doesn't overlap the table borders
 		}
 
-		&__focus-element {
-			&:focus {
+		&__scroll-container {
+			@at-root #{$root}:has(#{$root}__focus-element:focus) & {
 				outline-color: var(--color-primary-variant);
 				outline-offset: 2px;
 				outline-style: solid;
 				outline-width: 3px;
 				transition: outline-offset 0.2s linear;
 			}
+		}
+
+		&__focus-element {
+			outline: none; // override global styles
 		}
 
 		&__cell {


### PR DESCRIPTION
## What changed?

This fixes the keyboard focus indicator for scrollable tables. Previously the focus outline was drawn directly on the visually-hidden `.kol-table__focus-element` (via `&__focus-element:focus`). The outline is now applied to the `.kol-table__scroll-container` using a `:has(#{$root}__focus-element:focus)` selector (with a `$root` reference introduced in `_kol-table-stateless-mixin.scss`), so the whole scroll container receives a visible focus ring when the focus element is focused. The default theme mixin (`kol-table-stateless-wc.scss`) was updated the same way and now explicitly sets `outline: none` on the focus element to override global styles. The React sample was adjusted to use a `300px` minWidth instead of `auto` so the horizontal scrollbar (and thus the focus behaviour) is demonstrable. This is a visual/accessibility fix with no API change.

## Linked issues

- Refs #7586 — Table scroll container focus styles

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies behebt den Tastatur-Fokusindikator für scrollbare Tabellen. Bisher wurde der Fokus-Rahmen direkt auf dem visuell versteckten `.kol-table__focus-element` (über `&__focus-element:focus`) gezeichnet. Der Rahmen wird nun über einen `:has(#{$root}__focus-element:focus)`-Selektor (mit einer neu eingeführten `$root`-Referenz in `_kol-table-stateless-mixin.scss`) auf den `.kol-table__scroll-container` angewendet, sodass der gesamte Scroll-Container einen sichtbaren Fokus-Ring erhält, wenn das Fokus-Element fokussiert ist. Das Default-Theme-Mixin (`kol-table-stateless-wc.scss`) wurde entsprechend angepasst und setzt am Fokus-Element nun explizit `outline: none`, um globale Styles zu überschreiben. Das React-Beispiel nutzt statt `auto` nun `300px` als minWidth, damit die horizontale Scrollleiste (und damit das Fokusverhalten) sichtbar wird. Ein visueller/Barrierefreiheits-Fix ohne API-Änderung.

### Verknüpfte Tickets

- Referenziert #7586 — Fokus-Styles des Tabellen-Scroll-Containers

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/@shared/_kol-table-stateless-mixin.scss` — Fokus-Outline vom Fokus-Element auf den Scroll-Container (`:has(...)`) verschoben, `$root`-Referenz ergänzt.
- `packages/themes/default/src/mixins/kol-table-stateless-wc.scss` — gleiche Umstellung im Default-Theme, `outline: none` am Fokus-Element.
- `packages/samples/react/src/components/table/horizontal-scrollbar.tsx` — `minWidth` von `auto` auf `300px` gesetzt, damit die Scrollleiste im Beispiel sichtbar ist.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
