### PR TITLE
style: remove redundant font-size inheritance from buttons in bwst and itzbund themes

### DIFF
--- a/packages/themes/bwst/src/components/button-link.scss
+++ b/packages/themes/bwst/src/components/button-link.scss
@@ -6,7 +6,6 @@
 		font-style: normal;
 		font-weight: 400;
 		text-decoration-line: underline;
-		font-size: inherit;
 	}
 
 	:is(a, button):focus {

--- a/packages/themes/itzbund/src/mixins/typography.scss
+++ b/packages/themes/itzbund/src/mixins/typography.scss
@@ -53,7 +53,6 @@
 	font-weight: 700;
 
 	button {
-		font-size: inherit;
 		line-height: 1.75;
 	}
 }


### PR DESCRIPTION
## What changed?

This change removes two now-redundant `font-size: inherit` declarations on `button` elements in the theme layer: one from `packages/themes/bwst/src/components/button-link.scss` and one from the `button` block of `packages/themes/itzbund/src/mixins/typography.scss`. Since font-size inheritance is now handled centrally in the base/global layer, these per-theme declarations are superfluous and are dropped. No public API changes and no intended visual change for consumers of these themes.

## Linked issues

- Refs #7476 — cleanup of redundant font-size handling in the theme layer.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung entfernt zwei nun redundante `font-size: inherit`-Deklarationen auf `button`-Elementen in der Theme-Ebene: eine aus `packages/themes/bwst/src/components/button-link.scss` und eine aus dem `button`-Block von `packages/themes/itzbund/src/mixins/typography.scss`. Da die Schriftgrößen-Vererbung jetzt zentral in der Basis-/Global-Ebene geregelt wird, sind diese Deklarationen je Theme überflüssig und entfallen. Keine Änderung an der öffentlichen API und keine beabsichtigte visuelle Änderung für Konsumenten dieser Themes.

### Verknüpfte Tickets

- Referenziert #7476 — Bereinigung redundanter Schriftgrößen-Behandlung in der Theme-Ebene.

### Art der Änderung

🔧 Intern (Theme-Bereinigung)

### Geänderte Dateien

- `packages/themes/bwst/src/components/button-link.scss` — redundantes `font-size: inherit` auf `button` entfernt.
- `packages/themes/itzbund/src/mixins/typography.scss` — redundantes `font-size: inherit` im `button`-Block entfernt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
