### PR TITLE
feat(split-button): always execute primary action on the main button

### DIFF
--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -1,16 +1,17 @@
 import type {
+	AccessKeyPropType,
 	AlternativeButtonLinkRolePropType,
+	AriaDescriptionPropType,
 	ButtonCallbacksPropType,
 	ButtonTypePropType,
 	ButtonVariantPropType,
 	CustomClassPropType,
 	IconsPropType,
-	LabelPropType,
-	NamePropType,
+	LabelWithExpertSlotPropType,
+	ShortKeyPropType,
 	SplitButtonProps,
 	SplitButtonStates,
 	StencilUnknown,
-	Stringified,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
 } from '../../schema';
@@ -34,6 +35,23 @@ import clsx from 'clsx';
 	},
 })
 export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
+	private primaryButtonWcRef?: HTMLKolButtonWcElement;
+
+	private readonly catchPrimaryRef = (ref?: HTMLKolButtonWcElement) => {
+		this.primaryButtonWcRef = ref;
+	};
+
+	@Method()
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async getValue(): Promise<StencilUnknown> {
+		return this._value;
+	}
+
+	@Method()
+	public async kolFocus() {
+		await this.primaryButtonWcRef?.kolFocus();
+	}
+
 	private readonly clickButtonHandler = {
 		onClick: (event: MouseEvent) => {
 			event.stopPropagation(); // stop propagation to avoid triggering the event that closes the popover
@@ -69,17 +87,22 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 							[this._variant as string]: this._variant !== 'custom',
 							[this._customClass as string]: this._variant === 'custom' && typeof this._customClass === 'string' && this._customClass.length > 0,
 						})}
+						ref={this.catchPrimaryRef}
+						_accessKey={this._accessKey}
 						_ariaControls={this._ariaControls}
+						_ariaDescription={this._ariaDescription}
 						_ariaExpanded={this._ariaExpanded}
 						_ariaSelected={this._ariaSelected}
 						_customClass={this._customClass}
 						_disabled={this._disabled}
 						_icons={this._icons}
+						_id={this._id}
 						_hideLabel={this._hideLabel}
 						_label={this._label}
 						_name={this._name}
 						_on={this.clickButtonHandler}
 						_role={this._role}
+						_shortKey={this._shortKey}
 						_syncValueBySelector={this._syncValueBySelector}
 						_tooltipAlign={this._tooltipAlign}
 						_type={this._type}
@@ -111,9 +134,19 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	}
 
 	/**
+	 * Defines which key combination can be used to trigger or focus the interactive element of the component.
+	 */
+	@Prop() public _accessKey?: AccessKeyPropType;
+
+	/**
 	 * Defines which elements are controlled by this component. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls)
 	 */
 	@Prop() public _ariaControls?: string;
+
+	/**
+	 * Defines the value for the aria-description attribute.
+	 */
+	@Prop() public _ariaDescription?: AriaDescriptionPropType;
 
 	/**
 	 * Defines whether the interactive element of the component expanded something. (https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
@@ -155,12 +188,12 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	/**
 	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.).
 	 */
-	@Prop() public _label!: LabelPropType;
+	@Prop() public _label!: LabelWithExpertSlotPropType;
 
 	/**
 	 * Defines the technical name of an input field.
 	 */
-	@Prop() public _name?: NamePropType;
+	@Prop() public _name?: string;
 
 	/**
 	 * Defines the callback functions for button events.
@@ -171,6 +204,11 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	 * Defines the role of the components primary element.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
+
+	/**
+	 * Adds a visual short key hint to the component.
+	 */
+	@Prop() public _shortKey?: ShortKeyPropType;
 
 	/**
 	 * Selector for synchronizing the value with another input element.
@@ -191,7 +229,7 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	/**
 	 * Defines the value that the button emits on click.
 	 */
-	@Prop() public _value?: Stringified<StencilUnknown>;
+	@Prop() public _value?: StencilUnknown;
 
 	/**
 	 * Defines which variant should be used for presentation.

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -41,8 +41,6 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 			if (typeof this._on?.onClick === 'function') {
 				// TODO: this._on is not validated
 				this._on?.onClick(event, this._value);
-			} else {
-				this.toggleDropdown();
 			}
 		},
 	};

--- a/packages/components/src/components/split-button/split-button.e2e.ts
+++ b/packages/components/src/components/split-button/split-button.e2e.ts
@@ -2,20 +2,6 @@ import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
 
 test.describe('kol-split-button', () => {
-	test('should display toggle popover when the primary button is clicked', async ({ page }) => {
-		await page.setContent(` <kol-split-button _label="Sample Button">Dropdown contents</kol-split-button> `);
-		const splitButton = page.locator('kol-split-button ');
-
-		const mainButton = splitButton.locator('.kol-split-button__button');
-		const popover = splitButton.locator('kol-popover-wc .kol-popover__content');
-
-		await expect(popover).not.toBeVisible();
-		await mainButton.click();
-		await expect(popover).toBeVisible();
-		await mainButton.click();
-		await expect(popover).not.toBeVisible();
-	});
-
 	test('should display toggle popover when the secondary button is clicked', async ({ page }) => {
 		await page.setContent(` <kol-split-button _label="Sample Button">Dropdown contents</kol-split-button> `);
 		const splitButton = page.locator('kol-split-button ');


### PR DESCRIPTION
## What changed?

The split-button's main (left) button now always performs its primary action through the `_on.onClick` callback instead of falling back to toggling the dropdown when no callback was set. Opening the dropdown popover is now handled exclusively by the secondary (right) button, matching the popover-button's functional component. The component also gained several accessibility-related props (`_accessKey`, `_shortKey`, `_ariaDescription`, `_id`, and expert-slot support on `_label`) and now exposes `getValue()` and `kolFocus()` methods that focus the primary button. The obsolete e2e test asserting that clicking the primary button toggled the popover was removed.

## Linked issues

- Closes #7800 — Split-Button always with a primary action (left button triggers the action, right button opens the popover).

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der linke Hauptbutton des Split-Buttons löst nun immer seine Primäraktion über den `_on.onClick`-Callback aus, statt bei fehlendem Callback das Dropdown umzuschalten. Das Öffnen des Popovers übernimmt ausschließlich der rechte, kleinere Button und nutzt dieselbe Functional Component wie der Popover-Button. Zusätzlich wurden mehrere Barrierefreiheits-Props ergänzt (`_accessKey`, `_shortKey`, `_ariaDescription`, `_id` sowie Expert-Slot-Unterstützung bei `_label`) und die Methoden `getValue()` und `kolFocus()` bereitgestellt. Der veraltete E2E-Test, der das Umschalten des Popovers über den Primärbutton prüfte, wurde entfernt.

### Verknüpfte Tickets

- Schließt #7800 — Split-Button immer mit Primäraktion (linker Button löst die Aktion aus, rechter Button öffnet das Popover).

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/split-button/shadow.tsx` — Primärbutton löst immer die Aktion aus; neue A11y-Props und die Methoden `getValue()`/`kolFocus()` wurden ergänzt.
- `packages/components/src/components/split-button/split-button.e2e.ts` — Entfernt den veralteten Test zum Umschalten des Popovers über den Primärbutton.

</details>