### PR TITLE
feat(combobox): highlight search term in single-select and combobox

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -228,6 +228,7 @@ export class KolCombobox implements ComboboxAPI {
 									<CustomSuggestionsOptionFc
 										index={index}
 										option={option}
+										searchTerm={this.state._value}
 										ref={(el) => {
 											if (el) this.refSuggestions[index] = el;
 										}}

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -280,6 +280,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 									<CustomSuggestionsOptionFc
 										index={index}
 										option={option.label}
+										searchTerm={this._inputValue}
 										ref={(el) => {
 											if (el) this.refOptions[index] = el;
 										}}

--- a/packages/components/src/functional-components/CustomSuggestionsOption/CustomSuggestionsOption.tsx
+++ b/packages/components/src/functional-components/CustomSuggestionsOption/CustomSuggestionsOption.tsx
@@ -6,10 +6,20 @@ export type CustomSuggestionsProps = JSXBase.HTMLAttributes<HTMLLIElement> & {
 	index: number;
 	option: W3CInputValue;
 	selected: boolean;
+	searchTerm?: string;
 	ref?: ((elm?: HTMLLIElement | undefined) => void) | undefined;
 };
 
-const CustomSuggestionsOptionFc: FC<CustomSuggestionsProps> = ({ index, ref, selected, onClick, onMouseOver, onFocus, onKeyDown, option }) => {
+const CustomSuggestionsOptionFc: FC<CustomSuggestionsProps> = ({ index, ref, selected, onClick, onMouseOver, onFocus, onKeyDown, option, searchTerm }) => {
+	const highlightSearchTerm = (text: string, searchTerm: string) => {
+		if (!searchTerm?.trim()) return text;
+
+		const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+		const parts = text.split(regex);
+
+		return parts.map((part, partIndex) => (regex.test(part) ? <mark key={partIndex}>{part}</mark> : part));
+	};
+
 	return (
 		<li
 			id={`option-${index}`}
@@ -25,7 +35,7 @@ const CustomSuggestionsOptionFc: FC<CustomSuggestionsProps> = ({ index, ref, sel
 			class="kol-custom-suggestions-option"
 			onKeyDown={onKeyDown}
 		>
-			{option}
+			{highlightSearchTerm(String(option), searchTerm || '')}
 		</li>
 	);
 };


### PR DESCRIPTION
## Summary

Dropdown suggestions in the combobox and single-select components now highlight the characters matching the current search term using a `<mark>` element.

## Changes

- Add `searchTerm` prop to `CustomSuggestionsOptionFc`
- Implement `highlightSearchTerm` helper that wraps matched substrings in `<mark>`
- Pass current input value as `searchTerm` in combobox and single-select option rendering

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Dropdown-Vorschläge in Combobox- und Einfachauswahl-Komponenten heben die mit dem aktuellen Suchbegriff übereinstimmenden Zeichen jetzt mithilfe eines `<mark>`-Elements hervor.

## Änderungen

- `searchTerm`-Prop zu `CustomSuggestionsOptionFc` hinzugefügt
- Hilfsfunktion `highlightSearchTerm` implementiert, die Treffer in `<mark>` einschließt
- Aktuellen Eingabewert als `searchTerm` an Combobox- und Einfachauswahl-Optionen übergeben

</details>