### PR TITLE
Fix path handling for visual tests

### DIFF
--- a/packages/tools/visual-tests/src/index.js
+++ b/packages/tools/visual-tests/src/index.js
@@ -1,11 +1,11 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import { readFile } from 'fs/promises';
 import child_process from 'node:child_process';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'url';
-import * as crypto from 'crypto';
-import { readFile } from 'fs/promises';
-import * as fs from 'fs';
 import portfinder from 'portfinder';
 import * as process from 'process';
+import { fileURLToPath } from 'url';
 
 const tempDir = process.env.RUNNER_TEMP || process.env.TMPDIR; // TODO: Check on Windows
 
@@ -27,15 +27,14 @@ if (!fs.existsSync(workingDir)) {
 }
 
 const buildPath = path.join(tempDir, `kolibri-visual-testing-build-${crypto.randomUUID()}`);
-const rawPackageJsonPath = new URL(path.join(workingDir, 'package.json'), import.meta.url).href;
-const packageJsonPath = process.platform === 'win32' ? pathToFileURL(rawPackageJsonPath) : rawPackageJsonPath;
-const packageJsonContent = await readFile(new URL(packageJsonPath, import.meta.url), 'utf8');
+const packageJsonPath = path.join(workingDir, 'package.json');
+const packageJsonContent = await readFile(packageJsonPath, 'utf8');
 const packageJson = JSON.parse(packageJsonContent);
 
 console.log(`
 Building React Sample App (v${packageJson?.version ?? '#.#.#'}) …`);
 
-const buildResult = child_process.spawnSync('pnpm', ['run', 'build', `--outDir="${buildPath}"`], {
+const buildResult = child_process.spawnSync('pnpm', ['run', 'build', `--outDir=${buildPath}`], {
 	cwd: workingDir,
 	encoding: 'utf-8',
 	shell: true,


### PR DESCRIPTION
## Summary
- fix the path handling in `visual-tests` to avoid Windows URL issues
- pass build outDir without extra quotes

This pull request refactors the `packages/tools/visual-tests/src/index.js` file to improve code readability and simplify logic. The most notable changes include reordering imports, simplifying the handling of file paths for cross-platform compatibility, and fixing a minor issue with the `--outDir` argument in a command.

### Code readability improvements:

* Reordered imports to group and organize them logically (e.g., standard modules, third-party modules) and alphabetically within groups.

### Cross-platform compatibility:

* Simplified the handling of the `package.json` file path by replacing `pathToFileURL` and `new URL` logic with `path.join`, ensuring consistent behavior across platforms.

### Minor fixes:

* Removed unnecessary quotes around the `--outDir` argument in the `child_process.spawnSync` command to fix potential issues with argument parsing.

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [x] Meaningful pull request title for the release notes
- [x] Pull request is linked to an issue and all changes relate to the issue
- [x] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [x] Documentation or migration has been updated (if applicable)
