### PR TITLE
fix(form-utils): replace Number with parseFloat for inline width parsing #7603

### DIFF
--- a/packages/samples/react/src/components/input-text/text-formatter.tsx
+++ b/packages/samples/react/src/components/input-text/text-formatter.tsx
@@ -115,7 +115,7 @@ export function InputTextFormatterDemo() {
 														return <KolInputText _label="Currency" _type={type} _value={value} _on={{ onBlur, onChange, onFocus }} />;
 													}}
 													displayType="input"
-													value={typeof field.value === 'number' ? Number(field.value).toFixed(2) : undefined}
+													value={typeof field.value === 'number' ? field.value.toFixed(2) : undefined}
 													onBlur={() => {
 														void form.setFieldTouched('currency', true);
 													}}

--- a/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
+++ b/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
@@ -47,7 +47,7 @@ function TableHorizontalScrollbarAdvanced() {
 		let width = 0;
 
 		for (const def of columnDefinitions as { width: string }[]) {
-			width += Number(def.width?.replace('px', '') || 0);
+			width += parseFloat(def.width?.replace('px', '') || '0');
 		}
 		return `${width}px`;
 	});


### PR DESCRIPTION
### Beschreibung der Änderungen

Im Rahmen des Tickets **#7603** wurden gezielt zwei Stellen im Code überarbeitet, um die Verwendung von `Number()` zu vermeiden und durch geeignetere Alternativen zu ersetzen:

1. **Formularfeld – toFixed-Anwendung**
   Die bisherige Umwandlung `Number(field.value).toFixed(2)` wurde durch `field.value.toFixed(2)` ersetzt. Da zuvor bereits geprüft wird, ob `field.value` vom Typ `number` ist, war der Einsatz von `Number()` überflüssig.

2. **CSS-Style – Breitenwert parsen**
   Beim Einlesen des `width`-Werts aus einem CSS-String (z. B. `"120px"`) wurde `Number(...)` durch `parseFloat(...)` ersetzt. Dies ermöglicht eine korrekte Verarbeitung auch bei Dezimalwerten 
