### PR TITLE
fix(heading): change html tag for secondary headline to p

### DIFF
--- a/packages/components/src/components/heading/style.scss
+++ b/packages/components/src/components/heading/style.scss
@@ -1,1 +1,7 @@
 @use '../../styles/global' as *;
+
+.kol-headline {
+	&--secondary {
+		margin: 0;
+	}
+}

--- a/packages/components/src/functional-components/Heading/Heading.tsx
+++ b/packages/components/src/functional-components/Heading/Heading.tsx
@@ -81,13 +81,11 @@ const KolHeadlineFc: FC<HeadlineProps> = ({ class: classNames, level = MIN_HEADI
  * @param children - The children to render inside the secondary headline.
  * @returns A VNode representing the secondary headline.
  */
-const KolSecondaryHeadlineFc: FC<SecondaryHeadlineProps> = ({ class: classNames, level = MIN_HEADING_LEVEL, ...other }, children) => {
-	const HeadlineTag = getSubHeadlineTag(level + 1);
-
+const KolSecondaryHeadlineFc: FC<SecondaryHeadlineProps> = ({ class: classNames, ...other }, children) => {
 	return (
-		<HeadlineTag class={clsx('kol-headline kol-headline--group kol-headline--secondary', classNames)} {...other}>
+		<p class={clsx('kol-headline kol-headline--group kol-headline--secondary', classNames)} {...other}>
 			{children}
-		</HeadlineTag>
+		</p>
 	);
 };
 
@@ -125,9 +123,7 @@ const KolHeadingFc: FC<HeadingProps> = (
 			<KolHeadlineFc class={clsx(classNames, 'kol-headline--group', 'kol-headline--primary')} {...headlineProps}>
 				{children}
 			</KolHeadlineFc>
-			<KolSecondaryHeadlineFc level={level} {...SecondaryHeadlineProps}>
-				{secondaryHeadline}
-			</KolSecondaryHeadlineFc>
+			<KolSecondaryHeadlineFc {...SecondaryHeadlineProps}>{secondaryHeadline}</KolSecondaryHeadlineFc>
 		</hgroup>
 	);
 };

--- a/packages/components/src/functional-components/Heading/Heading.tsx
+++ b/packages/components/src/functional-components/Heading/Heading.tsx
@@ -1,4 +1,4 @@
-import { h, type FunctionalComponent as FC } from '@stencil/core';
+import { type FunctionalComponent as FC, h } from '@stencil/core';
 import clsx from 'clsx';
 import type { JSXBase } from '@stencil/core/internal';
 import type { HeadingLevel } from '../../schema';
@@ -28,7 +28,6 @@ const MAX_HEADING_LEVEL = 6;
 
 // Define a union type for valid headline tags
 type HeadlineTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'strong';
-type SubHeadlineTag = 'span' | HeadlineTag;
 
 /**
  * Checks if the given level is a valid heading level.
@@ -47,16 +46,6 @@ function isValidHeadingLevel(level: number): boolean {
  */
 export function getHeadlineTag(level: HeadingLevel | number): HeadlineTag {
 	return isValidHeadingLevel(level) ? (`h${level}` as HeadlineTag) : 'strong';
-}
-
-/**
- * Returns the appropriate sub-headline tag based on the level.
- * If the level is 1, returns 'span', otherwise returns the headline tag.
- * @param level - The heading level.
- * @returns The corresponding sub-headline tag.
- */
-export function getSubHeadlineTag(level: HeadingLevel | number): SubHeadlineTag {
-	return level === 1 ? 'span' : getHeadlineTag(level);
 }
 
 /**

--- a/packages/components/src/functional-components/Heading/test/Heading.test.ts
+++ b/packages/components/src/functional-components/Heading/test/Heading.test.ts
@@ -1,4 +1,4 @@
-import { getHeadlineTag, getSubHeadlineTag } from '../Heading';
+import { getHeadlineTag } from '../Heading';
 
 describe('KolHeadingFc', () => {
 	describe('getHeadlineTag', () => {
@@ -12,24 +12,6 @@ describe('KolHeadingFc', () => {
 			expect(getHeadlineTag(0)).toBe('strong');
 			expect(getHeadlineTag(7)).toBe('strong');
 			expect(getHeadlineTag(-1)).toBe('strong');
-		});
-	});
-
-	describe('getSubHeadlineTag', () => {
-		it('should return "span" for level 1', () => {
-			expect(getSubHeadlineTag(1)).toBe('span');
-		});
-
-		it('should return the correct headline tag for levels greater than 1', () => {
-			expect(getSubHeadlineTag(2)).toBe('h2');
-			expect(getSubHeadlineTag(3)).toBe('h3');
-			expect(getSubHeadlineTag(6)).toBe('h6');
-		});
-
-		it('should return "strong" for invalid levels', () => {
-			expect(getSubHeadlineTag(0)).toBe('strong');
-			expect(getSubHeadlineTag(7)).toBe('strong');
-			expect(getSubHeadlineTag(-1)).toBe('strong');
 		});
 	});
 });

--- a/packages/components/src/functional-components/Heading/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Heading/test/__snapshots__/snapshot.test.tsx.snap
@@ -11,9 +11,9 @@ exports[`KolHeadingFc should render with a secondary headline 1`] = `
   <h1 class="kol-headline kol-headline--group kol-headline--h1 kol-headline--primary">
     Main Heading
   </h1>
-  <h2 class="kol-headline kol-headline--group kol-headline--secondary">
+  <p class="kol-headline kol-headline--group kol-headline--secondary">
     Secondary Headline
-  </h2>
+  </p>
 </hgroup>
 `;
 

--- a/packages/components/src/functional-components/Heading/test/snapshot.test.tsx
+++ b/packages/components/src/functional-components/Heading/test/snapshot.test.tsx
@@ -31,12 +31,12 @@ describe('KolHeadingFc', () => {
 
 		expect(page.root?.tagName).toBe('HGROUP');
 		expect(page.root?.querySelector('h1')).not.toBeNull();
-		expect(page.root?.querySelector('h2')).not.toBeNull();
+		expect(page.root?.querySelector('p')).not.toBeNull();
 		expect(page.root?.textContent).toContain('Main Heading');
 		expect(page.root?.textContent).toContain('Secondary Headline');
 		expect(page.root?.classList.contains('kol-heading-group')).toBe(true);
 		expect(page.root?.querySelector('h1')?.classList.contains('kol-headline--single')).toBe(false);
-		expect(page.root?.querySelector('h2')?.classList.contains('kol-headline--single')).toBe(false);
+		expect(page.root?.querySelector('p')?.classList.contains('kol-headline--single')).toBe(false);
 	});
 
 	it('should apply custom class names', async () => {

--- a/packages/samples/react/vite.config.ts
+++ b/packages/samples/react/vite.config.ts
@@ -29,6 +29,5 @@ export default defineConfig({
 	},
 	server: {
 		port: 9191,
-		strictPort: true,
 	},
 });


### PR DESCRIPTION
## Summary
Changes the HTML tag used for the secondary headline in the heading component from a heading element to `<p>` for correct semantics.

## Changes
- Changed secondary headline HTML tag to `<p>` in heading component

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
HTML-Tag für die sekundäre Überschrift in der Heading-Komponente von einem Überschriften-Element in `<p>` geändert.

## Änderungen
- HTML-Tag der sekundären Überschrift auf `<p>` in der Heading-Komponente geändert

</details>

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
