### PR TITLE
test: disable failing axe tests in internal themes

### DIFF
--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -233,6 +233,9 @@ ROUTES.set('form/error-list', {
 	},
 });
 ROUTES.set('heading/badge', {
+	axe: {
+		skipFailures: true,
+	},
 	snapshot: {
 		skip: true,
 		zoom: {
@@ -241,6 +244,9 @@ ROUTES.set('heading/badge', {
 	},
 });
 ROUTES.set('heading/basic', {
+	axe: {
+		skipFailures: true,
+	},
 	snapshot: {
 		viewportSize: {
 			width: 250,
@@ -253,6 +259,9 @@ ROUTES.set('heading/basic', {
 });
 ROUTES.set('heading/secondary');
 ROUTES.set('heading/paragraph', {
+	axe: {
+		skipFailures: true,
+	},
 	snapshot: {
 		skip: true,
 		zoom: {


### PR DESCRIPTION
## Summary
Temporarily disables failing Axe accessibility tests for internal themes pending investigation.

## Changes
- Disabled failing Axe tests in internal themes

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Fehlschlagende Axe-Barrierefreiheitstests für interne Themes bis zur Klärung vorübergehend deaktiviert.

## Änderungen
- Fehlschlagende Axe-Tests in internen Themes deaktiviert

</details>