### PR TITLE
feat(toast): add onClose callback

### DIFF
--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -74,6 +74,7 @@ export class KolToastContainer implements ToasterAPI {
 				...this.state,
 				_toastStates: this.state._toastStates.filter((localToastState) => localToastState.id !== toastState.id),
 			};
+			toastState.toast.onClose?.();
 		}, TRANSITION_TIMEOUT);
 	}
 
@@ -101,6 +102,9 @@ export class KolToastContainer implements ToasterAPI {
 					...this.state,
 					_toastStates: this.state._toastStates.filter((toastState) => toastsToClose.every((toastToClose) => toastToClose.id !== toastState.id)),
 				};
+				toastsToClose.forEach((toastState) => {
+					toastState.toast.onClose?.();
+				});
 			}, TRANSITION_TIMEOUT);
 		}
 	}

--- a/packages/components/src/schema/components/toaster.ts
+++ b/packages/components/src/schema/components/toaster.ts
@@ -18,6 +18,7 @@ export type Toast = {
 	 */
 	alertVariant?: AlertVariant;
 	variant?: AlertVariant;
+	onClose?: () => void;
 };
 
 export type ToastState = {

--- a/packages/samples/react/src/components/toast/basic.tsx
+++ b/packages/samples/react/src/components/toast/basic.tsx
@@ -20,6 +20,9 @@ export const ToastBasic: FC = () => {
 			description: 'Toasty',
 			label: `Initial Toast`,
 			type: 'warning',
+			onClose: () => {
+				console.log('Simple toast has been closed.');
+			},
 		});
 	};
 

--- a/packages/samples/react/vite.config.ts
+++ b/packages/samples/react/vite.config.ts
@@ -27,6 +27,5 @@ export default defineConfig({
 	},
 	server: {
 		port: 9191,
-		strictPort: true,
 	},
 });


### PR DESCRIPTION
## Summary

Adds an optional `onClose` callback to the `Toast` type that is invoked when a toast notification is dismissed, whether individually or via `closeAll`.

## Changes

- Add `onClose?: () => void` to the `Toast` schema type
- Call `onClose` after a toast is removed in `KolToastContainer`
- Call `onClose` for each toast dismissed by `closeAll`
- Add usage example to the basic toast sample

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Fügt einen optionalen `onClose`-Callback zum `Toast`-Typ hinzu, der ausgelöst wird, wenn eine Toast-Benachrichtigung geschlossen wird – einzeln oder über `closeAll`.

## Änderungen

- `onClose?: () => void` zum `Toast`-Schema-Typ hinzugefügt
- `onClose` wird nach dem Entfernen eines Toasts im `KolToastContainer` aufgerufen
- `onClose` wird für jeden über `closeAll` geschlossenen Toast aufgerufen
- Nutzungsbeispiel im Toast-Grundbeispiel ergänzt

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
