### PR TITLE
feat(toast): add onClose callback

### DIFF
--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -74,6 +74,7 @@ export class KolToastContainer implements ToasterAPI {
 				...this.state,
 				_toastStates: this.state._toastStates.filter((localToastState) => localToastState.id !== toastState.id),
 			};
+			toastState.toast.onClose?.();
 		}, TRANSITION_TIMEOUT);
 	}
 
@@ -101,6 +102,9 @@ export class KolToastContainer implements ToasterAPI {
 					...this.state,
 					_toastStates: this.state._toastStates.filter((toastState) => toastsToClose.every((toastToClose) => toastToClose.id !== toastState.id)),
 				};
+				toastsToClose.forEach((toastState) => {
+					toastState.toast.onClose?.();
+				});
 			}, TRANSITION_TIMEOUT);
 		}
 	}

--- a/packages/components/src/schema/components/toaster.ts
+++ b/packages/components/src/schema/components/toaster.ts
@@ -14,6 +14,7 @@ export type Toast = {
 	label: LabelPropType;
 	type: AlertType;
 	variant?: AlertVariant;
+	onClose?: () => void;
 };
 
 export type ToastState = {

--- a/packages/samples/react/src/components/toast/basic.tsx
+++ b/packages/samples/react/src/components/toast/basic.tsx
@@ -20,6 +20,9 @@ export const ToastBasic: FC = () => {
 			description: 'Toasty',
 			label: `Initial Toast`,
 			type: 'warning',
+			onClose: () => {
+				console.log('Simple toast has been closed.');
+			},
 		});
 	};
 


### PR DESCRIPTION
## Summary
Adds an `onClose` callback to the Toast component that fires when the toast is dismissed.

## Changes
- Added `onClose` callback to Toast component

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`onClose`-Callback zur Toast-Komponente hinzugefügt, der beim Schließen ausgelöst wird.

## Änderungen
- `onClose`-Callback zur Toast-Komponente hinzugefügt

</details>