### PR TITLE
style(progress): replace inline style width with svg width attribute in BarSvg

### DIFF
--- a/packages/components/src/components/progress/shadow.tsx
+++ b/packages/components/src/components/progress/shadow.tsx
@@ -35,28 +35,8 @@ const BarSvg = ({ state }: { state: ProgressStates }) => {
 
 	return (
 		<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="12" overflow="visible">
-			<rect
-				class="kol-progress__bar-background"
-				x="1"
-				y="1"
-				height="11"
-				rx="5"
-				fill="currentColor"
-				stroke="currentColor"
-				stroke-width="3"
-				style={{ width: `100%` }}
-			></rect>
-			<rect
-				class="kol-progress__bar-border"
-				x="1"
-				y="1"
-				height="11"
-				rx="5"
-				fill="currentColor"
-				stroke="currentColor"
-				stroke-width="1"
-				style={{ width: `100%` }}
-			></rect>
+			<rect class="kol-progress__bar-background" x="1" y="1" height="11" rx="5" fill="currentColor" stroke="currentColor" stroke-width="3" width="100%"></rect>
+			<rect class="kol-progress__bar-border" x="1" y="1" height="11" rx="5" fill="currentColor" stroke="currentColor" stroke-width="1" width="100%"></rect>
 			<rect
 				class="kol-progress__bar-progress"
 				x="3"

--- a/packages/components/src/components/progress/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/progress/test/__snapshots__/snapshot.spec.tsx.snap
@@ -9,8 +9,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(0% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 2ch;">
@@ -38,8 +38,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(0% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 3ch;">
@@ -67,8 +67,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(40.476190476190474% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 3ch;">
@@ -96,8 +96,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(50% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 2ch;">
@@ -125,8 +125,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=42 _
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(238.0952380952381% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 3ch;">
@@ -154,8 +154,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(0% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 3ch;">
@@ -183,8 +183,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(42% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 3ch;">
@@ -212,8 +212,8 @@ exports[`kol-progress should render with _label="Label" _variant="bar" _max=100 
           Label
         </div>
         <svg height="12" overflow="visible" width="100%" xmlns="http://www.w3.org/2000/svg">
-          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" x="1" y="1" style="width: 100%;"></rect>
-          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" x="1" y="1" style="width: 100%;"></rect>
+          <rect class="kol-progress__bar-background" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="3" width="100%" x="1" y="1"></rect>
+          <rect class="kol-progress__bar-border" fill="currentColor" height="11" rx="5" stroke="currentColor" stroke-width="1" width="100%" x="1" y="1"></rect>
           <rect class="kol-progress__bar-progress" fill="currentColor" height="7" rx="3.5" stroke="currentColor" stroke-width="3" x="3" y="3" style="width: calc(100% - 4px);"></rect>
         </svg>
         <div class="kol-progress__bar-value" style="width: 3ch;">


### PR DESCRIPTION
## Summary
Replaces the inline CSS `width` style with the SVG `width` attribute in the `BarSvg` progress component.

## Changes
- Replaced inline `width` style with SVG `width` attribute in BarSvg

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Inline-CSS-`width`-Stil durch das SVG-`width`-Attribut in der `BarSvg`-Fortschrittskomponente ersetzt.

## Änderungen
- Inline-`width`-Stil durch SVG-`width`-Attribut in BarSvg ersetzt

</details>