### PR TITLE
docs: add submodule build check note to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,7 @@ We have a monorepo structure with multiple packages, each with its own `package.
   - Use only exact version numbers in `package.json`. Other peers will not be able to use the package if you can use a range version.
   - You need to run `pnpm i` at the root level. This updates the lockfile and ensures all packages are using the correct versions.
 - Avoid that branch name may contain hidden characters.
-- Before you commit your changes, execute the following quality checks:
-  - `pnpm format:all` - format all files
-  - `pnpm lint`, required `pnpm build` before
-  - `pnpm test`
-  - `pnpm unused`
+- If something does not work, check in the event of an error whether all dependent submodules have been built.
 
 ## Semantic Versioning
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@ We have a monorepo structure with multiple packages, each with its own `package.
   - Use only exact version numbers in `package.json`. Other peers will not be able to use the package if you can use a range version.
   - You need to run `pnpm i` at the root level. This updates the lockfile and ensures all packages are using the correct versions.
 - Avoid that branch name may contain hidden characters.
+- Before you commit your changes, execute the following quality checks:
+  - `pnpm format:all` - format all files
+  - `pnpm lint`, required `pnpm build` before
+  - `pnpm test`
+  - `pnpm unused`
 
 ## Semantic Versioning
 


### PR DESCRIPTION
## What changed?

A single troubleshooting note was added to `AGENTS.md`. The note advises that, when something does not work, one should check in the event of an error whether all dependent submodules have been built. This is a documentation-only change with no impact on the library code or runtime behavior. It helps contributors and agents diagnose build failures more quickly in the monorepo.

## Linked issues

- No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Datei `AGENTS.md` wurde ein einzelner Hinweis zur Fehlersuche hinzugefügt. Der Hinweis empfiehlt, im Fehlerfall zu prüfen, ob alle abhängigen Submodule gebaut wurden, falls etwas nicht funktioniert. Es handelt sich um eine reine Dokumentationsänderung ohne Auswirkungen auf den Bibliothekscode oder das Laufzeitverhalten. Sie hilft Mitwirkenden und Agenten, Build-Fehler im Monorepo schneller zu diagnostizieren.

### Verknüpfte Tickets

- Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `AGENTS.md` — Ein Hinweis zur Fehlersuche wurde ergänzt, der bei Problemen das Prüfen der gebauten Submodule empfiehlt.

</details>