### PR TITLE
chore: reconfigure all `tsconfig.json`'s

### DIFF
--- a/packages/adapters/angular/v17/tsconfig.json
+++ b/packages/adapters/angular/v17/tsconfig.json
@@ -34,5 +34,5 @@
 		"skipLibCheck": true
 	},
 	"files": ["src/index.ts"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/angular/v18/tsconfig.json
+++ b/packages/adapters/angular/v18/tsconfig.json
@@ -34,5 +34,5 @@
 		"skipLibCheck": true
 	},
 	"files": ["src/index.ts"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/angular/v19/tsconfig.json
+++ b/packages/adapters/angular/v19/tsconfig.json
@@ -34,5 +34,5 @@
 		"skipLibCheck": true
 	},
 	"files": ["src/index.ts"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/angular/v20/tsconfig.json
+++ b/packages/adapters/angular/v20/tsconfig.json
@@ -34,5 +34,5 @@
 		"skipLibCheck": true
 	},
 	"files": ["src/index.ts"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/hydrate/tsconfig.json
+++ b/packages/adapters/hydrate/tsconfig.json
@@ -21,6 +21,5 @@
 		"importHelpers": false,
 		"strict": true
 	},
-	"compileOnSave": false,
-	"buildOnSave": false
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/preact/tsconfig.json
+++ b/packages/adapters/preact/tsconfig.json
@@ -21,6 +21,5 @@
 		"importHelpers": false,
 		"strict": true
 	},
-	"compileOnSave": false,
-	"buildOnSave": false
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/react-standalone/tsconfig.json
+++ b/packages/adapters/react-standalone/tsconfig.json
@@ -22,6 +22,5 @@
 		"importHelpers": false,
 		"strict": true
 	},
-	"compileOnSave": false,
-	"buildOnSave": false
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/react/tsconfig.json
+++ b/packages/adapters/react/tsconfig.json
@@ -22,6 +22,5 @@
 		"importHelpers": false,
 		"strict": true
 	},
-	"compileOnSave": false,
-	"buildOnSave": false
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/adapters/solid/tsconfig.json
+++ b/packages/adapters/solid/tsconfig.json
@@ -22,6 +22,5 @@
 		"importHelpers": false,
 		"strict": true
 	},
-	"compileOnSave": false,
-	"buildOnSave": false
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -70,11 +70,11 @@ const config = {
 		'@stencil-community/strict-mutable': 'off',
 		'@stencil-community/ban-exported-const-enums': 'off',
 		'@stencil-community/strict-boolean-conditions': 'off',
-               '@stencil-community/ban-default-true': 'off',
+		'@stencil-community/ban-default-true': 'off',
 
-'eqeqeq': 'error',
+		eqeqeq: 'error',
 
-               'react/jsx-no-bind': 'off',
+		'react/jsx-no-bind': 'off',
 
 		'no-console': 'error',
 	},

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -21,5 +21,5 @@
 		"skipLibCheck": true
 	},
 	"include": ["src"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/samples/angular/tsconfig.json
+++ b/packages/samples/angular/tsconfig.json
@@ -1,6 +1,5 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
-	"compileOnSave": false,
 	"compilerOptions": {
 		"outDir": "./dist/out-tsc",
 		"strict": true,
@@ -25,5 +24,6 @@
 		"strictInjectionParameters": true,
 		"strictInputAccessModifiers": true,
 		"strictTemplates": true
-	}
+	},
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/samples/react/.eslintrc.js
+++ b/packages/samples/react/.eslintrc.js
@@ -13,12 +13,12 @@ config.overrides.push({
 			jsx: true,
 		},
 	},
-        rules: {
-                '@typescript-eslint/consistent-type-imports': 'error',
-                '@typescript-eslint/no-unsafe-member-access': 'error',
-                'react/no-unused-state': 'error',
-                'eqeqeq': 'error',
-        },
+	rules: {
+		'@typescript-eslint/consistent-type-imports': 'error',
+		'@typescript-eslint/no-unsafe-member-access': 'error',
+		'react/no-unused-state': 'error',
+		eqeqeq: 'error',
+	},
 });
 
 config.plugins = config.plugins || [];

--- a/packages/samples/react/tsconfig.json
+++ b/packages/samples/react/tsconfig.json
@@ -26,5 +26,6 @@
 		"jsxFactory": "React.createElement",
 		"jsxFragmentFactory": "React.Fragment"
 	},
-	"include": ["**/*.ts", "**/*.tsx"]
+	"include": ["**/*.ts", "**/*.tsx"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/themes/.eslintrc.cjs
+++ b/packages/themes/.eslintrc.cjs
@@ -6,9 +6,9 @@ module.exports = {
 		tsconfigRootDir: __dirname,
 	},
 	plugins: ['@typescript-eslint'],
-        extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
-        rules: {
-                '@typescript-eslint/no-namespace': 'off',
-                'eqeqeq': 'error',
-        },
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking'],
+	rules: {
+		'@typescript-eslint/no-namespace': 'off',
+		eqeqeq: 'error',
+	},
 };

--- a/packages/themes/default/tsconfig.json
+++ b/packages/themes/default/tsconfig.json
@@ -1,31 +1,9 @@
 {
+	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"allowUnreachableCode": false,
-		"allowSyntheticDefaultImports": true,
-		"declaration": true,
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"esModuleInterop": true,
-		"lib": ["dom", "es2015"],
-		"module": "ESNext",
-		"preserveSymlinks": true,
-		"moduleResolution": "node",
-		"noImplicitAny": true,
-		"noImplicitReturns": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
 		"outDir": "dist",
-		"removeComments": true,
-		"sourceMap": true,
-		"jsx": "react",
-		"target": "es2015",
-		"forceConsistentCasingInFileNames": false,
-		"importHelpers": false,
-		"strict": true,
-		"skipLibCheck": true
+		"types": ["../shims-css.d.ts"]
 	},
-	"compileOnSave": false,
-	"buildOnSave": false,
-	"exclude": ["node_modules/**"],
-	"include": ["src/**/*.ts", "src/**/*.tsx", "src/globals.d.ts"]
+	"exclude": ["node_modules", "dist"],
+	"include": ["src/**/*"]
 }

--- a/packages/themes/ecl/tsconfig.json
+++ b/packages/themes/ecl/tsconfig.json
@@ -1,31 +1,9 @@
 {
+	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"allowUnreachableCode": false,
-		"allowSyntheticDefaultImports": true,
-		"declaration": true,
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"esModuleInterop": true,
-		"lib": ["dom", "es2015"],
-		"module": "ESNext",
-		"preserveSymlinks": true,
-		"moduleResolution": "node",
-		"noImplicitAny": true,
-		"noImplicitReturns": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
 		"outDir": "dist",
-		"removeComments": true,
-		"sourceMap": true,
-		"jsx": "react",
-		"target": "es2015",
-		"forceConsistentCasingInFileNames": false,
-		"importHelpers": false,
-		"strict": true,
-		"skipLibCheck": true
+		"types": ["../shims-css.d.ts"]
 	},
-	"compileOnSave": false,
-	"buildOnSave": false,
-	"exclude": ["node_modules/**"],
-	"include": ["src/**/*.ts", "src/**/*.tsx", "src/globals.d.ts"]
+	"exclude": ["node_modules", "dist"],
+	"include": ["src/**/*"]
 }

--- a/packages/themes/shims-css.d.ts
+++ b/packages/themes/shims-css.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+	const content: string;
+	export default content;
+}

--- a/packages/themes/tsconfig.base.json
+++ b/packages/themes/tsconfig.base.json
@@ -2,12 +2,14 @@
 	"compilerOptions": {
 		"allowUnreachableCode": false,
 		"allowSyntheticDefaultImports": true,
+		"allowArbitraryExtensions": true,
 		"declaration": true,
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"esModuleInterop": true,
 		"lib": ["dom", "es2015"],
 		"module": "ESNext",
+		"preserveSymlinks": true,
 		"moduleResolution": "node",
 		"noImplicitAny": true,
 		"noImplicitReturns": true,
@@ -20,8 +22,8 @@
 		"target": "es2015",
 		"forceConsistentCasingInFileNames": false,
 		"importHelpers": false,
-		"strict": false
+		"strict": true,
+		"skipLibCheck": true
 	},
-	"include": ["src/**/*.ts", "src/**/*.tsx"],
 	"exclude": ["node_modules", "dist"]
 }

--- a/packages/themes/tsconfig.json
+++ b/packages/themes/tsconfig.json
@@ -1,30 +1,8 @@
 {
+	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"allowUnreachableCode": false,
-		"allowSyntheticDefaultImports": true,
-		"declaration": true,
-		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"esModuleInterop": true,
-		"lib": ["dom", "es2015"],
-		"module": "ESNext",
-		"preserveSymlinks": true,
-		"moduleResolution": "node",
-		"noImplicitAny": true,
-		"noImplicitReturns": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"outDir": "dist",
-		"removeComments": true,
-		"sourceMap": true,
-		"jsx": "react",
-		"target": "es2015",
-		"forceConsistentCasingInFileNames": false,
-		"importHelpers": false,
-		"strict": true,
-		"skipLibCheck": true
+		"types": ["./shims-css.d.ts"]
 	},
-	"compileOnSave": false,
-	"buildOnSave": false,
-	"exclude": ["node_modules/**", "dist/"]
+	"include": ["src/**/*", "default/src/**/*", "ecl/src/**/*"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/tools/benchmark-tests/tsconfig.json
+++ b/packages/tools/benchmark-tests/tsconfig.json
@@ -7,5 +7,6 @@
 		"esModuleInterop": true,
 		"types": ["@wdio/globals/types", "mocha", "node"]
 	},
-	"include": ["./tests/**/*.ts"]
+	"include": ["./tests/**/*.ts"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/packages/tools/kolibri-cli/tsconfig.json
+++ b/packages/tools/kolibri-cli/tsconfig.json
@@ -12,5 +12,6 @@
 		"skipLibCheck": true,
 		"strict": true
 	},
-	"include": ["src"]
+	"include": ["src"],
+	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## What changed?

This PR standardizes the TypeScript build configuration across every package in the monorepo. A shared `tsconfig.base.json` was introduced in the `themes` package and is now extended by the root, `default`, and `ecl` theme configs to eliminate duplicated compiler options. Deprecated `compileOnSave`/`buildOnSave` flags were removed, and `exclude` was standardized to `["node_modules", "dist"]` in the adapters, components, samples, themes, and tools packages. A new `shims-css.d.ts` SCSS module declaration was added and wired in via the `types` field, and several `.eslintrc` files were reformatted (indentation/quoting of the `eqeqeq` rule). These are build- and tooling-level changes with no impact on the published component behavior.

## Linked issues

- No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese PR vereinheitlicht die TypeScript-Build-Konfiguration über alle Pakete des Monorepos hinweg. Im `themes`-Paket wurde eine gemeinsame `tsconfig.base.json` eingeführt, die nun vom Root-, `default`- und `ecl`-Theme-Config erweitert wird, um doppelte Compiler-Optionen zu vermeiden. Veraltete `compileOnSave`/`buildOnSave`-Flags wurden entfernt und `exclude` wurde repoweit auf `["node_modules", "dist"]` standardisiert. Zusätzlich wurde eine neue SCSS-Modul-Deklaration `shims-css.d.ts` ergänzt und über das `types`-Feld eingebunden; mehrere `.eslintrc`-Dateien wurden formatiert. Es handelt sich um reine Build- und Tooling-Änderungen ohne Auswirkung auf das Verhalten der Komponenten.

### Verknüpfte Tickets

- Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/themes/tsconfig.base.json` — Neue gemeinsame Basis-TypeScript-Konfiguration für das Themes-Paket.
- `packages/themes/{default,ecl}/tsconfig.json` — Erben nun von der Basis-Konfiguration und setzen nur noch spezifische Optionen.
- `packages/themes/tsconfig.json` — Erweitert die Basis-Konfiguration und bündelt die Includes der Sub-Themes.
- `packages/themes/shims-css.d.ts` — Neue Typ-Deklaration für den Import von `*.scss`-Modulen.
- `packages/adapters/**/tsconfig.json` — Entfernen von `compileOnSave`/`buildOnSave` und standardisiertes `exclude`.
- `packages/{components,samples,tools}/**/tsconfig.json` — Standardisiertes `exclude` auf `["node_modules", "dist"]`.
- `packages/{components,samples/react,themes}/.eslintrc*` — Formatierungskorrekturen (u. a. `eqeqeq`-Regel).

</details>


The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
