### PR TITLE
fix(number): replace Number with parseFloat for inline width parsing

### DIFF
--- a/packages/samples/react/src/components/input-text/text-formatter.tsx
+++ b/packages/samples/react/src/components/input-text/text-formatter.tsx
@@ -115,7 +115,7 @@ export function InputTextFormatterDemo() {
 														return <KolInputText _label="Currency" _type={type} _value={value} _on={{ onBlur, onChange, onFocus }} />;
 													}}
 													displayType="input"
-													value={typeof field.value === 'number' ? Number(field.value).toFixed(2) : undefined}
+													value={typeof field.value === 'number' ? field.value.toFixed(2) : undefined}
 													onBlur={() => {
 														void form.setFieldTouched('currency', true);
 													}}

--- a/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
+++ b/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
@@ -47,7 +47,7 @@ function TableHorizontalScrollbarAdvanced() {
 		let width = 0;
 
 		for (const def of columnDefinitions as { width: string }[]) {
-			width += Number(def.width?.replace('px', '') || 0);
+			width += parseFloat(def.width?.replace('px', '') || '0');
 		}
 		return `${width}px`;
 	});


### PR DESCRIPTION
## Summary
Replaces usage of `Number()` with `parseFloat()` for inline width CSS parsing in the number input component.

## Changes
- Replaced `Number()` with `parseFloat()` for inline width CSS value parsing

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`Number()` durch `parseFloat()` für die Analyse von Inline-Width-CSS-Werten in der Number-Input-Komponente ersetzt.

## Änderungen
- `Number()` durch `parseFloat()` für Inline-Width-CSS-Wert-Parsing ersetzt

</details>