### PR TITLE
feat(spin): improve accessible labeling

### DIFF
--- a/packages/components/src/components/spin/shadow.tsx
+++ b/packages/components/src/components/spin/shadow.tsx
@@ -1,10 +1,10 @@
 import type { JSX } from '@stencil/core';
-import { validateShow, validateSpinVariant } from '../../schema';
+import { validateLabel, validateShow, validateSpinVariant } from '../../schema';
 import { Component, Fragment, h, Host, Prop, State, Watch } from '@stencil/core';
 
 import { translate } from '../../i18n';
 
-import type { ShowPropType, SpinAPI, SpinStates, SpinVariantPropType } from '../../schema';
+import type { LabelPropType, ShowPropType, SpinAPI, SpinStates, SpinVariantPropType } from '../../schema';
 import clsx from 'clsx';
 function renderSpin(variant: SpinVariantPropType): JSX.Element {
 	switch (variant) {
@@ -36,17 +36,24 @@ export class KolSpin implements SpinAPI {
 
 	public render(): JSX.Element {
 		return (
-			<Host class="kol-spin">
+			<Host class="kol-spin" aria-live={this.state._label ? 'polite' : undefined}>
 				{this.state._show ? (
-					<span
-						aria-busy="true"
-						aria-label={translate('kol-action-running')}
-						aria-live="polite"
-						class={clsx('kol-spin__spinner', `kol-spin__spinner--${this.state._variant}`)}
-						role="alert"
-					>
-						{renderSpin(this.state._variant)}
-					</span>
+					<>
+						{this.state._label && (
+							<span aria-hidden="true" class="kol-spin__label">
+								{this.state._label}
+							</span>
+						)}
+						<span
+							aria-busy="true"
+							aria-label={this.state._label ?? translate('kol-action-running')}
+							aria-live="polite"
+							class={clsx('kol-spin__spinner', `kol-spin__spinner--${this.state._variant}`)}
+							role="alert"
+						>
+							{renderSpin(this.state._variant)}
+						</span>
+					</>
 				) : (
 					this.showToggled && <span aria-label={translate('kol-action-done')} aria-busy="false" aria-live="polite" role="alert"></span>
 				)}
@@ -65,6 +72,11 @@ export class KolSpin implements SpinAPI {
 	 */
 	@Prop() public _variant?: SpinVariantPropType = 'dot';
 
+	/**
+	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.).
+	 */
+	@Prop() public _label?: LabelPropType;
+
 	@State() public state: SpinStates = {
 		_variant: 'dot',
 	};
@@ -80,8 +92,14 @@ export class KolSpin implements SpinAPI {
 		validateSpinVariant(this, value);
 	}
 
+	@Watch('_label')
+	public validateLabel(value?: LabelPropType): void {
+		validateLabel(this, value);
+	}
+
 	public componentWillLoad(): void {
 		this.validateShow(this._show);
 		this.validateVariant(this._variant);
+		this.validateLabel(this._label);
 	}
 }

--- a/packages/components/src/components/spin/style.scss
+++ b/packages/components/src/components/spin/style.scss
@@ -7,9 +7,12 @@
 	.kol-spin {
 		font-size: rem(16);
 
+		&__label {
+			display: block;
+		}
+
 		&__spinner {
 			display: block;
-			padding: rem(2);
 			position: relative;
 		}
 	}

--- a/packages/components/src/components/spin/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/spin/test/__snapshots__/snapshot.spec.tsx.snap
@@ -6,6 +6,22 @@ exports[`kol-spin should render with _show=false 1`] = `
 </kol-spin>
 `;
 
+exports[`kol-spin should render with _show=true _label="Loading" 1`] = `
+<kol-spin _show="" aria-live="polite" class="kol-spin">
+  <template shadowrootmode="open">
+    <span aria-hidden="true" class="kol-spin__label">
+      Loading
+    </span>
+    <span aria-busy="true" aria-label="Loading" aria-live="polite" class="kol-spin__spinner kol-spin__spinner--dot" role="alert">
+      <span class="kol-spin__spinner-element kol-spin__spinner-element--1"></span>
+      <span class="kol-spin__spinner-element kol-spin__spinner-element--2"></span>
+      <span class="kol-spin__spinner-element kol-spin__spinner-element--3"></span>
+      <span class="kol-spin__spinner-element kol-spin__spinner-element--neutral"></span>
+    </span>
+  </template>
+</kol-spin>
+`;
+
 exports[`kol-spin should render with _show=true 1`] = `
 <kol-spin _show="" class="kol-spin">
   <template shadowrootmode="open">

--- a/packages/components/src/components/spin/test/snapshot.spec.tsx
+++ b/packages/components/src/components/spin/test/snapshot.spec.tsx
@@ -4,4 +4,4 @@ import { executeSnapshotTests } from '../../../utils/testing';
 
 import { KolSpin } from '../shadow';
 
-executeSnapshotTests<SpinProps>(KolSpinTag, [KolSpin], [{ _show: false }, { _show: true }]);
+executeSnapshotTests<SpinProps>(KolSpinTag, [KolSpin], [{ _show: false }, { _show: true }, { _show: true, _label: 'Loading' }]);

--- a/packages/components/src/schema/components/spin.ts
+++ b/packages/components/src/schema/components/spin.ts
@@ -1,12 +1,12 @@
 import type { Generic } from 'adopted-style-sheets';
 
-import type { PropShow, PropSpinVariant } from '../props';
+import type { PropLabel, PropShow, PropSpinVariant } from '../props';
 
 type RequiredProps = NonNullable<unknown>;
-type OptionalProps = PropSpinVariant & PropShow;
+type OptionalProps = PropSpinVariant & PropShow & PropLabel;
 
 type RequiredStates = PropSpinVariant;
-type OptionalStates = PropShow;
+type OptionalStates = PropShow & PropLabel;
 
 export type SpinProps = Generic.Element.Members<RequiredProps, OptionalProps>;
 export type SpinStates = Generic.Element.Members<RequiredStates, OptionalStates>;

--- a/packages/samples/react/src/components/spin/label.tsx
+++ b/packages/samples/react/src/components/spin/label.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { KolSpin } from '@public-ui/react';
+
+import type { FC } from 'react';
+import { SampleDescription } from '../SampleDescription';
+
+export const SpinLabel: FC = () => (
+	<>
+		<SampleDescription>
+			<p>This sample shows KolSpin with an accessible label.</p>
+		</SampleDescription>
+
+		<KolSpin _show _label="Loading" />
+	</>
+);

--- a/packages/samples/react/src/components/spin/routes.ts
+++ b/packages/samples/react/src/components/spin/routes.ts
@@ -2,11 +2,13 @@ import { Routes } from '../../shares/types';
 import { SpinBasic } from './basic';
 import { SpinCustom } from './custom';
 import { SpinCycle } from './cycle';
+import { SpinLabel } from './label';
 
 export const SPIN_ROUTES: Routes = {
 	spin: {
 		basic: SpinBasic,
 		cycle: SpinCycle,
 		custom: SpinCustom,
+		label: SpinLabel,
 	},
 };

--- a/packages/themes/default/src/components/spin.scss
+++ b/packages/themes/default/src/components/spin.scss
@@ -1,0 +1,15 @@
+@use '../mixins/rem' as *;
+
+@layer kol-theme-component {
+	.kol-spin {
+		margin: rem(4) 0;
+
+		&__spinner {
+			padding: rem(2);
+		}
+
+		&__label {
+			margin-bottom: rem(4);
+		}
+	}
+}

--- a/packages/themes/default/src/index.ts
+++ b/packages/themes/default/src/index.ts
@@ -44,6 +44,7 @@ import toastContainerCss from './components/toast-container.scss';
 import toolbarCss from './components/toolbar.scss';
 import treeItemCss from './components/tree-item.scss';
 import treeCss from './components/tree.scss';
+import spinCss from './components/spin.scss';
 
 export const DEFAULT = KoliBri.createTheme('default', {
 	GLOBAL: globalCss,
@@ -82,6 +83,7 @@ export const DEFAULT = KoliBri.createTheme('default', {
 	'KOL-SELECT': selectCss,
 	'KOL-SINGLE-SELECT': singleSelect,
 	'KOL-SKIP-NAV': skipNavCss,
+	'KOL-SPIN': spinCss,
 	'KOL-SPLIT-BUTTON': splitButtonCss,
 	'KOL-TABLE-STATEFUL': tableStatefulCss,
 	'KOL-TABLE-STATELESS': tableStatelessCss,


### PR DESCRIPTION
## Summary
- render label span as aria-hidden
- use `_label` as aria-label for spinner
- update snapshots

------

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [x] Meaningful pull request title for the release notes
- [x] Pull request is linked to an issue and all changes relate to the issue
- [x] Tests to protect this code implemented (if applicable)
- [x] Manual test performed successfully (if applicable)
- [x] Documentation or migration has been updated (if applicable)
