### PR TITLE
fix(sample): fix sidebar z-index to avoid tooltip overlap

### DIFF
--- a/packages/samples/react/src/style.scss
+++ b/packages/samples/react/src/style.scss
@@ -63,6 +63,7 @@ hr {
 	.app-sidebar {
 		border-right: 1px solid gray;
 		position: relative;
+		z-index: 1;
 
 		& .scrollable-container-wrapper {
 			position: fixed;


### PR DESCRIPTION
## Summary
Fixes the sidebar z-index in the sample app to prevent tooltips from appearing behind it.

## Changes
- Fixed sidebar z-index to avoid tooltip overlap

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Sidebar-z-index in der Beispielanwendung korrigiert, um zu verhindern, dass Tooltips dahinter erscheinen.

## Änderungen
- Sidebar-z-index für korrekte Tooltip-Darstellung angepasst

</details>