### PR TITLE
ci: upload axe results and skip axe tests when updating snapshots

### DIFF
--- a/.github/actions/upload-reports/action.yml
+++ b/.github/actions/upload-reports/action.yml
@@ -13,3 +13,4 @@ runs:
         path: |
           packages/**/playwright-report/
           packages/**/test-results/**/*.png
+          packages/**/test-results/axe-default/**

--- a/packages/tools/visual-tests/tests/axe-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/axe-snapshots.spec.js
@@ -38,7 +38,7 @@ test.use({
 
 ROUTES.forEach((options, route) => {
 	// Skip unnecessary axe tests
-	if (options?.axe?.skip === true) {
+	if (options?.axe?.skip === true || process.argv.includes('--update-snapshots')) {
 		return;
 	}
 	test(`snapshot for ${route}`, async ({ page }, testInfo) => {
@@ -82,7 +82,7 @@ ROUTES.forEach((options, route) => {
 			{
 				outputDirPath: outputPath.replace(/\/[^/]+$/, ''),
 				outputDir: `axe-${themeName}`,
-				reportFileName: `${route.replace('/', '-')}.html`,
+				reportFileName: `${route.replace(/[/?]/g, '-')}.html`,
 			},
 		);
 	});


### PR DESCRIPTION
## What changed?

The `upload-reports` GitHub Action now also collects the Axe report artifacts from `packages/**/test-results/axe-default/**`, so accessibility results are uploaded and available for inspection in CI. The visual-tests Axe snapshot suite now skips its Axe test runs when Playwright is invoked with `--update-snapshots`, preventing unnecessary Axe checks during snapshot regeneration. The Axe report file name generation was also hardened to sanitize `?` characters in route names (in addition to `/`) so report files are written correctly. This is a CI/tooling-only change with no impact on the published packages.

## Linked issues

- Refs #7892 — Probleme mit Axe beheben (Axe reports were not uploaded as artifacts and Axe tests ran during snapshot updates)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die GitHub-Action `upload-reports` sammelt jetzt zusätzlich die Axe-Report-Artefakte aus `packages/**/test-results/axe-default/**`, sodass die Barrierefreiheits-Ergebnisse in der CI hochgeladen und einsehbar sind. Die Axe-Snapshot-Tests der Visual-Tests werden nun übersprungen, wenn Playwright mit `--update-snapshots` aufgerufen wird, damit beim Aktualisieren der Snapshots keine unnötigen Axe-Prüfungen laufen. Zusätzlich wurde die Erzeugung des Report-Dateinamens robuster gemacht, indem neben `/` auch `?` im Routennamen ersetzt wird. Es handelt sich um eine reine CI-/Tooling-Änderung ohne Auswirkung auf die veröffentlichten Pakete.

### Verknüpfte Tickets

- Refs #7892 — Probleme mit Axe beheben (Axe-Reports wurden nicht als Artefakt hochgeladen und Axe-Tests liefen bei Snapshot-Updates mit)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/actions/upload-reports/action.yml` — Nimmt die Axe-Report-Artefakte in den Upload-Pfad auf.
- `packages/tools/visual-tests/tests/axe-snapshots.spec.js` — Überspringt Axe-Tests bei `--update-snapshots` und bereinigt `?` im Report-Dateinamen.

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
