### PR TITLE
ci: fix axe report upload and snapshot-update handling

### DIFF
--- a/.github/actions/upload-reports/action.yml
+++ b/.github/actions/upload-reports/action.yml
@@ -13,3 +13,4 @@ runs:
         path: |
           packages/**/playwright-report/
           packages/**/test-results/**/*.png
+          packages/**/test-results/axe-default/**

--- a/packages/tools/visual-tests/tests/axe-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/axe-snapshots.spec.js
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test';
 import { checkA11y, injectAxe } from 'axe-playwright';
 import { ROUTES } from './sample-app.routes.js';
+import process from 'process';
 
 const themeName = (process.env.THEME_EXPORT || 'default').toLocaleLowerCase();
 const rename = (snapshotName) => {
@@ -38,7 +39,7 @@ test.use({
 
 ROUTES.forEach((options, route) => {
 	// Skip unnecessary axe tests
-	if (options?.axe?.skip === true) {
+	if (options?.axe?.skip === true || process.argv.includes('--update-snapshots')) {
 		return;
 	}
 	test(`snapshot for ${route}`, async ({ page }, testInfo) => {

--- a/packages/tools/visual-tests/tests/axe-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/axe-snapshots.spec.js
@@ -82,7 +82,7 @@ ROUTES.forEach((options, route) => {
 			{
 				outputDirPath: outputPath.replace(/\/[^/]+$/, ''),
 				outputDir: `axe-${themeName}`,
-				reportFileName: `${route.replace('/', '-')}.html`,
+				reportFileName: `${route.replace(/[/?]/g, '-')}.html`,
 			},
 		);
 	});


### PR DESCRIPTION
## What changed?

This change fixes the Axe accessibility visual-test workflow. `.github/actions/upload-reports/action.yml` now also uploads the `packages/**/test-results/axe-default/**` directory so the generated Axe HTML reports are retained as CI artifacts. In `packages/tools/visual-tests/tests/axe-snapshots.spec.js`, `process` is now explicitly imported, the Axe tests are skipped when Playwright runs with `--update-snapshots` (avoiding failures during snapshot regeneration), and the report file name sanitisation was widened from replacing only `/` to replacing both `/` and `?` (`/[/?]/g`) so route-derived file names are valid. No component or public API behaviour changes.

## Linked issues

- Refs #7892 — Axe workflow failures

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung behebt den Axe-Barrierefreiheits-Workflow für die Visual-Tests. `.github/actions/upload-reports/action.yml` lädt nun zusätzlich das Verzeichnis `packages/**/test-results/axe-default/**` hoch, damit die generierten Axe-HTML-Reports als CI-Artefakte erhalten bleiben. In `packages/tools/visual-tests/tests/axe-snapshots.spec.js` wird `process` jetzt explizit importiert, die Axe-Tests werden bei einem Playwright-Lauf mit `--update-snapshots` übersprungen (um Fehler bei der Snapshot-Neuerstellung zu vermeiden), und die Bereinigung des Report-Dateinamens wurde von nur `/` auf `/` und `?` erweitert (`/[/?]/g`), damit aus Routen abgeleitete Dateinamen gültig sind. Keine Änderung an Komponenten oder öffentlicher API.

### Verknüpfte Tickets

- Referenziert #7892 — Fehler im Axe-Workflow

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/actions/upload-reports/action.yml` — lädt zusätzlich die `axe-default`-Testergebnisse als Artefakt hoch.
- `packages/tools/visual-tests/tests/axe-snapshots.spec.js` — `process`-Import ergänzt, Axe-Tests bei `--update-snapshots` übersprungen, Dateinamen-Bereinigung um `?` erweitert.

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
