### PR TITLE
fix(components): move vibrate comment to helper

### DIFF
--- a/packages/components/src/components/alert/component.tsx
+++ b/packages/components/src/components/alert/component.tsx
@@ -20,7 +20,7 @@ export class KolAlertWc implements AlertAPI {
 	private readonly close = () => {
 		this._on?.onClose?.(new Event('Close'));
 		if (this.host) {
-			dispatchDomEvent(this.host, KolEvent.close);
+			dispatchDomEvent(this.host as HTMLElement, KolEvent.close);
 		}
 	};
 

--- a/packages/components/src/functional-components/Alert/Alert.tsx
+++ b/packages/components/src/functional-components/Alert/Alert.tsx
@@ -15,6 +15,31 @@ export type KolAlertFcProps = JSXBase.HTMLAttributes<HTMLDivElement> &
 		onAlertTimeout?: () => void;
 	};
 
+/**
+ * - https://developer.mozilla.org/de/docs/Web/API/Navigator/vibrate
+ * - https://googlechrome.github.io/samples/vibration/
+ * - Ongoing discussion: https://github.com/public-ui/kolibri/issues/7191
+ * @todo Move side-effect out of render-function to avoid multiple incarnations.
+ */
+const vibrateOnError = (): void => {
+	if (typeof navigator === 'undefined' || typeof navigator.vibrate !== 'function') {
+		return;
+	}
+	const ua = navigator.userActivation;
+	const hasGesture = ua?.isActive || ua?.hasBeenActive;
+	if (!hasGesture) {
+		return;
+	}
+	if (!matchMedia('(any-pointer: coarse)').matches) {
+		return;
+	}
+	try {
+		navigator.vibrate([100, 75, 100, 75, 100]);
+	} catch {
+		/* no-op */
+	}
+};
+
 const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 	const {
 		class: classNames = {},
@@ -30,15 +55,7 @@ const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 	} = props;
 
 	if (alert) {
-		/**
-		 * - https://developer.mozilla.org/de/docs/Web/API/Navigator/vibrate
-		 * - https://googlechrome.github.io/samples/vibration/
-		 * - Ongoing discussion: https://github.com/public-ui/kolibri/issues/7191
-		 * @todo Move side-effect out of render-function to avoid multiple incarnations.
-		 */
-		if (navigator.userActivation?.hasBeenActive) {
-			navigator?.vibrate?.([100, 75, 100, 75, 100]);
-		}
+		vibrateOnError();
 
 		setTimeout(() => {
 			onAlertTimeout?.();


### PR DESCRIPTION
## Summary

Extracts the vibrate-on-error side effect in the `Alert` functional component into a dedicated `vibrateOnError` helper function, adding proper guards for API availability, touch device detection, and user activation state.

## Changes

- Extract vibrate logic into `vibrateOnError()` helper in `Alert.tsx`
- Add guards: check `navigator.vibrate` exists, require `(any-pointer: coarse)` media query, and verify `userActivation`
- Fix TypeScript cast: `dispatchDomEvent(this.host as HTMLElement, ...)` in `alert/component.tsx`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Extrahiert den Vibrations-Nebeneffekt in der `Alert`-Funktionalkomponente in eine eigene `vibrateOnError`-Hilfsfunktion mit angemessenen Überprüfungen für API-Verfügbarkeit, Touch-Geräteerkennung und Nutzer-Aktivierungszustand.

## Änderungen

- Vibrations-Logik in `vibrateOnError()`-Hilfsfunktion in `Alert.tsx` ausgelagert
- Prüfungen hinzugefügt: `navigator.vibrate` vorhanden, `(any-pointer: coarse)`-Medienabfrage und `userActivation`-Überprüfung
- TypeScript-Cast korrigiert: `dispatchDomEvent(this.host as HTMLElement, ...)` in `alert/component.tsx`

</details>