### PR TITLE
refactor: enable eqeqeq eslint rule and fix non-strict equality checks

### DIFF
--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -70,9 +70,11 @@ const config = {
 		'@stencil-community/strict-mutable': 'off',
 		'@stencil-community/ban-exported-const-enums': 'off',
 		'@stencil-community/strict-boolean-conditions': 'off',
-		'@stencil-community/ban-default-true': 'off',
+               '@stencil-community/ban-default-true': 'off',
 
-		'react/jsx-no-bind': 'off',
+'eqeqeq': 'error',
+
+               'react/jsx-no-bind': 'off',
 
 		'no-console': 'error',
 	},

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -356,7 +356,7 @@ export class KolCombobox implements ComboboxAPI {
 
 	@Listen('click', { target: 'window' })
 	handleWindowClick(event: MouseEvent) {
-		if (this.host != undefined && !this.host.contains(event.target as Node)) {
+		if (this.host !== undefined && !this.host.contains(event.target as Node)) {
 			this._isOpen = false;
 		}
 	}

--- a/packages/components/src/components/input-date/controller.ts
+++ b/packages/components/src/components/input-date/controller.ts
@@ -132,7 +132,7 @@ export class InputDateController extends InputIconController implements InputDat
 		return watchValidator(
 			this.component,
 			propName,
-			(value): boolean => value === undefined || value == null || value === '' || this.validateDateString(value),
+			(value): boolean => value === undefined || value === null || value === '' || this.validateDateString(value),
 			new Set(['Date', 'string{ISO-8601}']),
 			InputDateController.tryParseToString(value, this.component._type, this.component._step),
 			{

--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -74,7 +74,7 @@ export class KolNav implements NavAPI {
 	private collapseChildren(children: ButtonOrLinkOrTextWithChildrenProps[]) {
 		this.state = {
 			...this.state,
-			_expandedChildren: this.state._expandedChildren.filter((searchChildren) => searchChildren != children),
+			_expandedChildren: this.state._expandedChildren.filter((searchChildren) => searchChildren !== children),
 		};
 	}
 

--- a/packages/components/src/components/progress/shadow.tsx
+++ b/packages/components/src/components/progress/shadow.tsx
@@ -109,18 +109,18 @@ export class KolProgress implements ProgressAPI {
 				>
 					{this.state._variant === 'bar' && this.state._label && <div class="kol-progress__bar-label">{this.state._label}</div>}
 					{createProgressSVG(this.state)}
-					{this.state._variant == 'cycle' && (
+					{this.state._variant === 'cycle' && (
 						<div class="kol-progress__cycle-text">
 							{this.state._label && <div class="kol-progress__cycle-label">{this.state._label}</div>}
 							<div class="kol-progress__cycle-value">{`${displayValue} ${this.state._unit}`}</div>
 						</div>
 					)}
-					{this.state._variant == 'bar' && (
+					{this.state._variant === 'bar' && (
 						<div class="kol-progress__bar-value" style={{ width: `${`${(isPercentage ? 100 : this.state._max) + 1}`.length}ch` }}>
 							{displayValue}
 						</div>
 					)}
-					{this.state._variant == 'bar' && <div class="kol-progress__bar-unit">{this.state._unit}</div>}
+					{this.state._variant === 'bar' && <div class="kol-progress__bar-unit">{this.state._unit}</div>}
 				</div>
 
 				{/* https://css-tricks.com/html5-progress-element/ */}

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -185,7 +185,7 @@ export class KolTableStateful implements TableAPI {
 	 */
 	private changeCellSort(headerCell: KoliBriTableHeaderCellWithLogic) {
 		if (typeof headerCell.compareFn === 'function') {
-			if (!this.state._allowMultiSort && headerCell.key != this.sortData[0]?.key) {
+			if (!this.state._allowMultiSort && headerCell.key !== this.sortData[0]?.key) {
 				// clear when another column is sorted and multi sort is not allowed
 				this.sortData = [];
 			}

--- a/packages/samples/react/.eslintrc.js
+++ b/packages/samples/react/.eslintrc.js
@@ -13,11 +13,12 @@ config.overrides.push({
 			jsx: true,
 		},
 	},
-	rules: {
-		'@typescript-eslint/consistent-type-imports': 'error',
-		'@typescript-eslint/no-unsafe-member-access': 'error',
-		'react/no-unused-state': 'error',
-	},
+        rules: {
+                '@typescript-eslint/consistent-type-imports': 'error',
+                '@typescript-eslint/no-unsafe-member-access': 'error',
+                'react/no-unused-state': 'error',
+                'eqeqeq': 'error',
+        },
 });
 
 config.plugins = config.plugins || [];

--- a/packages/samples/react/src/components/drawer/basic.tsx
+++ b/packages/samples/react/src/components/drawer/basic.tsx
@@ -30,7 +30,7 @@ export const DrawerBasic: FC = () => {
 			<DrawerRadioAlign value={align} onChange={(_, value) => setAlign(value as AlignPropType)} />
 			<div className="flex flex-wrap gap-4">
 				<KolDrawer ref={drawerElement} _label="I am a drawer" _align={align} _on={{ onClose: () => console.log('Drawer onClose triggered!') }}>
-					<div className={align === 'left' || align == 'right' ? 'drawer-content-vertical' : ''}>
+					<div className={align === 'left' || align === 'right' ? 'drawer-content-vertical' : ''}>
 						<p>
 							Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
 							voluptua.

--- a/packages/themes/.eslintrc.cjs
+++ b/packages/themes/.eslintrc.cjs
@@ -6,8 +6,9 @@ module.exports = {
 		tsconfigRootDir: __dirname,
 	},
 	plugins: ['@typescript-eslint'],
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
-	rules: {
-		'@typescript-eslint/no-namespace': 'off',
-	},
+        extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
+        rules: {
+                '@typescript-eslint/no-namespace': 'off',
+                'eqeqeq': 'error',
+        },
 };

--- a/packages/themes/default/.eslintrc.cjs
+++ b/packages/themes/default/.eslintrc.cjs
@@ -6,8 +6,9 @@ module.exports = {
 		tsconfigRootDir: __dirname,
 	},
 	plugins: ['@typescript-eslint'],
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
-	rules: {
-		'@typescript-eslint/no-namespace': 'off',
-	},
+        extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
+        rules: {
+                '@typescript-eslint/no-namespace': 'off',
+                'eqeqeq': 'error',
+        },
 };

--- a/packages/themes/ecl/.eslintrc.cjs
+++ b/packages/themes/ecl/.eslintrc.cjs
@@ -6,8 +6,9 @@ module.exports = {
 		tsconfigRootDir: __dirname,
 	},
 	plugins: ['@typescript-eslint'],
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
-	rules: {
-		'@typescript-eslint/no-namespace': 'off',
-	},
+        extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
+        rules: {
+                '@typescript-eslint/no-namespace': 'off',
+                'eqeqeq': 'error',
+        },
 };

--- a/packages/tools/kolibri-cli/.eslintrc.cjs
+++ b/packages/tools/kolibri-cli/.eslintrc.cjs
@@ -17,16 +17,19 @@ module.exports = {
 		sourceType: 'module',
 		tsconfigRootDir: __dirname,
 	},
-	plugins: [
-		'html',
-		// 'jsdoc',
-		// 'json',
-		// 'jsx-a11y',
-		'react',
-	],
-	settings: {
-		react: {
-			version: 'detect',
-		},
-	},
+        plugins: [
+                'html',
+                // 'jsdoc',
+                // 'json',
+                // 'jsx-a11y',
+                'react',
+        ],
+        rules: {
+                'eqeqeq': 'error',
+        },
+        settings: {
+                react: {
+                        version: 'detect',
+                },
+        },
 };

--- a/packages/tools/visual-tests/.eslintrc.cjs
+++ b/packages/tools/visual-tests/.eslintrc.cjs
@@ -6,13 +6,16 @@ module.exports = {
 	root: true,
 	extends: ['eslint:recommended'],
 	parser: '@babel/eslint-parser',
-	parserOptions: {
-		babelOptions: {
-			babelrc: false,
-			configFile: false,
-			plugins: ['@babel/plugin-syntax-import-attributes'],
-			presets: ['@babel/preset-env'],
-		},
-		requireConfigFile: false,
-	},
+        parserOptions: {
+                babelOptions: {
+                        babelrc: false,
+                        configFile: false,
+                        plugins: ['@babel/plugin-syntax-import-attributes'],
+                        presets: ['@babel/preset-env'],
+                },
+                requireConfigFile: false,
+        },
+        rules: {
+                'eqeqeq': 'error',
+        },
 };


### PR DESCRIPTION
## What changed?

This change enables the `eqeqeq` ESLint rule across the repository's lint configurations — `packages/components`, `packages/samples/react`, `packages/themes` (root, `default`, `ecl`), `packages/tools/kolibri-cli`, and `packages/tools/visual-tests`. To satisfy the newly enforced rule, the remaining loose-equality comparisons (`==` / `!=`) were replaced with strict equality (`===` / `!==`) in the `combobox`, `input-date`, `nav`, `progress`, and `table-stateful` components, as well as in the `drawer` React sample. This is a code-quality/tooling change with no public API or component behavior change for consumers.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung aktiviert die ESLint-Regel `eqeqeq` in den Lint-Konfigurationen des Repositories — `packages/components`, `packages/samples/react`, `packages/themes` (root, `default`, `ecl`), `packages/tools/kolibri-cli` und `packages/tools/visual-tests`. Um die neu erzwungene Regel zu erfüllen, wurden die verbliebenen unstrikten Vergleiche (`==` / `!=`) durch strikte Vergleiche (`===` / `!==`) ersetzt — in den Komponenten `combobox`, `input-date`, `nav`, `progress` und `table-stateful` sowie im `drawer`-React-Beispiel. Es handelt sich um eine Code-Qualitäts-/Tooling-Änderung ohne Änderung an der öffentlichen API oder am Komponentenverhalten für Konsumenten.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/.eslintrc.js` — `eqeqeq: 'error'` aktiviert.
- `packages/samples/react/.eslintrc.js`, `packages/themes/.eslintrc.cjs`, `packages/themes/default/.eslintrc.cjs`, `packages/themes/ecl/.eslintrc.cjs`, `packages/tools/kolibri-cli/.eslintrc.cjs`, `packages/tools/visual-tests/.eslintrc.cjs` — `eqeqeq`-Regel ergänzt.
- `packages/components/src/components/{combobox,input-date,nav,progress,table-stateful}/…` — unstrikte Vergleiche auf strikte Gleichheit umgestellt.
- `packages/samples/react/src/components/drawer/basic.tsx` — `==` durch `===` ersetzt.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
