### PR TITLE
docs: mention building packages before running lint and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ The samples are located in `packages/samples/react` and demonstrate how to use t
 ## Linting and Formatting
 
 - Run `pnpm lint` to check for linting errors across all packages. This script runs ESLint, Stylelint and TypeScript checks. You can try to automatically fix linting issues with `pnpm lint:eslint --fix`, but this may not resolve all issues.
+- Ensure all packages are built by running `pnpm build` before executing `pnpm lint` or `pnpm test`. Some packages rely on generated artifacts that linting and testing depend on.
 - Run `pnpm format` to format all code files using Prettier. You can try to automatically fix linting issues with `pnpm format -w`, but this may not resolve all issues.
 
 ## Testing


### PR DESCRIPTION
## What changed?

Adds a single line to the "Linting and Formatting" section of `AGENTS.md` instructing contributors to build all packages (`pnpm build`) before running `pnpm lint` or `pnpm test`, because some packages rely on generated artifacts that linting and testing depend on. Documentation only — no code or public API changes.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ergänzt eine einzelne Zeile im Abschnitt „Linting and Formatting" von `AGENTS.md`, die Mitwirkende anweist, vor `pnpm lint` oder `pnpm test` zunächst alle Pakete zu bauen (`pnpm build`), da einige Pakete auf generierte Artefakte angewiesen sind, von denen Linting und Tests abhängen. Reine Dokumentation — keine Code- oder API-Änderung.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `AGENTS.md` — Hinweis ergänzt, vor Lint/Test zuerst `pnpm build` auszuführen.

</details>