### PR TITLE
7538 feat(input-range): make _min and _max props required

### DIFF
--- a/packages/components/src/components/@else/all/component.tsx
+++ b/packages/components/src/components/@else/all/component.tsx
@@ -39,7 +39,7 @@ export class KolAll implements Generic.Element.ComponentApi<RequiredProps, Optio
 				<kol-input-number _label=""></kol-input-number>
 				<kol-input-password _label=""></kol-input-password>
 				<kol-input-radio _label="" _options={[]}></kol-input-radio>
-				<kol-input-range _label=""></kol-input-range>
+				<kol-input-range _label="" _max={100} _min={0}></kol-input-range>
 				<kol-input-text _label=""></kol-input-text>
 				<kol-link _href="" _label="Label"></kol-link>
 				<kol-modal _label=""></kol-modal>

--- a/packages/components/src/components/input-range/controller.ts
+++ b/packages/components/src/components/input-range/controller.ts
@@ -1,5 +1,5 @@
 import type { InputRangeProps, InputRangeWatches, InputTypeOnOff, NumberString, SuggestionsPropType } from '../../schema';
-import { validateSuggestions, watchValidator } from '../../schema';
+import { validateSuggestions, watchNumber, watchValidator } from '../../schema';
 
 import { InputIconController } from '../@deprecated/input/controller-icon';
 
@@ -24,11 +24,23 @@ export class InputRangeController extends InputIconController implements InputRa
 	}
 
 	public validateMax(value?: number | NumberString): void {
-		this.validateNumber('_max', value);
+		if (typeof value !== 'number') {
+			value = 100;
+		}
+
+		watchNumber(this.component, '_max', value, {
+			required: true,
+		});
 	}
 
 	public validateMin(value?: number | NumberString): void {
-		this.validateNumber('_min', value);
+		if (typeof value !== 'number') {
+			value = 0;
+		}
+
+		watchNumber(this.component, '_min', value, {
+			required: true,
+		});
 	}
 
 	public validateStep(value?: number | NumberString): void {

--- a/packages/components/src/components/input-range/input-range.e2e.ts
+++ b/packages/components/src/components/input-range/input-range.e2e.ts
@@ -18,6 +18,7 @@ test.describe(COMPONENT_NAME, () => {
 		componentName: COMPONENT_NAME,
 		fillAction,
 		testValue: Number(TEST_VALUE),
+		additionalProperties: '_min="0" _max="100"',
 	});
 	testInputCallbacksAndEvents<HTMLKolInputRangeElement>({
 		componentName: COMPONENT_NAME,
@@ -26,6 +27,7 @@ test.describe(COMPONENT_NAME, () => {
 		selectInput,
 		expectedValue: Number(TEST_VALUE),
 		testValue: TEST_VALUE,
+		additionalProperties: '_min="0" _max="100"',
 	});
 	testInputMessage<HTMLKolInputRangeElement>(COMPONENT_NAME);
 });

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -267,12 +267,12 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	/**
 	 * Defines the largest possible input value.
 	 */
-	@Prop() public _max?: number | NumberString;
+	@Prop() public _max!: number | NumberString;
 
 	/**
 	 * Defines the smallest possible input value.
 	 */
-	@Prop() public _min?: number | NumberString;
+	@Prop() public _min!: number | NumberString;
 
 	/**
 	 * Defines the properties for a message rendered as Alert component.
@@ -332,6 +332,8 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 		_id: `id-${nonce()}`,
 		_label: '', // ⚠ required
 		_suggestions: [],
+		_max: 100, // ⚠ required
+		_min: 0, // ⚠ required
 	};
 	@State() private _initialValueType: 'number' | 'NumberString' = 'number';
 	@State() private inputHasFocus = false;

--- a/packages/components/src/schema/components/input-range.ts
+++ b/packages/components/src/schema/components/input-range.ts
@@ -18,12 +18,13 @@ import type {
 } from '../props';
 import type { InputTypeOnDefault, InputTypeOnOff, KoliBriHIcons, NumberString, Stringified, W3CInputValue } from '../types';
 
-type RequiredProps = PropLabelWithExpertSlot;
+type RequiredProps = PropLabelWithExpertSlot & {
+	max: number | NumberString;
+	min: number | NumberString;
+};
 type OptionalProps = {
 	autoComplete: InputTypeOnOff;
 	hint: string;
-	max: number | NumberString;
-	min: number | NumberString;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	step: number | NumberString;
@@ -42,13 +43,14 @@ type OptionalProps = {
 type RequiredStates = {
 	autoComplete: InputTypeOnOff;
 	suggestions: W3CInputValue[];
+	max: number;
+	min: number;
 } & PropId &
 	PropHideMsg &
 	PropLabelWithExpertSlot;
+
 type OptionalStates = {
 	hint: string;
-	max: number;
-	min: number;
 	on: InputTypeOnDefault;
 	step: number;
 	value: number;

--- a/packages/samples/react/src/scenarios/disabled-interactive-elements.tsx
+++ b/packages/samples/react/src/scenarios/disabled-interactive-elements.tsx
@@ -119,26 +119,32 @@ export const DisabledInteractiveElements: FC = () => {
 						</KolDetails>
 					</div>
 				</KolCard>
-				{[KolInputCheckbox, KolInputColor, KolInputDate, KolInputEmail, KolInputFile, KolInputNumber, KolInputPassword, KolInputRange, KolInputText].map(
-					(Input) => {
-						const render = (
-							Input as typeof KolInputCheckbox & {
-								render: { displayName: string };
-							}
-						).render;
-						const name = render.displayName;
-						return (
-							<KolCard key={name} _label={name} _level={0}>
-								<div className="grid gap-4">
-									<Input _label="Label" />
-									<Input _disabled _label="Label" />
-									<Input _hideLabel _label="Label" />
-									<Input _disabled _hideLabel _label="Label" />
-								</div>
-							</KolCard>
-						);
-					},
-				)}
+				{[KolInputCheckbox, KolInputColor, KolInputDate, KolInputEmail, KolInputFile, KolInputNumber, KolInputPassword, KolInputText].map((Input) => {
+					const render = (
+						Input as typeof KolInputCheckbox & {
+							render: { displayName: string };
+						}
+					).render;
+					const name = render.displayName;
+					return (
+						<KolCard key={name} _label={name} _level={0}>
+							<div className="grid gap-4">
+								<Input _label="Label" />
+								<Input _disabled _label="Label" />
+								<Input _hideLabel _label="Label" />
+								<Input _disabled _hideLabel _label="Label" />
+							</div>
+						</KolCard>
+					);
+				})}
+				<KolCard _label="KolInputRange" _level={0}>
+					<div className="grid gap-4">
+						<KolInputRange _label="Label" _min={0} _max={100} />
+						<KolInputRange _disabled _label="Label" _min={0} _max={100} />
+						<KolInputRange _hideLabel _label="Label" _min={0} _max={100} />
+						<KolInputRange _disabled _hideLabel _label="Label" _min={0} _max={100} />
+					</div>
+				</KolCard>
 				{[KolInputRadio, KolSelect].map((Input) => {
 					const render = (
 						Input as typeof KolInputRadio & {

--- a/packages/samples/react/src/scenarios/focus-elements.tsx
+++ b/packages/samples/react/src/scenarios/focus-elements.tsx
@@ -52,7 +52,7 @@ const getFocusElements = () => {
 			ref={ref}
 		/>
 	));
-	focusElements.set('inputRange', (_, ref) => <KolInputRange className="w-full" _name="range" _label="Range" ref={ref} />);
+	focusElements.set('inputRange', (_, ref) => <KolInputRange className="w-full" _name="range" _label="Range" ref={ref} _min={0} _max={100} />);
 	focusElements.set('inputText', (_, ref) => <KolInputText className="w-full" _name="text" _label="Text" ref={ref} />);
 	focusElements.set('select', (_, ref) => (
 		<KolSelect

--- a/packages/samples/react/src/scenarios/same-height-of-all-interactive-elements.tsx
+++ b/packages/samples/react/src/scenarios/same-height-of-all-interactive-elements.tsx
@@ -51,7 +51,7 @@ export const SameHeightOfAllInteractiveElements: FC = () => {
 				<KolInputEmail _hideLabel _icons="codicon codicon-home" _label="Input-Email" />
 				<KolInputNumber _hideLabel _icons="codicon codicon-home" _label="Input-Number" />
 				<KolInputPassword _hideLabel _icons="codicon codicon-home" _label="Input-Password" />
-				<KolInputRange _hideLabel _icons="codicon codicon-home" _label="Input-Range" />
+				<KolInputRange _hideLabel _icons="codicon codicon-home" _label="Input-Range" _min={0} _max={100} />
 				<KolInputText _hideLabel _icons="codicon codicon-home" _label="Input-Text" />
 				<KolSelect _hideLabel _icons="codicon codicon-home" _label="Combobox" _options={[]} />
 				<KolSingleSelect _hideLabel _icons="codicon codicon-home" _label="Combobox" _options={[]} />

--- a/packages/samples/react/src/scenarios/static-form.tsx
+++ b/packages/samples/react/src/scenarios/static-form.tsx
@@ -75,7 +75,7 @@ export const StaticForm: FC = () => {
 							{ label: 'Option B', value: 'B' },
 						]}
 					/>
-					<KolInputRange _name="range" _label="Range" />
+					<KolInputRange _name="range" _label="Range" _min={0} _max={100} />
 					<KolInputText _name="text" _label="Text" />
 					<KolSelect
 						_name="select"


### PR DESCRIPTION
Refs: #7538

# `kol-input-range`: Props `_min` und `_max` als **required**

## Überblick

Dieses PR setzt die Migration von `kol-input-range` auf **verpflichtende Props** `_min` und `_max` um, im Rahmen von Kolibri **v4**. Die Änderung ist **breaking**, da bisher beide Props optional waren.

## Änderungen im Detail

### 1. shadow.tsx

- `@Prop()`-Deklarationen für `_min` und `_max` von optional (`?`) auf required (`!`) geändert.
- Ergänzt um Initialwerte im internen State (zur Vermeidung von Laufzeitfehlern)

### 2. controller.ts

- Bestehende Methoden `validateMax()` und `validateMin()` angepasst für required Props

### 3. schema/components/input-range.ts

- `_min` und `_max` in:
  - `RequiredProps` (vorher optional)
  - `RequiredStates` (vorher optional) verschoben.

### 4. @else/all/component.tsx

- Interne Sammelkomponente angepasst mit expliziten `_min` und `_max` Werten für `<kol-input-range>`

### 5. Tests (input-range.e2e.ts)

- Für bestehende Test-Utilities ergänzt um `additionalProperties: '_min="0" _max="100"'`
- Tests erfolgreich in allen Browsern (Chromium, Firefox, WebKit).

## Breaking Change

Alle Implementierungen von `<kol-input-range>` **müssen künftig** `_min` und `_max` explizit übergeben.

## Getestet

- E2E-Tests (Chromium, Firefox, WebKit) erfolgreich.
- Manuelle Tests in React-Samples 
  - Ohne `{...props}` und ohne `_min` und `_max` = Fehlermeldung:
    - `Type '{ _msg: { _type: "info"; _description: string; }; _label: string; }' is missing the following properties from type 'KolInputRange': "_max", "_min"`

---

### Additional Fixes
Während des build-and-check traten noch Fehler in den React-Samples "scenarios" auf.

Folgende Fixes habe ich durchgeführt:

- **Betroffene Dateien:**
  - `src/scenarios/disabled-interactive-elements.tsx`
  - `src/scenarios/focus-elements.tsx`
  - `src/scenarios/same-height-of-all-interactive-elements.tsx`
  - `src/scenarios/static-form.tsx`

- **Änderung:**  
Ich habe an den Stellen, wo `<KolInputRange>` verwendet wurde, die Props `_min={0}` und `_max={100}` ergänzt.