### PR TITLE
test: refactor input e2e test helpers to use options objects

### DIFF
--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -7,8 +7,14 @@ const TEST_VALUE = 'Hello World';
 const OPTIONS = ['North', 'South', 'West', 'East'];
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolComboboxElement>(COMPONENT_NAME, TEST_VALUE);
-	testInputCallbacksAndEvents<HTMLKolComboboxElement>(COMPONENT_NAME, TEST_VALUE);
+	testInputValueReflection<HTMLKolComboboxElement>({
+		componentName: COMPONENT_NAME,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolComboboxElement>({
+		componentName: COMPONENT_NAME,
+		testValue: TEST_VALUE,
+	});
 
 	test('should fire input and change events', async ({ page }) => {
 		await page.setContent(`<kol-combobox _label="Input" _suggestions=${JSON.stringify(OPTIONS)}></kol-combobox>`);

--- a/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
+++ b/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
@@ -11,7 +11,12 @@ const fillAction: FillAction = async (page) => {
 const OMITTED_EVENTS = ['click'];
 
 test.describe(COMPONENT_NAME, () => {
-	testInputCallbacksAndEvents<HTMLKolInputCheckboxElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OMITTED_EVENTS);
+	testInputCallbacksAndEvents<HTMLKolInputCheckboxElement>({
+		componentName: COMPONENT_NAME,
+		fillAction,
+		omittedEvents: OMITTED_EVENTS,
+		testValue: TEST_VALUE,
+	});
 
 	test(`should reflect the _checked property on the web component`, async ({ page }) => {
 		const getCheckedProperty = () => page.locator(COMPONENT_NAME).evaluate((element: HTMLKolInputCheckboxElement) => element._checked);

--- a/packages/components/src/components/input-color/input-color.e2e.ts
+++ b/packages/components/src/components/input-color/input-color.e2e.ts
@@ -15,8 +15,18 @@ const fillAction: FillAction = async (page) => {
 const selectTextInput = (page: Page & E2EPage) => page.locator('input[type="text"]');
 const selectColorInput = (page: Page & E2EPage) => page.locator('input[type="color"]');
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolInputColorElement>(COMPONENT_NAME, TEST_VALUE, fillAction);
-	testInputCallbacksAndEvents<HTMLKolInputColorElement>(COMPONENT_NAME, TEST_VALUE, fillAction, ['input'], undefined, selectTextInput);
+	testInputValueReflection<HTMLKolInputColorElement>({
+		componentName: COMPONENT_NAME,
+		fillAction,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolInputColorElement>({
+		componentName: COMPONENT_NAME,
+		fillAction,
+		omittedEvents: ['input'],
+		selectInput: selectTextInput,
+		testValue: TEST_VALUE,
+	});
 	test('should sync value between color input and text input', async ({ page }) => {
 		await page.setContent(`<${COMPONENT_NAME} _label="Color Picker"></${COMPONENT_NAME}>`);
 		const colorInput = selectColorInput(page);

--- a/packages/components/src/components/input-date/input-date.e2e.ts
+++ b/packages/components/src/components/input-date/input-date.e2e.ts
@@ -48,7 +48,14 @@ test.describe('kol-input-date', () => {
 				element._value = value;
 			}, TEST_VALUE_DATE);
 		};
-		testInputCallbacksAndEvents('kol-input-date', TEST_VALUE_DATE, fillAction, ['click', 'focus', 'blur'], undefined, undefined, 'toEqual'); // emitted events are tested independently of type
+		testInputCallbacksAndEvents<HTMLKolInputDateElement>({
+			componentName: 'kol-input-date',
+			expectedValue: TEST_VALUE_DATE,
+			fillAction,
+			omittedEvents: ['click', 'focus', 'blur'],
+			testValue: TEST_VALUE_DATE,
+			equalityCheck: 'toEqual',
+		}); // emitted events are tested independently of type
 	});
 
 	test.describe('when value is String', () => {
@@ -72,7 +79,11 @@ test.describe('kol-input-date', () => {
 			await expect(page.locator('input')).toHaveValue('04:02');
 		});
 
-		testInputCallbacksAndEvents('kol-input-date', TEST_VALUE_STRING, undefined, ['click', 'focus', 'blur']); // emitted events are tested independently of type
+		testInputCallbacksAndEvents<HTMLKolInputDateElement>({
+			componentName: 'kol-input-date',
+			omittedEvents: ['click', 'focus', 'blur'],
+			testValue: TEST_VALUE_STRING,
+		}); // emitted events are tested independently of type
 	});
 
 	test.describe('Value reflection', () => {
@@ -295,5 +306,9 @@ test.describe('kol-input-date', () => {
 		});
 	});
 
-	testInputCallbacksAndEvents('kol-input-date', TEST_VALUE_STRING, undefined, ['input', 'change']); // emitted events are tested specifically for value type
+	testInputCallbacksAndEvents<HTMLKolInputDateElement>({
+		componentName: 'kol-input-date',
+		omittedEvents: ['input', 'change'],
+		testValue: TEST_VALUE_STRING,
+	}); // emitted events are tested specifically for value type
 });

--- a/packages/components/src/components/input-email/input-email.e2e.ts
+++ b/packages/components/src/components/input-email/input-email.e2e.ts
@@ -5,6 +5,11 @@ const COMPONENT_NAME = 'kol-input-email';
 const TEST_VALUE = 'example@example.com';
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolInputEmailElement>(COMPONENT_NAME, TEST_VALUE);
-	testInputCallbacksAndEvents<HTMLKolInputEmailElement>(COMPONENT_NAME);
+	testInputValueReflection<HTMLKolInputEmailElement>({
+		componentName: COMPONENT_NAME,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolInputEmailElement>({
+		componentName: COMPONENT_NAME,
+	});
 });

--- a/packages/components/src/components/input-file/input-file.e2e.ts
+++ b/packages/components/src/components/input-file/input-file.e2e.ts
@@ -16,7 +16,12 @@ const fillAction: FillAction = async (page) => {
 };
 
 test.describe(COMPONENT_NAME, () => {
-	testInputCallbacksAndEvents<HTMLKolInputFileElement>(COMPONENT_NAME, TEST_VALUE, fillAction, ['input', 'change']);
+	testInputCallbacksAndEvents<HTMLKolInputFileElement>({
+		componentName: COMPONENT_NAME,
+		fillAction,
+		omittedEvents: ['input', 'change'],
+		testValue: TEST_VALUE,
+	});
 
 	test.describe('Callbacks', () => {
 		[Callback.onInput, Callback.onChange].forEach((callbackName) => {

--- a/packages/components/src/components/input-number/input-number.e2e.ts
+++ b/packages/components/src/components/input-number/input-number.e2e.ts
@@ -65,8 +65,16 @@ const fillAndTest = async (page: E2EPage, input: string, expectedValue: unknown)
 };
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolInputNumberElement>(COMPONENT_NAME, Number(TEST_VALUE), fillAction);
-	testInputCallbacksAndEvents<HTMLKolInputNumberElement>(COMPONENT_NAME, TEST_VALUE, undefined, undefined, undefined, undefined, undefined, Number(TEST_VALUE));
+	testInputValueReflection<HTMLKolInputNumberElement>({
+		componentName: COMPONENT_NAME,
+		fillAction,
+		testValue: Number(TEST_VALUE),
+	});
+	testInputCallbacksAndEvents<HTMLKolInputNumberElement>({
+		componentName: COMPONENT_NAME,
+		expectedValue: Number(TEST_VALUE),
+		testValue: TEST_VALUE,
+	});
 
 	test.describe('type handling', () => {
 		// Test cases for different initial values

--- a/packages/components/src/components/input-password/input-password.e2e.ts
+++ b/packages/components/src/components/input-password/input-password.e2e.ts
@@ -6,8 +6,13 @@ const COMPONENT_NAME = 'kol-input-password';
 const TEST_VALUE = 'Hunter2';
 
 test.describe('kol-input-password', () => {
-	testInputValueReflection<HTMLKolInputPasswordElement>(COMPONENT_NAME, TEST_VALUE);
-	testInputCallbacksAndEvents<HTMLKolInputPasswordElement>(COMPONENT_NAME);
+	testInputValueReflection<HTMLKolInputPasswordElement>({
+		componentName: COMPONENT_NAME,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolInputPasswordElement>({
+		componentName: COMPONENT_NAME,
+	});
 
 	test.describe('Password Visibility Toggle', () => {
 		test('should toggle the password visibility when button is clicked', async ({ page }) => {

--- a/packages/components/src/components/input-radio/input-radio.e2e.ts
+++ b/packages/components/src/components/input-radio/input-radio.e2e.ts
@@ -18,8 +18,20 @@ const fillAction: FillAction = async (page) => {
 const selectInput = (page: Page & E2EPage) => page.locator('input').first();
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolInputNumberElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OPTIONS_ATTRIBUTE);
-	testInputCallbacksAndEvents<HTMLKolInputNumberElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OMITTED_EVENTS, OPTIONS_ATTRIBUTE, selectInput);
+	testInputValueReflection<HTMLKolInputNumberElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		fillAction,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolInputNumberElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		fillAction,
+		omittedEvents: OMITTED_EVENTS,
+		selectInput,
+		testValue: TEST_VALUE,
+	});
 
 	test.describe('value to option matching', () => {
 		const OBJECT_FIRST = { id: 1, text: 'first' };

--- a/packages/components/src/components/input-range/input-range.e2e.ts
+++ b/packages/components/src/components/input-range/input-range.e2e.ts
@@ -13,15 +13,17 @@ const fillAction: FillAction = async (page) => {
 const selectInput = (page: Page & E2EPage) => page.locator('input[type=number]');
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolInputRangeElement>(COMPONENT_NAME, Number(TEST_VALUE), fillAction);
-	testInputCallbacksAndEvents<HTMLKolInputRangeElement>(
-		COMPONENT_NAME,
-		TEST_VALUE,
+	testInputValueReflection<HTMLKolInputRangeElement>({
+		componentName: COMPONENT_NAME,
 		fillAction,
-		['change'],
-		undefined,
+		testValue: Number(TEST_VALUE),
+	});
+	testInputCallbacksAndEvents<HTMLKolInputRangeElement>({
+		componentName: COMPONENT_NAME,
+		fillAction,
+		omittedEvents: ['change'],
 		selectInput,
-		undefined,
-		Number(TEST_VALUE),
-	);
+		expectedValue: Number(TEST_VALUE),
+		testValue: TEST_VALUE,
+	});
 });

--- a/packages/components/src/components/input-text/input-text.e2e.ts
+++ b/packages/components/src/components/input-text/input-text.e2e.ts
@@ -21,6 +21,11 @@ test.describe('kol-input-text', () => {
 		});
 	});
 
-	testInputValueReflection<HTMLKolInputTextElement>(COMPONENT_NAME, TEST_VALUE);
-	testInputCallbacksAndEvents<HTMLKolInputTextElement>(COMPONENT_NAME);
+	testInputValueReflection<HTMLKolInputTextElement>({
+		componentName: COMPONENT_NAME,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolInputTextElement>({
+		componentName: COMPONENT_NAME,
+	});
 });

--- a/packages/components/src/components/select/select.e2e.ts
+++ b/packages/components/src/components/select/select.e2e.ts
@@ -20,6 +20,19 @@ const fillAction: FillAction = async (page) => {
 const selectInput = (page: Page & E2EPage) => page.locator('select');
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolSelectElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OPTIONS_ATTRIBUTE, 'toEqual');
-	testInputCallbacksAndEvents<HTMLKolSelectElement>(COMPONENT_NAME, TEST_VALUE, fillAction, undefined, OPTIONS_ATTRIBUTE, selectInput, 'toEqual');
+	testInputValueReflection<HTMLKolSelectElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		equalityCheck: 'toEqual',
+		fillAction,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolSelectElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		fillAction,
+		selectInput,
+		testValue: TEST_VALUE,
+		equalityCheck: 'toEqual',
+	});
 });

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -19,8 +19,18 @@ const fillAction: FillAction = async (page) => {
 };
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolSingleSelectElement>(COMPONENT_NAME, TEST_VALUE, fillAction, OPTIONS_ATTRIBUTE);
-	testInputCallbacksAndEvents<HTMLKolSingleSelectElement>(COMPONENT_NAME, TEST_VALUE, fillAction, undefined, OPTIONS_ATTRIBUTE);
+	testInputValueReflection<HTMLKolSingleSelectElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		fillAction,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolSingleSelectElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		fillAction,
+		testValue: TEST_VALUE,
+	});
 
 	test.describe('kol-single-select additional interactions', () => {
 		test('should open listbox on button click and close on ESC', async ({ page }) => {

--- a/packages/components/src/components/textarea/textarea.e2e.ts
+++ b/packages/components/src/components/textarea/textarea.e2e.ts
@@ -5,6 +5,11 @@ const COMPONENT_NAME = 'kol-textarea';
 const TEST_VALUE = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
 
 test.describe(COMPONENT_NAME, () => {
-	testInputValueReflection<HTMLKolTextareaElement>(COMPONENT_NAME, TEST_VALUE);
-	testInputCallbacksAndEvents<HTMLKolTextareaElement>(COMPONENT_NAME);
+	testInputValueReflection<HTMLKolTextareaElement>({
+		componentName: COMPONENT_NAME,
+		testValue: TEST_VALUE,
+	});
+	testInputCallbacksAndEvents<HTMLKolTextareaElement>({
+		componentName: COMPONENT_NAME,
+	});
 });

--- a/packages/components/src/e2e/input-callbacks-and-events.ts
+++ b/packages/components/src/e2e/input-callbacks-and-events.ts
@@ -7,17 +7,28 @@ import { INPUTS_SELECTOR } from './utils/inputsSelector';
 import { Callback } from '../schema/enums';
 import { KolEvent } from '../utils/events';
 
+type TestInputCallbacksAndEventsOptions = {
+	additionalProperties?: string;
+	componentName: string;
+	equalityCheck?: 'toBe' | 'toEqual';
+	expectedValue?: unknown;
+	fillAction?: FillAction;
+	omittedEvents?: string[];
+	selectInput?: (page: Page & E2EPage) => Locator;
+	testValue?: unknown;
+};
+
 /* @todo needs refactoring (https://github.com/public-ui/kolibri/issues/7791) */
-const testInputCallbacksAndEvents = <ElementType extends { _on?: InputTypeOnDefault } & (HTMLElement | SVGElement)>(
-	componentName: string,
-	testValue: unknown = 'Test Input',
-	fillAction?: FillAction,
-	omittedEvents: string[] = [],
-	additionalProperties: string = '',
-	selectInput?: (page: Page & E2EPage) => Locator,
-	equalityCheck: 'toBe' | 'toEqual' = 'toBe',
-	expectedValue?: unknown,
-) => {
+const testInputCallbacksAndEvents = <ElementType extends { _on?: InputTypeOnDefault } & (HTMLElement | SVGElement)>({
+	additionalProperties = '',
+	componentName,
+	equalityCheck = 'toBe',
+	expectedValue,
+	fillAction,
+	omittedEvents = [],
+	selectInput,
+	testValue = 'Test Input',
+}: TestInputCallbacksAndEventsOptions) => {
 	test.describe('Callbacks and DOM events', () => {
 		const EVENTS: [string, Callback, KolEvent, unknown?, unknown?][] = [
 			['click', Callback.onClick, KolEvent.click],

--- a/packages/components/src/e2e/input-value-reflection.ts
+++ b/packages/components/src/e2e/input-value-reflection.ts
@@ -3,13 +3,21 @@ import { expect } from '@playwright/test';
 import type { FillAction } from './utils/FillAction';
 import { INPUTS_SELECTOR } from './utils/inputsSelector';
 
-const testInputValueReflection = <ElementType extends { _value?: unknown } & (HTMLElement | SVGElement)>(
-	componentName: string,
-	testValue?: unknown,
-	fillAction?: FillAction,
-	additionalProperties: string = '',
-	equalityCheck: 'toBe' | 'toEqual' = 'toBe',
-) => {
+type TestInputValueReflectionOptions = {
+	additionalProperties?: string;
+	componentName: string;
+	equalityCheck?: 'toBe' | 'toEqual';
+	fillAction?: FillAction;
+	testValue?: unknown;
+};
+
+const testInputValueReflection = <ElementType extends { _value?: unknown } & (HTMLElement | SVGElement)>({
+	additionalProperties = '',
+	componentName,
+	equalityCheck = 'toBe',
+	fillAction,
+	testValue,
+}: TestInputValueReflectionOptions) => {
 	test(`should reflect the _value property on the web component`, async ({ page }) => {
 		await page.setContent(`<${componentName} _label="Input" ${additionalProperties}></${componentName}>`);
 		if (fillAction) {


### PR DESCRIPTION
## What changed?

This change refactors the shared E2E test helpers `testInputCallbacksAndEvents` (`packages/components/src/e2e/input-callbacks-and-events.ts`) and `testInputValueReflection` (`packages/components/src/e2e/input-value-reflection.ts`) to accept a single typed options object (`TestInputCallbacksAndEventsOptions` / `TestInputValueReflectionOptions`) instead of a long list of positional parameters. All 14 input/select component E2E test files (combobox, input-checkbox, input-color, input-date, input-email, input-file, input-number, input-password, input-radio, input-range, input-text, select, single-select, textarea) are updated to call these helpers with named options. This is a test-code-only refactor that improves readability and removes error-prone `undefined` positional placeholders; it does not touch any shipped component source or public API.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung refaktoriert die gemeinsam genutzten E2E-Test-Helfer `testInputCallbacksAndEvents` (`packages/components/src/e2e/input-callbacks-and-events.ts`) und `testInputValueReflection` (`packages/components/src/e2e/input-value-reflection.ts`), sodass sie statt einer langen Liste positioneller Parameter ein einzelnes typisiertes Optionsobjekt (`TestInputCallbacksAndEventsOptions` / `TestInputValueReflectionOptions`) entgegennehmen. Alle 14 E2E-Testdateien der Input-/Select-Komponenten (combobox, input-checkbox, input-color, input-date, input-email, input-file, input-number, input-password, input-radio, input-range, input-text, select, single-select, textarea) werden auf den Aufruf mit benannten Optionen umgestellt. Es handelt sich um einen reinen Testcode-Refactor, der die Lesbarkeit verbessert und fehleranfällige positionelle `undefined`-Platzhalter beseitigt; kein ausgelieferter Komponenten-Quellcode und keine öffentliche API sind betroffen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern (Test-Refactoring)

### Geänderte Dateien

- `packages/components/src/e2e/input-callbacks-and-events.ts` — Helfer auf Optionsobjekt umgestellt (neuer Typ `TestInputCallbacksAndEventsOptions`).
- `packages/components/src/e2e/input-value-reflection.ts` — Helfer auf Optionsobjekt umgestellt (neuer Typ `TestInputValueReflectionOptions`).
- `packages/components/src/components/**/**.e2e.ts` (14 Dateien) — Aufrufe auf benannte Optionen aktualisiert.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
