### PR TITLE
fix(pagination): remove exportparts from page buttons

### DIFF
--- a/packages/components/src/components/pagination/shadow.tsx
+++ b/packages/components/src/components/pagination/shadow.tsx
@@ -105,7 +105,6 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="first"
-									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={this.state._page <= 1}
 									_icons={leftDoubleArrowIcon}
@@ -120,7 +119,6 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="previous"
-									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={this.state._page <= 1}
 									_icons={leftSingleArrow}
@@ -136,7 +134,6 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="next"
-									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={count <= this.state._page}
 									_icons={rightSingleArrowIcon}
@@ -151,7 +148,6 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="last"
-									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={count <= this.state._page}
 									_icons={rightDoubleArrowIcon}
@@ -308,19 +304,15 @@ export class KolPagination implements PaginationAPI {
 		return (
 			<li key={nonce()}>
 				<KolButtonWcTag
-					exportparts="icon"
+					_ariaDescription={translate('kol-page')}
 					_customClass={this.state._customClass}
-					_label=""
+					_label={NUMBER_FORMATTER.format(page)}
 					_on={{
 						onClick: (event: Event) => {
 							this.onClick(event, page);
 						},
 					}}
-				>
-					<span slot="expert">
-						<span class="visually-hidden">{translate('kol-page')}</span> {NUMBER_FORMATTER.format(page)}
-					</span>
-				</KolButtonWcTag>
+				></KolButtonWcTag>
 			</li>
 		);
 	}
@@ -328,11 +320,14 @@ export class KolPagination implements PaginationAPI {
 	private getSelectedPageButton(page: number): JSX.Element {
 		return (
 			<li key={nonce()}>
-				<KolButtonWcTag class="selected" _customClass={this.state._customClass} _disabled={true} _label="">
-					<span slot="expert">
-						<span class="visually-hidden">{translate('kol-page')}</span> {NUMBER_FORMATTER.format(page)}
-					</span>
-				</KolButtonWcTag>
+				<KolButtonWcTag
+					class="selected"
+					aria-current="page"
+					_ariaDescription={translate('kol-page')}
+					_customClass={this.state._customClass}
+					_disabled={true}
+					_label={NUMBER_FORMATTER.format(page)}
+				></KolButtonWcTag>
 			</li>
 		);
 	}

--- a/packages/components/src/components/pagination/shadow.tsx
+++ b/packages/components/src/components/pagination/shadow.tsx
@@ -105,6 +105,7 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="first"
+									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={this.state._page <= 1}
 									_icons={leftDoubleArrowIcon}
@@ -119,6 +120,7 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="previous"
+									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={this.state._page <= 1}
 									_icons={leftSingleArrow}
@@ -134,6 +136,7 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="next"
+									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={count <= this.state._page}
 									_icons={rightSingleArrowIcon}
@@ -148,6 +151,7 @@ export class KolPagination implements PaginationAPI {
 							<li>
 								<KolButtonWcTag
 									class="last"
+									exportparts="icon"
 									_customClass={this.state._customClass}
 									_disabled={count <= this.state._page}
 									_icons={rightDoubleArrowIcon}
@@ -304,15 +308,19 @@ export class KolPagination implements PaginationAPI {
 		return (
 			<li key={nonce()}>
 				<KolButtonWcTag
-					_ariaDescription={translate('kol-page')}
+					exportparts="icon"
 					_customClass={this.state._customClass}
-					_label={NUMBER_FORMATTER.format(page)}
+					_label=""
 					_on={{
 						onClick: (event: Event) => {
 							this.onClick(event, page);
 						},
 					}}
-				></KolButtonWcTag>
+				>
+					<span slot="expert">
+						<span class="visually-hidden">{translate('kol-page')}</span> {NUMBER_FORMATTER.format(page)}
+					</span>
+				</KolButtonWcTag>
 			</li>
 		);
 	}
@@ -320,14 +328,11 @@ export class KolPagination implements PaginationAPI {
 	private getSelectedPageButton(page: number): JSX.Element {
 		return (
 			<li key={nonce()}>
-				<KolButtonWcTag
-					class="selected"
-					aria-current="page"
-					_ariaDescription={translate('kol-page')}
-					_customClass={this.state._customClass}
-					_disabled={true}
-					_label={NUMBER_FORMATTER.format(page)}
-				></KolButtonWcTag>
+				<KolButtonWcTag class="selected" aria-current="page" _customClass={this.state._customClass} _disabled={true} _label="">
+					<span slot="expert">
+						<span class="visually-hidden">{translate('kol-page')}</span> {NUMBER_FORMATTER.format(page)}
+					</span>
+				</KolButtonWcTag>
 			</li>
 		);
 	}

--- a/packages/components/src/components/pagination/shadow.tsx
+++ b/packages/components/src/components/pagination/shadow.tsx
@@ -305,34 +305,35 @@ export class KolPagination implements PaginationAPI {
 	};
 
 	private getUnselectedPageButton(page: number): JSX.Element {
+		const pageText = NUMBER_FORMATTER.format(page);
 		return (
 			<li key={nonce()}>
 				<KolButtonWcTag
-					exportparts="icon"
+					_ariaDescription={`${translate('kol-page')} ${pageText}`}
 					_customClass={this.state._customClass}
-					_label=""
+					_label={pageText}
 					_on={{
 						onClick: (event: Event) => {
 							this.onClick(event, page);
 						},
 					}}
-				>
-					<span slot="expert">
-						<span class="visually-hidden">{translate('kol-page')}</span> {NUMBER_FORMATTER.format(page)}
-					</span>
-				</KolButtonWcTag>
+				></KolButtonWcTag>
 			</li>
 		);
 	}
 
 	private getSelectedPageButton(page: number): JSX.Element {
+		const pageText = NUMBER_FORMATTER.format(page);
 		return (
 			<li key={nonce()}>
-				<KolButtonWcTag class="selected" aria-current="page" _customClass={this.state._customClass} _disabled={true} _label="">
-					<span slot="expert">
-						<span class="visually-hidden">{translate('kol-page')}</span> {NUMBER_FORMATTER.format(page)}
-					</span>
-				</KolButtonWcTag>
+				<KolButtonWcTag
+					aria-current="page"
+					class="selected"
+					_ariaDescription={`${translate('kol-page')} ${pageText}`}
+					_customClass={this.state._customClass}
+					_disabled={true}
+					_label={pageText}
+				></KolButtonWcTag>
 			</li>
 		);
 	}

--- a/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
@@ -22,24 +22,10 @@ exports[`kol-pagination should render with _label="Label" _on={} _max=2 _page=1 
           <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="previous" exportparts="icon"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _disabled="" _label="" aria-current="page" class="selected">
-            <span slot="expert">
-              <span class="visually-hidden">
-                kol-page
-              </span>
-              1
-            </span>
-          </kol-button-wc>
+          <kol-button-wc _ariadescription="kol-page 1" _disabled="" _label="1" aria-current="page" class="selected"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _label="" exportparts="icon">
-            <span slot="expert">
-              <span class="visually-hidden">
-                kol-page
-              </span>
-              2
-            </span>
-          </kol-button-wc>
+          <kol-button-wc _ariadescription="kol-page 2" _label="2"></kol-button-wc>
         </li>
         <li>
           <kol-button-wc _hidelabel="" _label="kol-page-next" _tooltipalign="top" class="next" exportparts="icon"></kol-button-wc>

--- a/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
@@ -16,36 +16,22 @@ exports[`kol-pagination should render with _label="Label" _on={} _max=2 _page=1 
     <nav aria-label="Label">
       <ul class="navigation-list">
         <li>
-          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-first" _tooltipalign="top" class="first" exportparts="icon"></kol-button-wc>
+          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-first" _tooltipalign="top" class="first"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="previous" exportparts="icon"></kol-button-wc>
+          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="previous"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _disabled="" _label="" class="selected">
-            <span slot="expert">
-              <span class="visually-hidden">
-                kol-page
-              </span>
-              1
-            </span>
-          </kol-button-wc>
+          <kol-button-wc _ariadescription="kol-page" _disabled="" _label="1" aria-current="page" class="selected"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _label="" exportparts="icon">
-            <span slot="expert">
-              <span class="visually-hidden">
-                kol-page
-              </span>
-              2
-            </span>
-          </kol-button-wc>
+          <kol-button-wc _ariadescription="kol-page" _label="2"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _hidelabel="" _label="kol-page-next" _tooltipalign="top" class="next" exportparts="icon"></kol-button-wc>
+          <kol-button-wc _hidelabel="" _label="kol-page-next" _tooltipalign="top" class="next"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _hidelabel="" _label="kol-page-last" _tooltipalign="top" class="last" exportparts="icon"></kol-button-wc>
+          <kol-button-wc _hidelabel="" _label="kol-page-last" _tooltipalign="top" class="last"></kol-button-wc>
         </li>
       </ul>
     </nav>

--- a/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
@@ -16,22 +16,36 @@ exports[`kol-pagination should render with _label="Label" _on={} _max=2 _page=1 
     <nav aria-label="Label">
       <ul class="navigation-list">
         <li>
-          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-first" _tooltipalign="top" class="first"></kol-button-wc>
+          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-first" _tooltipalign="top" class="first" exportparts="icon"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="previous"></kol-button-wc>
+          <kol-button-wc _disabled="" _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="previous" exportparts="icon"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _ariadescription="kol-page" _disabled="" _label="1" aria-current="page" class="selected"></kol-button-wc>
+          <kol-button-wc _disabled="" _label="" aria-current="page" class="selected">
+            <span slot="expert">
+              <span class="visually-hidden">
+                kol-page
+              </span>
+              1
+            </span>
+          </kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _ariadescription="kol-page" _label="2"></kol-button-wc>
+          <kol-button-wc _label="" exportparts="icon">
+            <span slot="expert">
+              <span class="visually-hidden">
+                kol-page
+              </span>
+              2
+            </span>
+          </kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _hidelabel="" _label="kol-page-next" _tooltipalign="top" class="next"></kol-button-wc>
+          <kol-button-wc _hidelabel="" _label="kol-page-next" _tooltipalign="top" class="next" exportparts="icon"></kol-button-wc>
         </li>
         <li>
-          <kol-button-wc _hidelabel="" _label="kol-page-last" _tooltipalign="top" class="last"></kol-button-wc>
+          <kol-button-wc _hidelabel="" _label="kol-page-last" _tooltipalign="top" class="last" exportparts="icon"></kol-button-wc>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
Removes `exportparts` from pagination page buttons to prevent unintended style leakage.

## Changes
- Removed `exportparts` attribute from page buttons in pagination

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`exportparts` von den Seitennavigationsschaltflächen der Paginierung entfernt.

## Änderungen
- `exportparts`-Attribut von Paginierungsschaltflächen entfernt

</details>