### PR TITLE
chore: make branch issue number optional

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -5,7 +5,7 @@
 # Modified version of: https://medium.com/@adrian.garcia.estaun/add-the-ticket-id-to-your-commit-messages-automatically-2debfa0fbe9d
 #
 
-ERROR_MESSAGE="Error: Branch name does not start with a ticket ID. Format: ticketID-branch-description. E.g.: '1234-update-tests'"
+MISSING_ISSUE_NUMBER_MESSAGE="Skip auto issue referencing. Branch name does not start with a ticket ID. Format: ticketID-branch-description. E.g.: '1234-update-tests'"
 
 # Gets the commit message received as parameter and the current branch name.
 COMMIT_MSG_FILE="$1"
@@ -28,10 +28,10 @@ if echo "$normalizedBranchName" | grep -qE '^[0-9]+[-_]'; then
   ticketID=$(echo "$normalizedBranchName" | sed -nE 's,([0-9]+)[_-].+,\1,p')
 
   if [ -z "$ticketID" ]; then
-      echo "$ERROR_MESSAGE"
-      exit 1
+      echo "$MISSING_ISSUE_NUMBER_MESSAGE"
+      exit 0
   fi
-  
+
   # Message already contains the ticket ID
   if echo "$message" | grep -qE '#[0-9]+'; then
     exit 0
@@ -41,6 +41,6 @@ if echo "$normalizedBranchName" | grep -qE '^[0-9]+[-_]'; then
 
   echo "$output" > "$1"
 else
-  echo "$ERROR_MESSAGE"
-  exit 1
+  echo "$MISSING_ISSUE_NUMBER_MESSAGE"
+  exit 0
 fi


### PR DESCRIPTION
## What changed?

The `.husky/prepare-commit-msg` git hook no longer blocks commits when the current branch name does not start with a ticket/issue ID. Previously the script printed an error message and exited with status 1, aborting the commit. Now both occurrences of that logic exit with status 0, letting the commit proceed, and the message was reworded (variable renamed from `ERROR_MESSAGE` to `MISSING_ISSUE_NUMBER_MESSAGE`) to clarify that automatic issue referencing is simply skipped rather than treated as a failure. A minor whitespace-only cleanup is also included.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Git-Hook `.husky/prepare-commit-msg` blockiert Commits nicht mehr, wenn der aktuelle Branch-Name nicht mit einer Ticket-/Issue-ID beginnt. Zuvor gab das Skript eine Fehlermeldung aus und beendete sich mit Status 1, wodurch der Commit abgebrochen wurde. Nun beenden sich beide Stellen dieser Logik mit Status 0, sodass der Commit durchläuft; zudem wurde die Meldung umformuliert (Variable von `ERROR_MESSAGE` in `MISSING_ISSUE_NUMBER_MESSAGE` umbenannt), um klarzustellen, dass das automatische Verknüpfen der Issue-Nummer lediglich übersprungen und nicht als Fehler behandelt wird. Eine kleine reine Whitespace-Bereinigung ist ebenfalls enthalten.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.husky/prepare-commit-msg` — `ERROR_MESSAGE` in `MISSING_ISSUE_NUMBER_MESSAGE` umbenannt (mit angepasstem Text) und den Exit-Code an beiden Stellen von 1 auf 0 geändert, damit Commits ohne Issue-Nummer im Branch-Namen nicht mehr blockiert werden.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
