### PR TITLE
refactor: enforce eqeqeq eslint rule across the repository

### DIFF
--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -75,6 +75,7 @@ const config = {
 		'react/jsx-no-bind': 'off',
 
 		'no-console': 'error',
+		eqeqeq: 'error',
 	},
 	settings: {
 		react: {

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -376,7 +376,7 @@ export class KolCombobox implements ComboboxAPI {
 
 	@Listen('click', { target: 'window' })
 	handleWindowClick(event: MouseEvent) {
-		if (this.host != undefined && !this.host.contains(event.target as Node)) {
+		if (this.host !== undefined && !this.host.contains(event.target as Node)) {
 			this._isOpen = false;
 		}
 	}

--- a/packages/components/src/components/input-date/controller.ts
+++ b/packages/components/src/components/input-date/controller.ts
@@ -131,7 +131,7 @@ export class InputDateController extends InputIconController implements InputDat
 		return watchValidator(
 			this.component,
 			propName,
-			(value): boolean => value === undefined || value == null || value === '' || this.validateDateString(value),
+			(value): boolean => value === undefined || value === null || value === '' || this.validateDateString(value),
 			new Set(['Date', 'string{ISO-8601}']),
 			InputDateController.tryParseToString(value, this.component._type, this.component._step),
 			{

--- a/packages/components/src/components/input-number/controller.ts
+++ b/packages/components/src/components/input-number/controller.ts
@@ -48,7 +48,7 @@ export class InputNumberController extends InputIconController implements InputN
 
 	private readonly validateIso8601 = (propName: string, value?: number | Iso8601 | null, afterPatch?: (v: string) => void) => {
 		const parsedValue = parseFloat(value as string);
-		const valueMatched = parsedValue == value;
+		const valueMatched = parsedValue === value;
 		return watchValidator(
 			this.component,
 			propName,

--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -73,7 +73,7 @@ export class KolNav implements NavAPI {
 	private collapseChildren(children: ButtonOrLinkOrTextWithChildrenProps[]) {
 		this.state = {
 			...this.state,
-			_expandedChildren: this.state._expandedChildren.filter((searchChildren) => searchChildren != children),
+			_expandedChildren: this.state._expandedChildren.filter((searchChildren) => searchChildren !== children),
 		};
 	}
 

--- a/packages/components/src/components/progress/shadow.tsx
+++ b/packages/components/src/components/progress/shadow.tsx
@@ -89,18 +89,18 @@ export class KolProgress implements ProgressAPI {
 				>
 					{this.state._variant === 'bar' && this.state._label && <div class="label">{this.state._label}</div>}
 					{createProgressSVG(this.state)}
-					{this.state._variant == 'cycle' && (
+					{this.state._variant === 'cycle' && (
 						<div class="text">
 							{this.state._label && <div class="label">{this.state._label}</div>}
 							<div class="value">{`${displayValue} ${this.state._unit}`}</div>
 						</div>
 					)}
-					{this.state._variant == 'bar' && (
+					{this.state._variant === 'bar' && (
 						<div class="value" style={{ width: `${`${(isPercentage ? 100 : this.state._max) + 1}`.length}ch` }}>
 							{displayValue}
 						</div>
 					)}
-					{this.state._variant == 'bar' && <div class="unit">{this.state._unit}</div>}
+					{this.state._variant === 'bar' && <div class="unit">{this.state._unit}</div>}
 				</div>
 
 				{/* https://css-tricks.com/html5-progress-element/ */}

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -211,7 +211,7 @@ export class KolTableStateful implements TableAPI {
 
 	private changeCellSort(headerCell: KoliBriTableHeaderCellWithLogic) {
 		if (typeof headerCell.compareFn === 'function') {
-			if (!this.state._allowMultiSort && headerCell.key != this.sortData[0]?.key) {
+			if (!this.state._allowMultiSort && headerCell.key !== this.sortData[0]?.key) {
 				// clear when another column is sorted and multi sort is not allowed
 				this.sortData = [];
 			}

--- a/packages/designer/.eslintrc.js
+++ b/packages/designer/.eslintrc.js
@@ -20,6 +20,9 @@ config.overrides.push({
 config.plugins = config.plugins || [];
 config.plugins.push('jsx-a11y');
 
+config.rules = config.rules || {};
+config.rules.eqeqeq = 'error';
+
 config.overrides[0].rules['@typescript-eslint/no-unsafe-member-access'] = ['warn'];
 
 config.settings = {

--- a/packages/samples/react/.eslintrc.js
+++ b/packages/samples/react/.eslintrc.js
@@ -24,6 +24,9 @@ config.plugins = config.plugins || [];
 config.plugins.push('react');
 config.plugins.push('jsx-a11y');
 
+config.rules = config.rules || {};
+config.rules.eqeqeq = 'error';
+
 config.settings = {
 	react: {
 		version: 'detect',

--- a/packages/samples/react/src/components/drawer/basic.tsx
+++ b/packages/samples/react/src/components/drawer/basic.tsx
@@ -34,7 +34,7 @@ export const DrawerBasic: FC = () => {
 			<DrawerRadioAlign value={align} onChange={(_, value) => setAlign(value as AlignPropType)} />
 			<div className="flex flex-wrap gap-4">
 				<KolDrawer ref={drawerElement} _label="I am a drawer" _align={align} _on={{ onClose: () => console.log('Drawer onClose triggered!') }}>
-					<div className={align === 'left' || align == 'right' ? 'drawer-content-vertical' : ''}>
+					<div className={align === 'left' || align === 'right' ? 'drawer-content-vertical' : ''}>
 						<p>
 							Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
 							voluptua.
@@ -50,7 +50,7 @@ export const DrawerBasic: FC = () => {
 					_label="I am a Drawer Modal"
 					_on={{ onClose: () => console.log('Drawer Modal onClose triggered!') }}
 				>
-					<div className={align === 'left' || align == 'right' ? 'drawer-content-vertical' : ''}>
+					<div className={align === 'left' || align === 'right' ? 'drawer-content-vertical' : ''}>
 						<p>
 							Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
 							voluptua.

--- a/packages/themes/.eslintrc.cjs
+++ b/packages/themes/.eslintrc.cjs
@@ -9,5 +9,6 @@ module.exports = {
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
 	rules: {
 		'@typescript-eslint/no-namespace': 'off',
+		eqeqeq: 'error',
 	},
 };

--- a/packages/themes/bwst/.eslintrc.cjs
+++ b/packages/themes/bwst/.eslintrc.cjs
@@ -9,5 +9,6 @@ module.exports = {
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
 	rules: {
 		'@typescript-eslint/no-namespace': 'off',
+		eqeqeq: 'error',
 	},
 };

--- a/packages/themes/default/.eslintrc.cjs
+++ b/packages/themes/default/.eslintrc.cjs
@@ -9,5 +9,6 @@ module.exports = {
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
 	rules: {
 		'@typescript-eslint/no-namespace': 'off',
+		eqeqeq: 'error',
 	},
 };

--- a/packages/tools/kolibri-cli/.eslintrc.cjs
+++ b/packages/tools/kolibri-cli/.eslintrc.cjs
@@ -24,6 +24,9 @@ module.exports = {
 		// 'jsx-a11y',
 		'react',
 	],
+	rules: {
+		eqeqeq: 'error',
+	},
 	settings: {
 		react: {
 			version: 'detect',

--- a/packages/tools/visual-tests/.eslintrc.cjs
+++ b/packages/tools/visual-tests/.eslintrc.cjs
@@ -15,4 +15,7 @@ module.exports = {
 		},
 		requireConfigFile: false,
 	},
+	rules: {
+		eqeqeq: 'error',
+	},
 };


### PR DESCRIPTION
## What changed?

This change activates the `eqeqeq` ESLint rule in all ESLint configurations across the repository — `packages/components`, `packages/designer`, `packages/samples/react`, `packages/themes` (root, `bwst`, `default`), `packages/tools/kolibri-cli`, and `packages/tools/visual-tests`. To comply with the newly enforced rule, remaining loose-equality comparisons (`==` / `!=`) were converted to strict equality (`===` / `!==`) in the `combobox`, `input-date`, `input-number`, `nav`, `progress`, and `table-stateful` components and in the `drawer` React sample. This is a code-quality/tooling change targeting the `release/2` branch; it introduces no public API or component behavior change for consumers.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung aktiviert die ESLint-Regel `eqeqeq` in allen ESLint-Konfigurationen des Repositories — `packages/components`, `packages/designer`, `packages/samples/react`, `packages/themes` (root, `bwst`, `default`), `packages/tools/kolibri-cli` und `packages/tools/visual-tests`. Um die Regel zu erfüllen, wurden verbliebene unstrikte Vergleiche (`==` / `!=`) in den Komponenten `combobox`, `input-date`, `input-number`, `nav`, `progress` und `table-stateful` sowie im `drawer`-React-Beispiel auf strikte Gleichheit (`===` / `!==`) umgestellt. Die Änderung zielt auf den `release/2`-Branch und bringt keine Änderung an der öffentlichen API oder am Komponentenverhalten für Konsumenten.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/.eslintrc.js`, `packages/designer/.eslintrc.js`, `packages/samples/react/.eslintrc.js`, `packages/themes/{,.bwst,.default}/.eslintrc.cjs`, `packages/tools/kolibri-cli/.eslintrc.cjs`, `packages/tools/visual-tests/.eslintrc.cjs` — `eqeqeq`-Regel aktiviert.
- `packages/components/src/components/{combobox,input-date,input-number,nav,progress,table-stateful}/…` — unstrikte Vergleiche auf strikte Gleichheit umgestellt.
- `packages/samples/react/src/components/drawer/basic.tsx` — `==` durch `===` ersetzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
