### PR TITLE
fix(single-select): select typed value on blur

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -87,10 +87,15 @@ export class KolSingleSelect implements SingleSelectAPI {
 	};
 
 	private onBlur() {
-		if (Array.isArray(this.state._options) && this.state._options.length > 0 && !this.state._options.some((option) => option.label === this._inputValue)) {
-			this._inputValue = this.state._options.find((option) => (option as Option<string>).value === this._value)?.label as string;
+		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
+
+		if (matchingOption) {
+			this.selectOption(matchingOption as Option<string>);
+		} else {
+			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];
 		}
+
 		this._isOpen = false;
 		this._hasOpened = false;
 	}


### PR DESCRIPTION
## Summary
Fixes an issue where a typed value in single-select was not selected when the component lost focus (blur).

## Changes
- Fixed typed value selection on blur in single-select

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Fehler behoben, bei dem ein eingetippter Wert in der Single-Select-Komponente beim Fokusverlust nicht ausgewählt wurde.

## Änderungen
- Auswahl des eingetippten Werts beim Fokusverlust in Single-Select korrigiert

</details>