### PR TITLE
fix(select): remove aria-hidden from disabled options

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -4,7 +4,7 @@
 
 ## select
 
-- Disabled options in KolSelect affect the total count in screen readers When an option in `KolSelect` is set to `disabled: true`, it is still counted by screen readers. This leads to incorrect numbering, for example, NVDA announces "2 of 4" instead of "2 of 3". To ensure the correct order, the `aria-hidden="true"` attribute should be set for `disabled` options. This will hide the disabled option from screen readers and keep the total number of items consistent.
+- Disabled options in KolSelect affect the total count in some screen readers. When an option is set to `disabled: true`, it may still be included in the overall option count announced by assistive technology. Using `aria-hidden="true"` on `<option>` is not conforming with WAI‑ARIA and causes browser warnings, therefore it has been removed. As a result, screen readers might announce a higher number of available options than can actually be selected.
 
 [🐞 GitHub issue #7453](https://github.com/public-ui/kolibri/pull/7453)
 

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -18,7 +18,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select accesskey="V" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -54,7 +54,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -90,7 +90,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--disabled" disabled="" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -126,7 +126,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -168,7 +168,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -210,7 +210,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -248,7 +248,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -287,7 +287,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -323,7 +323,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -360,7 +360,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select accesskey="V" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -396,7 +396,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -432,7 +432,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--disabled" disabled="" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -468,7 +468,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -510,7 +510,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -552,7 +552,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -590,7 +590,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -629,7 +629,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -665,7 +665,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -701,7 +701,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -738,7 +738,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -774,7 +774,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--touched" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -810,7 +810,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" multiple="" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled" disabled="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -846,7 +846,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -883,7 +883,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -919,7 +919,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select kol-select--touched" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">
@@ -955,7 +955,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
             <form>
               <input hidden="" type="submit">
               <select autocapitalize="off" autocorrect="off" class="kol-select" id="id-nonce" name="field">
-                <option aria-hidden="true" class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
+                <option class="kol-select__option kol-select__option--disabled kol-select__option--selected" disabled="" selected="" value="-0">
                   Frau
                 </option>
                 <option class="kol-select__option" value="-1">

--- a/packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx
+++ b/packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx
@@ -41,6 +41,10 @@ const NativeOptionFc: FC<NativeOptionProps> = ({
 				classNames,
 			)}
 			selected={isSelected}
+			// removed the aria-hidden attribute because the browser caused errors and ignores it
+			// see also:
+			// - https://github.com/public-ui/kolibri/issues/7755
+			// - https://github.com/public-ui/public-ui.github.io/issues/336
 			disabled={disabled}
 			value={index}
 			{...other}

--- a/packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx
+++ b/packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx
@@ -42,7 +42,6 @@ const NativeOptionFc: FC<NativeOptionProps> = ({
 			)}
 			selected={isSelected}
 			disabled={disabled}
-			aria-hidden={disabled ? 'true' : undefined} //See Known Issue: https://github.com/public-ui/kolibri/blob/develop/KNOWN_ISSUES.md
 			value={index}
 			{...other}
 		>


### PR DESCRIPTION
## What changed?

This change removes the invalid `aria-hidden={disabled ? 'true' : undefined}` attribute from the native `<option>` rendered by the `NativeOption` functional component (`packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx`), which backs disabled options in `KolSelect`. `aria-hidden` is not conforming on `<option>` elements — browsers ignore it and log warnings — so it is dropped, with a comment linking the related issues. The `KNOWN_ISSUES.md` entry for `select` is updated to explain that `aria-hidden` was removed for WAI-ARIA conformance (with the trade-off that some screen readers may still count disabled options), and the `select` Jest snapshots are regenerated to reflect the removed attribute. This targets the `develop` branch. No public API changes; only the rendered markup of disabled options changes.

## Linked issues

- Refs #7755 — invalid `aria-hidden` on disabled select options caused browser warnings.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung entfernt das ungültige Attribut `aria-hidden={disabled ? 'true' : undefined}` von dem nativen `<option>`, das von der Funktionskomponente `NativeOption` (`packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx`) gerendert wird und deaktivierten Optionen in `KolSelect` zugrunde liegt. `aria-hidden` ist auf `<option>`-Elementen nicht konform — Browser ignorieren es und geben Warnungen aus — daher wird es mit einem Kommentar zu den zugehörigen Issues entfernt. Der `KNOWN_ISSUES.md`-Eintrag für `select` wird aktualisiert und erklärt, dass `aria-hidden` aus Gründen der WAI-ARIA-Konformität entfernt wurde (mit dem Nachteil, dass einige Screenreader deaktivierte Optionen weiterhin mitzählen können); die `select`-Jest-Snapshots werden neu generiert. Die Änderung zielt auf den `develop`-Branch. Keine Änderung an der öffentlichen API; nur das gerenderte Markup deaktivierter Optionen ändert sich.

### Verknüpfte Tickets

- Referenziert #7755 — ungültiges `aria-hidden` auf deaktivierten Select-Optionen verursachte Browser-Warnungen.

### Art der Änderung

🐛 Fehlerbehebung (Barrierefreiheit)

### Geänderte Dateien

- `packages/components/src/functional-components/inputs/NativeOption/NativeOption.tsx` — ungültiges `aria-hidden` von deaktivierten Optionen entfernt.
- `KNOWN_ISSUES.md` — `select`-Eintrag zur WAI-ARIA-Konformität aktualisiert.
- `packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshots an das geänderte Markup angepasst.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
