### PR TITLE
refactor: rename rem function to to-rem

### DIFF
--- a/packages/components/src/components/@shared/_kol-alert-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-alert-mixin.scss
@@ -20,7 +20,7 @@
 
 		.close {
 			/* Visible with forced colors */
-			outline: transparent solid rem(1);
+			outline: transparent solid to-rem(1);
 		}
 	}
 }

--- a/packages/components/src/components/@shared/_mixins.scss
+++ b/packages/components/src/components/@shared/_mixins.scss
@@ -1,3 +1,3 @@
-@function rem($size) {
+@function to-rem($size) {
 	@return calc(#{$size}rem / var(--kolibri-root-font-size, 16));
 }

--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -8,7 +8,7 @@
 		/*
 		 * Minimum size of interactive elements.
 		 */
-		--a11y-min-size: #{rem(44)};
+		--a11y-min-size: #{to-rem(44)};
 		/*
 		 * No element should be used without a background and font color whose contrast ratio has
 		 * not been checked. By initially setting the background color to white and the font color

--- a/packages/components/src/components/avatar/style.scss
+++ b/packages/components/src/components/avatar/style.scss
@@ -7,10 +7,10 @@
 		border-radius: 50%;
 		overflow: hidden;
 		/* Visible with forced colors  */
-		outline: transparent solid rem(1);
+		outline: transparent solid to-rem(1);
 		/*theme?*/
-		width: rem(100);
-		height: rem(100);
+		width: to-rem(100);
+		height: to-rem(100);
 	}
 
 	.image {
@@ -26,6 +26,6 @@
 		justify-content: center;
 		/*theme?*/
 		background-color: #d3d3d3;
-		font-size: rem(40);
+		font-size: to-rem(40);
 	}
 }

--- a/packages/components/src/components/badge/style.scss
+++ b/packages/components/src/components/badge/style.scss
@@ -7,7 +7,7 @@
 		display: inline-flex;
 		place-items: center;
 		/* Visible with forced colors  */
-		outline: transparent solid rem(1);
+		outline: transparent solid to-rem(1);
 	}
 
 	:host > span > .kol-button-wc button {

--- a/packages/components/src/components/card/style.scss
+++ b/packages/components/src/components/card/style.scss
@@ -7,7 +7,7 @@
 		height: 100%;
 		position: relative;
 		/* Visible with forced colors  */
-		outline: transparent solid rem(1);
+		outline: transparent solid to-rem(1);
 	}
 
 	.close {

--- a/packages/components/src/components/combobox/style.scss
+++ b/packages/components/src/components/combobox/style.scss
@@ -43,7 +43,7 @@
 			overflow-x: hidden;
 			z-index: 2;
 			background-color: white;
-			max-height: rem(250);
+			max-height: to-rem(250);
 		}
 
 		&__item {

--- a/packages/components/src/components/drawer/style.scss
+++ b/packages/components/src/components/drawer/style.scss
@@ -61,7 +61,7 @@
 
 		&__content {
 			position: relative;
-			padding: rem(16);
+			padding: to-rem(16);
 		}
 	}
 }

--- a/packages/components/src/components/input-checkbox/checkbox.scss
+++ b/packages/components/src/components/input-checkbox/checkbox.scss
@@ -23,8 +23,8 @@
 		}
 
 		& .checkbox-input-element {
-			width: rem(22);
-			height: rem(22);
+			width: to-rem(22);
+			height: to-rem(22);
 		}
 	}
 }

--- a/packages/components/src/components/input-checkbox/switch.scss
+++ b/packages/components/src/components/input-checkbox/switch.scss
@@ -16,8 +16,8 @@
 	.switch input[type='checkbox']::before {
 		background-color: #000;
 		height: 1.2em;
-		left: calc(0.25em - rem(2));
-		top: calc(0.25em - rem(2));
+		left: calc(0.25em - to-rem(2));
+		top: calc(0.25em - to-rem(2));
 		position: absolute;
 		transition: 0.5s;
 		width: 1.2em;
@@ -41,7 +41,7 @@
 		position: absolute;
 		z-index: 1;
 		top: 50%;
-		left: rem(4);
+		left: to-rem(4);
 		transform: translate(0, -50%);
 		transition: 0.5s;
 		color: #000;

--- a/packages/components/src/components/input-range/style.scss
+++ b/packages/components/src/components/input-range/style.scss
@@ -25,7 +25,7 @@
 		border: 1px solid #000;
 		display: inline-block;
 		flex-grow: 1;
-		height: rem(8);
+		height: to-rem(8);
 		line-height: 1.5;
 		padding: 0;
 		margin: 0;
@@ -35,8 +35,8 @@
 
 	input[type='range']::-webkit-slider-thumb {
 		background-color: #000;
-		height: rem(20);
-		width: rem(20);
+		height: to-rem(20);
+		width: to-rem(20);
 		border-radius: 20px;
 		cursor: pointer;
 		-webkit-appearance: none;
@@ -44,8 +44,8 @@
 
 	input[type='range']::-moz-range-thumb {
 		background-color: #000;
-		height: rem(20);
-		width: rem(20);
+		height: to-rem(20);
+		width: to-rem(20);
 		border-radius: 20px;
 		cursor: pointer;
 		-moz-appearance: none;

--- a/packages/components/src/components/input.scss
+++ b/packages/components/src/components/input.scss
@@ -46,11 +46,11 @@
 
 	/* needed hack for vertical alignment */
 	input[type='file'] {
-		padding: calc((var(--a11y-min-size) - rem(16)) / 10) 0.5em;
+		padding: calc((var(--a11y-min-size) - to-rem(16)) / 10) 0.5em;
 	}
 
 	/* needed hack for vertical alignment */
 	select[multiple] option {
-		padding: calc((var(--a11y-min-size) - rem(16)) / 2) 0.5em;
+		padding: calc((var(--a11y-min-size) - to-rem(16)) / 2) 0.5em;
 	}
 }

--- a/packages/components/src/components/kolibri/style.scss
+++ b/packages/components/src/components/kolibri/style.scss
@@ -7,7 +7,7 @@
 	}
 
 	text {
-		font-size: rem(90);
+		font-size: to-rem(90);
 		letter-spacing: normal;
 		word-spacing: normal;
 	}

--- a/packages/components/src/components/link-group/style.scss
+++ b/packages/components/src/components/link-group/style.scss
@@ -14,8 +14,8 @@
 	}
 
 	:is(ol, ul).horizontal li {
-		margin-left: rem(20);
-		margin-right: rem(4);
+		margin-left: to-rem(20);
+		margin-right: to-rem(4);
 	}
 
 	:is(ol, ul).horizontal li:first-child {
@@ -27,8 +27,8 @@
 	}
 
 	:is(ol, ul).vertical li {
-		margin-left: rem(28);
-		margin-right: rem(8);
+		margin-left: to-rem(28);
+		margin-right: to-rem(8);
 	}
 
 	li.list-none {

--- a/packages/components/src/components/link.scss
+++ b/packages/components/src/components/link.scss
@@ -26,7 +26,7 @@
 	}
 
 	.skip {
-		left: rem(-99999);
+		left: to-rem(-99999);
 		overflow: hidden;
 		position: absolute;
 		z-index: 9999999;
@@ -42,6 +42,6 @@
 
 	.kol-icon.external-link-icon {
 		display: inline-flex;
-		margin-left: rem(8);
+		margin-left: to-rem(8);
 	}
 }

--- a/packages/components/src/components/pagination/style.scss
+++ b/packages/components/src/components/pagination/style.scss
@@ -6,7 +6,7 @@
 	:host {
 		align-items: center;
 		display: grid;
-		gap: rem(16);
+		gap: to-rem(16);
 		grid-template-columns: 1fr auto;
 	}
 

--- a/packages/components/src/components/single-select/style.scss
+++ b/packages/components/src/components/single-select/style.scss
@@ -2,7 +2,7 @@
 @use '../style' as *;
 @use '../input-line' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: var(--visible-options, 5);
 
 @layer kol-component {
@@ -38,7 +38,7 @@ $visible-options: var(--visible-options, 5);
 			overflow-x: hidden;
 			z-index: 2;
 			background-color: white;
-			max-height: calc($option-height * $visible-options + rem(2)) !important;
+			max-height: calc($option-height * $visible-options + to-rem(2)) !important;
 		}
 
 		&__item {
@@ -56,7 +56,7 @@ $visible-options: var(--visible-options, 5);
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			min-height: rem(50);
+			min-height: to-rem(50);
 		}
 	}
 }

--- a/packages/components/src/components/skip-nav/style.scss
+++ b/packages/components/src/components/skip-nav/style.scss
@@ -13,7 +13,7 @@
 	}
 
 	.kol-link-wc a {
-		left: rem(-99999);
+		left: to-rem(-99999);
 		overflow: hidden;
 		position: absolute;
 		z-index: 9999999;

--- a/packages/components/src/components/spin/cycle.scss
+++ b/packages/components/src/components/spin/cycle.scss
@@ -2,8 +2,8 @@
 
 @layer kol-component {
 	.spin.cycle {
-		width: rem(48);
-		height: rem(48);
+		width: to-rem(48);
+		height: to-rem(48);
 	}
 
 	.spin.cycle > .loader {

--- a/packages/components/src/components/spin/dot.scss
+++ b/packages/components/src/components/spin/dot.scss
@@ -2,46 +2,46 @@
 
 @layer kol-component {
 	.spin.dot {
-		height: rem(16);
-		width: rem(48);
+		height: to-rem(16);
+		width: to-rem(48);
 	}
 
 	.spin.dot > span {
 		animation-timing-function: cubic-bezier(0, 1, 1, 0);
 		border-radius: 50%;
 		border: 0.16px solid #fff;
-		height: rem(12.8);
+		height: to-rem(12.8);
 		position: absolute;
-		top: rem(0.16);
-		width: rem(12.8);
+		top: to-rem(0.16);
+		width: to-rem(12.8);
 	}
 
 	.spin.dot > span:first-child {
 		background-color: #000;
 		z-index: 0;
 		animation: 1s infinite spin1;
-		left: rem(0.16);
+		left: to-rem(0.16);
 	}
 
 	.spin.dot > span:nth-child(2) {
 		background-color: #000;
 		z-index: 1;
 		animation: 1s infinite spin2;
-		left: rem(0.16);
+		left: to-rem(0.16);
 	}
 
 	.spin.dot > span:nth-child(3) {
 		background-color: #000;
 		z-index: 1;
 		animation: 1s infinite spin2;
-		left: rem(17.6);
+		left: to-rem(17.6);
 	}
 
 	.spin.dot > span:nth-child(4) {
 		background-color: #666;
 		z-index: 0;
 		animation: 1s infinite spin3;
-		left: rem(33.6);
+		left: to-rem(33.6);
 	}
 
 	@keyframes spin1 {
@@ -60,7 +60,7 @@
 		}
 
 		100% {
-			transform: translate(rem(16), 0);
+			transform: translate(to-rem(16), 0);
 		}
 	}
 

--- a/packages/components/src/components/spin/style.scss
+++ b/packages/components/src/components/spin/style.scss
@@ -6,7 +6,7 @@
 @layer kol-component {
 	.spin {
 		display: block;
-		padding: rem(2);
+		padding: to-rem(2);
 		position: relative;
 	}
 }

--- a/packages/components/src/components/split-button/style.scss
+++ b/packages/components/src/components/split-button/style.scss
@@ -21,7 +21,7 @@
 
 	.kol-popover {
 		.popover {
-			margin-top: rem(2);
+			margin-top: to-rem(2);
 		}
 
 		.arrow {

--- a/packages/components/src/components/style.scss
+++ b/packages/components/src/components/style.scss
@@ -4,7 +4,7 @@
 
 @layer kol-global {
 	:host {
-		font-size: rem(16);
+		font-size: to-rem(16);
 		/*
 		 * The max-width is needed to prevent the table from overflowing the
 		 * parent node, if the table is wider than the parent node.

--- a/packages/components/src/components/toolbar/style.scss
+++ b/packages/components/src/components/toolbar/style.scss
@@ -7,7 +7,7 @@
 	.toolbar {
 		display: flex;
 		align-items: center;
-		gap: rem(16);
+		gap: to-rem(16);
 		flex-wrap: wrap;
 
 		&:focus-within {

--- a/packages/components/src/components/tooltip/style.scss
+++ b/packages/components/src/components/tooltip/style.scss
@@ -29,10 +29,10 @@
 	}
 
 	.kol-tooltip-wc .tooltip-arrow {
-		height: rem(10);
+		height: to-rem(10);
 		position: absolute;
 		transform: rotate(45deg);
-		width: rem(10);
+		width: to-rem(10);
 		z-index: 999;
 	}
 

--- a/packages/components/src/components/tree-item/style.scss
+++ b/packages/components/src/components/tree-item/style.scss
@@ -2,10 +2,10 @@
 @use '../style' as *;
 
 @layer kol-component {
-	$base-horizontal-padding: rem(8);
+	$base-horizontal-padding: to-rem(8);
 
 	.tree-item {
-		--indentation: var(--tree-item-indentation, #{rem(10)}); // Set `--tree-item-indentation` in themes to control padding
+		--indentation: var(--tree-item-indentation, #{to-rem(10)}); // Set `--tree-item-indentation` in themes to control padding
 	}
 
 	ul {
@@ -16,7 +16,7 @@
 
 	.tree-link {
 		&.first-level > a {
-			padding-left: rem(6);
+			padding-left: to-rem(6);
 		}
 
 		& > a {
@@ -24,7 +24,7 @@
 			display: inline-flex;
 			min-height: var(--a11y-min-size);
 			padding-left: max(calc((var(--indentation) * var(--level)) + $base-horizontal-padding), $base-horizontal-padding);
-			padding-right: rem(6);
+			padding-right: to-rem(6);
 		}
 	}
 

--- a/packages/samples/react/src/@shared/_mixins.scss
+++ b/packages/samples/react/src/@shared/_mixins.scss
@@ -1,3 +1,3 @@
-@function rem($size) {
+@function to-rem($size) {
 	@return calc(#{$size}rem / var(--kolibri-root-font-size, 16));
 }

--- a/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/layout.scss
+++ b/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/layout.scss
@@ -1,11 +1,11 @@
 @use '../../@shared/mixins' as *;
 
 .mainlayout {
-	min-height: calc(100vh - rem(32));
+	min-height: calc(100vh - to-rem(32));
 	width: 100%;
 	display: grid;
-	column-gap: rem(16);
-	grid-template-columns: rem(400) calc(100% - rem(460));
+	column-gap: to-rem(16);
+	grid-template-columns: to-rem(400) calc(100% - to-rem(460));
 	grid-template-rows: 1fr;
 	grid-template-areas: 'nav content';
 

--- a/packages/samples/react/src/style.scss
+++ b/packages/samples/react/src/style.scss
@@ -8,7 +8,7 @@
 body {
 	margin: 0;
 	font-family: Verdana;
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: normal;
 }
 
@@ -41,7 +41,7 @@ hr {
 	background-color: black;
 	display: flex;
 	flex-direction: column;
-	padding: rem(8);
+	padding: to-rem(8);
 }
 
 .w-image {
@@ -49,13 +49,13 @@ hr {
 }
 
 .drawer-content-vertical {
-	width: rem(400);
+	width: to-rem(400);
 }
 
 @media (min-width: 1024px) {
 	.app-container {
 		display: grid;
-		grid-template-columns: rem(360) calc(100% - rem(360));
+		grid-template-columns: to-rem(360) calc(100% - to-rem(360));
 		min-height: 100vh;
 		height: 100%;
 	}
@@ -70,8 +70,8 @@ hr {
 			top: 0;
 			bottom: 0;
 			left: 0;
-			width: rem(330);
-			margin: rem(16);
+			width: to-rem(330);
+			margin: to-rem(16);
 			flex-direction: column;
 			display: flex;
 

--- a/packages/themes/default/src/@shared/input-core.scss
+++ b/packages/themes/default/src/@shared/input-core.scss
@@ -1,13 +1,13 @@
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {
 	@include kol-alert-theme;
 
 	.kol-input {
-		gap: rem(4);
+		gap: to-rem(4);
 
 		&.disabled .input {
 			background-color: var(--color-mute);
@@ -35,16 +35,16 @@
 			border-radius: var(--border-radius);
 			border-style: solid;
 			border-width: 2px;
-			padding: 0 rem(8);
+			padding: 0 to-rem(8);
 
 			&:is(.icon-left, .icon-right) {
-				padding-left: rem(16);
-				padding-right: rem(16);
+				padding-left: to-rem(16);
+				padding-right: to-rem(16);
 			}
 
 			&:is(.icon-left, .icon-right) input {
-				padding-left: rem(8);
-				padding-right: rem(8);
+				padding-left: to-rem(8);
+				padding-right: to-rem(8);
 			}
 
 			> input:first-child {

--- a/packages/themes/default/src/components/abbr.scss
+++ b/packages/themes/default/src/components/abbr.scss
@@ -1,8 +1,8 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	abbr {
-		border-bottom: dashed var(--color-text) rem(1);
+		border-bottom: dashed var(--color-text) to-rem(1);
 		text-decoration: none;
 	}
 }

--- a/packages/themes/default/src/components/accordion.scss
+++ b/packages/themes/default/src/components/accordion.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/focus-outline' as *;
 @use '../mixins/typography' as *;
 
@@ -11,8 +11,8 @@
 		&__content {
 			margin: 0;
 			padding-left: 2.25em;
-			padding-bottom: rem(12);
-			padding-right: rem(8);
+			padding-bottom: to-rem(12);
+			padding-right: to-rem(8);
 		}
 
 		&__heading {
@@ -40,10 +40,10 @@
 			}
 
 			border-radius: var(--border-radius);
-			min-height: rem(35.2);
+			min-height: to-rem(35.2);
 
 			button {
-				padding: rem(12) rem(8);
+				padding: to-rem(12) to-rem(8);
 
 				:focus {
 					outline: none;

--- a/packages/themes/default/src/components/badge.scss
+++ b/packages/themes/default/src/components/badge.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
@@ -24,21 +24,21 @@
 		color: inherit;
 		border-top-right-radius: var(--border-radius);
 		border-bottom-right-radius: var(--border-radius);
-		padding: rem(3.2);
+		padding: to-rem(3.2);
 	}
 
 	:host > span .kol-span-wc {
-		padding: rem(4) rem(12);
+		padding: to-rem(4) to-rem(12);
 	}
 
 	:host > span > .kol-span-wc {
 		align-items: center;
 		font-style: normal;
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	:host > span > .kol-span-wc > span {
 		display: flex;
-		gap: rem(4);
+		gap: to-rem(4);
 	}
 }

--- a/packages/themes/default/src/components/breadcrumb.scss
+++ b/packages/themes/default/src/components/breadcrumb.scss
@@ -1,13 +1,13 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	li:has(:is(.kol-icon + .kol-link, .kol-icon + span)) .kol-icon {
-		font-size: rem(12);
+		font-size: to-rem(12);
 		color: var(--color-subtle);
 	}
 
 	.kol-link::part(icon) {
-		font-size: rem(20);
+		font-size: to-rem(20);
 	}
 
 	ul li:last-child > span {

--- a/packages/themes/default/src/components/button-link.scss
+++ b/packages/themes/default/src/components/button-link.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:is(a, button) {
@@ -28,7 +28,7 @@
 	}
 
 	.skip {
-		left: rem(-99999);
+		left: to-rem(-99999);
 		overflow: hidden;
 		position: absolute;
 		z-index: 9999999;

--- a/packages/themes/default/src/components/button.scss
+++ b/packages/themes/default/src/components/button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button;

--- a/packages/themes/default/src/components/card.scss
+++ b/packages/themes/default/src/components/card.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host > div {
@@ -16,15 +16,15 @@
 	}
 
 	:host div.header {
-		padding: rem(16) rem(16) rem(8) rem(16);
+		padding: to-rem(16) to-rem(16) to-rem(8) to-rem(16);
 	}
 
 	:host div.content {
-		padding: rem(8) rem(16) rem(16);
+		padding: to-rem(8) to-rem(16) to-rem(16);
 		overflow: hidden;
 	}
 
 	:host div.footer {
-		padding: rem(8) rem(16);
+		padding: to-rem(8) to-rem(16);
 	}
 }

--- a/packages/themes/default/src/components/combobox.scss
+++ b/packages/themes/default/src/components/combobox.scss
@@ -1,9 +1,9 @@
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -17,13 +17,13 @@ $visible-options: 5;
 			display: inline-flex;
 			align-items: center;
 			width: 100%;
-			padding: 0 rem(8);
+			padding: 0 to-rem(8);
 		}
 
 		&__input {
 			flex-grow: 1;
 			border: none;
-			width: calc(100% - rem(40));
+			width: calc(100% - to-rem(40));
 			position: relative;
 
 			&::placeholder {
@@ -42,8 +42,8 @@ $visible-options: 5;
 		&__icon {
 			display: grid;
 			place-items: center;
-			padding-left: rem(8);
-			padding-right: rem(8);
+			padding-left: to-rem(8);
+			padding-right: to-rem(8);
 
 			&:focus {
 				outline: 0;
@@ -58,7 +58,7 @@ $visible-options: 5;
 			overflow-y: auto;
 			overflow-x: hidden;
 			width: 100%;
-			max-height: calc($option-height * $visible-options + rem(2));
+			max-height: calc($option-height * $visible-options + to-rem(2));
 		}
 
 		&__item {
@@ -66,7 +66,7 @@ $visible-options: 5;
 			align-items: center;
 			min-height: $option-height;
 			line-height: 1;
-			padding: rem(10) rem(12);
+			padding: to-rem(10) to-rem(12);
 
 			&[aria-selected],
 			&:focus {
@@ -78,7 +78,7 @@ $visible-options: 5;
 	}
 
 	.kol-input {
-		gap: rem(4);
+		gap: to-rem(4);
 	}
 
 	.kol-input .error:not(.hidden-error) {
@@ -113,17 +113,17 @@ $visible-options: 5;
 		border-radius: var(--border-radius);
 		border-style: solid;
 		border-width: 2px;
-		padding: 0 rem(8);
+		padding: 0 to-rem(8);
 	}
 
 	.input:is(.icon-left, .icon-right) {
-		padding-left: rem(16);
-		padding-right: rem(16);
+		padding-left: to-rem(16);
+		padding-right: to-rem(16);
 	}
 
 	.input:is(.icon-left, .icon-right) input {
-		padding-left: rem(8);
-		padding-right: rem(8);
+		padding-left: to-rem(8);
+		padding-right: to-rem(8);
 	}
 
 	.input > input:first-child {

--- a/packages/themes/default/src/components/details.scss
+++ b/packages/themes/default/src/components/details.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/indented-text' as *;
 @use '../mixins/focus-outline' as *;
 
@@ -11,7 +11,7 @@
 		&__content {
 			&.indented-text {
 				@include indented-text;
-				margin: rem(4) 0 0 rem(10.4);
+				margin: to-rem(4) 0 0 to-rem(10.4);
 			}
 		}
 
@@ -21,7 +21,7 @@
 
 		&__heading-button {
 			.kol-icon {
-				font-size: rem(19.2);
+				font-size: to-rem(19.2);
 			}
 
 			.kol-span-wc {

--- a/packages/themes/default/src/components/drawer.scss
+++ b/packages/themes/default/src/components/drawer.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 $duration: 0.4s;
 

--- a/packages/themes/default/src/components/input-checkbox.scss
+++ b/packages/themes/default/src/components/input-checkbox.scss
@@ -1,7 +1,7 @@
 @use '../mixins/alert-wc' as *;
 @use '../mixins/focus-outline' as *;
 @use '../mixins/input-error' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {
@@ -13,27 +13,27 @@
 		justify-items: left;
 		width: 100%;
 		min-height: var(--a11y-min-size);
-		gap: rem(6.4);
+		gap: to-rem(6.4);
 	}
 
 	.kol-input.default {
-		grid-template-columns: rem(24) auto;
+		grid-template-columns: to-rem(24) auto;
 	}
 
 	.kol-input.default[data-label-align='left']:not(.hide-label) {
-		grid-template-columns: auto rem(24);
+		grid-template-columns: auto to-rem(24);
 	}
 
 	.kol-input.switch {
-		grid-template-columns: rem(56) auto;
+		grid-template-columns: to-rem(56) auto;
 	}
 
 	.kol-input.switch[data-label-align='left']:not(.hide-label) {
-		grid-template-columns: auto rem(56);
+		grid-template-columns: auto to-rem(56);
 	}
 
 	.kol-input.button {
-		gap: rem(6.4) rem(1);
+		gap: to-rem(6.4) to-rem(1);
 	}
 
 	.checkbox-container {
@@ -105,7 +105,7 @@
 
 	/* CHECKBOX */
 	.kol-input label span {
-		margin-top: rem(2);
+		margin-top: to-rem(2);
 	}
 
 	.required label > span::after {
@@ -127,9 +127,9 @@
 
 	.kol-input.default input[type='checkbox'] {
 		border-radius: var(--border-radius);
-		height: calc(6 * rem(4));
-		min-width: calc(6 * rem(4));
-		width: calc(6 * rem(4));
+		height: calc(6 * to-rem(4));
+		min-width: calc(6 * to-rem(4));
+		width: calc(6 * to-rem(4));
 	}
 
 	.kol-input.default input[type='checkbox']:indeterminate {
@@ -138,7 +138,7 @@
 
 	.kol-input.default .icon {
 		color: var(--color-light);
-		margin-left: rem(4);
+		margin-left: to-rem(4);
 	}
 
 	.kol-input.switch input[type='checkbox'] {
@@ -151,14 +151,14 @@
 		position: relative;
 		width: 3.5em;
 		/* Visible with forced colors  */
-		outline: transparent solid rem(1);
+		outline: transparent solid to-rem(1);
 	}
 
 	.kol-input.switch input[type='checkbox']:before {
 		width: 1.25em;
 		height: 1.25em;
-		left: calc(0.25em - rem(2));
-		top: calc(0.25em - rem(2));
+		left: calc(0.25em - to-rem(2));
+		top: calc(0.25em - to-rem(2));
 		border-radius: 1.25em;
 		background-color: white;
 		position: absolute;
@@ -184,7 +184,7 @@
 		& .icon {
 			width: 1.25em;
 			height: 1.25em;
-			left: rem(2);
+			left: to-rem(2);
 		}
 
 		&.checked .icon {
@@ -225,7 +225,7 @@
 			align-self: stretch;
 			display: flex;
 
-			padding-right: rem(16);
+			padding-right: to-rem(16);
 
 			.input-label-span {
 				margin: auto auto;

--- a/packages/themes/default/src/components/input-color.scss
+++ b/packages/themes/default/src/components/input-color.scss
@@ -1,9 +1,9 @@
 @use '../@shared/input-core' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	input[type='color'] {
 		border: none;
-		min-height: rem(40);
+		min-height: to-rem(40);
 	}
 }

--- a/packages/themes/default/src/components/input-file.scss
+++ b/packages/themes/default/src/components/input-file.scss
@@ -1,2 +1,2 @@
 @use '../@shared/input-core' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;

--- a/packages/themes/default/src/components/input-radio.scss
+++ b/packages/themes/default/src/components/input-radio.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
 @use '../mixins/typography' as *;
@@ -60,7 +60,7 @@
 		cursor: pointer;
 		display: flex;
 		flex-direction: row;
-		gap: rem(8);
+		gap: to-rem(8);
 		margin: 0;
 		min-height: var(--a11y-min-size);
 		position: relative;
@@ -81,9 +81,9 @@
 		appearance: none;
 		transition: 0.5s;
 		border-radius: 100%;
-		height: calc(6 * rem(4));
-		min-width: calc(6 * rem(4));
-		width: calc(6 * rem(4));
+		height: calc(6 * to-rem(4));
+		min-width: calc(6 * to-rem(4));
+		width: calc(6 * to-rem(4));
 	}
 
 	.radio-input-wrapper input[type='radio']:before {

--- a/packages/themes/default/src/components/input-range.scss
+++ b/packages/themes/default/src/components/input-range.scss
@@ -1,17 +1,17 @@
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {
 	@include kol-alert-theme;
 
 	.inputs-wrapper {
-		gap: rem(16);
+		gap: to-rem(16);
 	}
 
 	.kol-input {
-		gap: rem(4);
+		gap: to-rem(4);
 	}
 
 	.kol-input .error:not(.hidden-error) {
@@ -41,20 +41,20 @@
 		border-radius: var(--border-radius);
 		border-style: solid;
 		border-width: 2px;
-		padding: 0 rem(8);
+		padding: 0 to-rem(8);
 	}
 
 	.input.icon-left > .kol-icon:first-child {
-		margin-right: rem(8);
+		margin-right: to-rem(8);
 	}
 
 	.input.icon-right > .kol-icon:last-child {
-		margin-left: rem(8);
+		margin-left: to-rem(8);
 	}
 
 	.input:is(.icon-left, .icon-right) {
-		padding-left: rem(16);
-		padding-right: rem(16);
+		padding-left: to-rem(16);
+		padding-right: to-rem(16);
 	}
 
 	:not(.disabled) .input:hover {

--- a/packages/themes/default/src/components/link-button.scss
+++ b/packages/themes/default/src/components/link-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button;

--- a/packages/themes/default/src/components/nav.scss
+++ b/packages/themes/default/src/components/nav.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/focus-outline' as *;
 @use '../mixins/button' as *;
 
@@ -20,18 +20,18 @@
 		align-items: center;
 		color: var(--color-primary);
 		display: flex;
-		gap: rem(8);
+		gap: to-rem(8);
 		min-height: var(--a11y-min-size);
 		text-decoration: none;
 
 		.vertical & {
 			border-left: 2px solid transparent;
-			padding-left: rem(16);
-			padding-right: rem(16);
+			padding-left: to-rem(16);
+			padding-right: to-rem(16);
 		}
 
 		.horizontal & {
-			padding: 0 rem(16);
+			padding: 0 to-rem(16);
 		}
 
 		.vertical .active & {
@@ -49,7 +49,7 @@
 
 	// nested lists
 	.list .list {
-		padding-left: rem(16);
+		padding-left: to-rem(16);
 	}
 
 	.active .entry-item a,

--- a/packages/themes/default/src/components/pagination.scss
+++ b/packages/themes/default/src/components/pagination.scss
@@ -1,5 +1,5 @@
 @use '../mixins/focus-outline' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.button:focus {
@@ -14,7 +14,7 @@
 		font-weight: 700;
 		min-height: var(--a11y-min-size);
 		min-width: var(--a11y-min-size);
-		padding: rem(8);
+		padding: to-rem(8);
 		text-align: center;
 		transition-duration: 0.5s;
 		transition-property: background-color, color, border-color;

--- a/packages/themes/default/src/components/popover-button.scss
+++ b/packages/themes/default/src/components/popover-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button;

--- a/packages/themes/default/src/components/progress.scss
+++ b/packages/themes/default/src/components/progress.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	svg line:first-child,

--- a/packages/themes/default/src/components/select.scss
+++ b/packages/themes/default/src/components/select.scss
@@ -1,5 +1,5 @@
 @use '../@shared/input-core' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	select {
@@ -10,7 +10,7 @@
 		}
 
 		option {
-			margin: rem(1) 0;
+			margin: to-rem(1) 0;
 			border-radius: var(--border-radius);
 			cursor: pointer;
 

--- a/packages/themes/default/src/components/single-select.scss
+++ b/packages/themes/default/src/components/single-select.scss
@@ -1,9 +1,9 @@
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -12,12 +12,12 @@ $visible-options: 5;
 	.single-select {
 		&__group {
 			width: 100%;
-			padding: 0 rem(8);
+			padding: 0 to-rem(8);
 		}
 
 		&__input {
 			border: none;
-			width: calc(100% - rem(40));
+			width: calc(100% - to-rem(40));
 			position: relative;
 
 			&::placeholder {
@@ -40,8 +40,8 @@ $visible-options: 5;
 		&__button {
 			display: grid;
 			place-items: center;
-			padding-left: rem(8);
-			padding-right: rem(8);
+			padding-left: to-rem(8);
+			padding-right: to-rem(8);
 
 			&:focus {
 				outline: 0;
@@ -53,7 +53,7 @@ $visible-options: 5;
 			border-width: 1px;
 			border-radius: var(--border-radius);
 			border-color: var(--color-subtle);
-			max-height: calc($option-height * $visible-options + rem(2));
+			max-height: calc($option-height * $visible-options + to-rem(2));
 			overflow-y: auto;
 			overflow-x: hidden;
 			width: 100%;
@@ -62,11 +62,11 @@ $visible-options: 5;
 		&__item {
 			min-height: $option-height;
 			line-height: 1;
-			padding: rem(10) rem(12);
+			padding: to-rem(10) to-rem(12);
 
 			.radio-label {
 				align-self: center;
-				padding-left: rem(1);
+				padding-left: to-rem(1);
 			}
 
 			&[aria-selected],
@@ -80,7 +80,7 @@ $visible-options: 5;
 	}
 
 	.kol-input {
-		gap: rem(4);
+		gap: to-rem(4);
 	}
 
 	.kol-input .error:not(.hidden-error) {
@@ -115,17 +115,17 @@ $visible-options: 5;
 		border-radius: var(--border-radius);
 		border-style: solid;
 		border-width: 2px;
-		padding: 0 rem(8);
+		padding: 0 to-rem(8);
 	}
 
 	.input:is(.icon-left, .icon-right) {
-		padding-left: rem(16);
-		padding-right: rem(16);
+		padding-left: to-rem(16);
+		padding-right: to-rem(16);
 	}
 
 	.input:is(.icon-left, .icon-right) input {
-		padding-left: rem(8);
-		padding-right: rem(8);
+		padding-left: to-rem(8);
+		padding-right: to-rem(8);
 	}
 
 	.input > input:first-child {

--- a/packages/themes/default/src/components/skip-nav.scss
+++ b/packages/themes/default/src/components/skip-nav.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-link-wc > a > .kol-span-wc {
@@ -7,7 +7,7 @@
 		border-width: var(--border-width);
 		gap: calc(var(--spacing) * 2);
 		line-height: 1;
-		padding: rem(8) rem(14);
+		padding: to-rem(8) to-rem(14);
 		background-color: var(--color-primary-variant);
 		border-color: var(--color-primary-variant);
 		color: var(--color-light);

--- a/packages/themes/default/src/components/split-button.scss
+++ b/packages/themes/default/src/components/split-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
@@ -20,7 +20,7 @@
 	.horizontal-line {
 		background-color: var(--color-primary);
 		border-radius: 2px;
-		width: rem(1);
+		width: to-rem(1);
 	}
 
 	@include kol-button;

--- a/packages/themes/default/src/components/tabs.scss
+++ b/packages/themes/default/src/components/tabs.scss
@@ -1,9 +1,9 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host .tabs-button-group {
 		display: inline-flex;
-		gap: rem(32);
+		gap: to-rem(32);
 		flex-wrap: wrap;
 	}
 
@@ -13,7 +13,7 @@
 		border-radius: var(--border-radius);
 		font-style: normal;
 		font-weight: 700;
-		font-size: rem(18);
+		font-size: to-rem(18);
 		line-height: 1.2;
 		min-height: var(--a11y-min-size);
 		min-width: var(--a11y-min-size);
@@ -39,7 +39,7 @@
 	}
 
 	button .kol-span-wc > span {
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	.tabs-content {
@@ -88,11 +88,11 @@
 	}
 
 	:host > .tabs-align-bottom > .tabs-button-group > div > div:first-child {
-		margin: 0 rem(16) 0 0;
+		margin: 0 to-rem(16) 0 0;
 	}
 
 	:host > .tabs-align-bottom > .tabs-button-group > div > div {
-		margin: 0 rem(16);
+		margin: 0 to-rem(16);
 	}
 
 	:host > .tabs-align-top {
@@ -109,11 +109,11 @@
 	}
 
 	:host > .tabs-align-top > .tabs-button-group > div > div:first-child {
-		margin: 0 rem(16) 0 0;
+		margin: 0 to-rem(16) 0 0;
 	}
 
 	:host > .tabs-align-top > .tabs-button-group > div > div {
-		margin: 0 rem(16);
+		margin: 0 to-rem(16);
 	}
 
 	:host > div {

--- a/packages/themes/default/src/components/textarea.scss
+++ b/packages/themes/default/src/components/textarea.scss
@@ -1,13 +1,13 @@
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {
 	@include kol-alert-theme;
 
 	.kol-input {
-		gap: rem(4);
+		gap: to-rem(4);
 	}
 
 	.kol-input .error:not(.hidden-error) {
@@ -45,17 +45,17 @@
 		border-radius: var(--border-radius);
 		border-style: solid;
 		border-width: 2px;
-		padding: 0 rem(8);
+		padding: 0 to-rem(8);
 	}
 
 	.input:is(.icon-left, .icon-right) {
-		padding-left: rem(16);
-		padding-right: rem(16);
+		padding-left: to-rem(16);
+		padding-right: to-rem(16);
 	}
 
 	.input:is(.icon-left, .icon-right) input {
-		padding-left: rem(8);
-		padding-right: rem(8);
+		padding-left: to-rem(8);
+		padding-right: to-rem(8);
 	}
 
 	.input > input:first-child {

--- a/packages/themes/default/src/components/toast-container.scss
+++ b/packages/themes/default/src/components/toast-container.scss
@@ -1,15 +1,15 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
 	:host {
-		top: rem(16);
-		right: rem(16);
-		width: rem(440);
+		top: to-rem(16);
+		right: to-rem(16);
+		width: to-rem(440);
 	}
 
 	.toast {
-		margin-top: rem(16);
+		margin-top: to-rem(16);
 
 		@include kol-alert-theme;
 	}

--- a/packages/themes/default/src/components/toolbar.scss
+++ b/packages/themes/default/src/components/toolbar.scss
@@ -1,9 +1,9 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.toolbar {
-		padding: rem(8) rem(14);
+		padding: to-rem(8) to-rem(14);
 		border-radius: var(--border-radius);
 		background-color: var(--color-light);
 		border-width: var(--border-width);

--- a/packages/themes/default/src/components/tree-item.scss
+++ b/packages/themes/default/src/components/tree-item.scss
@@ -1,8 +1,8 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.tree-item {
-		--tree-item-indentation: #{rem(20)};
+		--tree-item-indentation: #{to-rem(20)};
 	}
 
 	.tree-link {

--- a/packages/themes/default/src/components/tree.scss
+++ b/packages/themes/default/src/components/tree.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.tree {

--- a/packages/themes/default/src/functions/to-rem.scss
+++ b/packages/themes/default/src/functions/to-rem.scss
@@ -1,3 +1,3 @@
-@function rem($size) {
+@function to-rem($size) {
 	@return calc(#{$size}rem / var(--kolibri-root-font-size, 16));
 }

--- a/packages/themes/default/src/global.scss
+++ b/packages/themes/default/src/global.scss
@@ -1,12 +1,12 @@
-@use 'mixins/rem' as *;
+@use 'functions/to-rem' as *;
 
 @layer kol-theme-global {
 	:host {
-		--border-radius: var(--kolibri-border-radius, #{rem(5)});
+		--border-radius: var(--kolibri-border-radius, #{to-rem(5)});
 		--font-family: var(--kolibri-font-family, Verdana, Arial, Calibri, Helvetica, sans-serif);
-		--font-size: var(--kolibri-font-size, #{rem(16)});
-		--spacing: var(--kolibri-spacing, #{rem(4)});
-		--border-width: var(--kolibri-border-width, #{rem(1)});
+		--font-size: var(--kolibri-font-size, #{to-rem(16)});
+		--spacing: var(--kolibri-spacing, #{to-rem(4)});
+		--border-width: var(--kolibri-border-width, #{to-rem(1)});
 		--color-primary: var(--kolibri-color-primary, #004b76);
 		--color-primary-variant: var(--kolibri-color-primary-variant, #0077b6);
 		--color-secondary: var(--kolibri-color-secondary, #ccebf7);
@@ -70,12 +70,12 @@
 	.kol-tooltip-wc .tooltip-content {
 		border-radius: var(--border-radius);
 		line-height: 1.5;
-		padding: rem(8) rem(12);
+		padding: to-rem(8) to-rem(12);
 	}
 
 	.kol-span-wc,
 	.kol-span-wc > span {
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	.badge-text-hint {

--- a/packages/themes/default/src/mixins/alert-wc.scss
+++ b/packages/themes/default/src/mixins/alert-wc.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 
 @mixin kol-alert-wc {
 	display: block;
@@ -38,7 +38,7 @@
 
 	.kol-alert-wc > .heading > div {
 		display: grid;
-		gap: rem(4);
+		gap: to-rem(4);
 	}
 
 	.msg > .heading > .kol-icon {
@@ -153,12 +153,12 @@
 	.card {
 		border-width: var(--border-width);
 		border-style: solid;
-		filter: drop-shadow(0 rem(2) rem(4) rgb(8, 35, 48, 0.24));
+		filter: drop-shadow(0 to-rem(2) to-rem(4) rgb(8, 35, 48, 0.24));
 		flex-direction: column;
 	}
 
 	.card > .heading {
-		padding: rem(8) rem(16);
+		padding: to-rem(8) to-rem(16);
 	}
 
 	.card[_has-closer] > .heading {
@@ -169,19 +169,19 @@
 
 	.card > .heading > div {
 		width: 100%;
-		min-height: rem(20);
+		min-height: to-rem(20);
 	}
 
 	.card > .heading .heading-icon {
 		justify-self: right;
-		margin-top: rem(-4);
+		margin-top: to-rem(-4);
 	}
 
 	.card > .heading .kol-heading-wc {
 		width: 100%;
 		color: var(--color-light);
 		display: flex;
-		font-size: rem(20);
+		font-size: to-rem(20);
 		line-height: 1;
 	}
 
@@ -190,7 +190,7 @@
 	}
 
 	.card > .content {
-		padding: rem(16);
+		padding: to-rem(16);
 	}
 
 	.card.default > .heading {
@@ -214,7 +214,7 @@
 	}
 
 	:is(.error, .info, .success, .warning) .heading-icon {
-		font-size: rem(20);
+		font-size: to-rem(20);
 	}
 
 	.card > div > .content {
@@ -251,7 +251,7 @@
 
 	.close > button.hide-label .kol-icon {
 		display: flex;
-		font-size: rem(19.2);
+		font-size: to-rem(19.2);
 	}
 
 	.close > button:active {

--- a/packages/themes/default/src/mixins/button.scss
+++ b/packages/themes/default/src/mixins/button.scss
@@ -1,5 +1,5 @@
 @use './focus-outline' as *;
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 
 @mixin kol-button {
 	:is(a, button) > .kol-span-wc {
@@ -9,7 +9,7 @@
 		border-width: var(--border-width);
 		min-height: var(--a11y-min-size);
 		min-width: var(--a11y-min-size);
-		padding: rem(8) rem(14);
+		padding: to-rem(8) to-rem(14);
 		text-align: center;
 		transition-duration: 0.5s;
 		transition-property: background-color, color, border-color;
@@ -106,7 +106,7 @@
 	}
 
 	:is(a, button).hide-label > .kol-span-wc {
-		padding: rem(12.8);
+		padding: to-rem(12.8);
 		width: unset;
 	}
 

--- a/packages/themes/default/src/mixins/focus-outline.scss
+++ b/packages/themes/default/src/mixins/focus-outline.scss
@@ -1,9 +1,9 @@
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 
 @mixin focus-outline {
 	border-radius: var(--border-radius);
 	outline-offset: 2px;
-	outline: var(--color-primary-variant) solid rem(3);
+	outline: var(--color-primary-variant) solid to-rem(3);
 	transition: 200ms outline-offset linear;
 }
 

--- a/packages/themes/default/src/mixins/indented-text.scss
+++ b/packages/themes/default/src/mixins/indented-text.scss
@@ -1,8 +1,8 @@
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 
 @mixin indented-text {
 	border-left: 2px solid var(--color-primary-variant);
-	padding: 0 rem(18) 0 rem(8);
-	margin-left: rem(-2);
+	padding: 0 to-rem(18) 0 to-rem(8);
+	margin-left: to-rem(-2);
 	width: 100%;
 }

--- a/packages/themes/default/src/mixins/input-error.scss
+++ b/packages/themes/default/src/mixins/input-error.scss
@@ -1,9 +1,9 @@
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @mixin input-error {
 	border-left: 3px solid var(--color-danger);
-	padding-left: rem(16);
+	padding-left: to-rem(16);
 
 	.input:focus-within {
 		outline-color: var(--color-danger);

--- a/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 
 @mixin kol-table-stateless-wc {
 	@layer kol-theme-component {
@@ -15,7 +15,7 @@
 		}
 
 		caption {
-			padding: rem(8);
+			padding: to-rem(8);
 		}
 
 		th {
@@ -26,7 +26,7 @@
 		tr.foot-spacer,
 		tr.head-spacer {
 			display: table-row;
-			height: rem(24);
+			height: to-rem(24);
 
 			td {
 				border-width: 0;
@@ -48,7 +48,7 @@
 		}
 
 		.table {
-			padding: rem(8);
+			padding: to-rem(8);
 
 			&:has(.focus-element:focus) {
 				outline-color: var(--color-primary-variant);
@@ -83,7 +83,7 @@
 
 		th div {
 			display: flex;
-			gap: rem(8);
+			gap: to-rem(8);
 			grid-template-columns: 1fr auto;
 			align-items: center;
 		}
@@ -94,7 +94,7 @@
 
 		th,
 		td {
-			padding: rem(8);
+			padding: to-rem(8);
 		}
 
 		th[aria-sort='ascending'],

--- a/packages/themes/default/src/mixins/link.scss
+++ b/packages/themes/default/src/mixins/link.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 
 @mixin kol-link {
 	:is(a, button) {
@@ -29,7 +29,7 @@
 	}
 
 	.skip {
-		left: rem(-99999);
+		left: to-rem(-99999);
 		overflow: hidden;
 		position: absolute;
 		z-index: 9999999;

--- a/packages/themes/default/src/mixins/typography.scss
+++ b/packages/themes/default/src/mixins/typography.scss
@@ -1,32 +1,32 @@
-@use './rem' as *;
+@use '../functions/to-rem' as *;
 
 @mixin kol-typography-body {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-h1 {
-	font-size: rem(24);
+	font-size: to-rem(24);
 	line-height: 1.667;
 }
 
 @mixin kol-typography-h2 {
-	font-size: rem(20);
+	font-size: to-rem(20);
 	line-height: 1.4;
 }
 
 @mixin kol-typography-h3 {
-	font-size: rem(18);
+	font-size: to-rem(18);
 	line-height: 1.333;
 }
 
 @mixin kol-typography-accordion {
 	font-weight: 700;
-	font-size: rem(18);
+	font-size: to-rem(18);
 	line-height: 1.1;
 }
 
 @mixin kol-typography-hint {
-	font-size: rem(14.4);
+	font-size: to-rem(14.4);
 	font-style: italic;
 }

--- a/packages/themes/ecl/src/ecl-ec/@shared/input-core.scss
+++ b/packages/themes/ecl/src/ecl-ec/@shared/input-core.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
@@ -15,7 +15,7 @@
 	select,
 	textarea {
 		border: none;
-		margin: rem(1);
+		margin: to-rem(1);
 		outline: none;
 	}
 
@@ -37,7 +37,7 @@
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 		order: 2;
 	}
 
@@ -52,7 +52,7 @@
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1) 0.5em;
+		padding: to-rem(1) 0.5em;
 	}
 
 	input::placeholder,
@@ -62,8 +62,8 @@
 
 	.input:focus-within {
 		box-shadow:
-			inset rem(1) rem(1) var(--color-blue),
-			inset rem(-1) rem(-1) var(--color-blue);
+			inset to-rem(1) to-rem(1) var(--color-blue),
+			inset to-rem(-1) to-rem(-1) var(--color-blue);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-ec/components/abbr.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/abbr.scss
@@ -1,8 +1,8 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	abbr {
-		border-bottom: dashed var(--color-text) rem(1);
+		border-bottom: dashed var(--color-text) to-rem(1);
 		text-decoration: none;
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/accordion.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/accordion.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.accordion {
@@ -19,7 +19,7 @@
 				span {
 					color: var(--color-grey);
 					font-weight: var(--font-weight-bold);
-					padding: rem(12) 0;
+					padding: to-rem(12) 0;
 					width: 100%;
 					border: none;
 				}
@@ -36,10 +36,10 @@
 			}
 
 			.kol-icon {
-				margin-bottom: rem(12);
-				margin-inline-end: rem(16);
+				margin-bottom: to-rem(12);
+				margin-inline-end: to-rem(16);
 				margin-inline-start: 0;
-				margin-top: rem(12);
+				margin-top: to-rem(12);
 			}
 		}
 

--- a/packages/themes/ecl/src/ecl-ec/components/badge.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/badge.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host > span {
 		font: normal normal var(--font-weight) 1em var(--font-family);
-		padding: calc(rem(8) - rem(1)) calc(rem(12) - rem(1));
+		padding: calc(to-rem(8) - to-rem(1)) calc(to-rem(12) - to-rem(1));
 		text-transform: uppercase;
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/breadcrumb.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/breadcrumb.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
 		font:
-			normal normal 400 rem(14) / rem(16) arial,
+			normal normal 400 to-rem(14) / to-rem(16) arial,
 			sans-serif;
 		font-weight: var(--font-weight-bold);
 	}
@@ -17,8 +17,8 @@
 	}
 
 	.kol-icon[exportparts*='separator'] {
-		margin-inline-end: rem(8);
-		margin-inline-start: rem(8);
+		margin-inline-end: to-rem(8);
+		margin-inline-start: to-rem(8);
 		padding: 0;
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/button-link.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/button-link.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:is(a, button) {
@@ -28,7 +28,7 @@
 	}
 
 	.skip {
-		left: rem(-99999);
+		left: to-rem(-99999);
 		overflow: hidden;
 		position: absolute;
 		z-index: 9999999;

--- a/packages/themes/ecl/src/ecl-ec/components/button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button;

--- a/packages/themes/ecl/src/ecl-ec/components/card.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/card.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host > div {

--- a/packages/themes/ecl/src/ecl-ec/components/combobox.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/combobox.scss
@@ -1,7 +1,7 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -23,13 +23,13 @@ $visible-options: 5;
 			color: var(--color-grey);
 			order: 4;
 			align-items: center;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {
 			border: none;
 			flex-grow: 1;
-			width: calc(100% - rem(24));
+			width: calc(100% - to-rem(24));
 			position: relative;
 
 			&::placeholder {
@@ -63,7 +63,7 @@ $visible-options: 5;
 			overflow-y: auto;
 			overflow-x: hidden;
 			width: 100%;
-			max-height: calc($option-height * $visible-options + rem(2));
+			max-height: calc($option-height * $visible-options + to-rem(2));
 		}
 
 		&__item {
@@ -71,7 +71,7 @@ $visible-options: 5;
 			align-items: center;
 			min-height: $option-height;
 			line-height: 1.2;
-			padding: rem(10) rem(12);
+			padding: to-rem(10) to-rem(12);
 
 			&[aria-selected],
 			&:focus {
@@ -107,7 +107,7 @@ $visible-options: 5;
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 		order: 2;
 	}
 
@@ -121,7 +121,7 @@ $visible-options: 5;
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1);
+		padding: to-rem(1);
 	}
 
 	input::placeholder,
@@ -131,8 +131,8 @@ $visible-options: 5;
 
 	.input:focus-within {
 		box-shadow:
-			inset rem(1) rem(1) var(--color-blue),
-			inset rem(-1) rem(-1) var(--color-blue);
+			inset to-rem(1) to-rem(1) var(--color-blue),
+			inset to-rem(-1) to-rem(-1) var(--color-blue);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-ec/components/details.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/details.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/indented-text' as *;
 
 @layer kol-theme-component {
@@ -13,7 +13,7 @@
 			}
 
 			.kol-icon {
-				font-size: rem(19.2);
+				font-size: to-rem(19.2);
 			}
 
 			.kol-span-wc > span {

--- a/packages/themes/ecl/src/ecl-ec/components/heading.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/heading.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
@@ -1,10 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
 	:host {
 		@include kol-alert-theme;
 	}
+
 	.checkbox-container {
 		justify-content: flex-start;
 	}
@@ -19,7 +20,7 @@
 		border-style: solid;
 		color: var(--color-grey);
 		line-height: 1.5;
-		font-size: rem(16);
+		font-size: to-rem(16);
 	}
 
 	input[type='checkbox']:focus {
@@ -70,7 +71,7 @@
 	}
 
 	.default .icon {
-		margin-left: rem(3.2);
+		margin-left: to-rem(3.2);
 	}
 
 	.default.checked .icon {
@@ -137,7 +138,7 @@
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 	}
 
 	.button:focus-within {

--- a/packages/themes/ecl/src/ecl-ec/components/input-radio.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-radio.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/typography' as *;
 
@@ -9,13 +9,13 @@
 
 	fieldset {
 		border: 0;
-		gap: rem(8);
+		gap: to-rem(8);
 		flex-wrap: wrap;
 		align-items: flex-start;
 	}
 
 	.input-slot {
-		gap: rem(4);
+		gap: to-rem(4);
 	}
 
 	fieldset .kol-alert-wc {
@@ -52,7 +52,7 @@
 	}
 
 	.radio-label {
-		padding-left: rem(8);
+		padding-left: to-rem(8);
 	}
 
 	input[type='radio'] {
@@ -110,7 +110,7 @@
 	}
 
 	.hint {
-		font-size: rem(14.4);
+		font-size: to-rem(14.4);
 		order: 4;
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/link-button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/link-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button;

--- a/packages/themes/ecl/src/ecl-ec/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/nav.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.list {
@@ -44,9 +44,9 @@
 		border-style: solid;
 		border-width: 2px;
 		color: var(--color-white);
-		font-size: rem(18);
+		font-size: to-rem(18);
 		justify-items: start;
-		padding: rem(16);
+		padding: to-rem(16);
 		height: 100%;
 	}
 

--- a/packages/themes/ecl/src/ecl-ec/components/pagination.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/pagination.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {

--- a/packages/themes/ecl/src/ecl-ec/components/popover-button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/popover-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button;
@@ -7,7 +7,7 @@
 	button .kol-span-wc {
 		border-radius: 0;
 		border-style: solid;
-		border-width: rem(2);
+		border-width: to-rem(2);
 		font-weight: var(--font-weight-bold);
 		margin: 0;
 		min-height: var(--a11y-min-size);

--- a/packages/themes/ecl/src/ecl-ec/components/progress.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/progress.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host progress,

--- a/packages/themes/ecl/src/ecl-ec/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/single-select.scss
@@ -1,7 +1,7 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -21,13 +21,13 @@ $visible-options: 5;
 			color: var(--color-grey);
 			order: 4;
 			align-items: center;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {
 			border: none;
 			flex-grow: 1;
-			width: calc(100% - rem(40));
+			width: calc(100% - to-rem(40));
 			position: relative;
 
 			&::placeholder {
@@ -62,14 +62,14 @@ $visible-options: 5;
 			border-style: solid;
 			border-width: 1px;
 			border-color: var(--color-blue);
-			max-height: calc($option-height * $visible-options + rem(1));
+			max-height: calc($option-height * $visible-options + to-rem(1));
 			overflow-y: auto;
 			overflow-x: hidden;
 			width: 100%;
 		}
 
 		&__item {
-			padding: rem(10) rem(12);
+			padding: to-rem(10) to-rem(12);
 			min-height: $option-height;
 			line-height: 1.2;
 
@@ -113,7 +113,7 @@ $visible-options: 5;
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 		order: 2;
 	}
 
@@ -127,7 +127,7 @@ $visible-options: 5;
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1);
+		padding: to-rem(1);
 	}
 
 	input::placeholder,
@@ -137,8 +137,8 @@ $visible-options: 5;
 
 	.input:focus-within {
 		box-shadow:
-			inset rem(1) rem(1) var(--color-blue),
-			inset rem(-1) rem(-1) var(--color-blue);
+			inset to-rem(1) to-rem(1) var(--color-blue),
+			inset to-rem(-1) to-rem(-1) var(--color-blue);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-ec/components/skip-nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/skip-nav.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-link-wc > a > .kol-span-wc {
@@ -6,7 +6,7 @@
 		border-style: solid;
 		border-width: 2px;
 		font-weight: var(--font-weight-bold);
-		gap: rem(8);
+		gap: to-rem(8);
 		line-height: 1;
 		padding: 0.25em 0.75em;
 		background-color: var(--color-blue);

--- a/packages/themes/ecl/src/ecl-ec/components/spin.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/spin.scss
@@ -1,8 +1,8 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.cycle {
-		padding: rem(2);
+		padding: to-rem(2);
 
 		& span {
 			background-color: var(--color-blue-75);

--- a/packages/themes/ecl/src/ecl-ec/components/split-button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/split-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {

--- a/packages/themes/ecl/src/ecl-ec/components/table-stateful.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/table-stateful.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/kol-table-stateless-wc' as *;
 
 @layer kol-theme-component {
@@ -15,7 +15,7 @@
 
 		:host > div:last-child .kol-pagination {
 			display: flex;
-			gap: rem(16);
+			gap: to-rem(16);
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/tabs.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tabs.scss
@@ -1,22 +1,22 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 	}
 
 	.tabs-button-group {
 		border-bottom: 1px solid var(--color-grey-25);
-		margin-bottom: rem(-1);
+		margin-bottom: to-rem(-1);
 	}
 
 	.tabs-button-group button {
 		border: none;
-		margin-bottom: rem(-1);
+		margin-bottom: to-rem(-1);
 	}
 
 	.tabs-button-group button .kol-span-wc {
-		padding: rem(8);
+		padding: to-rem(8);
 		min-height: var(--a11y-min-size);
 		min-width: var(--a11y-min-size);
 	}

--- a/packages/themes/ecl/src/ecl-ec/components/toast-container.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/toast-container.scss
@@ -1,18 +1,18 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
 	:host {
-		top: rem(16);
-		right: rem(16);
-		width: rem(440);
+		top: to-rem(16);
+		right: to-rem(16);
+		width: to-rem(440);
 		max-width: 100%;
 	}
 
 	.toast {
 		display: block;
 		background-color: #fff;
-		margin-top: rem(16);
+		margin-top: to-rem(16);
 
 		@include kol-alert-theme;
 	}

--- a/packages/themes/ecl/src/ecl-ec/components/toolbar.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/toolbar.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.tree-item {

--- a/packages/themes/ecl/src/ecl-ec/components/tree.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.tree {

--- a/packages/themes/ecl/src/ecl-ec/global.scss
+++ b/packages/themes/ecl/src/ecl-ec/global.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-global {
 	.kol-tooltip-wc .tooltip-area {
@@ -10,8 +10,8 @@
 	}
 
 	.kol-tooltip-wc .tooltip-content {
-		padding: rem(4) rem(8);
-		font-size: rem(14);
+		padding: to-rem(4) to-rem(8);
+		font-size: to-rem(14);
 		lborder: 1px2;
 		border-radius: 2px;
 		border: 1px solid #626262;
@@ -52,20 +52,20 @@
 		--color-black: #000;
 		--color-white: #fff;
 		--font-family: Arial, sans-serif;
-		--font-size: #{rem(16)};
+		--font-size: #{to-rem(16)};
 		--font-weight: 400;
 		--font-weight-bold: 600;
 		--line-height: 1.5;
 		--line-height-heading: 1.2;
-		--spacing-4xl: #{rem(64)};
-		--spacing-3xl: #{rem(48)};
-		--spacing-2xl: #{rem(40)};
-		--spacing-xl: #{rem(32)};
-		--spacing-l: #{rem(24)};
-		--spacing-m: #{rem(16)};
-		--spacing-s: #{rem(12)};
-		--spacing-xs: #{rem(8)};
-		--spacing-2xs: #{rem(4)};
+		--spacing-4xl: #{to-rem(64)};
+		--spacing-3xl: #{to-rem(48)};
+		--spacing-2xl: #{to-rem(40)};
+		--spacing-xl: #{to-rem(32)};
+		--spacing-l: #{to-rem(24)};
+		--spacing-m: #{to-rem(16)};
+		--spacing-s: #{to-rem(12)};
+		--spacing-xs: #{to-rem(8)};
+		--spacing-2xs: #{to-rem(4)};
 	}
 
 	a,

--- a/packages/themes/ecl/src/ecl-ec/mixins/alert-wc.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/alert-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin kol-alert-wc($color: null) {
 	color: var($color);
@@ -30,22 +30,22 @@
 	}
 
 	.card {
-		padding-bottom: rem(24);
-		padding-inline-end: rem(8);
-		padding-inline-start: rem(24);
-		padding-top: rem(24);
+		padding-bottom: to-rem(24);
+		padding-inline-end: to-rem(8);
+		padding-inline-start: to-rem(24);
+		padding-top: to-rem(24);
 	}
 
 	.card .heading {
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	.card .content {
-		margin-left: rem(40);
+		margin-left: to-rem(40);
 	}
 
 	.card .heading .kol-icon {
-		font-size: rem(32);
+		font-size: to-rem(32);
 	}
 
 	.default {

--- a/packages/themes/ecl/src/ecl-ec/mixins/indented-text.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/indented-text.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin indented-text {
 	border-end-start-radius: 0;
-	border-inline-start: rem(10) solid var(--color-yellow);
+	border-inline-start: to-rem(10) solid var(--color-yellow);
 	border-start-start-radius: 0;
-	padding-bottom: rem(16);
-	padding-inline-start: rem(24);
-	padding-top: rem(16);
+	padding-bottom: to-rem(16);
+	padding-inline-start: to-rem(24);
+	padding-top: to-rem(16);
 	margin: 0;
 }

--- a/packages/themes/ecl/src/ecl-ec/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/kol-table-stateless-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin kol-table-stateless-wc {
 	@layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-ec/mixins/typography.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/typography.scss
@@ -1,36 +1,36 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin kol-typography-body {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-h1 {
-	font-size: rem(32);
+	font-size: to-rem(32);
 	line-height: 1.25;
 }
 
 @mixin kol-typography-h2 {
-	font-size: rem(28);
+	font-size: to-rem(28);
 	line-height: 1.143;
 }
 
 @mixin kol-typography-h3 {
-	font-size: rem(24);
+	font-size: to-rem(24);
 	line-height: 1.1667;
 }
 
 @mixin kol-typography-h4 {
-	font-size: rem(20);
+	font-size: to-rem(20);
 	line-height: 1.4;
 }
 
 @mixin kol-typography-h5 {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-hint {
-	font-size: rem(14.4);
+	font-size: to-rem(14.4);
 	font-style: italic;
 }

--- a/packages/themes/ecl/src/ecl-eu/@shared/input-core.scss
+++ b/packages/themes/ecl/src/ecl-eu/@shared/input-core.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
@@ -15,7 +15,7 @@
 	select,
 	textarea {
 		border: none;
-		margin: rem(1);
+		margin: to-rem(1);
 		outline: none;
 	}
 
@@ -38,7 +38,7 @@
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 		order: 2;
 	}
 
@@ -53,7 +53,7 @@
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1) 0.5em;
+		padding: to-rem(1) 0.5em;
 	}
 
 	input::placeholder,
@@ -63,8 +63,8 @@
 
 	.input:focus-within {
 		box-shadow:
-			inset rem(1) rem(1) var(--color-blue),
-			inset rem(-1) rem(-1) var(--color-blue);
+			inset to-rem(1) to-rem(1) var(--color-blue),
+			inset to-rem(-1) to-rem(-1) var(--color-blue);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/components/abbr.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/abbr.scss
@@ -1,8 +1,8 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	abbr {
-		border-bottom: dashed var(--color-text) rem(1);
+		border-bottom: dashed var(--color-text) to-rem(1);
 		text-decoration: none;
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/accordion.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/accordion.scss
@@ -1,13 +1,13 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.accordion {
 		border-radius: 8px;
 		box-shadow:
-			0 rem(2) rem(4) rgb(9 49 142 / 8%),
-			0 0 rem(10) rgb(9 49 142 / 4%),
-			0 rem(4) rem(5) rgb(9 49 142 / 4%),
-			0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+			0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+			0 0 to-rem(10) rgb(9 49 142 / 4%),
+			0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+			0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 		margin: 0;
 		overflow: hidden;
 
@@ -27,9 +27,9 @@
 				position: relative;
 				display: block;
 				font:
-					normal normal 400 rem(18) / rem(28) arial,
+					normal normal 400 to-rem(18) / to-rem(28) arial,
 					sans-serif;
-				padding: rem(24);
+				padding: to-rem(24);
 				text-align: start;
 				width: 100%;
 				line-height: 1.2;
@@ -40,19 +40,19 @@
 
 				&::before {
 					background-color: #fc0;
-					border-end-end-radius: rem(2);
-					border-end-start-radius: rem(2);
+					border-end-end-radius: to-rem(2);
+					border-end-start-radius: to-rem(2);
 					content: '';
-					height: rem(4);
+					height: to-rem(4);
 					position: absolute;
-					left: rem(24);
+					left: to-rem(24);
 					top: 0;
 					width: 3rem (2);
 				}
 			}
 
 			.kol-icon {
-				margin-right: rem(12);
+				margin-right: to-rem(12);
 
 				&::part(icon)::before {
 					color: #0e47cb;
@@ -63,22 +63,22 @@
 		}
 
 		&__content {
-			-webkit-border-start: rem(4) solid #0e47cb;
+			-webkit-border-start: to-rem(4) solid #0e47cb;
 			-webkit-margin-start: 0;
 			border-bottom: 2px solid #cfdaf5;
-			border-inline-start: rem(4) solid #0e47cb;
+			border-inline-start: to-rem(4) solid #0e47cb;
 			color: #515560;
 			font:
-				normal normal 400 rem(16) / rem(24) arial,
+				normal normal 400 to-rem(16) / to-rem(24) arial,
 				sans-serif;
 			margin-inline-start: 0;
-			padding: rem(24);
+			padding: to-rem(24);
 		}
 
 		.open &__heading-button {
 			button {
-				border-start-end-radius: rem(8);
-				border-start-start-radius: rem(8);
+				border-start-end-radius: to-rem(8);
+				border-start-start-radius: to-rem(8);
 			}
 
 			.kol-icon::part(icon)::before {

--- a/packages/themes/ecl/src/ecl-eu/components/badge.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/badge.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host > span {
-		font: normal normal var(--font-weight) rem(14) / 1em var(--font-family);
-		padding: calc(rem(8) - rem(1)) calc(rem(12) - rem(1));
+		font: normal normal var(--font-weight) to-rem(14) / 1em var(--font-family);
+		padding: calc(to-rem(8) - to-rem(1)) calc(to-rem(12) - to-rem(1));
 		text-transform: uppercase;
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/button.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/button.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {
 	:host {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 	}
 
 	@include kol-button;

--- a/packages/themes/ecl/src/ecl-eu/components/card.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/card.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host > div {

--- a/packages/themes/ecl/src/ecl-eu/components/combobox.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/combobox.scss
@@ -1,7 +1,7 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -40,13 +40,13 @@ $visible-options: 5;
 			color: var(--color-grey);
 			order: 4;
 			align-items: center;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {
 			border: none;
 			flex-grow: 1;
-			width: calc(100% - rem(24));
+			width: calc(100% - to-rem(24));
 			position: relative;
 
 			&::placeholder {
@@ -80,7 +80,7 @@ $visible-options: 5;
 			overflow-y: auto;
 			overflow-x: hidden;
 			width: 100%;
-			max-height: calc($option-height * $visible-options + rem(2));
+			max-height: calc($option-height * $visible-options + to-rem(2));
 		}
 
 		&__item {
@@ -88,7 +88,7 @@ $visible-options: 5;
 			align-items: center;
 			min-height: $option-height;
 			line-height: 1.2;
-			padding: rem(10) rem(12);
+			padding: to-rem(10) to-rem(12);
 
 			&[aria-selected],
 			&:focus {
@@ -123,7 +123,7 @@ $visible-options: 5;
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 		order: 2;
 	}
 
@@ -139,7 +139,7 @@ $visible-options: 5;
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1);
+		padding: to-rem(1);
 	}
 
 	input::placeholder,
@@ -149,8 +149,8 @@ $visible-options: 5;
 
 	.input:focus-within {
 		box-shadow:
-			inset rem(1) rem(1) var(--color-blue),
-			inset rem(-1) rem(-1) var(--color-blue);
+			inset to-rem(1) to-rem(1) var(--color-blue),
+			inset to-rem(-1) to-rem(-1) var(--color-blue);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/components/details.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/details.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/indented-text' as *;
 
 @layer kol-theme-component {
@@ -13,7 +13,7 @@
 			}
 
 			.kol-icon {
-				font-size: rem(19.2);
+				font-size: to-rem(19.2);
 			}
 
 			.kol-span-wc > span {

--- a/packages/themes/ecl/src/ecl-eu/components/heading.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/heading.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
@@ -70,7 +70,7 @@
 	}
 
 	.default .icon {
-		margin-left: rem(3.2);
+		margin-left: to-rem(3.2);
 	}
 
 	.default.checked .icon {
@@ -137,7 +137,7 @@
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 	}
 
 	.button:focus-within {

--- a/packages/themes/ecl/src/ecl-eu/components/input-radio.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-radio.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/typography' as *;
 
@@ -9,7 +9,7 @@
 
 	fieldset {
 		border: 0;
-		gap: rem(8);
+		gap: to-rem(8);
 		flex-wrap: wrap;
 		align-items: flex-start;
 	}
@@ -48,7 +48,7 @@
 	}
 
 	.radio-label {
-		padding-left: rem(8);
+		padding-left: to-rem(8);
 	}
 
 	input[type='radio'] {
@@ -107,7 +107,7 @@
 	}
 
 	.hint {
-		font-size: rem(14.4);
+		font-size: to-rem(14.4);
 		order: 4;
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/input-range.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-range.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
@@ -7,6 +7,6 @@
 	}
 
 	.inputs-wrapper {
-		gap: rem(16);
+		gap: to-rem(16);
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/link-button.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/link-button.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {
 	:host {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 	}
 
 	@include kol-button;

--- a/packages/themes/ecl/src/ecl-eu/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/nav.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.list {
@@ -44,9 +44,9 @@
 		border-style: solid;
 		border-width: 2px;
 		color: var(--color-white);
-		font-size: rem(18);
+		font-size: to-rem(18);
 		justify-items: start;
-		padding: rem(16);
+		padding: to-rem(16);
 		height: 100%;
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/components/pagination.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/pagination.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
@@ -6,7 +6,7 @@
 	}
 
 	.button {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 		border-radius: 4px;
 
 		&:focus {
@@ -19,9 +19,9 @@
 		min-width: var(--a11y-min-size);
 		border-radius: 4px;
 		font:
-			normal normal 400 rem(16) / rem(20) Arial,
+			normal normal 400 to-rem(16) / to-rem(20) Arial,
 			sans-serif;
-		padding: rem(12);
+		padding: to-rem(12);
 		background-color: #fc0;
 		color: #171a22;
 	}
@@ -36,10 +36,10 @@
 		background-color: #fc0;
 		border-color: #fc0;
 		box-shadow:
-			0 rem(2) rem(4) rgb(9 49 142 / 8%),
-			0 0 rem(10) rgb(9 49 142 / 4%),
-			0 rem(4) rem(5) rgb(9 49 142 / 4%),
-			0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+			0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+			0 0 to-rem(10) rgb(9 49 142 / 4%),
+			0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+			0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 	}
 
 	.button:disabled .button-inner {

--- a/packages/themes/ecl/src/ecl-eu/components/popover-button.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/popover-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button;

--- a/packages/themes/ecl/src/ecl-eu/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/single-select.scss
@@ -1,13 +1,14 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
 	:host {
 		@include kol-alert-theme;
 	}
+
 	.single-select {
 		position: relative;
 
@@ -18,7 +19,7 @@ $visible-options: 5;
 			min-height: var(--a11y-min-size);
 			color: var(--color-grey);
 			order: 4;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {
@@ -59,7 +60,7 @@ $visible-options: 5;
 			border-style: solid;
 			border-width: 1px;
 			border-color: var(--color-blue);
-			max-height: calc($option-height * $visible-options + rem(2));
+			max-height: calc($option-height * $visible-options + to-rem(2));
 			overflow-y: auto;
 			overflow-x: hidden;
 			width: 100%;
@@ -69,7 +70,7 @@ $visible-options: 5;
 			display: flex;
 			align-items: flex-start;
 			justify-items: center;
-			padding: rem(10) rem(12);
+			padding: to-rem(10) to-rem(12);
 			min-height: $option-height;
 			line-height: 1.2;
 
@@ -112,7 +113,7 @@ $visible-options: 5;
 	}
 
 	.hint {
-		font-size: rem(14);
+		font-size: to-rem(14);
 		order: 2;
 	}
 
@@ -128,7 +129,7 @@ $visible-options: 5;
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1);
+		padding: to-rem(1);
 	}
 
 	input::placeholder,
@@ -138,8 +139,8 @@ $visible-options: 5;
 
 	.input:focus-within {
 		box-shadow:
-			inset rem(1) rem(1) var(--color-blue),
-			inset rem(-1) rem(-1) var(--color-blue);
+			inset to-rem(1) to-rem(1) var(--color-blue),
+			inset to-rem(-1) to-rem(-1) var(--color-blue);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/components/skip-nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/skip-nav.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-link-wc > a > .kol-span-wc {
 		border-radius: 4px;
-		gap: rem(8);
+		gap: to-rem(8);
 		line-height: 1;
-		padding: rem(12);
+		padding: to-rem(12);
 		background-color: #0e47cb;
 		color: #fff;
 		cursor: pointer;

--- a/packages/themes/ecl/src/ecl-eu/components/spin.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/spin.scss
@@ -1,8 +1,8 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.cycle {
-		padding: rem(2);
+		padding: to-rem(2);
 
 		& span {
 			background-color: var(--color-blue-80);

--- a/packages/themes/ecl/src/ecl-eu/components/table-stateful.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/table-stateful.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/kol-table-stateless-wc' as *;
 
 @layer kol-theme-component {
@@ -8,7 +8,7 @@
 	}
 
 	.pagination {
-		gap: rem(16);
+		gap: to-rem(16);
 	}
 
 	@media (min-width: 1024px) {
@@ -19,7 +19,7 @@
 
 		:host > div:last-child .kol-pagination {
 			display: flex;
-			gap: rem(16);
+			gap: to-rem(16);
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/tabs.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tabs.scss
@@ -1,22 +1,22 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 	}
 
 	.tabs-button-group {
 		border-bottom: 1px solid var(--color-grey-25);
-		margin-bottom: rem(-1);
+		margin-bottom: to-rem(-1);
 	}
 
 	.tabs-button-group button {
 		border: none;
-		margin-bottom: rem(-1);
+		margin-bottom: to-rem(-1);
 	}
 
 	.tabs-button-group button .kol-span-wc {
-		padding: rem(4);
+		padding: to-rem(4);
 		min-height: var(--a11y-min-size);
 		min-width: var(--a11y-min-size);
 	}

--- a/packages/themes/ecl/src/ecl-eu/components/toast-container.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/toast-container.scss
@@ -1,18 +1,18 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
 	:host {
-		top: rem(16);
-		right: rem(16);
-		width: rem(440);
+		top: to-rem(16);
+		right: to-rem(16);
+		width: to-rem(440);
 		max-width: 100%;
 	}
 
 	.toast {
 		display: block;
 		background-color: #fff;
-		margin-top: rem(16);
+		margin-top: to-rem(16);
 
 		@include kol-alert-theme;
 

--- a/packages/themes/ecl/src/ecl-eu/components/toolbar.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/toolbar.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {
@@ -6,10 +6,10 @@
 		padding: var(--spacing-s);
 		border-radius: 8px;
 		box-shadow:
-			0 rem(2) rem(4) rgb(9 49 142 / 8%),
-			0 0 rem(10) rgb(9 49 142 / 4%),
-			0 rem(4) rem(5) rgb(9 49 142 / 4%),
-			0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+			0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+			0 0 to-rem(10) rgb(9 49 142 / 4%),
+			0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+			0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 		background-color: var(--color-white);
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.tree-item {

--- a/packages/themes/ecl/src/ecl-eu/components/tree.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @layer kol-theme-component {
 	.tree {

--- a/packages/themes/ecl/src/ecl-eu/global.scss
+++ b/packages/themes/ecl/src/ecl-eu/global.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../functions/to-rem' as *;
 
 @layer kol-theme-global {
 	.kol-tooltip-wc .tooltip-area {
@@ -10,8 +10,8 @@
 	}
 
 	.kol-tooltip-wc .tooltip-content {
-		padding: rem(4) rem(8);
-		font-size: rem(14);
+		padding: to-rem(4) to-rem(8);
+		font-size: to-rem(14);
 		line-height: 1.2;
 		bborder: 1px2px;
 		border: 1px solid #626262;
@@ -109,20 +109,20 @@
 		--color-white: #fff;
 		--color-black: #000;
 		--font-family: Arial, sans-serif;
-		--font-size: #{rem(16)};
+		--font-size: #{to-rem(16)};
 		--font-weight-regular: 400;
 		--font-weight-bold: 700;
 		--line-height-regular: 1.5;
 		--line-height-heading: 1.2;
-		--spacing-4xl: #{rem(64)};
-		--spacing-3xl: #{rem(48)};
-		--spacing-2xl: #{rem(40)};
-		--spacing-xl: #{rem(32)};
-		--spacing-l: #{rem(24)};
-		--spacing-m: #{rem(16)};
-		--spacing-s: #{rem(12)};
-		--spacing-xs: #{rem(8)};
-		--spacing-2xs: #{rem(4)};
+		--spacing-4xl: #{to-rem(64)};
+		--spacing-3xl: #{to-rem(48)};
+		--spacing-2xl: #{to-rem(40)};
+		--spacing-xl: #{to-rem(32)};
+		--spacing-l: #{to-rem(24)};
+		--spacing-m: #{to-rem(16)};
+		--spacing-s: #{to-rem(12)};
+		--spacing-xs: #{to-rem(8)};
+		--spacing-2xs: #{to-rem(4)};
 	}
 
 	:host {
@@ -167,27 +167,27 @@
 
 	p.l,
 	p.lead {
-		font-size: rem(20);
-		line-height: rem(28);
+		font-size: to-rem(20);
+		line-height: to-rem(28);
 	}
 
 	p,
 	p.m,
 	p.medium {
-		font-size: rem(16);
-		line-height: rem(24);
+		font-size: to-rem(16);
+		line-height: to-rem(24);
 	}
 
 	p.s,
 	p.small {
-		font-size: rem(14);
-		line-height: rem(20);
+		font-size: to-rem(14);
+		line-height: to-rem(20);
 	}
 
 	p.xs,
 	p.extra-small {
-		font-size: rem(12);
-		line-height: rem(20);
+		font-size: to-rem(12);
+		line-height: to-rem(20);
 	}
 
 	.badge-text-hint {

--- a/packages/themes/ecl/src/ecl-eu/mixins/alert-wc.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/alert-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin kol-alert-wc($color: null) {
 	color: var($color);
@@ -30,22 +30,22 @@
 	}
 
 	.card {
-		padding-bottom: rem(24);
-		padding-inline-end: rem(8);
-		padding-inline-start: rem(24);
-		padding-top: rem(24);
+		padding-bottom: to-rem(24);
+		padding-inline-end: to-rem(8);
+		padding-inline-start: to-rem(24);
+		padding-top: to-rem(24);
 	}
 
 	.card .heading {
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	.card .content {
-		margin-left: rem(40);
+		margin-left: to-rem(40);
 	}
 
 	.card .heading .kol-icon {
-		font-size: rem(32);
+		font-size: to-rem(32);
 	}
 
 	.default {

--- a/packages/themes/ecl/src/ecl-eu/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/button.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin kol-button {
 	a,
@@ -19,11 +19,11 @@
 		min-width: var(--a11y-min-size);
 		border-radius: 4px;
 		font:
-			normal normal 400 rem(16) / rem(20) arial,
+			normal normal 400 to-rem(16) / to-rem(20) arial,
 			sans-serif;
 		font-weight: 400;
 		margin: 0;
-		padding: rem(12);
+		padding: to-rem(12);
 		line-height: 1.2;
 	}
 
@@ -39,10 +39,10 @@
 	a:hover > .kol-span-wc,
 	button:hover > .kol-span-wc {
 		box-shadow:
-			0 rem(2) rem(4) rgb(9 49 142 / 8%),
-			0 0 rem(10) rgb(9 49 142 / 4%),
-			0 rem(4) rem(5) rgb(9 49 142 / 4%),
-			0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+			0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+			0 0 to-rem(10) rgb(9 49 142 / 4%),
+			0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+			0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 	}
 
 	a.primary > .kol-span-wc,
@@ -66,7 +66,7 @@
 		background-color: #fff;
 		border: 2px solid #0e47cb;
 		color: #0e47cb;
-		padding: calc(rem(12) - rem(2)) calc(rem(16) - rem(2));
+		padding: calc(to-rem(12) - to-rem(2)) calc(to-rem(16) - to-rem(2));
 	}
 
 	a.secondary:focus-visible > .kol-span-wc,

--- a/packages/themes/ecl/src/ecl-eu/mixins/indented-text.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/indented-text.scss
@@ -1,13 +1,13 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin indented-text {
-	-webkit-border-start: rem(8) solid #0e47cb;
-	-webkit-padding-start: rem(24);
-	border-end-start-radius: rem(4);
-	border-inline-start: rem(8) solid #0e47cb;
-	border-start-start-radius: rem(4);
+	-webkit-border-start: to-rem(8) solid #0e47cb;
+	-webkit-padding-start: to-rem(24);
+	border-end-start-radius: to-rem(4);
+	border-inline-start: to-rem(8) solid #0e47cb;
+	border-start-start-radius: to-rem(4);
 	display: inline-block;
-	padding-bottom: rem(16);
-	padding-inline-start: rem(24);
-	padding-top: rem(16);
+	padding-bottom: to-rem(16);
+	padding-inline-start: to-rem(24);
+	padding-top: to-rem(16);
 }

--- a/packages/themes/ecl/src/ecl-eu/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/kol-table-stateless-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin kol-table-stateless-wc {
 	@layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-eu/mixins/typography.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/typography.scss
@@ -1,41 +1,41 @@
-@use '../../mixins/rem' as *;
+@use '../../functions/to-rem' as *;
 
 @mixin kol-typography-body {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-h1 {
-	font-size: rem(42);
+	font-size: to-rem(42);
 	line-height: 3.25;
 }
 
 @mixin kol-typography-h2 {
-	font-size: rem(36);
+	font-size: to-rem(36);
 	line-height: 2.755;
 }
 
 @mixin kol-typography-h3 {
-	font-size: rem(32);
+	font-size: to-rem(32);
 	line-height: 2.5;
 }
 
 @mixin kol-typography-h4 {
-	font-size: rem(28);
+	font-size: to-rem(28);
 	line-height: 2;
 }
 
 @mixin kol-typography-h5 {
-	font-size: rem(24);
+	font-size: to-rem(24);
 	line-height: 1.75;
 }
 
 @mixin kol-typography-h6 {
-	font-size: rem(20);
+	font-size: to-rem(20);
 	line-height: 1.75;
 }
 
 @mixin kol-typography-hint {
-	font-size: rem(14.4);
+	font-size: to-rem(14.4);
 	font-style: italic;
 }

--- a/packages/themes/ecl/src/functions/to-rem.scss
+++ b/packages/themes/ecl/src/functions/to-rem.scss
@@ -1,3 +1,3 @@
-@function rem($size) {
+@function to-rem($size) {
 	@return calc(#{$size}rem / var(--kolibri-root-font-size, 16));
 }


### PR DESCRIPTION
## Summary
Renames the `rem()` CSS utility function to `to-rem()` for clearer semantics.

## Changes
- Renamed `rem()` function to `to-rem()` across the codebase

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
CSS-Hilfsfunktion `rem()` für klarere Semantik in `to-rem()` umbenannt.

## Änderungen
- Funktion `rem()` überall im Code in `to-rem()` umbenannt

</details>