### PR TITLE
fix(input-radio): apply group disabled state to all radio inputs and wrappers

### DIFF
--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -65,6 +65,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 		return {
 			state: this.state,
 			component: 'fieldset',
+			disabled: Boolean(this._disabled),
 			class: clsx('kol-form-field--radio'),
 			formFieldLabelProps: {
 				component: 'legend',
@@ -88,7 +89,11 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	}
 
 	private getOptionProps(option: RadioOption<StencilUnknown>, id: string): FieldControlStateWrapperProps {
-		const obj: FieldControlStateWrapperProps = {
+		const groupDisabled = Boolean(this._disabled);
+		const optionDisabled = Boolean(option.disabled);
+		const disabled = groupDisabled || optionDisabled;
+
+		return {
 			state: this.state,
 			id: id,
 			hint: option.hint,
@@ -97,16 +102,15 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 			fieldControlLabelProps: {
 				showBadge: false,
 			},
+			disabled: disabled,
 		};
-
-		if (option.disabled) {
-			obj.disabled = true;
-		}
-
-		return obj;
 	}
 
 	private getInputProps(option: RadioOption<StencilUnknown>, id: string, index: number, selected: boolean): RadioStateWrapperProps {
+		const groupDisabled = Boolean(this._disabled);
+		const optionDisabled = Boolean(option.disabled);
+		const disabled = groupDisabled || optionDisabled;
+
 		return {
 			state: this.state,
 			inputProps: {
@@ -117,7 +121,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 				name: this.state._name || this.state._id,
 				value: `-${index}`,
 				checked: selected,
-				disabled: option.disabled,
+				disabled: disabled,
 
 				...this.controller.onFacade,
 				onChange: this.onChange,

--- a/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
@@ -148,8 +148,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         </div>
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
-            <label class="kol-input-radio">
-              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+            <label class="kol-input-radio kol-input-radio--disabled">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -162,8 +162,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         </div>
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
-            <label class="kol-input-radio">
-              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+            <label class="kol-input-radio kol-input-radio--disabled">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">
@@ -691,8 +691,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         </div>
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
-            <label class="kol-input-radio">
-              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+            <label class="kol-input-radio kol-input-radio--disabled">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -705,8 +705,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         </div>
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
-            <label class="kol-input-radio">
-              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+            <label class="kol-input-radio kol-input-radio--disabled">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">


### PR DESCRIPTION
## What changed?

This change fixes `KolInputRadio` so that a group-level `_disabled` flag is propagated to every individual radio option, not just to options that carry their own `disabled` value. In `packages/components/src/components/input-radio/shadow.tsx`, `getOptionProps` and `getInputProps` now compute the effective disabled state as `groupDisabled || optionDisabled` (`disabled = Boolean(this._disabled) || Boolean(option.disabled)`) and pass it to each input and its field-control wrapper; the fieldset also receives `disabled: Boolean(this._disabled)`. As a result, disabling the whole radio group now renders each `<input type="radio">` with the `disabled` attribute and the `--disabled` wrapper/label classes. The component's Jest snapshots are updated accordingly.

## Linked issues

- Closes #7866 — group `_disabled` was not applied to the individual radio inputs/wrappers.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung behebt `KolInputRadio`, sodass ein gruppenweites `_disabled`-Flag an jede einzelne Radio-Option weitergegeben wird — nicht nur an Optionen mit eigenem `disabled`-Wert. In `packages/components/src/components/input-radio/shadow.tsx` berechnen `getOptionProps` und `getInputProps` den effektiven Deaktiviert-Zustand nun als `groupDisabled || optionDisabled` (`disabled = Boolean(this._disabled) || Boolean(option.disabled)`) und geben ihn an jedes Input-Element und dessen Field-Control-Wrapper weiter; das Fieldset erhält zusätzlich `disabled: Boolean(this._disabled)`. Dadurch wird beim Deaktivieren der gesamten Radio-Gruppe jedes `<input type="radio">` mit dem `disabled`-Attribut und den `--disabled`-Wrapper-/Label-Klassen gerendert. Die Jest-Snapshots der Komponente werden entsprechend aktualisiert.

### Verknüpfte Tickets

- Schließt #7866 — gruppenweites `_disabled` wurde nicht auf die einzelnen Radio-Inputs/Wrapper angewendet.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-radio/shadow.tsx` — gruppenweiten `_disabled`-Zustand auf alle Inputs und Wrapper anwenden.
- `packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshots an das geänderte Markup angepasst.

</details>