### PR TITLE
docs: enforce KoliBri spelling and ESM imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,8 @@ The samples are located in `packages/samples/react` and demonstrate how to use t
 - Lists and enumerations in code should be kept in alphanumeric order. This also applies to import specifiers and union type literals.
 - Commit messages follow the **Conventional Commits** specification.
 - See also the [Contributing Guide](CONTRIBUTING.md) for more details on coding conventions and best practices.
+- Spell "KoliBri" with this casing in all documentation and code. The only exception is the component named KolKolibri.
+- Use ESM import syntax in browser code and scripts whenever supported, instead of `require` imports.
 
 ## Linting and Formatting
 


### PR DESCRIPTION
## Summary
Updates AGENTS.md to enforce correct KoliBri spelling and ESM import conventions.

## Changes
- Added KoliBri spelling and ESM import rules to AGENTS.md

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
AGENTS.md aktualisiert, um korrekte KoliBri-Schreibweise und ESM-Import-Konventionen durchzusetzen.

## Änderungen
- KoliBri-Schreibweise und ESM-Import-Regeln in AGENTS.md hinzugefügt

</details>