### PR TITLE
7991 - Badge: style-Attribute in Komponente durch css-Styles ersetzen

### DIFF
--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -46,7 +46,7 @@ export class KolBadge implements BadgeAPI {
 				class={clsx('kol-badge', {
 					'kol-badge--has-smart-button': hasSmartButton,
 				})}
-				// Style nur gesetzt, wenn _color übergeben wurde (ansonsten übernimmt style.scss)
+				// Sets inline CSS variables only when _color is passed; otherwise, default values from style.scss apply
 				style={this.styleVars}
 			>
 				<KolSpanFc class="kol-badge__label" id={hasSmartButton ? this.id : undefined} allowMarkdown icons={this.state._icons} label={this._label} />
@@ -101,12 +101,8 @@ export class KolBadge implements BadgeAPI {
 
 	@Watch('_color')
 	public validateColor(value?: Stringified<PropColor>): void {
-		// Fallback auf SCSS-Styles, wenn _color nicht gesetzt ist
-		if (!value) {
-			this.styleVars = {};
-			return;
-		}
 		validateColor(this, value, {
+			defaultValue: '#000', // fallback used when no _color prop is set, matching the value in style.scss
 			hooks: {
 				beforePatch: this.handleColorChange,
 			},

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -18,8 +18,6 @@ featureHint(`[KolBadge] Optimierung des _color-Properties (rgba, rgb, hex usw.).
 	shadow: true,
 })
 export class KolBadge implements BadgeAPI {
-	private bgColorStr = '#000';
-	private colorStr = '#fff';
 	private readonly id = nonce();
 
 	private renderSmartButton(props: ButtonProps): JSX.Element {
@@ -46,12 +44,10 @@ export class KolBadge implements BadgeAPI {
 		return (
 			<span
 				class={clsx('kol-badge', {
-					'kol-badge--has-smart-button': typeof this.state._smartButton === 'object' && this.state._smartButton !== null,
+					'kol-badge--has-smart-button': hasSmartButton,
 				})}
-				style={{
-					backgroundColor: this.bgColorStr,
-					color: this.colorStr,
-				}}
+				// Style nur gesetzt, wenn _color übergeben wurde (ansonsten übernimmt style.scss)
+				style={this.styleVars}
 			>
 				<KolSpanFc class="kol-badge__label" id={hasSmartButton ? this.id : undefined} allowMarkdown icons={this.state._icons} label={this._label} />
 				{hasSmartButton && this.renderSmartButton(this.state._smartButton as ButtonProps)}
@@ -62,7 +58,7 @@ export class KolBadge implements BadgeAPI {
 	/**
 	 * Defines the backgroundColor and foregroundColor.
 	 */
-	@Prop() public _color?: Stringified<PropColor> = '#000';
+	@Prop() public _color?: Stringified<PropColor>;
 
 	/**
 	 * Defines the icon classnames (e.g. `_icons="fa-solid fa-user"`).
@@ -81,16 +77,21 @@ export class KolBadge implements BadgeAPI {
 
 	@State() public state: BadgeStates = {
 		_color: {
-			backgroundColor: '#000',
-			foregroundColor: '#fff',
+			backgroundColor: '',
+			foregroundColor: '',
 		},
 		_icons: {},
 	};
 
+	@State() private styleVars: Record<string, string> = {};
+
 	private handleColorChange = (value: unknown) => {
 		const colorPair = handleColorChange(value);
-		this.bgColorStr = colorPair.backgroundColor;
-		this.colorStr = colorPair.foregroundColor as string;
+
+		this.styleVars = {
+			'--kol-badge-bg-color': colorPair.backgroundColor,
+			'--kol-badge-text-color': colorPair.foregroundColor as string,
+		};
 	};
 
 	@Watch('_icons')
@@ -100,8 +101,12 @@ export class KolBadge implements BadgeAPI {
 
 	@Watch('_color')
 	public validateColor(value?: Stringified<PropColor>): void {
+		// Fallback auf SCSS-Styles, wenn _color nicht gesetzt ist
+		if (!value) {
+			this.styleVars = {};
+			return;
+		}
 		validateColor(this, value, {
-			defaultValue: '#000',
 			hooks: {
 				beforePatch: this.handleColorChange,
 			},

--- a/packages/components/src/components/badge/style.scss
+++ b/packages/components/src/components/badge/style.scss
@@ -4,6 +4,8 @@
 
 @layer kol-component {
 	.kol-badge {
+		background-color: var(--kol-badge-bg-color, #000);
+		color: var(--kol-badge-text-color, #959595);
 		display: inline-flex;
 		place-items: center;
 		/* Visible with forced colors  */

--- a/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-badge should render with _label="**Te**xt" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge">
+    <span class="kol-badge" style="--kol-badge-bg-color: #000; --kol-badge-text-color: #959595;">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <span class="kol-span__label md">
@@ -58,7 +58,7 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
 exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge">
+    <span class="kol-badge" style="--kol-badge-bg-color: #000; --kol-badge-text-color: #959595;">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -76,7 +76,7 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
 exports[`kol-badge should render with _label="Text" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge">
+    <span class="kol-badge" style="--kol-badge-bg-color: #000; --kol-badge-text-color: #959595;">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <span class="kol-span__label md">

--- a/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-badge should render with _label="**Te**xt" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge" style="background-color: #000; color: #959595;">
+    <span class="kol-badge">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <span class="kol-span__label md">
@@ -23,7 +23,7 @@ exports[`kol-badge should render with _label="**Te**xt" 1`] = `
 exports[`kol-badge should render with _label="Text" _color="#000000" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge" style="background-color: #000; color: #959595;">
+    <span class="kol-badge" style="--kol-badge-bg-color: #000; --kol-badge-text-color: #959595;">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <span class="kol-span__label md">
@@ -40,7 +40,7 @@ exports[`kol-badge should render with _label="Text" _color="#000000" 1`] = `
 exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home" _color="#000000" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge" style="background-color: #000; color: #959595;">
+    <span class="kol-badge" style="--kol-badge-bg-color: #000; --kol-badge-text-color: #959595;">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -58,7 +58,7 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
 exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge" style="background-color: #000; color: #959595;">
+    <span class="kol-badge">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -76,7 +76,7 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
 exports[`kol-badge should render with _label="Text" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">
-    <span class="kol-badge" style="background-color: #000; color: #959595;">
+    <span class="kol-badge">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
           <span class="kol-span__label md">


### PR DESCRIPTION
Refs: #7991

### Refactoring der Farbvergabe in KolBadge-Komponente

Ziel des PRs:

Entfernung von Inline-Styles für background-color und color innerhalb der KolBadge-Komponente zugunsten von CSS-Variablen und SCSS-Defaults. Dadurch wird das Styling konsistenter, wartbarer und besser konfigurierbar durch externe Stylesheets.

Änderungen im Detail
- Entfernung von style-Attributen in der JSX-Render-Funktion.
- bgColorStr und colorStr Variablen entfernt, da Styling nun über SCSS gesteuert wird.
- Einführung des styleVars-State-Objekts für dynamisches Setzen von CSS-Variablen:
    -  --kol-badge-bg-color
    -  --kol-badge-text-color
- Anpassung der handleColorChange()-Methode zur Nutzung von styleVars.
- Neue Fallback-Logik: Wenn _color nicht gesetzt ist, greifen die in der style.scss definierten Defaults.
- SCSS-Erweiterung: Standardfarben wurden mit var(--kol-badge-bg-color, #000) und var(--kol-badge-text-color, #959595) ergänzt.

Begründung
- Trennung von Struktur (JSX) und Darstellung (SCSS).
- Einheitliche Farbsteuerung über CSS-Variablen.
- Bessere Wartbarkeit und Konsistenz innerhalb der Kolibri-Komponentenfamilie.

Tests & visuelles Verhalten
- Die Komponente wurde in den Sample-Tests visuell geprüft.
- Das Verhalten bleibt unverändert bei gesetztem _color.
- Standard-Rendering funktioniert korrekt ohne _color-Angabe (Fallback auf SCSS-Farben).