### PR TITLE
refactor: disable accessible autocomplete overlay comments

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -207,6 +207,7 @@ export class KolCombobox implements ComboboxAPI {
 									aria-labelledby={this.state._id}
 									aria-activedescendant={this._isOpen && this._focusedOptionIndex >= 0 ? `option-${this._focusedOptionIndex}` : undefined}
 									autoCapitalize="off"
+									autoComplete="off" /* disable browser's not accessible autocomplete popup */
 									autoCorrect="off"
 									disabled={this.state._disabled}
 									id={this.state._id}

--- a/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -37,7 +37,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -61,7 +61,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" disabled="" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -85,7 +85,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -109,7 +109,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -133,7 +133,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -157,7 +157,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -181,7 +181,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -205,7 +205,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -229,7 +229,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -254,7 +254,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -278,7 +278,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -302,7 +302,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
         </span>
         <div slot="input">
           <div class="combobox__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocomplete="off" autocorrect="off" class="combobox__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
             <button class="combobox__icon" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>

--- a/packages/components/src/components/form/shadow.tsx
+++ b/packages/components/src/components/form/shadow.tsx
@@ -74,7 +74,13 @@ export class KolForm implements FormAPI {
 
 	private renderFormElement(): JSX.Element {
 		return (
-			<form method="post" onSubmit={this.onSubmit} onReset={this.onReset} autoComplete="off" noValidate>
+			<form
+				autoComplete="off" /* disable browser's not accessible autocomplete popup */
+				method="post"
+				onSubmit={this.onSubmit}
+				onReset={this.onReset}
+				noValidate
+			>
 				{this.state._requiredText === true ? (
 					<p>
 						<div class="mandatory-fields-hint">{translate('kol-form-description')}</div>

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -237,6 +237,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 									aria-label={this.state._hideLabel && typeof this.state._label === 'string' ? this.state._label : undefined}
 									aria-activedescendant={this._isOpen && this._focusedOptionIndex >= 0 ? `option-${this._focusedOptionIndex}` : undefined}
 									autoCapitalize="off"
+									autoComplete="off" /* disable browser's not accessible autocomplete popup */
 									autoCorrect="off"
 									disabled={this.state._disabled}
 									name={this.state._name}

--- a/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -37,7 +37,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -61,7 +61,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" disabled="" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" disabled="" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" disabled="" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -85,7 +85,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -109,7 +109,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -133,7 +133,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -157,7 +157,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -181,7 +181,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -205,7 +205,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -229,7 +229,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -254,7 +254,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -278,7 +278,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>
@@ -302,7 +302,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         </span>
         <div slot="input">
           <div class="single-select__group">
-            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+            <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocomplete="off" autocorrect="off" class="single-select__input" data-testid="single-select-input" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
             <button class="single-select__button" tabindex="-1">
               <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
             </button>


### PR DESCRIPTION
## Summary
Disables code comments related to the accessible autocomplete overlay implementation.

## Changes
- Disabled accessible autocomplete overlay comments

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Code-Kommentare zur barrierefreien Autocomplete-Overlay-Implementierung deaktiviert.

## Änderungen
- Barrierefreie Autocomplete-Overlay-Kommentare deaktiviert

</details>