### PR TITLE
feat(table): allow rendering cells without key when render function is provided

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -262,35 +262,35 @@ export class KolTableStateless implements TableStatelessAPI {
 		return max;
 	}
 
-	private getThePrimaryHeadersWithKeysIfExists(headers: KoliBriTableHeaderCell[][]): KoliBriTableHeaderCell[] {
-		const primaryHeadersWithKeys: KoliBriTableHeaderCell[] = [];
+	private getThePrimaryHeadersWithKeyOrRenderFunction(headers: KoliBriTableHeaderCell[][]): KoliBriTableHeaderCell[] {
+		const primaryHeaders: KoliBriTableHeaderCell[] = [];
 
 		headers.forEach((cells) => {
 			cells.forEach((cell) => {
-				if (typeof cell.key === 'string') {
-					primaryHeadersWithKeys.push(cell);
+				if (typeof cell.key === 'string' || typeof cell.render === 'function') {
+					primaryHeaders.push(cell);
 				}
 			});
 		});
 
-		return primaryHeadersWithKeys;
+		return primaryHeaders;
 	}
 
 	private getPrimaryHeaders(headers: KoliBriTableHeaders): KoliBriTableHeaderCell[] {
-		let primaryHeadersWithKeys: KoliBriTableHeaderCell[] = this.getThePrimaryHeadersWithKeysIfExists(headers.horizontal ?? []);
+		let primaryHeaders: KoliBriTableHeaderCell[] = this.getThePrimaryHeadersWithKeyOrRenderFunction(headers.horizontal ?? []);
 
 		/**
 		 * It is important to note that the rendering direction of the data is implicitly set,
 		 * if either the horizontal or vertical header cells have keys.
 		 */
 		this.horizontal = true;
-		if (primaryHeadersWithKeys.length === 0) {
-			primaryHeadersWithKeys = this.getThePrimaryHeadersWithKeysIfExists(headers.vertical ?? []);
-			if (primaryHeadersWithKeys.length > 0) {
+		if (primaryHeaders.length === 0) {
+			primaryHeaders = this.getThePrimaryHeadersWithKeyOrRenderFunction(headers.vertical ?? []);
+			if (primaryHeaders.length > 0) {
 				this.horizontal = false;
 			}
 		}
-		return primaryHeadersWithKeys;
+		return primaryHeaders;
 	}
 
 	private createDataField(data: KoliBriTableDataType[], headers: KoliBriTableHeaders, isFoot?: boolean): (KoliBriTableCell & KoliBriTableDataType)[][] {
@@ -346,9 +346,9 @@ export class KolTableStateless implements TableStatelessAPI {
 					if (
 						typeof primaryHeader[j] === 'object' &&
 						primaryHeader[j] !== null &&
-						typeof primaryHeader[j].key === 'string' &&
 						typeof row === 'object' &&
-						row !== null
+						row !== null &&
+						(typeof primaryHeader[j].key === 'string' || typeof primaryHeader[j].render === 'function')
 					) {
 						dataRow.push({
 							...primaryHeader[j],
@@ -362,9 +362,9 @@ export class KolTableStateless implements TableStatelessAPI {
 					if (
 						typeof primaryHeader[i] === 'object' &&
 						primaryHeader[i] !== null &&
-						typeof primaryHeader[i].key === 'string' &&
 						typeof data[j] === 'object' &&
-						data[j] !== null
+						data[j] !== null &&
+						(typeof primaryHeader[i].key === 'string' || typeof primaryHeader[i].render === 'function')
 					) {
 						dataRow.push({
 							...primaryHeader[i],

--- a/packages/samples/react/src/components/table/render-cell.tsx
+++ b/packages/samples/react/src/components/table/render-cell.tsx
@@ -84,7 +84,6 @@ const HEADERS: KoliBriTableHeaders = {
 			},
 			{
 				label: 'Action (react)',
-				key: 'order',
 				width: '20em',
 
 				/* Example 4: Render function using React */

--- a/packages/samples/react/src/components/table/sort-data.tsx
+++ b/packages/samples/react/src/components/table/sort-data.tsx
@@ -39,7 +39,6 @@ const HEADERS_VERTICAL: KoliBriTableHeaders = {
 			{ label: 'order', key: 'order', textAlign: 'center' },
 			{
 				label: 'date',
-				key: 'date',
 				textAlign: 'center',
 				render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as Data).date),
 				sort: (data) =>


### PR DESCRIPTION
## Summary

Table cells can now be rendered without a `key` property when a `render` function is defined. Previously, cells without a `key` were excluded from data mapping even if they had a custom render function.

## Changes

- Update `getThePrimaryHeadersWithKeyOrRenderFunction` to include cells that have either a `key` or a `render` function
- Update `createDataField` condition to accept cells with either `key` or `render`
- Remove unnecessary `key` from sample render-cell and sort-data examples

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Tabellenzellen können jetzt auch ohne `key`-Eigenschaft gerendert werden, sofern eine `render`-Funktion definiert ist. Zuvor wurden solche Zellen trotz vorhandener Render-Funktion aus dem Daten-Mapping ausgeschlossen.

## Änderungen

- `getThePrimaryHeadersWithKeyOrRenderFunction` akzeptiert nun Zellen mit `key` oder `render`-Funktion
- Bedingung in `createDataField` entsprechend angepasst
- Überflüssige `key`-Angaben aus Beispiel-Komponenten entfernt

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
