### PR TITLE
chore: add postinstall message

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -73,14 +73,18 @@
 		"test:watch": "cross-env NODE_ENV=test stencil test --spec --watchAll",
 		"postpack": "mv package.bak.json package.json",
 		"prepack": "npm run build && cp package.json package.bak.json && rimraf dist/collection dist/kolibri/assets/@leanup dist/types/assets/@leanup && node scripts/anonymous.js && node scripts/minify.js",
+		"postinstall": "node ./postinstall.js",
 		"xunused": "knip"
 	},
 	"dependencies": {
 		"@floating-ui/dom": "1.7.1",
 		"adopted-style-sheets": "1.1.9-rc.19",
+		"boxen": "8.0.1",
+		"chalk": "5.4.1",
 		"clsx": "2.1.1",
 		"color-convert": "3.1.0",
 		"color-rgba": "2.4.0",
+		"figlet": "1.8.1",
 		"lodash-es": "4.17.21",
 		"markdown-it": "14.1.0",
 		"query-selector-all-shadow-root": "0.0.3",
@@ -144,6 +148,7 @@
 		"dist",
 		"doc",
 		"custom-elements.json",
+		"postinstall.js",
 		"vscode-custom-data.json"
 	]
 }

--- a/packages/components/postinstall.js
+++ b/packages/components/postinstall.js
@@ -1,0 +1,38 @@
+module.exports = async () => {
+	if (process.env.CI === 'true') {
+		return;
+	}
+	const { default: chalk } = await import('chalk');
+	const { default: boxen } = await import('boxen');
+	const figlet = require('figlet');
+
+	const isGerman = (process.env.LANG || '').startsWith('de');
+	const title = chalk.cyan(figlet.textSync('KoliBri', { font: 'Standard' }));
+
+	const english = [
+		'Help us make KoliBri even more accessible!',
+		'',
+		'-  Star our repo & submit pull requests',
+		'-  Give feedback via GitHub issues',
+		'-  Documentation – https://public-ui.github.io',
+		'-  Open Source – https://github.com/public-ui',
+	].join('\n');
+
+	const german = [
+		'Hilf mit, KoliBri noch barrierefreier zu machen!',
+		'',
+		'-  Starte unser Repo & reiche Pull-Requests ein',
+		'-  Gib Feedback über GitHub Issues',
+		'-  Dokumentation – https://public-ui.github.io',
+		'-  Open Source – https://github.com/public-ui',
+	].join('\n');
+
+	const message = isGerman ? german : english;
+
+	console.log(title);
+	console.log(boxen(message, { padding: 1, borderStyle: 'round' }));
+};
+
+if (require.main === module) {
+	module.exports();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,12 @@ importers:
       adopted-style-sheets:
         specifier: 1.1.9-rc.19
         version: 1.1.9-rc.19
+      boxen:
+        specifier: 8.0.1
+        version: 8.0.1
+      chalk:
+        specifier: 5.4.1
+        version: 5.4.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -367,6 +373,9 @@ importers:
       color-rgba:
         specifier: 2.4.0
         version: 2.4.0
+      figlet:
+        specifier: 1.8.1
+        version: 1.8.1
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21
@@ -5391,6 +5400,10 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
+  boxen@8.0.1:
+    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -5521,6 +5534,10 @@ packages:
   camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -7078,6 +7095,11 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  figlet@1.8.1:
+    resolution: {integrity: sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==}
+    engines: {node: '>= 0.4.0'}
+    hasBin: true
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -13107,6 +13129,10 @@ packages:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
     engines: {node: '>=12'}
 
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
@@ -19073,6 +19099,17 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
+  boxen@8.0.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 8.0.0
+      chalk: 5.4.1
+      cli-boxes: 3.0.0
+      string-width: 7.2.0
+      type-fest: 4.40.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.0
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -19249,6 +19286,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   camelcase@7.0.1: {}
+
+  camelcase@8.0.0: {}
 
   caniuse-api@3.0.0:
     dependencies:
@@ -21149,6 +21188,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  figlet@1.8.1: {}
 
   figures@3.2.0:
     dependencies:
@@ -28609,6 +28650,10 @@ snapshots:
   widest-line@4.0.1:
     dependencies:
       string-width: 5.1.2
+
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
 
   wildcard@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Adds a `postinstall` script to `@public-ui/components` that displays an ASCII art KoliBri banner with community engagement links when users install the package. The script is skipped in CI environments and adapts its message to English or German based on the system locale.

## Changes

- Add `postinstall.js` script using `figlet`, `chalk`, and `boxen`
- Register `postinstall` npm lifecycle hook in `package.json`
- Add `boxen`, `chalk`, `figlet` as runtime dependencies

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Fügt ein `postinstall`-Skript zu `@public-ui/components` hinzu, das nach der Installation ein KoliBri-ASCII-Art-Banner mit Links zur Community anzeigt. Das Skript wird in CI-Umgebungen übersprungen und passt die Nachricht anhand der Systemsprache an.

## Änderungen

- `postinstall.js`-Skript mit `figlet`, `chalk` und `boxen` hinzugefügt
- `postinstall` npm-Lifecycle-Hook in `package.json` registriert
- `boxen`, `chalk`, `figlet` als Laufzeit-Abhängigkeiten hinzugefügt

</details>