### PR TITLE
feat(samples-react): remove draft warnings

### DIFF
--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -4,7 +4,6 @@ import { useLocation } from 'react-router';
 import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
 
 import PackageJson from '@public-ui/components/package.json';
-import { KolBadge } from '@public-ui/react';
 
 import { BackPage } from './components/BackPage';
 import { Sidebar } from './components/Sidebar';
@@ -12,7 +11,7 @@ import { useSetCurrentLocation } from './hooks/useSetCurrentLocation';
 import { HideMenusContext } from './shares/HideMenusContext';
 import { ROUTES } from './shares/routes';
 import { getTheme, getThemeName, setStorage, setTheme } from './shares/store';
-import { THEMES, THEME_OPTIONS, isDraftTheme } from './shares/theme';
+import { THEMES, THEME_OPTIONS } from './shares/theme';
 
 import type { Route as MyRoute, Routes as MyRoutes } from './shares/types';
 
@@ -137,7 +136,6 @@ export const App: FC = () => {
 				)}
 
 				<main className="flex flex-col items-stretch p-4" id="route-container">
-					{!hideMenus && isDraftTheme(theme) && <KolBadge className="block mb-3" _label="In progress" _color="#db5461" />}
 					<Routes>
 						{ROUTE_TREE}
 						<Route path="*" element={<Navigate to={ROUTE_LIST[0]} replace />} />

--- a/packages/samples/react/src/components/combobox/basic.tsx
+++ b/packages/samples/react/src/components/combobox/basic.tsx
@@ -1,19 +1,14 @@
 import type { FC } from 'react';
-import { useContext } from 'react';
 import React from 'react';
 import { FormWrap } from '../FormWrap';
 import { ComboboxVariants } from './partials/variants';
 import { SampleDescription } from '../SampleDescription';
-import { KolBadge } from '@public-ui/react';
-import { HideMenusContext } from '../../shares/HideMenusContext';
 export const ComboboxBasic: FC = () => {
-	const hideMenus = useContext(HideMenusContext);
 	return (
 		<>
 			<SampleDescription>
 				<p>KolCombobox combines a text input with a suggestion list, enabling users to either type in a value or to select on of the suggestions.</p>
 			</SampleDescription>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 
 			<FormWrap RefComponent={ComboboxVariants} />
 		</>

--- a/packages/samples/react/src/components/drawer/basic.tsx
+++ b/packages/samples/react/src/components/drawer/basic.tsx
@@ -1,10 +1,9 @@
 import type { FC } from 'react';
-import React, { useRef, useState, useContext, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { HideMenusContext } from '../../shares/HideMenusContext';
 import type { AlignPropType } from '@public-ui/components';
-import { KolDrawer, KolButton, KolBadge, KolInputCheckbox } from '@public-ui/react';
+import { KolDrawer, KolButton, KolInputCheckbox } from '@public-ui/react';
 import { SampleDescription } from '../SampleDescription';
 
 import { DrawerRadioAlign } from './partials/align';
@@ -12,7 +11,6 @@ export const DrawerBasic: FC = () => {
 	const [searchParams] = useSearchParams();
 	const defaultAlign = searchParams.get('align') as AlignPropType;
 	const defaultCloser = searchParams.get('closer') === 'true';
-	const hideMenus = useContext(HideMenusContext);
 	const drawerElement = useRef<HTMLKolDrawerElement>(null);
 
 	const [align, setAlign] = useState<AlignPropType>(defaultAlign || 'left');
@@ -25,7 +23,6 @@ export const DrawerBasic: FC = () => {
 	}, [defaultAlign]);
 	return (
 		<>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 			<SampleDescription>
 				<p>KolDrawer shows a dialog attached to one of the sides of the viewport, when opened. This sample illustrates the four alignments.</p>
 			</SampleDescription>

--- a/packages/samples/react/src/components/drawer/controlled.tsx
+++ b/packages/samples/react/src/components/drawer/controlled.tsx
@@ -1,10 +1,9 @@
 import type { FC } from 'react';
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { HideMenusContext } from '../../shares/HideMenusContext';
 import type { AlignPropType } from '@public-ui/components';
-import { KolDrawer, KolButton, KolBadge } from '@public-ui/react';
+import { KolDrawer, KolButton } from '@public-ui/react';
 import { SampleDescription } from '../SampleDescription';
 
 import { DrawerRadioAlign } from './partials/align';
@@ -12,12 +11,10 @@ import { DrawerRadioAlign } from './partials/align';
 export const DrawerControlled: FC = () => {
 	const [searchParams] = useSearchParams();
 	const defaultAlign = searchParams.get('align') as AlignPropType;
-	const hideMenus = useContext(HideMenusContext);
 	const [open, setOpen] = useState(false);
 	const [align, setAlign] = useState<AlignPropType>(defaultAlign || 'left');
 	return (
 		<div>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 			<SampleDescription>
 				<p>
 					This sample shows the KolDrawer controlled by the property <code>_open</code> instead of methods.

--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -1,12 +1,10 @@
 import type { FC } from 'react';
-import React, { useContext } from 'react';
+import React from 'react';
 import { SampleDescription } from '../SampleDescription';
-import { KolBadge, KolPopoverButton, KolToolbar, KolHeading } from '@public-ui/react';
+import { KolPopoverButton, KolToolbar, KolHeading } from '@public-ui/react';
 import { useToasterService } from '../../hooks/useToasterService';
-import { HideMenusContext } from '../../shares/HideMenusContext';
 
 export const PopoverButtonBasic: FC = () => {
-	const hideMenus = useContext(HideMenusContext);
 	const { dummyClickEventHandler } = useToasterService();
 
 	const dummyEventHandler = {
@@ -39,7 +37,6 @@ export const PopoverButtonBasic: FC = () => {
 					right, bottom, left) using the <code>_popoverAlign</code> prop.
 				</p>
 			</SampleDescription>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 
 			<div className="flex flex-col gap-4">
 				<KolHeading _label="Vertical toolbar with action buttons" _level={2}></KolHeading>

--- a/packages/samples/react/src/components/single-select/basic.tsx
+++ b/packages/samples/react/src/components/single-select/basic.tsx
@@ -1,21 +1,15 @@
 import React from 'react';
 import type { FC } from 'react';
 import { FormWrap } from '../FormWrap';
-import { HideMenusContext } from '../../shares/HideMenusContext';
 import { SampleDescription } from '../SampleDescription';
 import { SingleSelectVariants } from './partials/variants';
-import { useContext } from 'react';
-import { KolBadge } from '@public-ui/react';
 
 export const SingleSelectBasic: FC = () => {
-	const hideMenus = useContext(HideMenusContext);
-
 	return (
 		<>
 			<SampleDescription>
 				<p>SingleSelect provides a select field for a single value, supported by a search field.</p>
 			</SampleDescription>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 
 			<FormWrap RefComponent={SingleSelectVariants} />
 		</>

--- a/packages/samples/react/src/components/toolbar/basic.tsx
+++ b/packages/samples/react/src/components/toolbar/basic.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
-import React, { useContext } from 'react';
-import { KolBadge, KolHeading, KolToolbar } from '@public-ui/react';
-import { HideMenusContext } from '../../shares/HideMenusContext';
+import React from 'react';
+import { KolHeading, KolToolbar } from '@public-ui/react';
 import { SampleDescription } from '../SampleDescription';
 
 export const ToolbarBasic: FC = () => {
@@ -36,7 +35,6 @@ export const ToolbarBasic: FC = () => {
 			_label: 'Bold',
 		},
 	];
-	const hideMenus = useContext(HideMenusContext);
 	return (
 		<>
 			<SampleDescription>
@@ -45,7 +43,6 @@ export const ToolbarBasic: FC = () => {
 					features button and link elements.
 				</p>
 			</SampleDescription>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 
 			<div className="flex flex-col gap-4">
 				<KolHeading _label="Orientation horizontal" _level={2} />

--- a/packages/samples/react/src/components/toolbar/disabled.tsx
+++ b/packages/samples/react/src/components/toolbar/disabled.tsx
@@ -1,17 +1,14 @@
 import type { FC } from 'react';
-import React, { useContext } from 'react';
-import { KolBadge, KolToolbar } from '@public-ui/react';
-import { HideMenusContext } from '../../shares/HideMenusContext';
+import React from 'react';
+import { KolToolbar } from '@public-ui/react';
 import { SampleDescription } from '../SampleDescription';
 
 export const ToolbarDisabled: FC = () => {
-	const hideMenus = useContext(HideMenusContext);
 	return (
 		<>
 			<SampleDescription>
 				<p>This sample shows KolToolbars with some of the elements disabled.</p>
 			</SampleDescription>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 
 			<KolToolbar
 				_label="Toolbar"

--- a/packages/samples/react/src/components/tree/basic.tsx
+++ b/packages/samples/react/src/components/tree/basic.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React, { useContext, useState } from 'react';
-import { KolBadge, KolButton, KolTree, KolTreeItem } from '@public-ui/react';
+import { KolButton, KolTree, KolTreeItem } from '@public-ui/react';
 import { getRandomEmoji } from '../../shares/randomEmoji';
 import { useParams } from 'react-router';
 import { HideMenusContext } from '../../shares/HideMenusContext';
@@ -29,7 +29,6 @@ export const TreeBasic: FC = () => {
 			<SampleDescription>
 				<p>KolTree renders a keyboard accessible nested navigation. Branches of the tree can be collapsed or expanded.</p>
 			</SampleDescription>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 
 			<KolTree _label="Sitemap" class="block w-fit">
 				<KolTreeItem _label={homeLabel} {...getItemProps('home')}></KolTreeItem>

--- a/packages/samples/react/src/shares/theme.ts
+++ b/packages/samples/react/src/shares/theme.ts
@@ -4,9 +4,9 @@ export const THEMES = ['default', 'ecl-ec', 'ecl-eu', 'unstyled'] as const;
 export type Theme = (typeof THEMES)[number];
 export type ThemeAndUnstyled = Theme | 'unstyled';
 
-const drafts: ThemeAndUnstyled[] = ['ecl-ec', 'ecl-eu'];
+// const drafts: ThemeAndUnstyled[] = ['ecl-ec', 'ecl-eu'];
 
-export const isDraftTheme = (theme: ThemeAndUnstyled) => drafts.includes(theme);
+// export const isDraftTheme = (theme: ThemeAndUnstyled) => drafts.includes(theme);
 
 export const isTheme = (value: unknown) => {
 	return THEMES.find((theme) => theme === value) !== undefined;


### PR DESCRIPTION
## Summary
Removes draft warnings from React sample components.

## Changes
- Removed draft warnings from React samples

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Entwurfs-Warnungen aus React-Beispielkomponenten entfernt.

## Änderungen
- Entwurfs-Warnungen aus React-Beispielen entfernt

</details>