### PR TITLE
fix(select): remove invalid aria-hidden from disabled options

### DIFF
--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -190,6 +190,10 @@ export class KolSelect implements SelectAPI, FocusableElement {
 									} else {
 										return (
 											<option
+												// removed the aria-hidden attribute because the browser caused errors and ignores it
+												// see also:
+												// - https://github.com/public-ui/kolibri/issues/7755
+												// - https://github.com/public-ui/public-ui.github.io/issues/336
 												disabled={option.disabled}
 												key={key}
 												// label={option.label}

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -191,7 +191,6 @@ export class KolSelect implements SelectAPI, FocusableElement {
 										return (
 											<option
 												disabled={option.disabled}
-												aria-hidden={option.disabled ? 'true' : undefined}
 												key={key}
 												// label={option.label}
 												selected={isSelected(this.state._value, (option as unknown as Option<W3CInputValue>).value)}

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _accessKey="V" 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _accessKey="V" 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _accesskey="V" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -14,7 +16,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select accesskey="V" autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -31,7 +33,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _alert=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _alert=true 1`
+] = `
 <kol-select _alert="" _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _alert="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -44,7 +48,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -61,7 +65,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _disabled=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _disabled=true 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _disabled="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -74,7 +80,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" disabled="" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -91,7 +97,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hint="Hint" 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hint="Hint" 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="Hint" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -104,7 +112,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -121,7 +129,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -134,7 +144,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -151,7 +161,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -164,7 +176,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -181,7 +193,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -194,7 +208,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -211,7 +225,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideError=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideError=true 1`
+] = `
 <kol-select _hide-error="" _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hideerror="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -224,7 +240,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -241,7 +257,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -254,7 +272,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -271,7 +289,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _accessKey="V" 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _accessKey="V" 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _accesskey="V" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -285,7 +305,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select accesskey="V" autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -302,7 +322,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _alert=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _alert=true 1`
+] = `
 <kol-select _alert="" _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _alert="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -315,7 +337,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -332,7 +354,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _disabled=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _disabled=true 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _disabled="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -345,7 +369,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" disabled="" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -362,7 +386,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _hint="Hint" 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _hint="Hint" 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="Hint" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -375,7 +401,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -392,7 +418,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -405,7 +433,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -422,7 +450,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -435,7 +465,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -452,7 +482,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -465,7 +497,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -482,7 +514,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideError=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideError=true 1`
+] = `
 <kol-select _hide-error="" _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hideerror="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -495,7 +529,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -512,7 +546,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -525,7 +561,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -542,7 +578,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _readOnly=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _readOnly=true 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _readonly="" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -555,7 +593,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -572,7 +610,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _shortKey="S" 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _shortKey="S" 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _shortkey="S" _tooltipalign="top" class="select" role="presentation">
@@ -586,7 +626,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -603,7 +643,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _touched=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _touched=true 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _alert="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" _touched="" class="select" role="presentation">
@@ -616,7 +658,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -633,7 +675,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -646,7 +690,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" multiple="" name="field">
-            <option aria-hidden="true" disabled="" value="-0">
+            <option disabled="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -663,7 +707,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _readOnly=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _readOnly=true 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _readonly="" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -676,7 +722,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -693,7 +739,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _shortKey="S" 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _shortKey="S" 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _shortkey="S" _tooltipalign="top" class="select" role="presentation">
@@ -707,7 +755,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -724,7 +772,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _touched=true 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _touched=true 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _alert="" _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" _touched="" class="select" role="presentation">
@@ -737,7 +787,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">
@@ -754,7 +804,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
-exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] 1`] = `
+exports[
+	`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] 1`
+] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="has-value kol-select">
   <template shadowrootmode="open">
     <kol-input _hint="" _id="id-nonce" _label="Label" _tooltipalign="top" class="select" role="presentation">
@@ -767,7 +819,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
         <form>
           <input hidden="" type="submit">
           <select autocapitalize="off" autocorrect="off" id="id-nonce" name="field">
-            <option aria-hidden="true" disabled="" selected="" value="-0">
+            <option disabled="" selected="" value="-0">
               Frau
             </option>
             <option value="-1">


### PR DESCRIPTION
## What changed?

This change removes the invalid `aria-hidden={option.disabled ? 'true' : undefined}` attribute from disabled `<option>` elements rendered by `KolSelect` in `packages/components/src/components/select/shadow.tsx`. `aria-hidden` is not valid on native `<option>` elements — browsers ignore it and emit console errors — so it is dropped and replaced with an explanatory comment linking the related issues. The `select` component's Jest snapshots (`select/test/__snapshots__/snapshot.spec.tsx.snap`) are regenerated to reflect the removed attribute. This targets the `release/2` branch. No public API changes; only the rendered markup of disabled options changes.

## Linked issues

- Refs #7755 — invalid `aria-hidden` on disabled select options caused browser console errors.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung entfernt das ungültige Attribut `aria-hidden={option.disabled ? 'true' : undefined}` von deaktivierten `<option>`-Elementen, die von `KolSelect` in `packages/components/src/components/select/shadow.tsx` gerendert werden. `aria-hidden` ist auf nativen `<option>`-Elementen nicht gültig — Browser ignorieren es und geben Konsolenfehler aus — daher wird es entfernt und durch einen erläuternden Kommentar mit Verweis auf die zugehörigen Issues ersetzt. Die Jest-Snapshots der `select`-Komponente (`select/test/__snapshots__/snapshot.spec.tsx.snap`) werden neu generiert, um das entfernte Attribut widerzuspiegeln. Die Änderung zielt auf den `release/2`-Branch. Keine Änderung an der öffentlichen API; nur das gerenderte Markup deaktivierter Optionen ändert sich.

### Verknüpfte Tickets

- Referenziert #7755 — ungültiges `aria-hidden` auf deaktivierten Select-Optionen verursachte Konsolenfehler im Browser.

### Art der Änderung

🐛 Fehlerbehebung (Barrierefreiheit)

### Geänderte Dateien

- `packages/components/src/components/select/shadow.tsx` — ungültiges `aria-hidden` von deaktivierten Optionen entfernt.
- `packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshots an das geänderte Markup angepasst.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
