### PR TITLE
build: fix the publish workflow using the correct angular versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,18 +116,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
-      - name: Build and publish adapter angular v15
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
-        working-directory: packages/adapters/angular/v15
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
-      - name: Build and publish adapter angular v16
-        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
-        working-directory: packages/adapters/angular/v16
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
       - name: Build and publish adapter angular v17
         run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v17
@@ -137,6 +125,18 @@ jobs:
       - name: Build and publish adapter angular v18
         run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
         working-directory: packages/adapters/angular/v18
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
+      - name: Build and publish adapter angular v19
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
+        working-directory: packages/adapters/angular/v19
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
+      - name: Build and publish adapter angular v20
+        run: pnpm publish --access ${{env.access}} --no-git-checks --tag ${{github.event.inputs.tag}} || echo "⚠️ Publish skipped – package already exists"
+        working-directory: packages/adapters/angular/v20
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPMJS_GRANULAR_TOKEN}}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## What changed?

This PR fixes the npm publish workflow in `.github/workflows/publish.yml` so it references the Angular adapter versions that actually exist in the monorepo. The build-and-publish steps were bumped from the obsolete `v15`, `v16`, `v17`, and `v18` targets to the current `v17`, `v18`, `v19`, and `v20` adapters. Both the step names and their `working-directory` paths were updated to match the correct package directories. This ensures the publish pipeline no longer targets non-existent adapter folders. No application or library source code is affected.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR korrigiert den npm-Publish-Workflow in `.github/workflows/publish.yml`, sodass er auf die tatsächlich im Monorepo vorhandenen Angular-Adapter-Versionen verweist. Die Build- und Publish-Schritte wurden von den veralteten Zielen `v15`, `v16`, `v17` und `v18` auf die aktuellen Adapter `v17`, `v18`, `v19` und `v20` angehoben. Sowohl die Schrittnamen als auch die `working-directory`-Pfade wurden entsprechend angepasst. Anwendungs- oder Bibliothekscode ist nicht betroffen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/publish.yml` — Die Build- und Publish-Schritte verweisen nun auf die Angular-Adapter-Versionen v17 bis v20 statt auf die veralteten Versionen v15 bis v18.

</details>
