### PR TITLE
chore: remove angular v15/v16 publish references and add v19/v20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,18 +115,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
-      - name: Build and publish adapter angular v15
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
-        working-directory: packages/adapters/angular/v15
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
-      - name: Build and publish adapter angular v16
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
-        working-directory: packages/adapters/angular/v16
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter angular v17
         run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v17
@@ -136,6 +124,18 @@ jobs:
       - name: Build and publish adapter angular v18
         run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v18
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
+      - name: Build and publish adapter angular v19
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
+        working-directory: packages/adapters/angular/v19
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
+      - name: Build and publish adapter angular v20
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
+        working-directory: packages/adapters/angular/v20
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true

--- a/README.md
+++ b/README.md
@@ -64,8 +64,3 @@ Let's make KoliBri **better** and **more colorful** together!
 - [Contributing](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Security](./docs/SECURITY.md)
-
-## Angular adapters
-
-KoliBri provides official Angular integration packages for versions 17, 18, 19 and 20.
-You can find them in `packages/adapters/angular`.

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ Let's make KoliBri **better** and **more colorful** together!
 - [Contributing](./CONTRIBUTING.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Security](./docs/SECURITY.md)
+
+## Angular adapters
+
+KoliBri provides official Angular integration packages for versions 17, 18, 19 and 20.
+You can find them in `packages/adapters/angular`.

--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,9 @@
 {
 	"packages": [
-		"packages/adapters/angular/v15",
-		"packages/adapters/angular/v16",
 		"packages/adapters/angular/v17",
 		"packages/adapters/angular/v18",
+		"packages/adapters/angular/v19",
+		"packages/adapters/angular/v20",
 		"packages/adapters/hydrate",
 		"packages/adapters/preact",
 		"packages/adapters/react",


### PR DESCRIPTION
## What changed?

Updated the GitHub Actions publish workflow (`.github/workflows/publish.yml`) to stop building and publishing the Angular v15 and v16 adapter packages and to add publish steps for the Angular v17, v18, v19 and v20 adapters. `lerna.json`'s package list was updated to match, removing the v15/v16 workspace entries and adding v19/v20. This is a follow-up to #7894, which performed the actual removal/addition of the adapter package sources; this PR only aligns the CI publish pipeline and lerna workspace configuration. No application source code, public API, or component behavior is affected.

## Linked issues

- Refs #7112 — Angular adapter version support (add v18/v19/v20, drop v15/v16)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der GitHub-Actions-Publish-Workflow (`.github/workflows/publish.yml`) wurde angepasst, sodass die Angular-Adapter v15 und v16 nicht mehr gebaut und veröffentlicht werden; stattdessen wurden Publish-Schritte für die Angular-Adapter v17, v18, v19 und v20 ergänzt. Die Paketliste in `lerna.json` wurde entsprechend aktualisiert (v15/v16 entfernt, v19/v20 ergänzt). Dies ist ein Folge-PR zu #7894, der das tatsächliche Entfernen/Hinzufügen der Adapter-Paketquellen vorgenommen hat; dieser PR gleicht lediglich die CI-Publish-Pipeline und die Lerna-Workspace-Konfiguration an. Anwendungsquellcode, öffentliche API oder Komponentenverhalten sind nicht betroffen.

### Verknüpfte Tickets

- Referenziert #7112 — Angular-Adapter-Versionsunterstützung (v18/v19/v20 ergänzen, v15/v16 entfernen)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/publish.yml` — Publish-Schritte für Angular-Adapter v15/v16 durch Schritte für v19/v20 ersetzt (neben den bestehenden v17/v18).
- `lerna.json` — `packages/adapters/angular/v15` und `v16` aus der Workspace-Liste entfernt, `v19` und `v20` ergänzt.

</details>