### PR TITLE
fix(popover-button): hide tooltip on the same element when the popover opens

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -67,17 +67,20 @@ import clsx from 'clsx';
 export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolButtonWcElement;
 	private buttonRef?: HTMLButtonElement;
+	private tooltipRef?: HTMLKolTooltipWcElement;
 
 	private readonly internalDescriptionById = nonce();
-
-	private readonly catchRef = (ref?: HTMLButtonElement) => {
-		this.buttonRef = ref;
-	};
 
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async kolFocus() {
 		this.buttonRef?.focus();
+	}
+
+	@Method()
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async hideTooltip() {
+		void this.tooltipRef?.hideTooltip();
 	}
 
 	private readonly onClick = (event: MouseEvent) => {
@@ -122,7 +125,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 		return (
 			<Host>
 				<button
-					ref={this.catchRef}
+					ref={(ref) => (this.buttonRef = ref)}
 					accessKey={this.state._accessKey || undefined}
 					aria-controls={this.state._ariaControls}
 					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
@@ -158,6 +161,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 					</KolSpanFc>
 				</button>
 				<KolTooltipWcTag
+					ref={(ref) => (this.tooltipRef = ref)}
 					/**
 					 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
 					 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -60,11 +60,15 @@ export class KolPopoverButton implements PopoverButtonProps {
 				// Reset the flag after the event loop tick.
 				this.justClosed = false;
 			}, 10); // timeout of 0 should be sufficient but doesn't work in Safari Mobile (needs further investigation).
-		} else if (this.refPopover) {
-			/**
-			 * Avoid "flicker" by hiding the element until the position is set in the `toggle` event handler. `alignFloatingElements` is responsible for setting the visibility back to 'visible'.
-			 */
-			this.refPopover.style.visibility = 'hidden';
+		} else {
+			if (this.refPopover) {
+				/**
+				 * Avoid "flicker" by hiding the element until the position is set in the `toggle` event handler. `alignFloatingElements` is responsible for setting the visibility back to 'visible'.
+				 */
+				this.refPopover.style.visibility = 'hidden';
+			}
+
+			void this.refButton?.hideTooltip();
 		}
 	}
 

--- a/packages/components/src/components/popover-button/popover-button.e2e.ts
+++ b/packages/components/src/components/popover-button/popover-button.e2e.ts
@@ -37,4 +37,20 @@ test.describe('kol-popover-button', () => {
 		await button.click({ force: true });
 		await expect(popover).not.toBeVisible();
 	});
+
+	test('should hide its tooltip when popover is shown', async ({ page }) => {
+		await page.setContent(`
+			<kol-popover-button _label="Toggle popover" _icons="codicon codicon-info" _hide-label>
+				Popover content
+			</kol-popover-button>
+		`);
+		const button = page.getByTestId('popover-button').locator('button');
+		const tooltip = page.locator('kol-tooltip-wc');
+
+		await button.hover();
+		await expect(tooltip).toBeVisible();
+
+		await button.click();
+		await expect(tooltip).not.toBeVisible();
+	});
 });

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -2,11 +2,15 @@ import { autoUpdate } from '@floating-ui/dom';
 import type { AlignPropType, BadgeTextPropType, IdPropType, LabelPropType, TooltipAPI, TooltipStates } from '../../schema';
 import { getDocument, validateBadgeText, validateAlign, validateId, validateLabel } from '../../schema';
 import type { JSX } from '@stencil/core';
+import { Method } from '@stencil/core';
 import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
 
 import { alignFloatingElements } from '../../utils/align-floating-elements';
 import { hideOverlay, showOverlay } from '../../utils/overlay';
 import { KolSpanFc } from '../../functional-components';
+
+// Timing Guidelines for Exposing Hidden Content: https://www.nngroup.com/articles/timing-exposing-content/
+const TOOLTIP_DELAY = 300;
 
 /**
  * @internal
@@ -21,8 +25,6 @@ export class KolTooltipWc implements TooltipAPI {
 	private arrowElement?: HTMLDivElement;
 	private previousSibling?: Element | null;
 	private tooltipElement?: HTMLDivElement;
-	private hasFocusIn = false;
-	private hasMouseIn = false;
 
 	private cleanupAutoPositioning?: () => void;
 
@@ -51,7 +53,26 @@ export class KolTooltipWc implements TooltipAPI {
 		}
 	};
 
-	private hideTooltip = (): void => {
+	private showTooltipTimeout?: ReturnType<typeof setTimeout>;
+	private showTooltipWithDelay = (): void => {
+		clearTimeout(this.showTooltipTimeout);
+		this.showTooltipTimeout = setTimeout(() => {
+			this.showTooltip();
+		}, TOOLTIP_DELAY);
+	};
+
+	private hideTooltipTimeout?: ReturnType<typeof setTimeout>;
+	private hideTooltipWithDelay = (): void => {
+		clearTimeout(this.hideTooltipTimeout);
+		this.hideTooltipTimeout = setTimeout(() => {
+			void this.hideTooltip();
+		}, TOOLTIP_DELAY);
+	};
+
+	@Method()
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async hideTooltip() {
+		clearTimeout(this.showTooltipTimeout); // Cancel scheduled tooltips
 		if (this.tooltipElement /* SSR instanceof HTMLElement */) {
 			hideOverlay(this.tooltipElement);
 			this.tooltipElement.style.setProperty('display', 'none');
@@ -62,29 +83,25 @@ export class KolTooltipWc implements TooltipAPI {
 			}
 		}
 		getDocument().removeEventListener('keyup', this.hideTooltipByEscape);
-	};
+	}
 
 	private hideTooltipByEscape = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape') {
-			this.hideTooltip();
+			void this.hideTooltip();
 		}
 	};
 
 	private handleMouseEnter() {
-		this.hasMouseIn = true;
-		this.showOrHideTooltip();
+		this.showTooltipWithDelay();
 	}
 	private handleMouseleave() {
-		this.hasMouseIn = false;
-		this.showOrHideTooltip();
+		this.hideTooltipWithDelay();
 	}
 	private handleFocusIn() {
-		this.hasFocusIn = true;
-		this.showOrHideTooltip();
+		this.showTooltipWithDelay();
 	}
 	private handleFocusout() {
-		this.hasFocusIn = false;
-		this.showOrHideTooltip();
+		this.hideTooltipWithDelay();
 	}
 
 	private addListeners = (el: Element): void => {
@@ -182,20 +199,6 @@ export class KolTooltipWc implements TooltipAPI {
 			required: true,
 		});
 	}
-
-	private overFocusTimeout?: ReturnType<typeof setTimeout>;
-
-	private showOrHideTooltip = (): void => {
-		clearTimeout(this.overFocusTimeout);
-		this.overFocusTimeout = setTimeout(() => {
-			if (this.hasMouseIn || this.hasFocusIn) {
-				this.showTooltip();
-			} else {
-				this.hideTooltip();
-			}
-			// Timing Guidelines for Exposing Hidden Content: https://www.nngroup.com/articles/timing-exposing-content/
-		}, 300);
-	};
 
 	public componentWillLoad(): void {
 		this.validateBadgeText(this._badgeText);


### PR DESCRIPTION
## What changed?

Fixes a bug where a button's tooltip remained visible after its associated popover was opened, causing both overlays to be shown at the same time on `kol-popover-button`. A new public `hideTooltip()` method was added to `KolButtonWc` and `KolTooltipWc`, letting the popover-button explicitly hide the button's tooltip when the popover opens. The tooltip's show/hide logic was refactored, replacing the combined hover/focus debounce timer with two independent delayed timers (`showTooltipWithDelay` / `hideTooltipWithDelay`); `hideTooltip` now also cancels any pending show timeout so the tooltip cannot appear after being explicitly hidden. A new e2e test verifies that hovering the popover-button shows the tooltip and that clicking to open the popover hides it.

## Linked issues

- Refs #7418 — Tooltip and popover shown simultaneously on the same element

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt einen Fehler, bei dem der Tooltip eines Buttons sichtbar blieb, nachdem das zugehörige Popover geöffnet wurde, sodass bei `kol-popover-button` beide Overlays gleichzeitig angezeigt wurden. Eine neue öffentliche Methode `hideTooltip()` wurde zu `KolButtonWc` und `KolTooltipWc` hinzugefügt, damit der Popover-Button den Tooltip des Buttons beim Öffnen des Popovers gezielt ausblenden kann. Die Show/Hide-Logik des Tooltips wurde überarbeitet: Der kombinierte Hover/Focus-Debounce-Timer wurde durch zwei unabhängige verzögerte Timer (`showTooltipWithDelay` / `hideTooltipWithDelay`) ersetzt; `hideTooltip` bricht nun außerdem einen ausstehenden Show-Timeout ab, damit der Tooltip nach dem expliziten Ausblenden nicht erneut erscheint. Ein neuer e2e-Test prüft, dass der Tooltip beim Hover erscheint und beim Öffnen des Popovers (Klick) ausgeblendet wird.

### Verknüpfte Tickets

- Referenziert #7418 — Tooltip und Popover werden gleichzeitig am selben Element angezeigt

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/button/component.tsx` — `tooltipRef` und öffentliche Methode `hideTooltip()` in `KolButtonWc` ergänzt, damit externe Komponenten den Tooltip ausblenden können.
- `packages/components/src/components/popover-button/component.tsx` — Beim Öffnen des Popovers wird nun zusätzlich `refButton.hideTooltip()` aufgerufen, um den Tooltip am selben Button zu schließen.
- `packages/components/src/components/tooltip/component.tsx` — Getrennte `showTooltipWithDelay`/`hideTooltipWithDelay`-Timer statt kombiniertem Debounce; `hideTooltip` als `@Method()` bereitgestellt und ausstehender Show-Timeout wird abgebrochen.
- `packages/components/src/components/popover-button/popover-button.e2e.ts` — Neuer e2e-Test für Anzeigen (Hover) und Ausblenden (Popover-Öffnung) des Tooltips.

</details>