### PR TITLE
fix(heading): change html tag for secondary headline to p

### DIFF
--- a/packages/components/src/components/heading/component.tsx
+++ b/packages/components/src/components/heading/component.tsx
@@ -85,32 +85,13 @@ export class KolHeadingWc implements HeadingAPI {
 		);
 	};
 
-	private readonly renderSecondaryHeadline = (headline: string, level?: number): JSX.Element => {
-		switch (level) {
-			case 1: // if the headline is only strong
-				return <span class="secondary-headline">{headline}</span>;
-			case 2: // if the headline is h1
-				return <h2 class="secondary-headline">{headline}</h2>;
-			case 3: // if the headline is h2
-				return <h3 class="secondary-headline">{headline}</h3>;
-			case 4: // if the headline is h3
-				return <h4 class="secondary-headline">{headline}</h4>;
-			case 5: // if the headline is h4
-				return <h5 class="secondary-headline">{headline}</h5>;
-			case 6: // if the headline is h5
-				return <h6 class="secondary-headline">{headline}</h6>;
-			default: // if the headline is h6
-				return <strong class="secondary-headline">{headline}</strong>;
-		}
-	};
-
 	public render(): JSX.Element {
 		return (
 			<Host class="kol-heading-wc">
 				{typeof this.state._secondaryHeadline === 'string' && this.state._secondaryHeadline.length > 0 ? (
 					<hgroup>
 						{this.renderHeadline(this.state._label, this.state._level)}
-						{this.state._secondaryHeadline && this.renderSecondaryHeadline(this.state._secondaryHeadline, this.state._level + 1)}
+						<p class="secondary-headline">{this.state._secondaryHeadline}</p>
 					</hgroup>
 				) : (
 					this.renderHeadline(this.state._label, this.state._level)

--- a/packages/components/src/components/heading/style.scss
+++ b/packages/components/src/components/heading/style.scss
@@ -1,1 +1,5 @@
 @use '../style' as *;
+
+.secondary-headline {
+	margin: 0;
+}

--- a/packages/components/src/components/heading/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/heading/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,151 +1,150 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`kol-heading should render with _label="Headline" _level=0 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _level="0" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Heading" _secondaryHeadline="Secondary Heading" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <hgroup>
+    <h1 class="headline headline-h1">
+      Heading
+    </h1>
+    <p class="secondary-headline">
+      Secondary Heading
+    </p>
+  </hgroup>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _level=1 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _level="1" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _level=0 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <strong class="headline headline-strong">
+    Headline
+  </strong>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _level=2 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _level="2" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _level=1 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h1">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _level=3 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _level="3" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _level=2 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h2 class="headline headline-h2">
+    Headline
+  </h2>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _level=4 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _level="4" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _level=3 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h3 class="headline headline-h3">
+    Headline
+  </h3>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _level=5 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _level="5" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _level=4 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h4 class="headline headline-h4">
+    Headline
+  </h4>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _level=6 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _level="6" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _level=5 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h5 class="headline headline-h5">
+    Headline
+  </h5>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _variant="h1" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _variant="h1" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _level=6 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h6 class="headline headline-h6">
+    Headline
+  </h6>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _variant="h2" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _variant="h2" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _variant="h1" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h1">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _variant="h3" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _variant="h3" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _variant="h2" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h2">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _variant="h4" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _variant="h4" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _variant="h3" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h3">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _variant="h5" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _variant="h5" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _variant="h4" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h4">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _variant="h6" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _variant="h6" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _variant="h5" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h5">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" _variant="strong" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" _variant="strong" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _variant="h6" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h6">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;
 
-exports[`kol-heading should render with _label="Headline" 1`] = `
-<kol-heading>
-  <template shadowrootmode="open">
-    <kol-heading-wc _label="Headline" class="kol-heading">
-      <slot name="expert" slot="expert"></slot>
-    </kol-heading-wc>
-  </template>
-</kol-heading>
+exports[`kol-heading-wc should render with _label="Headline" _variant="strong" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-strong">
+    Headline
+  </h1>
+</kol-heading-wc>
+`;
+
+exports[`kol-heading-wc should render with _label="Headline" 1`] = `
+<kol-heading-wc class="kol-heading-wc">
+  <!---->
+  <h1 class="headline headline-h1">
+    Headline
+  </h1>
+</kol-heading-wc>
 `;

--- a/packages/components/src/components/heading/test/snapshot.spec.tsx
+++ b/packages/components/src/components/heading/test/snapshot.spec.tsx
@@ -1,15 +1,18 @@
-import { KolHeadingTag } from '../../../core/component-names';
+import { KolHeadingWcTag } from '../../../core/component-names';
 import type { HeadingProps } from '../../../schema';
 import { executeSnapshotTests } from '../../../utils/testing';
-
-import { KolHeading } from '../shadow';
+import { KolHeadingWc } from '../component';
 
 executeSnapshotTests<HeadingProps>(
-	KolHeadingTag,
-	[KolHeading],
+	KolHeadingWcTag,
+	[KolHeadingWc],
 	[
 		{ _label: 'Headline' },
 		...[0, 1, 2, 3, 4, 5, 6].map((_level) => ({ _label: 'Headline', _level }) as HeadingProps),
 		...['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong'].map((_variant) => ({ _label: 'Headline', _variant }) as HeadingProps),
+		{
+			_label: 'Heading',
+			_secondaryHeadline: 'Secondary Heading',
+		},
 	],
 );


### PR DESCRIPTION
## Summary
Changes the HTML tag used for the secondary headline in the heading component from a heading element to `<p>` for correct semantics.

## Changes
- Changed secondary headline HTML tag to `<p>` in heading component

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
HTML-Tag für die sekundäre Überschrift in der Heading-Komponente von einem Überschriften-Element in `<p>` geändert.

## Änderungen
- HTML-Tag der sekundären Überschrift auf `<p>` in der Heading-Komponente geändert

</details>