### PR TITLE
fix: add missing index.html to files in package.json

### DIFF
--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -70,6 +70,7 @@
 		"dist",
 		"public",
 		"src",
+		"index.html",
 		"tsconfig.json",
 		"unocss.config.ts",
 		"vite.config.ts"


### PR DESCRIPTION
## Summary

Adds the missing `index.html` entry to the `files` array in `packages/samples/react/package.json` so it is included in the published package.

## Changes

- Add `index.html` to the `files` list in `packages/samples/react/package.json`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Fügt den fehlenden `index.html`-Eintrag zum `files`-Array in `packages/samples/react/package.json` hinzu, damit die Datei im veröffentlichten Paket enthalten ist.

## Änderungen

- `index.html` zur `files`-Liste in `packages/samples/react/package.json` hinzugefügt

</details>