### PR TITLE
7566 - (KolSpin) Alternative _label Prop added (Samples updated too)

### DIFF
--- a/packages/components/src/components/spin/shadow.tsx
+++ b/packages/components/src/components/spin/shadow.tsx
@@ -1,10 +1,10 @@
 import type { JSX } from '@stencil/core';
-import { validateShow, validateSpinVariant } from '../../schema';
+import { validateShow, validateSpinVariant, validateLabelWithExpertSlot } from '../../schema';
 import { Component, Fragment, h, Host, Prop, State, Watch } from '@stencil/core';
 
 import { translate } from '../../i18n';
 
-import type { ShowPropType, SpinAPI, SpinStates, SpinVariantPropType } from '../../schema';
+import type { LabelPropType, LabelWithExpertSlotPropType, ShowPropType, SpinAPI, SpinStates, SpinVariantPropType } from '../../schema';
 import clsx from 'clsx';
 function renderSpin(variant: SpinVariantPropType): JSX.Element {
 	switch (variant) {
@@ -36,19 +36,21 @@ export class KolSpin implements SpinAPI {
 
 	public render(): JSX.Element {
 		return (
-			<Host class="kol-spin">
+			<Host class="kol-spin" aria-live={this._label ? 'polite' : null}>
 				{this.state._show ? (
-					<span
-						aria-busy="true"
-						aria-label={translate('kol-action-running')}
-						aria-live="polite"
-						class={clsx('kol-spin__spinner', `kol-spin__spinner--${this.state._variant}`)}
-						role="alert"
-					>
-						{renderSpin(this.state._variant)}
-					</span>
+					<>
+						{this._label && <label class="kol-spin__label">{this._label}</label>}
+						<span
+							aria-busy="true"
+							aria-label={translate('kol-action-running')}
+							class={clsx('kol-spin__spinner', `kol-spin__spinner--${this.state._variant}`)}
+							role="alert"
+						>
+							{renderSpin(this.state._variant)}
+						</span>
+					</>
 				) : (
-					this.showToggled && <span aria-label={translate('kol-action-done')} aria-busy="false" aria-live="polite" role="alert"></span>
+					this.showToggled && <span aria-label={translate('kol-action-done')} aria-busy="false" role="alert"></span>
 				)}
 			</Host>
 		);
@@ -65,6 +67,11 @@ export class KolSpin implements SpinAPI {
 	 */
 	@Prop() public _variant?: SpinVariantPropType = 'dot';
 
+	/**
+	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.).
+	 */
+	@Prop() public _label?: LabelWithExpertSlotPropType;
+
 	@State() public state: SpinStates = {
 		_variant: 'dot',
 	};
@@ -80,7 +87,13 @@ export class KolSpin implements SpinAPI {
 		validateSpinVariant(this, value);
 	}
 
+	@Watch('_label')
+	public validateLabel(value?: LabelPropType): void {
+		validateLabelWithExpertSlot(this, value);
+	}
+
 	public componentWillLoad(): void {
+		this.validateLabel(this._label);
 		this.validateShow(this._show);
 		this.validateVariant(this._variant);
 	}

--- a/packages/components/src/components/spin/style.scss
+++ b/packages/components/src/components/spin/style.scss
@@ -7,6 +7,7 @@
 	.kol-spin {
 		&__spinner {
 			display: block;
+			margin-top: 0.15rem;
 			padding: rem(2);
 			position: relative;
 		}

--- a/packages/components/src/components/spin/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/spin/test/__snapshots__/snapshot.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`kol-spin should render with _show=false 1`] = `
 exports[`kol-spin should render with _show=true 1`] = `
 <kol-spin _show="" class="kol-spin">
   <template shadowrootmode="open">
-    <span aria-busy="true" aria-label="kol-action-running" aria-live="polite" class="kol-spin__spinner kol-spin__spinner--dot" role="alert">
+    <span aria-busy="true" aria-label="kol-action-running" class="kol-spin__spinner kol-spin__spinner--dot" role="alert">
       <span class="kol-spin__spinner-element kol-spin__spinner-element--1"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--2"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--3"></span>

--- a/packages/samples/react/src/components/spin/basic.tsx
+++ b/packages/samples/react/src/components/spin/basic.tsx
@@ -4,6 +4,7 @@ import { KolSpin } from '@public-ui/react';
 
 import type { FC } from 'react';
 import { SampleDescription } from '../SampleDescription';
+import { SampleColumns } from '../SampleColumns';
 
 export const SpinBasic: FC = () => (
 	<>
@@ -11,6 +12,15 @@ export const SpinBasic: FC = () => (
 			<p>KolSpin renders a loading indicator. This sample shows the default variant &quot;dot&quot;.</p>
 		</SampleDescription>
 
-		<KolSpin _show />
+		<SampleColumns>
+			<fieldset>
+				<legend>KolSpin &quot;Basic&quot; (show Label)</legend>
+				<KolSpin _show _label="In Progress..." />
+			</fieldset>
+			<fieldset>
+				<legend>KolSpin &quot;Basic&quot; (hide Label)</legend>
+				<KolSpin _show />
+			</fieldset>
+		</SampleColumns>
 	</>
 );

--- a/packages/samples/react/src/components/spin/custom.css
+++ b/packages/samples/react/src/components/spin/custom.css
@@ -8,6 +8,15 @@
 	position: relative;
 	animation: pulse 1s linear infinite;
 }
+
+.kol-spin {
+	font-size: 0.2rem;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+}
+
 .loader:after {
 	content: '';
 	position: absolute;
@@ -27,17 +36,20 @@
 	0% {
 		transform: translate(-50%, -50%) scale(0);
 	}
+
 	60%,
 	100% {
 		transform: translate(-50%, -50%) scale(1);
 	}
 }
+
 @keyframes pulse {
 	0%,
 	60%,
 	100% {
 		transform: scale(1);
 	}
+
 	80% {
 		transform: scale(1.2);
 	}

--- a/packages/samples/react/src/components/spin/custom.tsx
+++ b/packages/samples/react/src/components/spin/custom.tsx
@@ -1,5 +1,6 @@
 import './custom.css';
 import { SampleDescription } from '../SampleDescription';
+import { SampleColumns } from '../SampleColumns';
 
 import React from 'react';
 
@@ -16,8 +17,19 @@ export const SpinCustom: FC = () => (
 			</p>
 		</SampleDescription>
 
-		<KolSpin _show _variant="none">
-			<span slot="expert" className="loader"></span>
-		</KolSpin>
+		<SampleColumns>
+			<fieldset>
+				<legend>KolSpin &quot;Custom&quot; (show Label)</legend>
+				<KolSpin _show _variant="none" _label="In Progress...">
+					<span slot="expert" className="loader"></span>
+				</KolSpin>
+			</fieldset>
+			<fieldset>
+				<legend>KolSpin &quot;Custom&quot; (hide Lable)</legend>
+				<KolSpin _show _variant="none">
+					<span slot="expert" className="loader"></span>
+				</KolSpin>
+			</fieldset>
+		</SampleColumns>
 	</>
 );

--- a/packages/samples/react/src/components/spin/cycle.tsx
+++ b/packages/samples/react/src/components/spin/cycle.tsx
@@ -4,6 +4,7 @@ import { KolSpin } from '@public-ui/react';
 
 import type { FC } from 'react';
 import { SampleDescription } from '../SampleDescription';
+import { SampleColumns } from '../SampleColumns';
 
 export const SpinCycle: FC = () => (
 	<>
@@ -11,6 +12,15 @@ export const SpinCycle: FC = () => (
 			<p>This sample shows the KolSpin variant &quot;cycle&quot;.</p>
 		</SampleDescription>
 
-		<KolSpin _show _variant="cycle" />
+		<SampleColumns>
+			<fieldset>
+				<legend>KolSpin &quot;Cycle&quot; (show Label)</legend>
+				<KolSpin _show _variant="cycle" _label="In Progress..." />
+			</fieldset>
+			<fieldset>
+				<legend>KolSpin &quot;Cycle&quot; (hide Lable)</legend>
+				<KolSpin _show _variant="cycle" />
+			</fieldset>
+		</SampleColumns>
 	</>
 );


### PR DESCRIPTION
Refs: #7566

## Feature: Alternatives `_label`-Prop für `kol-spin`

### Beschreibung

Dieses PR ergänzt das `kol-spin`-Element um ein optionales `_label`-Attribut, das sowohl die visuelle als auch die barrierefreie Nutzung verbessert.

### Änderungen im Detail

- Neues, optionales Attribut: `_label`
- Wird `_label` gesetzt:
  - erscheint der übergebene Text oberhalb des Spinners (als semantisches `<label>`)
  - erhält das Root-Element `aria-live="polite"` zur verbesserten Screenreader-Unterstützung
- Default-Verhalten bleibt unverändert, wenn `_label` nicht gesetzt ist
- Keine Breaking Changes für bestehende Implementierungen

### Tests & Dokumentation

- Visual-Tests wurden angepasst und decken beide Zustände ab (`_label` gesetzt und nicht gesetzt)
- `readme.md` und zentrale `doc/spin.md` enthalten aktualisierte API-Dokumentation
