### PR TITLE
Add migration task for _hideError rename

### DIFF
--- a/packages/tools/kolibri-cli/src/migrate/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/index.ts
@@ -12,6 +12,7 @@ import { commonTasks } from './runner/tasks';
 import { testTasks } from './runner/tasks/test';
 import { v1Tasks } from './runner/tasks/v1';
 import { v2Tasks } from './runner/tasks/v2';
+import { v3Tasks } from './runner/tasks/v3';
 import { getAssetTasks } from './runner/tasks/v1/assets';
 import {
 	getContentOfProjectPkgJson,
@@ -110,6 +111,7 @@ Source folder to migrate: ${baseDir}
 				runner.registerTasks(commonTasks);
 				runner.registerTasks(v1Tasks);
 				runner.registerTasks(v2Tasks);
+				runner.registerTasks(v3Tasks);
 				runner.registerTasks(getAssetTasks(baseDir));
 
 				if (options.testTasks) {

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/index.ts
@@ -1,0 +1,6 @@
+import { AbstractTask } from '../../abstract-task';
+import { InputCheckboxRenameHideErrorToHideMsg } from './input-checkbox';
+
+export const v3Tasks: AbstractTask[] = [];
+
+v3Tasks.push(InputCheckboxRenameHideErrorToHideMsg);

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/input-checkbox.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/input-checkbox.ts
@@ -1,0 +1,3 @@
+import { RenamePropertyNameTask } from '../common/RenamePropertyNameTask';
+
+export const InputCheckboxRenameHideErrorToHideMsg = RenamePropertyNameTask.getInstance('kol-input-checkbox', '_hide-error', '_hide-msg', '^3');


### PR DESCRIPTION
## Summary
- support v3 migrations in kolibri-cli
- add checkbox migration to rename `_hide-error` to `_hide-msg`

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test` *(fails: `@public-ui/test-tag-name-transformer` visual test script)*

------
https://chatgpt.com/codex/tasks/task_e_6875ec81c478832ba1986fc65ccf7b35

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [ ] Meaningful pull request title for the release notes
- [ ] Pull request is linked to an issue and all changes relate to the issue
- [ ] Tests to protect this code implemented (if applicable)
- [ ] Manual test performed successfully (if applicable)
- [ ] Documentation or migration has been updated (if applicable)
