### PR TITLE
fix(popover-button): tweak styling and update samples

### DIFF
--- a/packages/components/src/components/@shared/_kol-popover-button-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-popover-button-mixin.scss
@@ -8,7 +8,7 @@
 			}
 
 			&__popover {
-				border: 1px solid #000;
+				border: 0;
 				margin: 0;
 				padding: 0;
 			}

--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -1,8 +1,7 @@
 import type { FC } from 'react';
-import { useContext } from 'react';
-import React from 'react';
+import React, { useContext } from 'react';
 import { SampleDescription } from '../SampleDescription';
-import { KolButton, KolPopoverButton, KolBadge } from '@public-ui/react';
+import { KolBadge, KolPopoverButton, KolToolbar, KolHeading } from '@public-ui/react';
 import { useToasterService } from '../../hooks/useToasterService';
 import { HideMenusContext } from '../../shares/HideMenusContext';
 
@@ -14,6 +13,24 @@ export const PopoverButtonBasic: FC = () => {
 		onClick: dummyClickEventHandler,
 	};
 
+	const TOOLBAR_ITEMS = [
+		{
+			_label: 'Edit',
+			_icons: 'codicon codicon-edit',
+			_on: dummyEventHandler,
+		},
+		{
+			_label: 'Delete',
+			_icons: 'codicon codicon-trash',
+			_on: dummyEventHandler,
+		},
+		{
+			_label: 'Duplicate',
+			_icons: 'codicon codicon-copy',
+			_on: dummyEventHandler,
+		},
+	];
+
 	return (
 		<>
 			<SampleDescription>
@@ -24,30 +41,23 @@ export const PopoverButtonBasic: FC = () => {
 			</SampleDescription>
 			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 
-			<div className="flex flex-wrap gap-4">
-				<KolPopoverButton _label={'Open popover'} _variant="primary" _icons={{ right: 'codicon codicon-chevron-down' }}>
-					<KolButton _label="Button within popover" _variant="primary" _on={dummyEventHandler} />
-					<br />
-					<br />
-					<KolButton _label="Second Button within popover" _on={dummyEventHandler} />
+			<div className="flex flex-col gap-4">
+				<KolHeading _label="Vertical toolbar with action buttons" _level={2}></KolHeading>
+
+				<KolPopoverButton _label={'Actions'} _variant="primary" _icons={{ right: 'codicon codicon-chevron-down' }}>
+					<KolToolbar _label="Action toolbar" _items={TOOLBAR_ITEMS} _orientation="vertical" />
 				</KolPopoverButton>
 
-				<KolPopoverButton _label="Open popover" _popoverAlign="right" _icons={{ right: 'codicon codicon-chevron-right' }}>
-					<p className="w-sm">
-						Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aspernatur aut dolore dolores itaque praesentium reprehenderit sed voluptatum!
-						Exercitationem ipsa magni maiores modi, placeat quas quos reprehenderit rerum sit veniam vitae.
-					</p>
-				</KolPopoverButton>
+				<KolHeading _label="Info icon with help text" _level={2}></KolHeading>
 
-				<KolPopoverButton _label="icon-only with tooltip" _icons="codicon codicon-info" _tooltipAlign="right" _hideLabel>
-					This is an explanation shown on click.
-				</KolPopoverButton>
-
-				<KolPopoverButton _label="">
-					<span slot="expert">
-						<u>Expert slot content</u>
-					</span>
-					This sample illustrates a button with expert slot.
+				<KolPopoverButton _label="Help" _icons="codicon codicon-info" _popoverAlign="right" tooltipAlign="bottom" _hideLabel>
+					<div className="w-sm p-2 border border-solid border-gray">
+						<KolHeading _label="Help Information" _level={3}></KolHeading>
+						<p>
+							<u>Lorem ipsum dolor sit amet</u>, consectetur adipisicing elit. Aspernatur aut dolore dolores itaque praesentium reprehenderit sed voluptatum!
+							Exercitationem ipsa magni maiores modi, placeat quas quos reprehenderit rerum sit veniam vitae.
+						</p>
+					</div>
 				</KolPopoverButton>
 			</div>
 		</>

--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -50,7 +50,7 @@ export const PopoverButtonBasic: FC = () => {
 
 				<KolHeading _label="Info icon with help text" _level={2}></KolHeading>
 
-				<KolPopoverButton _label="Help" _icons="codicon codicon-info" _popoverAlign="right" tooltipAlign="bottom" _hideLabel>
+				<KolPopoverButton _label="Help" _icons="codicon codicon-info" _popoverAlign="right" _tooltipAlign="bottom" _hideLabel>
 					<div className="w-sm p-2 border border-solid border-gray">
 						<KolHeading _label="Help Information" _level={3}></KolHeading>
 						<p>

--- a/packages/themes/default/src/components/popover-button.scss
+++ b/packages/themes/default/src/components/popover-button.scss
@@ -12,11 +12,4 @@
 			border-radius: var(--border-radius);
 		}
 	}
-
-	.kol-popover-button {
-		&__popover {
-			border: var(--border-width) solid var(--color-primary);
-			padding: var(--spacing);
-		}
-	}
 }


### PR DESCRIPTION
## Summary

Removes hardcoded border styling from the popover button component and updates the sample to show practical use cases with a toolbar and info popover.

## Changes

- Remove `border: 1px solid #000` from the popover button shared mixin
- Remove theme-specific border/padding overrides from the default theme
- Update sample to use `KolToolbar` for an action button menu and `KolHeading` for a help info popover

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Entfernt hartcodierten Rahmen-Stil aus der Popover-Button-Komponente und aktualisiert das Beispiel mit praxisnahen Anwendungsfällen.

## Änderungen

- `border: 1px solid #000` aus dem gemeinsamen Popover-Button-Mixin entfernt
- Themenspezifische Rahmen- und Abstandsüberschreibungen aus dem Standardthema entfernt
- Beispiel auf `KolToolbar` für Aktionsschaltflächen und `KolHeading` für ein Info-Popover aktualisiert

</details>