### PR TITLE
refactor: rename rem function to to-rem

### DIFF
--- a/packages/components/src/components/@shared/_kol-button-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-button-mixin.scss
@@ -9,7 +9,7 @@
 		}
 
 		.#{$block-classname} {
-			font-style: rem(16);
+			font-style: to-rem(16);
 			display: inline-flex;
 			place-items: center;
 			text-align: center;

--- a/packages/components/src/components/@shared/_kol-link-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-link-mixin.scss
@@ -34,7 +34,7 @@
 
 			&__icon {
 				display: inline-flex;
-				margin-left: rem(8);
+				margin-left: to-rem(8);
 			}
 		}
 	}

--- a/packages/components/src/components/@shared/_kol-pagination-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-pagination-mixin.scss
@@ -5,7 +5,7 @@
 		.kol-pagination {
 			align-items: center;
 			display: grid;
-			gap: rem(16);
+			gap: to-rem(16);
 			grid-template-columns: 1fr auto;
 
 			&__navigation-list {

--- a/packages/components/src/components/@shared/_kol-table-settings-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-table-settings-mixin.scss
@@ -10,17 +10,17 @@
 			z-index: 1;
 
 			&__columns-container {
-				margin-top: rem(16);
-				max-height: rem(200);
+				margin-top: to-rem(16);
+				max-height: to-rem(200);
 				overflow: auto;
 			}
 
 			&__columns {
 				align-items: center;
 				display: grid;
-				gap: rem(8);
+				gap: to-rem(8);
 				grid-auto-rows: min-content;
-				grid-template-columns: min-content 1fr rem(100) auto auto;
+				grid-template-columns: min-content 1fr to-rem(100) auto auto;
 				overflow: hidden;
 			}
 

--- a/packages/components/src/components/@shared/_mixins.scss
+++ b/packages/components/src/components/@shared/_mixins.scss
@@ -1,3 +1,3 @@
-@function rem($size) {
+@function to-rem($size) {
 	@return calc(#{$size}rem / var(--kolibri-root-font-size, 16));
 }

--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -8,7 +8,7 @@
 		/*
 		 * Minimum size of interactive elements.
 		 */
-		--a11y-min-size: #{rem(44)};
+		--a11y-min-size: #{to-rem(44)};
 		/*
 		 * No element should be used without a background and font color whose contrast ratio has
 		 * not been checked. By initially setting the background color to white and the font color
@@ -42,7 +42,7 @@
 	}
 
 	/*
-	 * All interactive elements should have a minimum size of rem(44).
+	 * All interactive elements should have a minimum size of to-rem(44).
 	 */
 	/* input:not([type='checkbox'], [type='radio'], [type='range']), */
 	/* option, */

--- a/packages/components/src/components/avatar/style.scss
+++ b/packages/components/src/components/avatar/style.scss
@@ -7,10 +7,10 @@
 		border-radius: 50%;
 		overflow: hidden;
 		/* Visible with forced colors  */
-		outline: transparent solid rem(1);
+		outline: transparent solid to-rem(1);
 		/*theme?*/
-		width: rem(100);
-		height: rem(100);
+		width: to-rem(100);
+		height: to-rem(100);
 
 		&__image {
 			width: 100%;
@@ -25,7 +25,7 @@
 			justify-content: center;
 			/*theme?*/
 			background-color: #d3d3d3;
-			font-size: rem(40);
+			font-size: to-rem(40);
 		}
 	}
 }

--- a/packages/components/src/components/badge/style.scss
+++ b/packages/components/src/components/badge/style.scss
@@ -7,7 +7,7 @@
 		display: inline-flex;
 		place-items: center;
 		/* Visible with forced colors  */
-		outline: transparent solid rem(1);
+		outline: transparent solid to-rem(1);
 
 		.kol-badge__smart-button {
 			.button {

--- a/packages/components/src/components/input-checkbox/style.scss
+++ b/packages/components/src/components/input-checkbox/style.scss
@@ -62,8 +62,8 @@
 		}
 
 		.kol-input {
-			width: rem(22);
-			height: rem(22);
+			width: to-rem(22);
+			height: to-rem(22);
 		}
 
 		&#{$root}--checked,
@@ -90,8 +90,8 @@
 			&::before {
 				background-color: #000;
 				height: 1.2em;
-				left: calc(0.25em - rem(2));
-				top: calc(0.25em - rem(2));
+				left: calc(0.25em - to-rem(2));
+				top: calc(0.25em - to-rem(2));
 				position: absolute;
 				transition: 0.5s;
 				width: 1.2em;
@@ -115,7 +115,7 @@
 			position: absolute;
 			z-index: 1;
 			top: 50%;
-			left: rem(4);
+			left: to-rem(4);
 			transform: translate(0, -50%);
 			transition: 0.5s;
 			color: #000;

--- a/packages/components/src/components/input-color/style.scss
+++ b/packages/components/src/components/input-color/style.scss
@@ -17,7 +17,7 @@
 		}
 
 		&--text {
-			width: rem(112);
+			width: to-rem(112);
 		}
 	}
 
@@ -25,7 +25,7 @@
 		align-items: center;
 		display: flex;
 		flex-direction: row;
-		gap: rem(6) !important;
+		gap: to-rem(6) !important;
 	}
 }
 

--- a/packages/components/src/components/input-file/style.scss
+++ b/packages/components/src/components/input-file/style.scss
@@ -12,7 +12,7 @@
 
 @layer kol-component {
 	.kol-input {
-		padding: calc((var(--a11y-min-size) - rem(16)) / 10) 0.5em;
+		padding: calc((var(--a11y-min-size) - to-rem(16)) / 10) 0.5em;
 		position: absolute;
 		inset: 0;
 		width: 100%;
@@ -48,7 +48,7 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-			margin-left: rem(4);
+			margin-left: to-rem(4);
 		}
 
 		&:has(> #{$root}__adornment--start):has(> #{$root}__adornment--end) {

--- a/packages/components/src/components/input-password/style.scss
+++ b/packages/components/src/components/input-password/style.scss
@@ -12,6 +12,6 @@
 
 @layer kol-component {
 	.kol-input-password {
-		--kol-tooltip-width: #{rem(160)};
+		--kol-tooltip-width: #{to-rem(160)};
 	}
 }

--- a/packages/components/src/components/input-range/style.scss
+++ b/packages/components/src/components/input-range/style.scss
@@ -32,7 +32,7 @@
 				border: 1px solid #000;
 				display: inline-block;
 				flex-grow: 1;
-				height: rem(8);
+				height: to-rem(8);
 				line-height: 1.5;
 				padding: 0;
 				margin: 0;
@@ -41,8 +41,8 @@
 
 				&::-webkit-slider-thumb {
 					background-color: #000;
-					height: rem(20);
-					width: rem(20);
+					height: to-rem(20);
+					width: to-rem(20);
 					border-radius: 20px;
 					-webkit-appearance: none;
 
@@ -57,8 +57,8 @@
 
 				&::-moz-range-thumb {
 					background-color: #000;
-					height: rem(20);
-					width: rem(20);
+					height: to-rem(20);
+					width: to-rem(20);
 					border-radius: 20px;
 					-moz-appearance: none;
 

--- a/packages/components/src/components/kolibri/style.scss
+++ b/packages/components/src/components/kolibri/style.scss
@@ -7,7 +7,7 @@
 		max-height: 100%;
 
 		&__text {
-			font-size: rem(90);
+			font-size: to-rem(90);
 			letter-spacing: normal;
 			word-spacing: normal;
 		}

--- a/packages/components/src/components/modal/style.scss
+++ b/packages/components/src/components/modal/style.scss
@@ -15,8 +15,8 @@
 
 		&__close-button {
 			position: absolute;
-			top: rem(1);
-			right: rem(1);
+			top: to-rem(1);
+			right: to-rem(1);
 			z-index: 1;
 		}
 	}

--- a/packages/components/src/components/select/style.scss
+++ b/packages/components/src/components/select/style.scss
@@ -31,7 +31,7 @@
 
 		/* needed hack for vertical alignment */
 		&[multiple] option {
-			padding: calc((var(--a11y-min-size) - rem(16)) / 2) 0.5em;
+			padding: calc((var(--a11y-min-size) - to-rem(16)) / 2) 0.5em;
 		}
 	}
 }

--- a/packages/components/src/components/single-select/style.scss
+++ b/packages/components/src/components/single-select/style.scss
@@ -16,7 +16,7 @@
 @include kol-input-container;
 @include kol-input;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: var(--visible-options, 5);
 
 @layer kol-component {
@@ -34,11 +34,11 @@ $visible-options: var(--visible-options, 5);
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			min-height: rem(50);
+			min-height: to-rem(50);
 		}
 
 		.kol-custom-suggestions-options-group {
-			max-height: calc($option-height * $visible-options + rem(2)) !important;
+			max-height: calc($option-height * $visible-options + to-rem(2)) !important;
 		}
 	}
 }

--- a/packages/components/src/components/skip-nav/style.scss
+++ b/packages/components/src/components/skip-nav/style.scss
@@ -14,7 +14,7 @@
 		}
 
 		.kol-link {
-			left: rem(-99999);
+			left: to-rem(-99999);
 			overflow: hidden;
 			position: absolute;
 			z-index: 9999999;

--- a/packages/components/src/components/spin/cycle.scss
+++ b/packages/components/src/components/spin/cycle.scss
@@ -4,8 +4,8 @@
 	.kol-spin {
 		&__spinner {
 			&--cycle {
-				width: rem(48);
-				height: rem(48);
+				width: to-rem(48);
+				height: to-rem(48);
 			}
 		}
 

--- a/packages/components/src/components/spin/dot.scss
+++ b/packages/components/src/components/spin/dot.scss
@@ -4,46 +4,46 @@
 	.kol-spin {
 		&__spinner {
 			&--dot {
-				height: rem(16);
-				width: rem(48);
+				height: to-rem(16);
+				width: to-rem(48);
 			}
 		}
 
 		&__spinner-element {
 			animation-timing-function: cubic-bezier(0, 1, 1, 0);
 			border-radius: 50%;
-			border: rem(0.16) solid #fff;
-			height: rem(12.8);
+			border: to-rem(0.16) solid #fff;
+			height: to-rem(12.8);
 			position: absolute;
-			top: rem(0.16);
-			width: rem(12.8);
+			top: to-rem(0.16);
+			width: to-rem(12.8);
 
 			&--1 {
 				background-color: #000;
 				z-index: 0;
 				animation: 1s infinite spin1;
-				left: rem(0.16);
+				left: to-rem(0.16);
 			}
 
 			&--2 {
 				background-color: #000;
 				z-index: 1;
 				animation: 1s infinite spin2;
-				left: rem(0.16);
+				left: to-rem(0.16);
 			}
 
 			&--3 {
 				background-color: #000;
 				z-index: 1;
 				animation: 1s infinite spin2;
-				left: rem(17.6);
+				left: to-rem(17.6);
 			}
 
 			&--neutral {
 				background-color: #666;
 				z-index: 0;
 				animation: 1s infinite spin3;
-				left: rem(33.6);
+				left: to-rem(33.6);
 			}
 		}
 	}
@@ -64,7 +64,7 @@
 		}
 
 		100% {
-			transform: translate(rem(16), 0);
+			transform: translate(to-rem(16), 0);
 		}
 	}
 

--- a/packages/components/src/components/spin/style.scss
+++ b/packages/components/src/components/spin/style.scss
@@ -7,7 +7,7 @@
 	.kol-spin {
 		&__spinner {
 			display: block;
-			padding: rem(2);
+			padding: to-rem(2);
 			position: relative;
 		}
 	}

--- a/packages/components/src/components/split-button/style.scss
+++ b/packages/components/src/components/split-button/style.scss
@@ -20,7 +20,7 @@
 
 		.kol-popover {
 			&__content {
-				margin-top: rem(2);
+				margin-top: to-rem(2);
 			}
 
 			&__arrow {

--- a/packages/components/src/components/tooltip/style.scss
+++ b/packages/components/src/components/tooltip/style.scss
@@ -24,10 +24,10 @@
 		&__arrow {
 			background-color: #fff;
 			color: #000;
-			height: rem(10);
+			height: to-rem(10);
 			position: absolute;
 			transform: rotate(45deg);
-			width: rem(10);
+			width: to-rem(10);
 			z-index: 999;
 		}
 

--- a/packages/components/src/components/tree-item/style.scss
+++ b/packages/components/src/components/tree-item/style.scss
@@ -2,11 +2,11 @@
 @use '../../styles/global' as *;
 
 @layer kol-component {
-	$base-horizontal-padding: rem(8);
+	$base-horizontal-padding: to-rem(8);
 
 	.kol-tree-item {
 		$root: &;
-		--indentation: var(--tree-item-indentation, #{rem(10)}); // Set `--tree-item-indentation` in themes to control padding
+		--indentation: var(--tree-item-indentation, #{to-rem(10)}); // Set `--tree-item-indentation` in themes to control padding
 
 		&__link {
 			.kol-link {
@@ -14,12 +14,12 @@
 				display: inline-flex;
 				min-height: var(--a11y-min-size);
 				padding-left: max(calc((var(--indentation) * var(--level)) + $base-horizontal-padding), $base-horizontal-padding);
-				padding-right: rem(6);
+				padding-right: to-rem(6);
 				text-decoration: none;
 			}
 
 			&--first-level .kol-link {
-				padding-left: rem(6);
+				padding-left: to-rem(6);
 			}
 		}
 

--- a/packages/components/src/styles/_global.scss
+++ b/packages/components/src/styles/_global.scss
@@ -4,7 +4,7 @@
 
 @layer kol-global {
 	:host {
-		font-size: rem(16);
+		font-size: to-rem(16);
 		/*
 		 * The max-width is needed to prevent the table from overflowing the
 		 * parent node, if the table is wider than the parent node.

--- a/packages/components/src/styles/_kol-alert-mixin.scss
+++ b/packages/components/src/styles/_kol-alert-mixin.scss
@@ -18,7 +18,7 @@
 
 			&__closer {
 				/* Visible with forced colors */
-				outline: transparent solid rem(1);
+				outline: transparent solid to-rem(1);
 			}
 		}
 	}

--- a/packages/components/src/styles/_kol-card-mixin.scss
+++ b/packages/components/src/styles/_kol-card-mixin.scss
@@ -6,7 +6,7 @@
 			height: 100%;
 			position: relative;
 			/* Visible with forced colors  */
-			outline: transparent solid rem(1);
+			outline: transparent solid to-rem(1);
 
 			&__close-button {
 				position: absolute;

--- a/packages/components/src/styles/_kol-custom-suggestions-options-group.scss
+++ b/packages/components/src/styles/_kol-custom-suggestions-options-group.scss
@@ -12,7 +12,7 @@
 			overflow-x: hidden;
 			z-index: 2;
 			background-color: white;
-			max-height: rem(250);
+			max-height: to-rem(250);
 		}
 	}
 }

--- a/packages/themes/default/README.md
+++ b/packages/themes/default/README.md
@@ -90,8 +90,8 @@ The following tokens are defined in `src/global.scss` and serve as the base for 
 | ------------------------- | ---------------------------------------------------------------------------- | ---------------------------- |
 | `--border-radius`         | `var(--kolibri-border-radius, 5px)`                                          | Default border radius        |
 | `--font-family`           | `var(--kolibri-font-family, Verdana, Arial, Calibri, Helvetica, sans-serif)` | Default font                 |
-| `--font-size`             | `var(--kolibri-font-size, #{rem(16)})`                                       | Base font size               |
-| `--spacing`               | `var(--kolibri-spacing, #{rem(4)})`                                          | Standard spacing             |
+| `--font-size`             | `var(--kolibri-font-size, #{to-rem(16)})`                                    | Base font size               |
+| `--spacing`               | `var(--kolibri-spacing, #{to-rem(4)})`                                       | Standard spacing             |
 | `--border-width`          | `var(--kolibri-border-width, 1px)`                                           | Border width                 |
 | `--color-primary`         | `var(--kolibri-color-primary, #004b76)`                                      | Primary accent color         |
 | `--color-primary-variant` | `var(--kolibri-color-primary-variant, #0077b6)`                              | Variant of the primary color |

--- a/packages/themes/default/src/components/abbr.scss
+++ b/packages/themes/default/src/components/abbr.scss
@@ -1,8 +1,8 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	abbr {
-		border-bottom: dashed var(--color-text) rem(1);
+		border-bottom: dashed var(--color-text) to-rem(1);
 		text-decoration: none;
 	}
 }

--- a/packages/themes/default/src/components/accordion.scss
+++ b/packages/themes/default/src/components/accordion.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/focus-outline' as *;
 @use '../mixins/typography' as *;
 
@@ -11,8 +11,8 @@
 		&__content {
 			margin: 0;
 			padding-left: 2.25em;
-			padding-bottom: rem(12);
-			padding-right: rem(8);
+			padding-bottom: to-rem(12);
+			padding-right: to-rem(8);
 		}
 
 		&__heading {
@@ -42,10 +42,10 @@
 			}
 
 			border-radius: var(--border-radius);
-			min-height: rem(35.2);
+			min-height: to-rem(35.2);
 
 			.kol-button {
-				padding: rem(12) rem(8);
+				padding: to-rem(12) to-rem(8);
 
 				:focus {
 					outline: none;

--- a/packages/themes/default/src/components/badge.scss
+++ b/packages/themes/default/src/components/badge.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-badge {
@@ -15,7 +15,7 @@
 				color: inherit;
 				border-top-right-radius: var(--border-radius);
 				border-bottom-right-radius: var(--border-radius);
-				padding: rem(3.2);
+				padding: to-rem(3.2);
 
 				&:hover {
 					background-color: var(--color-primary-variant);
@@ -25,20 +25,20 @@
 				&__text {
 					align-items: center;
 					font-style: normal;
-					padding: rem(4) rem(12);
+					padding: to-rem(4) to-rem(12);
 				}
 			}
 		}
 
 		&__label {
-			padding: rem(4) rem(12);
+			padding: to-rem(4) to-rem(12);
 			align-items: center;
 			font-style: normal;
-			gap: rem(8);
+			gap: to-rem(8);
 
 			.kol-span__container {
 				display: flex;
-				gap: rem(4);
+				gap: to-rem(4);
 			}
 		}
 	}

--- a/packages/themes/default/src/components/breadcrumb.scss
+++ b/packages/themes/default/src/components/breadcrumb.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/link' as *;
 
 @layer kol-theme-component {
@@ -11,12 +11,12 @@
 
 		&__link {
 			&::part(icon) {
-				font-size: rem(20);
+				font-size: to-rem(20);
 			}
 		}
 
 		&__icon {
-			font-size: rem(12);
+			font-size: to-rem(12);
 			color: var(--color-subtle);
 		}
 	}

--- a/packages/themes/default/src/components/button-link.scss
+++ b/packages/themes/default/src/components/button-link.scss
@@ -1,5 +1,5 @@
 @use '../mixins/link' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-link('kol-button');

--- a/packages/themes/default/src/components/button.scss
+++ b/packages/themes/default/src/components/button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');

--- a/packages/themes/default/src/components/card.scss
+++ b/packages/themes/default/src/components/card.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/kol-card' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/default/src/components/combobox.scss
+++ b/packages/themes/default/src/components/combobox.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
 @use '../mixins/typography' as *;
@@ -7,7 +7,7 @@
 @use '../mixins/custom-suggestions-toggle' as *;
 @use '../@shared/input-core' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -26,7 +26,7 @@ $visible-options: 5;
 		&__input {
 			flex-grow: 1;
 			border: none;
-			width: calc(100% - rem(40));
+			width: calc(100% - to-rem(40));
 			position: relative;
 
 			&::placeholder {

--- a/packages/themes/default/src/components/details.scss
+++ b/packages/themes/default/src/components/details.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/indented-text' as *;
 @use '../mixins/focus-outline' as *;
 
@@ -11,7 +11,7 @@
 		&__content {
 			&.indented-text {
 				@include indented-text;
-				margin: rem(4) 0 0 rem(10.4);
+				margin: to-rem(4) 0 0 to-rem(10.4);
 			}
 		}
 
@@ -21,7 +21,7 @@
 
 		&__heading-button {
 			.kol-icon {
-				font-size: rem(19.2);
+				font-size: to-rem(19.2);
 			}
 
 			.kol-span {

--- a/packages/themes/default/src/components/drawer.scss
+++ b/packages/themes/default/src/components/drawer.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/kol-card' as *;
 
 $duration: 0.4s;

--- a/packages/themes/default/src/components/input-checkbox.scss
+++ b/packages/themes/default/src/components/input-checkbox.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/focus-outline' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/typography' as *;
@@ -26,10 +26,11 @@
 		$root: &;
 
 		&--label-align-left:not(.kol-input-checkbox__field-control--variant-button) &__label {
-			padding-right: rem(6.4);
+			padding-right: to-rem(6.4);
 		}
+
 		&--label-align-right:not(.kol-input-checkbox__field-control--variant-button) &__label {
-			padding-left: rem(6.4);
+			padding-left: to-rem(6.4);
 		}
 	}
 
@@ -82,9 +83,9 @@
 
 		.kol-input {
 			border-radius: var(--border-radius);
-			height: calc(6 * rem(4));
-			min-width: calc(6 * rem(4));
-			width: calc(6 * rem(4));
+			height: calc(6 * to-rem(4));
+			min-width: calc(6 * to-rem(4));
+			width: calc(6 * to-rem(4));
 		}
 
 		.kol-icon {
@@ -96,7 +97,7 @@
 		.kol-icon {
 			width: 1.25em;
 			height: 1.25em;
-			left: rem(2);
+			left: to-rem(2);
 		}
 
 		.kol-input {
@@ -109,7 +110,7 @@
 			position: relative;
 			width: 3.5em;
 			/* Visible with forced colors  */
-			outline: transparent solid rem(1);
+			outline: transparent solid to-rem(1);
 
 			&:focus {
 				@include switch-outline;
@@ -118,8 +119,8 @@
 			&:before {
 				width: 1.25em;
 				height: 1.25em;
-				left: calc(0.25em - rem(2));
-				top: calc(0.25em - rem(2));
+				left: calc(0.25em - to-rem(2));
+				top: calc(0.25em - to-rem(2));
 				border-radius: 1.25em;
 				background-color: white;
 				position: absolute;
@@ -175,7 +176,7 @@
 					align-self: stretch;
 					display: flex;
 
-					padding-right: rem(16);
+					padding-right: to-rem(16);
 
 					&-text {
 						margin: auto auto;
@@ -222,11 +223,11 @@
 				&:not(.kol-field-control--hide-label) {
 					.kol-field-control {
 						&__label {
-							clip-path: inset(rem(-10) rem(-10) rem(-10) 0);
+							clip-path: inset(to-rem(-10) to-rem(-10) to-rem(-10) 0);
 						}
 
 						&__input {
-							clip-path: inset(rem(-10) 0 rem(-10) rem(-10));
+							clip-path: inset(to-rem(-10) 0 to-rem(-10) to-rem(-10));
 						}
 					}
 				}
@@ -256,11 +257,11 @@
 						&:not(.kol-field-control--hide-label) {
 							.kol-field-control {
 								&__label {
-									clip-path: inset(rem(-10) 0 rem(-10) rem(-10));
+									clip-path: inset(to-rem(-10) 0 to-rem(-10) to-rem(-10));
 								}
 
 								&__input {
-									clip-path: inset(rem(-10) rem(-10) rem(-10) 0);
+									clip-path: inset(to-rem(-10) to-rem(-10) to-rem(-10) 0);
 								}
 							}
 						}

--- a/packages/themes/default/src/components/input-color.scss
+++ b/packages/themes/default/src/components/input-color.scss
@@ -1,9 +1,9 @@
 @use '../@shared/input-text' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 .kol-input-color {
 	&__inputs-wrapper {
-		gap: rem(16);
+		gap: to-rem(16);
 	}
 
 	&__input {
@@ -11,7 +11,7 @@
 		&--color {
 			background-color: var(--color-light);
 			border: 1px solid var(--color-subtle);
-			min-height: calc(var(--a11y-min-size) - rem(8));
+			min-height: calc(var(--a11y-min-size) - to-rem(8));
 		}
 	}
 }

--- a/packages/themes/default/src/components/input-file.scss
+++ b/packages/themes/default/src/components/input-file.scss
@@ -1,6 +1,6 @@
 @use '../@shared/input-text' as *;
 @use '../mixins/input-file' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {
@@ -8,7 +8,7 @@
 
 	.kol-input-container {
 		gap: initial;
-		padding: 0 0 0 rem(8);
+		padding: 0 0 0 to-rem(8);
 
 		&__filename {
 			color: var(--color-subtle);
@@ -30,7 +30,7 @@
 	}
 
 	.kol-input {
-		padding-top: calc(0.5em + rem(2));
+		padding-top: calc(0.5em + to-rem(2));
 		background-color: transparent;
 	}
 }

--- a/packages/themes/default/src/components/input-radio.scss
+++ b/packages/themes/default/src/components/input-radio.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/typography' as *;
 @use '../mixins/form-field' as *;
@@ -27,7 +27,7 @@
 		}
 
 		&__input {
-			gap: rem(4);
+			gap: to-rem(4);
 
 			&--orientation-horizontal {
 				margin-top: calc(var(--spacing) / 2);
@@ -57,7 +57,7 @@
 
 			&:focus {
 				outline-offset: 2px;
-				outline: var(--color-primary-variant) solid rem(3);
+				outline: var(--color-primary-variant) solid to-rem(3);
 				transition: 200ms outline-offset linear;
 
 				&:hover {

--- a/packages/themes/default/src/components/input-range.scss
+++ b/packages/themes/default/src/components/input-range.scss
@@ -1,10 +1,10 @@
 @use '../@shared/input-core' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-input-range {
 		&__inputs-wrapper {
-			gap: rem(16);
+			gap: to-rem(16);
 		}
 	}
 }

--- a/packages/themes/default/src/components/link-button.scss
+++ b/packages/themes/default/src/components/link-button.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/default/src/components/modal.scss
+++ b/packages/themes/default/src/components/modal.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-modal {

--- a/packages/themes/default/src/components/nav.scss
+++ b/packages/themes/default/src/components/nav.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/focus-outline' as *;
 
 @layer kol-theme-component {
@@ -14,7 +14,7 @@
 
 			// nested lists
 			&--nested {
-				padding-left: rem(16);
+				padding-left: to-rem(16);
 
 				.kol-link,
 				.kol-button {
@@ -38,7 +38,7 @@
 				align-items: center;
 				color: var(--color-primary);
 				display: flex;
-				gap: rem(8);
+				gap: to-rem(8);
 				min-height: var(--a11y-min-size);
 				text-decoration: none;
 
@@ -48,12 +48,12 @@
 
 				#{$root}__list--vertical & {
 					border-left: 2px solid transparent;
-					padding-left: rem(16);
-					padding-right: rem(16);
+					padding-left: to-rem(16);
+					padding-right: to-rem(16);
 				}
 
 				#{$root}--horizontal & {
-					padding: 0 rem(16);
+					padding: 0 to-rem(16);
 				}
 
 				#{$root}--vertical #{$root}__list-item--active & {
@@ -116,7 +116,7 @@
 					color: var(--text-color);
 					min-height: var(--a11y-min-size);
 					min-width: var(--a11y-min-size);
-					padding: rem(8) rem(14);
+					padding: to-rem(8) to-rem(14);
 					text-align: center;
 					transition-duration: 0.5s;
 					transition-property: background-color, color, border-color;
@@ -129,7 +129,7 @@
 					}
 
 					@at-root #{$root}--hide-label & {
-						padding: rem(12.8);
+						padding: to-rem(12.8);
 						width: unset;
 
 						.kol-span__label {

--- a/packages/themes/default/src/components/popover-button.scss
+++ b/packages/themes/default/src/components/popover-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');

--- a/packages/themes/default/src/components/progress.scss
+++ b/packages/themes/default/src/components/progress.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-progress {

--- a/packages/themes/default/src/components/select.scss
+++ b/packages/themes/default/src/components/select.scss
@@ -1,5 +1,5 @@
 @use '../@shared/input-core' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-select {
@@ -10,7 +10,7 @@
 		}
 
 		&__option {
-			margin: rem(1) 0;
+			margin: to-rem(1) 0;
 			border-radius: var(--border-radius);
 
 			&:active:not(:disabled),

--- a/packages/themes/default/src/components/single-select.scss
+++ b/packages/themes/default/src/components/single-select.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/input-error' as *;
 @use '../mixins/typography' as *;
@@ -7,7 +7,7 @@
 @use '../mixins/custom-suggestions-toggle' as *;
 @use '../@shared/input-core' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -26,7 +26,7 @@ $visible-options: 5;
 		&__input {
 			flex-grow: 1;
 			border: none;
-			width: calc(100% - rem(40));
+			width: calc(100% - to-rem(40));
 			position: relative;
 
 			&::placeholder {

--- a/packages/themes/default/src/components/skip-nav.scss
+++ b/packages/themes/default/src/components/skip-nav.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-skip-nav {
@@ -9,7 +9,7 @@
 				border-width: var(--border-width);
 				gap: calc(var(--spacing) * 2);
 				line-height: 1;
-				padding: rem(8) rem(14);
+				padding: to-rem(8) to-rem(14);
 				background-color: var(--color-primary-variant);
 				border-color: var(--color-primary-variant);
 				color: var(--color-light);

--- a/packages/themes/default/src/components/split-button.scss
+++ b/packages/themes/default/src/components/split-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-split-button {
@@ -21,7 +21,7 @@
 		&__horizontal-line {
 			background-color: var(--color-primary);
 			border-radius: 2px;
-			width: rem(1);
+			width: to-rem(1);
 		}
 
 		&__secondary-button {
@@ -37,7 +37,7 @@
 			font-weight: 700;
 			min-height: var(--a11y-min-size);
 			min-width: var(--a11y-min-size);
-			padding: rem(8) rem(14);
+			padding: to-rem(8) to-rem(14);
 			text-align: center;
 			transition-duration: 0.5s;
 			transition-property: background-color, color, border-color;

--- a/packages/themes/default/src/components/tabs.scss
+++ b/packages/themes/default/src/components/tabs.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-tabs {
@@ -25,7 +25,7 @@
 			--display: flex;
 			--grid-template-rows: 1fr auto;
 
-			--button-group-gap: #{rem(32)};
+			--button-group-gap: #{to-rem(32)};
 			--button-group-order: 1;
 		}
 
@@ -33,7 +33,7 @@
 			--display: flex;
 			--grid-template-rows: auto 1fr;
 
-			--button-group-gap: #{rem(32)};
+			--button-group-gap: #{to-rem(32)};
 			--button-group-order: 0;
 		}
 
@@ -52,7 +52,7 @@
 			border: none;
 			font-style: normal;
 			font-weight: 700;
-			font-size: rem(18);
+			font-size: to-rem(18);
 			line-height: 1.2;
 			min-height: var(--a11y-min-size);
 			min-width: var(--a11y-min-size);
@@ -81,7 +81,7 @@
 			}
 
 			.kol-span__container {
-				gap: rem(8);
+				gap: to-rem(8);
 			}
 		}
 

--- a/packages/themes/default/src/components/toast-container.scss
+++ b/packages/themes/default/src/components/toast-container.scss
@@ -1,16 +1,16 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
 	@include kol-alert-theme;
 
 	:host {
-		top: rem(16);
-		right: rem(16);
-		width: rem(440);
+		top: to-rem(16);
+		right: to-rem(16);
+		width: to-rem(440);
 	}
 
 	.kol-toast-item {
-		margin-top: rem(16);
+		margin-top: to-rem(16);
 	}
 }

--- a/packages/themes/default/src/components/toolbar.scss
+++ b/packages/themes/default/src/components/toolbar.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');
@@ -17,6 +17,7 @@
 		.kol-toolbar--orientation-horizontal & {
 			border-right: 0;
 		}
+
 		.kol-toolbar--orientation-vertical & {
 			border-bottom: 0;
 		}

--- a/packages/themes/default/src/components/tree-item.scss
+++ b/packages/themes/default/src/components/tree-item.scss
@@ -1,9 +1,9 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-tree-item {
 		$root: &;
-		--tree-item-indentation: #{rem(20)};
+		--tree-item-indentation: #{to-rem(20)};
 
 		&__link {
 			display: block;

--- a/packages/themes/default/src/components/tree.scss
+++ b/packages/themes/default/src/components/tree.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-tree {

--- a/packages/themes/default/src/global.scss
+++ b/packages/themes/default/src/global.scss
@@ -1,11 +1,11 @@
-@use 'mixins/rem' as *;
+@use 'mixins/to-rem' as *;
 
 @layer kol-theme-global {
 	:host {
 		--border-radius: var(--kolibri-border-radius, 5px);
 		--font-family: var(--kolibri-font-family, Verdana, Arial, Calibri, Helvetica, sans-serif);
-		--font-size: var(--kolibri-font-size, #{rem(16)});
-		--spacing: var(--kolibri-spacing, #{rem(4)});
+		--font-size: var(--kolibri-font-size, #{to-rem(16)});
+		--spacing: var(--kolibri-spacing, #{to-rem(4)});
 		--border-width: var(--kolibri-border-width, 1px);
 		--color-primary: var(--kolibri-color-primary, #004b76);
 		--color-primary-variant: var(--kolibri-color-primary-variant, #0077b6);
@@ -69,13 +69,13 @@
 			background-color: var(--color-light);
 			border-radius: var(--border-radius);
 			line-height: 1.5;
-			padding: rem(8) rem(12);
+			padding: to-rem(8) to-rem(12);
 		}
 	}
 
 	.kol-span,
 	.kol-span__container {
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	.badge-text-hint {

--- a/packages/themes/default/src/mixins/alert-wc.scss
+++ b/packages/themes/default/src/mixins/alert-wc.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-alert {
 	display: block;
@@ -26,7 +26,7 @@
 		&--variant-card {
 			border-radius: var(--border-radius);
 			border: var(--border-width) solid var(--alert-accent-color);
-			filter: drop-shadow(0 rem(2) rem(4) rgb(8, 35, 48, 0.24));
+			filter: drop-shadow(0 to-rem(2) to-rem(4) rgb(8, 35, 48, 0.24));
 			flex-direction: column;
 		}
 
@@ -56,18 +56,18 @@
 			place-items: center;
 
 			@at-root #{$root}--variant-card & {
-				padding: rem(8) rem(16);
+				padding: to-rem(8) to-rem(16);
 				background-color: var(--alert-accent-color);
 			}
 		}
 
 		&__container-content {
 			display: grid;
-			gap: rem(4);
+			gap: to-rem(4);
 
 			@at-root #{$root}--variant-card & {
 				width: 100%;
-				min-height: rem(20);
+				min-height: to-rem(20);
 			}
 		}
 
@@ -90,7 +90,7 @@
 			}
 
 			.kol-icon {
-				font-size: rem(19.2);
+				font-size: to-rem(19.2);
 			}
 		}
 
@@ -104,7 +104,7 @@
 				width: 100%;
 				color: var(--color-light);
 				display: flex;
-				font-size: rem(20);
+				font-size: to-rem(20);
 				line-height: 1;
 			}
 		}
@@ -114,7 +114,7 @@
 			padding: 0;
 
 			@at-root #{$root}:not(#{$root}--type-default) & {
-				font-size: rem(20);
+				font-size: to-rem(20);
 			}
 
 			@at-root #{$root}--variant-msg & {
@@ -124,13 +124,13 @@
 
 			@at-root #{$root}--variant-card & {
 				justify-self: right;
-				margin-top: rem(-4);
+				margin-top: to-rem(-4);
 			}
 		}
 
 		&__content {
 			@at-root #{$root}--variant-card & {
-				padding: rem(16);
+				padding: to-rem(16);
 			}
 		}
 	}

--- a/packages/themes/default/src/mixins/button.scss
+++ b/packages/themes/default/src/mixins/button.scss
@@ -1,5 +1,5 @@
 @use './focus-outline' as *;
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-button($block-classname) {
 	:host {
@@ -84,7 +84,7 @@
 
 			min-height: var(--a11y-min-size);
 			min-width: var(--a11y-min-size);
-			padding: rem(8) rem(14);
+			padding: to-rem(8) to-rem(14);
 			text-align: center;
 			transition-duration: 0.5s;
 			transition-property: background-color, color, border-color;
@@ -97,7 +97,7 @@
 			}
 
 			@at-root #{$root}--hide-label & {
-				padding: rem(12);
+				padding: to-rem(12);
 				width: unset;
 
 				.kol-span__label {

--- a/packages/themes/default/src/mixins/custom-suggestions-option.scss
+++ b/packages/themes/default/src/mixins/custom-suggestions-option.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-option-theme($option-height) {
 	.kol-custom-suggestions-option {
@@ -6,7 +6,7 @@
 		align-items: center;
 		min-height: $option-height;
 		line-height: 1;
-		padding: rem(10) rem(12);
+		padding: to-rem(10) to-rem(12);
 
 		&[aria-selected] {
 			color: var(--color-primary-variant);

--- a/packages/themes/default/src/mixins/custom-suggestions-options-group.scss
+++ b/packages/themes/default/src/mixins/custom-suggestions-options-group.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-options-group-theme($option-height, $visible-options) {
 	.kol-custom-suggestions-options-group {
@@ -8,8 +8,8 @@
 		border-color: var(--color-subtle);
 		overflow-y: auto;
 		overflow-x: hidden;
-		max-height: calc($option-height * $visible-options + rem(2));
-		left: rem(-8);
-		right: rem(-8);
+		max-height: calc($option-height * $visible-options + to-rem(2));
+		left: to-rem(-8);
+		right: to-rem(-8);
 	}
 }

--- a/packages/themes/default/src/mixins/custom-suggestions-toggle.scss
+++ b/packages/themes/default/src/mixins/custom-suggestions-toggle.scss
@@ -1,11 +1,11 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-toggle-theme {
 	.kol-custom-suggestions-toggle {
 		display: grid;
 		place-items: center;
-		padding-left: rem(8);
-		padding-right: rem(8);
+		padding-left: to-rem(8);
+		padding-right: to-rem(8);
 
 		&:focus {
 			outline: 0;

--- a/packages/themes/default/src/mixins/field-control.scss
+++ b/packages/themes/default/src/mixins/field-control.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-field-control-theme {
 	.kol-field-control {

--- a/packages/themes/default/src/mixins/focus-outline.scss
+++ b/packages/themes/default/src/mixins/focus-outline.scss
@@ -1,9 +1,9 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin focus-outline {
 	border-radius: var(--border-radius);
 	outline-offset: 2px;
-	outline: var(--color-primary-variant) solid rem(3);
+	outline: var(--color-primary-variant) solid to-rem(3);
 	transition: 200ms outline-offset linear;
 }
 

--- a/packages/themes/default/src/mixins/form-field.scss
+++ b/packages/themes/default/src/mixins/form-field.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 @use './alert-wc' as *;
 @use './typography' as *;
 
@@ -6,7 +6,7 @@
 	.kol-form-field {
 		$root: &;
 
-		gap: rem(4);
+		gap: to-rem(4);
 
 		&__hint {
 			@include kol-typography-hint;
@@ -14,7 +14,7 @@
 
 		&--error:not(&--hide-msg) {
 			border-left: 3px solid var(--color-danger);
-			padding-left: rem(16);
+			padding-left: to-rem(16);
 
 			.kol-form-field__msg {
 				&.kol-alert--type-error {

--- a/packages/themes/default/src/mixins/indented-text.scss
+++ b/packages/themes/default/src/mixins/indented-text.scss
@@ -1,8 +1,8 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin indented-text {
 	border-left: 2px solid var(--color-primary-variant);
-	padding: 0 rem(18) 0 rem(8);
-	margin-left: rem(-2);
+	padding: 0 to-rem(18) 0 to-rem(8);
+	margin-left: to-rem(-2);
 	width: 100%;
 }

--- a/packages/themes/default/src/mixins/input-error.scss
+++ b/packages/themes/default/src/mixins/input-error.scss
@@ -1,9 +1,9 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @mixin input-error {
 	border-left: 3px solid var(--color-danger);
-	padding-left: rem(16);
+	padding-left: to-rem(16);
 
 	.input:focus-within {
 		outline-color: var(--color-danger);

--- a/packages/themes/default/src/mixins/input-file.scss
+++ b/packages/themes/default/src/mixins/input-file.scss
@@ -1,7 +1,7 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-input-container {
-		padding: 0 0 0 rem(8);
+		padding: 0 0 0 to-rem(8);
 	}
 }

--- a/packages/themes/default/src/mixins/input.scss
+++ b/packages/themes/default/src/mixins/input.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 @use './focus-outline' as *;
 
 @mixin kol-input-theme {
@@ -10,21 +10,21 @@
 		border-radius: var(--border-radius);
 		border-style: solid;
 		border-width: 2px;
-		padding: 0 rem(8);
-		gap: rem(6);
+		padding: 0 to-rem(8);
+		gap: to-rem(6);
 
 		@at-root #{$root}__adornment {
-			min-width: rem(8);
+			min-width: to-rem(8);
 
 			&--start {
 				> .kol-icon {
-					margin-left: rem(8);
+					margin-left: to-rem(8);
 				}
 			}
 
 			&--end {
 				> .kol-icon {
-					margin-right: rem(8);
+					margin-right: to-rem(8);
 				}
 			}
 		}

--- a/packages/themes/default/src/mixins/kol-card.scss
+++ b/packages/themes/default/src/mixins/kol-card.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-card {
 	.kol-card {
@@ -11,11 +11,11 @@
 		border-radius: var(--border-radius);
 
 		&__header {
-			padding: rem(16) rem(16) rem(8) rem(16);
+			padding: to-rem(16) to-rem(16) to-rem(8) to-rem(16);
 		}
 
 		&__content {
-			padding: rem(8) rem(16) rem(16);
+			padding: to-rem(8) to-rem(16) to-rem(16);
 			overflow: hidden;
 		}
 

--- a/packages/themes/default/src/mixins/kol-table-settings-wc.scss
+++ b/packages/themes/default/src/mixins/kol-table-settings-wc.scss
@@ -1,33 +1,33 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 @use './button' as *;
 @use './focus-outline' as *;
 
 @mixin kol-table-settings-theme {
 	.kol-table-settings {
-		right: rem(8);
-		top: rem(8);
+		right: to-rem(8);
+		top: to-rem(8);
 
 		&__content {
-			padding: rem(24);
+			padding: to-rem(24);
 			@include kol-button('kol-button'); // use buttons styles only in the content, not for the popover button
 		}
 
 		&__error-message {
 			display: block;
-			margin-top: rem(16);
+			margin-top: to-rem(16);
 		}
 
 		&__columns {
-			padding: rem(8); // some space for hover and focus styles
+			padding: to-rem(8); // some space for hover and focus styles
 		}
 
 		&__actions {
 			border-top: var(--border-width) solid var(--color-mute-variant);
 			display: flex;
-			gap: rem(8);
+			gap: to-rem(8);
 			justify-content: flex-end;
-			margin-top: rem(16);
-			padding-top: rem(16);
+			margin-top: to-rem(16);
+			padding-top: to-rem(16);
 		}
 	}
 

--- a/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 @use './kol-table-settings-wc' as *;
 @use './alert-wc' as *;
 @use './pagination-mixin' as *;
@@ -16,7 +16,7 @@
 
 		overflow-x: auto;
 		overflow-y: hidden;
-		padding: rem(8);
+		padding: to-rem(8);
 
 		&__table,
 		&__caption {
@@ -32,7 +32,7 @@
 		}
 
 		&__caption {
-			padding: rem(8) var(--a11y-min-size) rem(8) rem(8);
+			padding: to-rem(8) var(--a11y-min-size) to-rem(8) to-rem(8);
 			min-height: calc(var(--a11y-min-size) + 2px); // leave some extra space so the settings button doesn't overlap the table borders
 		}
 
@@ -51,7 +51,7 @@
 		}
 
 		&__cell {
-			padding: rem(8);
+			padding: to-rem(8);
 
 			&--header {
 				font-weight: normal;
@@ -71,14 +71,14 @@
 
 		&__selection {
 			display: flex;
-			gap: rem(8);
+			gap: to-rem(8);
 			grid-template-columns: 1fr auto;
 			align-items: center;
 		}
 
 		&__spacer {
 			display: table-row;
-			height: rem(24);
+			height: to-rem(24);
 		}
 
 		&__spacer-line {

--- a/packages/themes/default/src/mixins/link.scss
+++ b/packages/themes/default/src/mixins/link.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-link($block-classname) {
 	.#{$block-classname} {

--- a/packages/themes/default/src/mixins/pagination-mixin.scss
+++ b/packages/themes/default/src/mixins/pagination-mixin.scss
@@ -1,4 +1,4 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 @use './focus-outline' as *;
 
 @mixin kol-pagination-styles {
@@ -7,7 +7,7 @@
 			&__pagination,
 			&__pagination-wrapper {
 				@media (min-width: 1024px) {
-					gap: rem(16);
+					gap: to-rem(16);
 				}
 			}
 		}
@@ -38,7 +38,7 @@
 					font-weight: 700;
 					min-height: var(--a11y-min-size);
 					min-width: var(--a11y-min-size);
-					padding: rem(8);
+					padding: to-rem(8);
 					text-align: center;
 					transition-duration: 0.5s;
 					transition-property: background-color, color, border-color;

--- a/packages/themes/default/src/mixins/to-rem.scss
+++ b/packages/themes/default/src/mixins/to-rem.scss
@@ -1,3 +1,3 @@
-@function rem($size) {
+@function to-rem($size) {
 	@return calc(#{$size}rem / var(--kolibri-root-font-size, 16));
 }

--- a/packages/themes/default/src/mixins/typography.scss
+++ b/packages/themes/default/src/mixins/typography.scss
@@ -1,32 +1,32 @@
-@use './rem' as *;
+@use '../mixins/to-rem' as *;
 
 @mixin kol-typography-body {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-h1 {
-	font-size: rem(24);
+	font-size: to-rem(24);
 	line-height: 1.667;
 }
 
 @mixin kol-typography-h2 {
-	font-size: rem(20);
+	font-size: to-rem(20);
 	line-height: 1.4;
 }
 
 @mixin kol-typography-h3 {
-	font-size: rem(18);
+	font-size: to-rem(18);
 	line-height: 1.333;
 }
 
 @mixin kol-typography-accordion {
 	font-weight: 700;
-	font-size: rem(18);
+	font-size: to-rem(18);
 	line-height: 1.1;
 }
 
 @mixin kol-typography-hint {
-	font-size: rem(14.4);
+	font-size: to-rem(14.4);
 	font-style: italic;
 }

--- a/packages/themes/ecl/README.md
+++ b/packages/themes/ecl/README.md
@@ -87,20 +87,20 @@ The token values are read from `src/ecl-ec/global.scss` and `src/ecl-eu/global.s
 | `--color-black`         | `#000`                | Black                   |
 | `--color-white`         | `#fff`                | White                   |
 | `--font-family`         | `Arial, sans-serif`   | Default font            |
-| `--font-size`           | `#{rem(16)}`          | Base font size          |
+| `--font-size`           | `#{to-rem(16)}`       | Base font size          |
 | `--font-weight`         | `400`                 | Regular font weight     |
 | `--font-weight-bold`    | `600`                 | Bold font               |
 | `--line-height`         | `1.5`                 | Line height text        |
 | `--line-height-heading` | `1.2`                 | Line height headings    |
-| `--spacing-4xl`         | `#{rem(64)}`          | Largest spacing         |
-| `--spacing-3xl`         | `#{rem(48)}`          | Very large spacing      |
-| `--spacing-2xl`         | `#{rem(40)}`          | Very large spacing      |
-| `--spacing-xl`          | `#{rem(32)}`          | Large spacing           |
-| `--spacing-l`           | `#{rem(24)}`          | Large spacing           |
-| `--spacing-m`           | `#{rem(16)}`          | Standard spacing        |
-| `--spacing-s`           | `#{rem(12)}`          | Small spacing           |
-| `--spacing-xs`          | `#{rem(8)}`           | Very small spacing      |
-| `--spacing-2xs`         | `#{rem(4)}`           | Tiny spacing            |
+| `--spacing-4xl`         | `#{to-rem(64)}`       | Largest spacing         |
+| `--spacing-3xl`         | `#{to-rem(48)}`       | Very large spacing      |
+| `--spacing-2xl`         | `#{to-rem(40)}`       | Very large spacing      |
+| `--spacing-xl`          | `#{to-rem(32)}`       | Large spacing           |
+| `--spacing-l`           | `#{to-rem(24)}`       | Large spacing           |
+| `--spacing-m`           | `#{to-rem(16)}`       | Standard spacing        |
+| `--spacing-s`           | `#{to-rem(12)}`       | Small spacing           |
+| `--spacing-xs`          | `#{to-rem(8)}`        | Very small spacing      |
+| `--spacing-2xs`         | `#{to-rem(4)}`        | Tiny spacing            |
 
 ### ECL EU Theme
 
@@ -197,17 +197,17 @@ The token values are read from `src/ecl-ec/global.scss` and `src/ecl-eu/global.s
 | `--color-white`           | `#fff`              | White                   |
 | `--color-black`           | `#000`              | Black                   |
 | `--font-family`           | `Arial, sans-serif` | Default font            |
-| `--font-size`             | `#{rem(16)}`        | Base font size          |
+| `--font-size`             | `#{to-rem(16)}`     | Base font size          |
 | `--font-weight-regular`   | `400`               | Regular font weight     |
 | `--font-weight-bold`      | `700`               | Bold font               |
 | `--line-height-regular`   | `1.5`               | Line height text        |
 | `--line-height-heading`   | `1.2`               | Line height headings    |
-| `--spacing-4xl`           | `#{rem(64)}`        | Largest spacing         |
-| `--spacing-3xl`           | `#{rem(48)}`        | Very large spacing      |
-| `--spacing-2xl`           | `#{rem(40)}`        | Very large spacing      |
-| `--spacing-xl`            | `#{rem(32)}`        | Large spacing           |
-| `--spacing-l`             | `#{rem(24)}`        | Large spacing           |
-| `--spacing-m`             | `#{rem(16)}`        | Standard spacing        |
-| `--spacing-s`             | `#{rem(12)}`        | Small spacing           |
-| `--spacing-xs`            | `#{rem(8)}`         | Very small spacing      |
-| `--spacing-2xs`           | `#{rem(4)}`         | Tiny spacing            |
+| `--spacing-4xl`           | `#{to-rem(64)}`     | Largest spacing         |
+| `--spacing-3xl`           | `#{to-rem(48)}`     | Very large spacing      |
+| `--spacing-2xl`           | `#{to-rem(40)}`     | Very large spacing      |
+| `--spacing-xl`            | `#{to-rem(32)}`     | Large spacing           |
+| `--spacing-l`             | `#{to-rem(24)}`     | Large spacing           |
+| `--spacing-m`             | `#{to-rem(16)}`     | Standard spacing        |
+| `--spacing-s`             | `#{to-rem(12)}`     | Small spacing           |
+| `--spacing-xs`            | `#{to-rem(8)}`      | Very small spacing      |
+| `--spacing-2xs`           | `#{to-rem(4)}`      | Tiny spacing            |

--- a/packages/themes/ecl/src/ecl-ec/@shared/input-core.scss
+++ b/packages/themes/ecl/src/ecl-ec/@shared/input-core.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/form-field-order' as *;
 @use '../mixins/form-field' as *;

--- a/packages/themes/ecl/src/ecl-ec/components/accordion.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/accordion.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-accordion {
@@ -19,7 +19,7 @@
 				&__text {
 					color: var(--color-grey);
 					font-weight: var(--font-weight-bold);
-					padding: rem(12) 0;
+					padding: to-rem(12) 0;
 					width: 100%;
 					border: none;
 				}
@@ -36,10 +36,10 @@
 			}
 
 			.kol-icon {
-				margin-bottom: rem(12);
-				margin-inline-end: rem(16);
+				margin-bottom: to-rem(12);
+				margin-inline-end: to-rem(16);
 				margin-inline-start: 0;
-				margin-top: rem(12);
+				margin-top: to-rem(12);
 			}
 		}
 

--- a/packages/themes/ecl/src/ecl-ec/components/badge.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/badge.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-badge {
 		font: normal normal var(--font-weight) 1em var(--font-family);
-		padding: calc(rem(8) - rem(1)) calc(rem(12) - rem(1));
+		padding: calc(to-rem(8) - to-rem(1)) calc(to-rem(12) - to-rem(1));
 		text-transform: uppercase;
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/breadcrumb.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/breadcrumb.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/link' as *;
 
 @layer kol-theme-component {
@@ -6,7 +6,7 @@
 
 	.kol-breadcrumb {
 		font:
-			normal normal 400 rem(14) / rem(16) arial,
+			normal normal 400 to-rem(14) / to-rem(16) arial,
 			sans-serif;
 		font-weight: var(--font-weight-bold);
 
@@ -16,8 +16,8 @@
 			}
 
 			&[exportparts*='separator'] {
-				margin-inline-end: rem(8);
-				margin-inline-start: rem(8);
+				margin-inline-end: to-rem(8);
+				margin-inline-start: to-rem(8);
 				padding: 0;
 			}
 		}

--- a/packages/themes/ecl/src/ecl-ec/components/button-link.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/button-link.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/link' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-ec/components/button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');

--- a/packages/themes/ecl/src/ecl-ec/components/card.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/card.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-card {

--- a/packages/themes/ecl/src/ecl-ec/components/combobox.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/combobox.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/custom-suggestions-option' as *;
 @use '../mixins/custom-suggestions-options-group' as *;
 @use '../mixins/custom-suggestions-toggle' as *;
 @use '../@shared/input-text' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -25,13 +25,13 @@ $visible-options: 5;
 			color: var(--color-grey);
 			order: 4;
 			align-items: center;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {
 			border: none;
 			flex-grow: 1;
-			width: calc(100% - rem(24));
+			width: calc(100% - to-rem(24));
 			position: relative;
 
 			&::placeholder {

--- a/packages/themes/ecl/src/ecl-ec/components/details.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/details.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/indented-text' as *;
 
 @layer kol-theme-component {
@@ -15,7 +15,7 @@
 			}
 
 			.kol-icon {
-				font-size: rem(19.2);
+				font-size: to-rem(19.2);
 			}
 
 			.kol-span__container {

--- a/packages/themes/ecl/src/ecl-ec/components/heading.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/heading.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-checkbox.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/required' as *;
 
@@ -9,7 +9,7 @@
 		color: var(--color-grey);
 
 		&__hint {
-			font-size: rem(14);
+			font-size: to-rem(14);
 		}
 
 		&__msg {
@@ -26,11 +26,11 @@
 
 		&__label {
 			@at-root #{$root}--label-align-left & {
-				padding-right: rem(8);
+				padding-right: to-rem(8);
 			}
 
 			@at-root #{$root}--label-align-right & {
-				padding-left: rem(8);
+				padding-left: to-rem(8);
 			}
 		}
 

--- a/packages/themes/ecl/src/ecl-ec/components/input-color.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-color.scss
@@ -1,9 +1,9 @@
 @use '../@shared/input-text' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 .kol-input-color {
 	&__inputs-wrapper {
-		gap: rem(16);
+		gap: to-rem(16);
 	}
 
 	&__input {
@@ -11,7 +11,7 @@
 		&--color {
 			background-color: var(--color-white);
 			border: 1px solid var(--color-blue);
-			min-height: calc(var(--a11y-min-size) - rem(8));
+			min-height: calc(var(--a11y-min-size) - to-rem(8));
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/components/input-file.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-file.scss
@@ -1,6 +1,6 @@
 @use '../@shared/input-text' as *;
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');
@@ -12,7 +12,7 @@
 	}
 
 	.kol-input-container {
-		padding: 0 0 0 rem(8);
+		padding: 0 0 0 to-rem(8);
 
 		&--is-dragover {
 			border-color: var(--color-blue);

--- a/packages/themes/ecl/src/ecl-ec/components/input-radio.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/input-radio.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/typography' as *;
 @use '../mixins/required' as *;
@@ -39,10 +39,10 @@
 
 	.kol-form-field {
 		border: 0;
-		gap: rem(8);
+		gap: to-rem(8);
 		flex-wrap: wrap;
 		align-items: flex-start;
-		padding: 0 rem(14) rem(10) rem(14);
+		padding: 0 to-rem(14) to-rem(10) to-rem(14);
 
 		&__label {
 			color: var(--color-grey);
@@ -58,7 +58,7 @@
 		}
 
 		&__input {
-			gap: rem(8);
+			gap: to-rem(8);
 		}
 
 		&__msg {
@@ -71,7 +71,7 @@
 	}
 
 	.kol-field-control {
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	.kol-input {

--- a/packages/themes/ecl/src/ecl-ec/components/link-button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/link-button.scss
@@ -1,8 +1,8 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-link {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 		appearance: none;
 		color: var(--color-blue);
 		text-decoration: underline;

--- a/packages/themes/ecl/src/ecl-ec/components/modal.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/modal.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-modal {

--- a/packages/themes/ecl/src/ecl-ec/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/nav.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-nav {
@@ -26,7 +26,7 @@
 
 			&:not(:first-child),
 			#{$root}__list--nested & {
-				border-top-width: rem(2);
+				border-top-width: to-rem(2);
 			}
 		}
 
@@ -59,7 +59,7 @@
 
 				&:focus {
 					outline-offset: -4px;
-					outline: var(--text-focus-outline-color) solid rem(2);
+					outline: var(--text-focus-outline-color) solid to-rem(2);
 				}
 
 				--text-focus-outline-color: var(--color-black);
@@ -90,8 +90,8 @@
 					border-width: 2px;
 					font-weight: var(--font-weight-bold);
 					margin: 0;
-					min-height: rem(44);
-					min-width: rem(44);
+					min-height: to-rem(44);
+					min-width: to-rem(44);
 					padding: 0.25em 0.75em;
 					line-height: 1.2;
 
@@ -112,9 +112,9 @@
 		border-style: solid;
 		border-width: 2px;
 		color: var(--color-white);
-		font-size: rem(18);
+		font-size: to-rem(18);
 		justify-items: start;
-		padding: rem(16);
+		padding: to-rem(16);
 		height: 100%;
 
 		:is(.kol-button, .kol-link):focus-within & {

--- a/packages/themes/ecl/src/ecl-ec/components/popover-button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/popover-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');

--- a/packages/themes/ecl/src/ecl-ec/components/progress.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/progress.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-progress {

--- a/packages/themes/ecl/src/ecl-ec/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/single-select.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/custom-suggestions-option' as *;
 @use '../mixins/custom-suggestions-options-group' as *;
 @use '../mixins/custom-suggestions-toggle' as *;
 @use '../@shared/input-text' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -23,13 +23,13 @@ $visible-options: 5;
 			color: var(--color-grey);
 			order: 4;
 			align-items: center;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {
 			border: none;
 			flex-grow: 1;
-			width: calc(100% - rem(40));
+			width: calc(100% - to-rem(40));
 			position: relative;
 
 			&::placeholder {

--- a/packages/themes/ecl/src/ecl-ec/components/skip-nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/skip-nav.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-skip-nav {
@@ -8,7 +8,7 @@
 				border-style: solid;
 				border-width: 2px;
 				font-weight: var(--font-weight-bold);
-				gap: rem(8);
+				gap: to-rem(8);
 				line-height: 1;
 				padding: 0.25em 0.75em;
 				background-color: var(--color-blue);

--- a/packages/themes/ecl/src/ecl-ec/components/spin.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/spin.scss
@@ -1,8 +1,8 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.cycle {
-		padding: rem(2);
+		padding: to-rem(2);
 
 		& span {
 			background-color: var(--color-blue-75);

--- a/packages/themes/ecl/src/ecl-ec/components/split-button.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/split-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-split-button {

--- a/packages/themes/ecl/src/ecl-ec/components/table-stateful.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/table-stateful.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/kol-table-stateless-wc' as *;
 
 @layer kol-theme-component {
@@ -23,7 +23,7 @@
 			@at-root #{$root}__pagination & {
 				@media (min-width: 1024px) {
 					display: flex;
-					gap: rem(16);
+					gap: to-rem(16);
 				}
 			}
 		}

--- a/packages/themes/ecl/src/ecl-ec/components/tabs.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tabs.scss
@@ -1,19 +1,19 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 	}
 
 	.kol-tabs {
 		&__button-group {
 			border-bottom: 1px solid var(--color-grey-25);
-			margin-bottom: rem(-1);
+			margin-bottom: to-rem(-1);
 		}
 
 		.kol-button {
 			border: none;
-			margin-bottom: rem(-1);
+			margin-bottom: to-rem(-1);
 
 			&:hover:not(:disabled) {
 				.kol-span {
@@ -23,7 +23,7 @@
 
 			&:focus {
 				.kol-span {
-					outline: var(--color-blue-130) solid rem(2);
+					outline: var(--color-blue-130) solid to-rem(2);
 				}
 			}
 
@@ -41,7 +41,7 @@
 			}
 
 			.kol-span {
-				padding: rem(8);
+				padding: to-rem(8);
 				min-height: var(--a11y-min-size);
 				min-width: var(--a11y-min-size);
 			}

--- a/packages/themes/ecl/src/ecl-ec/components/toast-container.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/toast-container.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
 	:host {
-		top: rem(16);
-		right: rem(16);
-		width: rem(440);
+		top: to-rem(16);
+		right: to-rem(16);
+		width: to-rem(440);
 		max-width: 100%;
 	}
 
@@ -13,7 +13,7 @@
 		@include kol-alert-theme;
 		display: block;
 		background-color: #fff;
-		margin-top: rem(16);
+		margin-top: to-rem(16);
 
 		&__alert {
 			display: block;

--- a/packages/themes/ecl/src/ecl-ec/components/toolbar.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/toolbar.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-tree-item {

--- a/packages/themes/ecl/src/ecl-ec/components/tree.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-tree {

--- a/packages/themes/ecl/src/ecl-ec/global.scss
+++ b/packages/themes/ecl/src/ecl-ec/global.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-global {
 	.kol-tooltip {
@@ -8,8 +8,8 @@
 
 		&__content {
 			background-color: #f2f2f2;
-			padding: rem(4) rem(8);
-			font-size: rem(14);
+			padding: to-rem(4) to-rem(8);
+			font-size: to-rem(14);
 			line-height: 1.2;
 			border-radius: 2px;
 			border: 1px solid #626262;
@@ -51,20 +51,20 @@
 		--color-black: #000;
 		--color-white: #fff;
 		--font-family: Arial, sans-serif;
-		--font-size: #{rem(16)};
+		--font-size: #{to-rem(16)};
 		--font-weight: 400;
 		--font-weight-bold: 600;
 		--line-height: 1.5;
 		--line-height-heading: 1.2;
-		--spacing-4xl: #{rem(64)};
-		--spacing-3xl: #{rem(48)};
-		--spacing-2xl: #{rem(40)};
-		--spacing-xl: #{rem(32)};
-		--spacing-l: #{rem(24)};
-		--spacing-m: #{rem(16)};
-		--spacing-s: #{rem(12)};
-		--spacing-xs: #{rem(8)};
-		--spacing-2xs: #{rem(4)};
+		--spacing-4xl: #{to-rem(64)};
+		--spacing-3xl: #{to-rem(48)};
+		--spacing-2xl: #{to-rem(40)};
+		--spacing-xl: #{to-rem(32)};
+		--spacing-l: #{to-rem(24)};
+		--spacing-m: #{to-rem(16)};
+		--spacing-s: #{to-rem(12)};
+		--spacing-xs: #{to-rem(8)};
+		--spacing-2xs: #{to-rem(4)};
 	}
 
 	:host {

--- a/packages/themes/ecl/src/ecl-ec/mixins/alert-wc.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/alert-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-alert-wc($color: null) {
 	color: var($color);
@@ -15,10 +15,10 @@
 		}
 
 		&--variant-card {
-			padding-bottom: rem(24);
-			padding-inline-end: rem(8);
-			padding-inline-start: rem(24);
-			padding-top: rem(24);
+			padding-bottom: to-rem(24);
+			padding-inline-end: to-rem(8);
+			padding-inline-start: to-rem(24);
+			padding-top: to-rem(24);
 			border-style: solid;
 			border-width: 2px;
 		}
@@ -47,7 +47,7 @@
 			background-color: var(--color-white);
 
 			@at-root #{$root}--variant-card & {
-				gap: rem(8);
+				gap: to-rem(8);
 			}
 		}
 
@@ -64,7 +64,7 @@
 
 			.kol-icon {
 				@at-root #{$root}--variant-card & {
-					font-size: rem(32);
+					font-size: to-rem(32);
 				}
 			}
 		}
@@ -78,13 +78,13 @@
 			}
 
 			@at-root #{$root}--variant-card & {
-				font-size: rem(32);
+				font-size: to-rem(32);
 			}
 		}
 
 		&__content {
 			@at-root #{$root}--variant-card & {
-				margin-left: rem(40);
+				margin-left: to-rem(40);
 			}
 		}
 	}

--- a/packages/themes/ecl/src/ecl-ec/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/button.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-button($block-classname) {
 	.#{$block-classname} {
@@ -10,7 +10,7 @@
 
 		&:focus {
 			outline-offset: -4px;
-			outline: var(--text-focus-outline-color) solid rem(2);
+			outline: var(--text-focus-outline-color) solid to-rem(2);
 		}
 
 		--text-focus-outline-color: var(--color-black);

--- a/packages/themes/ecl/src/ecl-ec/mixins/custom-suggestions-option.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/custom-suggestions-option.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-option-theme($option-height) {
 	.kol-custom-suggestions-option {
@@ -6,7 +6,7 @@
 		align-items: center;
 		min-height: $option-height;
 		line-height: 1.2;
-		padding: rem(10) rem(12);
+		padding: to-rem(10) to-rem(12);
 
 		&[aria-selected] {
 			color: var(--color-blue);

--- a/packages/themes/ecl/src/ecl-ec/mixins/custom-suggestions-options-group.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/custom-suggestions-options-group.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-options-group-theme($option-height, $visible-options) {
 	.kol-custom-suggestions-options-group {
@@ -8,6 +8,6 @@
 		overflow-y: auto;
 		overflow-x: hidden;
 		width: 100%;
-		max-height: calc($option-height * $visible-options + rem(2));
+		max-height: calc($option-height * $visible-options + to-rem(2));
 	}
 }

--- a/packages/themes/ecl/src/ecl-ec/mixins/custom-suggestions-toggle.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/custom-suggestions-toggle.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-toggle-theme {
 	.kol-custom-suggestions-toggle {

--- a/packages/themes/ecl/src/ecl-ec/mixins/form-field.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/form-field.scss
@@ -1,5 +1,5 @@
 @use './required' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @mixin kol-form-field-theme {
@@ -16,7 +16,7 @@
 		}
 
 		&__hint {
-			font-size: rem(14);
+			font-size: to-rem(14);
 		}
 
 		&__msg {

--- a/packages/themes/ecl/src/ecl-ec/mixins/indented-text.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/indented-text.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin indented-text {
 	border-end-start-radius: 0;
-	border-inline-start: rem(10) solid var(--color-yellow);
+	border-inline-start: to-rem(10) solid var(--color-yellow);
 	border-start-start-radius: 0;
-	padding-bottom: rem(16);
-	padding-inline-start: rem(24);
-	padding-top: rem(16);
+	padding-bottom: to-rem(16);
+	padding-inline-start: to-rem(24);
+	padding-top: to-rem(16);
 	margin: 0;
 }

--- a/packages/themes/ecl/src/ecl-ec/mixins/input-container.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/input-container.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-input-container-theme {
 	.kol-input-container {
@@ -7,12 +7,12 @@
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1) 0.5em;
+		padding: to-rem(1) 0.5em;
 
 		&:focus-within {
 			box-shadow:
-				inset rem(1) rem(1) var(--color-blue),
-				inset rem(-1) rem(-1) var(--color-blue);
+				inset to-rem(1) to-rem(1) var(--color-blue),
+				inset to-rem(-1) to-rem(-1) var(--color-blue);
 			outline: none;
 		}
 

--- a/packages/themes/ecl/src/ecl-ec/mixins/input-text.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/input-text.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-input-text-theme {
 	.kol-input,
 	.kol-select,
 	.kol-textarea {
 		border: none;
-		margin: rem(1);
+		margin: to-rem(1);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-ec/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/kol-table-stateless-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use './alert-wc' as *;
 @use './pagination-mixin' as *;
 
@@ -28,14 +28,14 @@
 			&--header {
 				@at-root #{$root}__head-row:first-child & {
 					border-width: 0;
-					border-top-width: rem(2);
+					border-top-width: to-rem(2);
 					border-style: solid;
 					border-color: var(--color-ice);
 				}
 
 				@at-root #{$root}__head-row:last-child & {
 					border-width: 0;
-					border-bottom-width: rem(2);
+					border-bottom-width: to-rem(2);
 					border-style: solid;
 					border-color: var(--color-ice);
 				}
@@ -70,7 +70,7 @@
 			width: 100%;
 			border-spacing: 0;
 			border-width: 0;
-			border-bottom-width: rem(2);
+			border-bottom-width: to-rem(2);
 			border-style: solid;
 			border-color: var(--color-ice);
 		}

--- a/packages/themes/ecl/src/ecl-ec/mixins/pagination-mixin.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/pagination-mixin.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-pagination-styles {
 	.kol-table-stateful {
 		&__pagination,
 		&__pagination-wrapper {
 			@media (min-width: 1024px) {
-				gap: rem(16);
+				gap: to-rem(16);
 			}
 		}
 	}

--- a/packages/themes/ecl/src/ecl-ec/mixins/typography.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/typography.scss
@@ -1,36 +1,36 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-typography-body {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-h1 {
-	font-size: rem(32);
+	font-size: to-rem(32);
 	line-height: 1.25;
 }
 
 @mixin kol-typography-h2 {
-	font-size: rem(28);
+	font-size: to-rem(28);
 	line-height: 1.143;
 }
 
 @mixin kol-typography-h3 {
-	font-size: rem(24);
+	font-size: to-rem(24);
 	line-height: 1.1667;
 }
 
 @mixin kol-typography-h4 {
-	font-size: rem(20);
+	font-size: to-rem(20);
 	line-height: 1.4;
 }
 
 @mixin kol-typography-h5 {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-hint {
-	font-size: rem(14.4);
+	font-size: to-rem(14.4);
 	font-style: italic;
 }

--- a/packages/themes/ecl/src/ecl-eu/@shared/input-core.scss
+++ b/packages/themes/ecl/src/ecl-eu/@shared/input-core.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/form-field-order' as *;
 @use '../mixins/form-field' as *;

--- a/packages/themes/ecl/src/ecl-eu/components/accordion.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/accordion.scss
@@ -1,13 +1,13 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-accordion {
 		border-radius: 8px;
 		box-shadow:
-			0 rem(2) rem(4) rgb(9 49 142 / 8%),
-			0 0 rem(10) rgb(9 49 142 / 4%),
-			0 rem(4) rem(5) rgb(9 49 142 / 4%),
-			0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+			0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+			0 0 to-rem(10) rgb(9 49 142 / 4%),
+			0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+			0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 		margin: 0;
 		overflow: hidden;
 
@@ -22,14 +22,14 @@
 				border: 0;
 				border-bottom-color: #cfdaf5;
 				border-bottom-style: solid;
-				border-bottom-width: rem(2);
+				border-bottom-width: to-rem(2);
 				color: #171a22;
 				position: relative;
 				display: block;
 				font:
-					normal normal 400 rem(18) / rem(28) arial,
+					normal normal 400 to-rem(18) / to-rem(28) arial,
 					sans-serif;
-				padding: rem(24);
+				padding: to-rem(24);
 				text-align: start;
 				width: 100%;
 				line-height: 1.2;
@@ -40,19 +40,19 @@
 
 				&::before {
 					background-color: #fc0;
-					border-end-end-radius: rem(2);
-					border-end-start-radius: rem(2);
+					border-end-end-radius: to-rem(2);
+					border-end-start-radius: to-rem(2);
 					content: '';
-					height: rem(4);
+					height: to-rem(4);
 					position: absolute;
-					left: rem(24);
+					left: to-rem(24);
 					top: 0;
 					width: 3rem (2);
 				}
 			}
 
 			.kol-icon {
-				margin-right: rem(12);
+				margin-right: to-rem(12);
 
 				&::part(icon)::before {
 					color: #0e47cb;
@@ -63,22 +63,22 @@
 		}
 
 		&__content {
-			-webkit-border-start: rem(4) solid #0e47cb;
+			-webkit-border-start: to-rem(4) solid #0e47cb;
 			-webkit-margin-start: 0;
 			border-bottom: 2px solid #cfdaf5;
-			border-inline-start: rem(4) solid #0e47cb;
+			border-inline-start: to-rem(4) solid #0e47cb;
 			color: #515560;
 			font:
-				normal normal 400 rem(16) / rem(24) arial,
+				normal normal 400 to-rem(16) / to-rem(24) arial,
 				sans-serif;
 			margin-inline-start: 0;
-			padding: rem(24);
+			padding: to-rem(24);
 		}
 
 		.collapsible--open &__heading-button {
 			.kol-button {
-				border-start-end-radius: rem(8);
-				border-start-start-radius: rem(8);
+				border-start-end-radius: to-rem(8);
+				border-start-start-radius: to-rem(8);
 			}
 
 			.kol-icon::part(icon)::before {

--- a/packages/themes/ecl/src/ecl-eu/components/badge.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/badge.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-badge {
-		font: normal normal var(--font-weight) rem(14) / 1em var(--font-family);
-		padding: calc(rem(8) - rem(1)) calc(rem(12) - rem(1));
+		font: normal normal var(--font-weight) to-rem(14) / 1em var(--font-family);
+		padding: calc(to-rem(8) - to-rem(1)) calc(to-rem(12) - to-rem(1));
 		text-transform: uppercase;
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/button.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/button.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-eu/components/card.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/card.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-card {

--- a/packages/themes/ecl/src/ecl-eu/components/combobox.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/combobox.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/custom-suggestions-option' as *;
 @use '../mixins/custom-suggestions-options-group' as *;
 @use '../mixins/custom-suggestions-toggle' as *;
 @use '../@shared/input-text' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -25,13 +25,13 @@ $visible-options: 5;
 			color: var(--color-grey);
 			order: 4;
 			align-items: center;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {
 			border: none;
 			flex-grow: 1;
-			width: calc(100% - rem(24));
+			width: calc(100% - to-rem(24));
 			position: relative;
 
 			&::placeholder {

--- a/packages/themes/ecl/src/ecl-eu/components/details.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/details.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/indented-text' as *;
 
 @layer kol-theme-component {
@@ -15,7 +15,7 @@
 			}
 
 			.kol-icon {
-				font-size: rem(19.2);
+				font-size: to-rem(19.2);
 			}
 
 			.kol-span__container {

--- a/packages/themes/ecl/src/ecl-eu/components/heading.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/heading.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/typography' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-checkbox.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/required' as *;
 
@@ -9,7 +9,7 @@
 		color: var(--color-grey);
 
 		&__hint {
-			font-size: rem(14);
+			font-size: to-rem(14);
 		}
 
 		&__msg {
@@ -26,11 +26,11 @@
 
 		&__label {
 			@at-root #{$root}--label-align-left & {
-				padding-right: rem(8);
+				padding-right: to-rem(8);
 			}
 
 			@at-root #{$root}--label-align-right & {
-				padding-left: rem(8);
+				padding-left: to-rem(8);
 			}
 		}
 

--- a/packages/themes/ecl/src/ecl-eu/components/input-color.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-color.scss
@@ -1,9 +1,9 @@
 @use '../@shared/input-text' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 .kol-input-color {
 	&__inputs-wrapper {
-		gap: rem(16);
+		gap: to-rem(16);
 	}
 
 	&__input {
@@ -11,7 +11,7 @@
 		&--color {
 			background-color: var(--color-white);
 			border: 1px solid var(--color-blue);
-			min-height: calc(var(--a11y-min-size) - rem(8));
+			min-height: calc(var(--a11y-min-size) - to-rem(8));
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/input-file.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-file.scss
@@ -1,6 +1,6 @@
 @use '../@shared/input-text' as *;
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');
@@ -13,7 +13,7 @@
 	}
 
 	.kol-input-container {
-		padding: 0 0 0 rem(8);
+		padding: 0 0 0 to-rem(8);
 
 		&--is-dragover {
 			border-color: var(--color-blue);

--- a/packages/themes/ecl/src/ecl-eu/components/input-radio.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-radio.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/typography' as *;
 @use '../mixins/required' as *;
@@ -39,10 +39,10 @@
 
 	.kol-form-field {
 		border: 0;
-		gap: rem(8);
+		gap: to-rem(8);
 		flex-wrap: wrap;
 		align-items: flex-start;
-		padding: 0 rem(14) rem(10) rem(14);
+		padding: 0 to-rem(14) to-rem(10) to-rem(14);
 
 		&__label {
 			color: var(--color-grey);
@@ -58,7 +58,7 @@
 		}
 
 		&__input {
-			gap: rem(8);
+			gap: to-rem(8);
 		}
 
 		&__msg {
@@ -71,7 +71,7 @@
 	}
 
 	.kol-field-control {
-		gap: rem(8);
+		gap: to-rem(8);
 	}
 
 	.kol-input {
@@ -155,7 +155,7 @@
 	// }
 
 	// .radio-label {
-	// 	padding-left: rem(8);
+	// 	padding-left: to-rem(8);
 	// }
 
 	// input[type='radio'] {
@@ -214,7 +214,7 @@
 	// }
 
 	// .hint {
-	// 	font-size: rem(14.4);
+	// 	font-size: to-rem(14.4);
 	// 	order: 4;
 	// }
 }

--- a/packages/themes/ecl/src/ecl-eu/components/input-range.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/input-range.scss
@@ -1,10 +1,10 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../@shared/input-core' as *;
 
 @layer kol-theme-component {
 	.kol-input-range {
 		&__inputs-wrapper {
-			gap: rem(16);
+			gap: to-rem(16);
 		}
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/components/link-button.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/link-button.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {

--- a/packages/themes/ecl/src/ecl-eu/components/modal.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/modal.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-modal {

--- a/packages/themes/ecl/src/ecl-eu/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/nav.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-nav {
@@ -26,7 +26,7 @@
 
 			&:not(:first-child),
 			#{$root}__list--nested & {
-				border-top-width: rem(2);
+				border-top-width: to-rem(2);
 			}
 		}
 
@@ -57,7 +57,7 @@
 		&__toggle-button {
 			.kol-button {
 				$root: &;
-				--kolibri-spacing: #{rem(4)};
+				--kolibri-spacing: #{to-rem(4)};
 				--text-focus-outline-color: var(--color-white);
 
 				appearance: none;
@@ -79,15 +79,15 @@
 
 				&__text {
 					text-decoration: none !important;
-					min-height: rem(44);
-					min-width: rem(44);
+					min-height: to-rem(44);
+					min-width: to-rem(44);
 					border-radius: 4px;
 					font:
-						normal normal 400 rem(16) / rem(20) arial,
+						normal normal 400 to-rem(16) / to-rem(20) arial,
 						sans-serif;
 					font-weight: 400;
 					margin: 0;
-					padding: rem(12);
+					padding: to-rem(12);
 					line-height: 1.2;
 
 					background-color: var(--text-background-color);
@@ -96,15 +96,15 @@
 					&:active,
 					&:hover {
 						box-shadow:
-							0 rem(2) rem(4) rgb(9 49 142 / 8%),
-							0 0 rem(10) rgb(9 49 142 / 4%),
-							0 rem(4) rem(5) rgb(9 49 142 / 4%),
-							0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+							0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+							0 0 to-rem(10) rgb(9 49 142 / 4%),
+							0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+							0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 					}
 
 					@at-root #{$root}:focus-visible & {
 						outline-offset: -4px;
-						outline: var(--text-focus-outline-color) solid rem(2);
+						outline: var(--text-focus-outline-color) solid to-rem(2);
 					}
 
 					@at-root #{$root}--hide-label & {
@@ -126,9 +126,9 @@
 		border-style: solid;
 		border-width: 2px;
 		color: var(--color-white);
-		font-size: rem(18);
+		font-size: to-rem(18);
 		justify-items: start;
-		padding: rem(16);
+		padding: to-rem(16);
 		height: 100%;
 
 		:is(.kol-button, .kol-link):focus-within & {

--- a/packages/themes/ecl/src/ecl-eu/components/pagination.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/pagination.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/pagination-mixin' as *;
 
 @layer kol-theme-component {
 	@include kol-pagination-styles;
 
 	.kol-button {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 		border-radius: 4px;
 
 		&:focus {
@@ -18,9 +18,9 @@
 		min-width: var(--a11y-min-size);
 		border-radius: 4px;
 		font:
-			normal normal 400 rem(16) / rem(20) Arial,
+			normal normal 400 to-rem(16) / to-rem(20) Arial,
 			sans-serif;
-		padding: rem(12);
+		padding: to-rem(12);
 		background-color: #fc0;
 		color: #171a22;
 
@@ -34,10 +34,10 @@
 			background-color: #fc0;
 			border-color: #fc0;
 			box-shadow:
-				0 rem(2) rem(4) rgb(9 49 142 / 8%),
-				0 0 rem(10) rgb(9 49 142 / 4%),
-				0 rem(4) rem(5) rgb(9 49 142 / 4%),
-				0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+				0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+				0 0 to-rem(10) rgb(9 49 142 / 4%),
+				0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+				0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 		}
 
 		.kol-pagination__button--selected & {

--- a/packages/themes/ecl/src/ecl-eu/components/popover-button.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/popover-button.scss
@@ -1,5 +1,5 @@
 @use '../mixins/button' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	@include kol-button('kol-button');

--- a/packages/themes/ecl/src/ecl-eu/components/single-select.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/single-select.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 @use '../mixins/custom-suggestions-option' as *;
 @use '../mixins/custom-suggestions-options-group' as *;
 @use '../mixins/custom-suggestions-toggle' as *;
 @use '../@shared/input-text' as *;
 
-$option-height: rem(40);
+$option-height: to-rem(40);
 $visible-options: 5;
 
 @layer kol-theme-component {
@@ -22,7 +22,7 @@ $visible-options: 5;
 			min-height: var(--a11y-min-size);
 			color: var(--color-grey);
 			order: 4;
-			padding: rem(1) 0.5em;
+			padding: to-rem(1) 0.5em;
 		}
 
 		&__input {

--- a/packages/themes/ecl/src/ecl-eu/components/skip-nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/skip-nav.scss
@@ -1,13 +1,13 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-skip-nav {
 		.kol-link {
 			&__text {
 				border-radius: 4px;
-				gap: rem(8);
+				gap: to-rem(8);
 				line-height: 1;
-				padding: rem(12);
+				padding: to-rem(12);
 				background-color: #0e47cb;
 				color: #fff;
 				cursor: pointer;

--- a/packages/themes/ecl/src/ecl-eu/components/spin.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/spin.scss
@@ -1,8 +1,8 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.cycle {
-		padding: rem(2);
+		padding: to-rem(2);
 
 		& span {
 			background-color: var(--color-blue-80);

--- a/packages/themes/ecl/src/ecl-eu/components/table-stateful.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/table-stateful.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/kol-table-stateless-wc' as *;
 
 @layer kol-theme-component {
@@ -16,7 +16,7 @@
 		&__pagination {
 			overflow-x: auto;
 			overflow-y: hidden;
-			gap: rem(16);
+			gap: to-rem(16);
 			grid-auto-flow: column;
 		}
 
@@ -24,7 +24,7 @@
 			@at-root #{$root}__pagination & {
 				@media (min-width: 1024px) {
 					display: flex;
-					gap: rem(16);
+					gap: to-rem(16);
 				}
 			}
 		}

--- a/packages/themes/ecl/src/ecl-eu/components/tabs.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tabs.scss
@@ -1,19 +1,19 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	:host {
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 	}
 
 	.kol-tabs {
 		&__button-group {
 			border-bottom: 1px solid var(--color-grey-25);
-			margin-bottom: rem(-1);
+			margin-bottom: to-rem(-1);
 		}
 
 		.kol-button {
 			border: none;
-			margin-bottom: rem(-1);
+			margin-bottom: to-rem(-1);
 
 			&:hover:not(:disabled) {
 				.kol-span {
@@ -22,7 +22,7 @@
 			}
 
 			&:focus .kol-span {
-				outline: var(--color-blue-130) solid rem(2);
+				outline: var(--color-blue-130) solid to-rem(2);
 			}
 
 			&.selected {
@@ -39,7 +39,7 @@
 			}
 
 			.kol-span {
-				padding: rem(4);
+				padding: to-rem(4);
 				min-height: var(--a11y-min-size);
 				min-width: var(--a11y-min-size);
 			}

--- a/packages/themes/ecl/src/ecl-eu/components/toast-container.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/toast-container.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/alert-wc' as *;
 
 @layer kol-theme-component {
 	:host {
-		top: rem(16);
-		right: rem(16);
-		width: rem(440);
+		top: to-rem(16);
+		right: to-rem(16);
+		width: to-rem(440);
 		max-width: 100%;
 	}
 
@@ -14,7 +14,7 @@
 
 		display: block;
 		background-color: #fff;
-		margin-top: rem(16);
+		margin-top: to-rem(16);
 
 		&__alert {
 			display: block;

--- a/packages/themes/ecl/src/ecl-eu/components/toolbar.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/toolbar.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use '../mixins/button' as *;
 
 @layer kol-theme-component {
@@ -9,10 +9,10 @@
 		padding: var(--spacing-s);
 		border-radius: 8px;
 		box-shadow:
-			0 rem(2) rem(4) rgb(9 49 142 / 8%),
-			0 0 rem(10) rgb(9 49 142 / 4%),
-			0 rem(4) rem(5) rgb(9 49 142 / 4%),
-			0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+			0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+			0 0 to-rem(10) rgb(9 49 142 / 4%),
+			0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+			0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 		background-color: var(--color-white);
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-tree-item {

--- a/packages/themes/ecl/src/ecl-eu/components/tree.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @layer kol-theme-component {
 	.kol-tree {

--- a/packages/themes/ecl/src/ecl-eu/global.scss
+++ b/packages/themes/ecl/src/ecl-eu/global.scss
@@ -1,4 +1,4 @@
-@use '../mixins/rem' as *;
+@use '../mixins/to-rem' as *;
 
 @layer kol-theme-global {
 	.kol-tooltip {
@@ -9,8 +9,8 @@
 		&__content {
 			background-color: #f2f2f2;
 
-			padding: rem(4) rem(8);
-			font-size: rem(14);
+			padding: to-rem(4) to-rem(8);
+			font-size: to-rem(14);
 			line-height: 1.2;
 			border-radius: 2px;
 			border: 1px solid #626262;
@@ -109,20 +109,20 @@
 		--color-white: #fff;
 		--color-black: #000;
 		--font-family: Arial, sans-serif;
-		--font-size: #{rem(16)};
+		--font-size: #{to-rem(16)};
 		--font-weight-regular: 400;
 		--font-weight-bold: 700;
 		--line-height-regular: 1.5;
 		--line-height-heading: 1.2;
-		--spacing-4xl: #{rem(64)};
-		--spacing-3xl: #{rem(48)};
-		--spacing-2xl: #{rem(40)};
-		--spacing-xl: #{rem(32)};
-		--spacing-l: #{rem(24)};
-		--spacing-m: #{rem(16)};
-		--spacing-s: #{rem(12)};
-		--spacing-xs: #{rem(8)};
-		--spacing-2xs: #{rem(4)};
+		--spacing-4xl: #{to-rem(64)};
+		--spacing-3xl: #{to-rem(48)};
+		--spacing-2xl: #{to-rem(40)};
+		--spacing-xl: #{to-rem(32)};
+		--spacing-l: #{to-rem(24)};
+		--spacing-m: #{to-rem(16)};
+		--spacing-s: #{to-rem(12)};
+		--spacing-xs: #{to-rem(8)};
+		--spacing-2xs: #{to-rem(4)};
 	}
 
 	:host {
@@ -167,26 +167,26 @@
 
 	p.l,
 	p.lead {
-		font-size: rem(20);
-		line-height: rem(28);
+		font-size: to-rem(20);
+		line-height: to-rem(28);
 	}
 
 	p,
 	p.m,
 	p.medium {
-		line-height: rem(24);
+		line-height: to-rem(24);
 	}
 
 	p.s,
 	p.small {
-		font-size: rem(14);
-		line-height: rem(20);
+		font-size: to-rem(14);
+		line-height: to-rem(20);
 	}
 
 	p.xs,
 	p.extra-small {
-		font-size: rem(12);
-		line-height: rem(20);
+		font-size: to-rem(12);
+		line-height: to-rem(20);
 	}
 
 	.badge-text-hint {

--- a/packages/themes/ecl/src/ecl-eu/mixins/alert-wc.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/alert-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-alert-wc($color: null) {
 	color: var($color);
@@ -15,10 +15,10 @@
 		}
 
 		&--variant-card {
-			padding-bottom: rem(24);
-			padding-inline-end: rem(8);
-			padding-inline-start: rem(24);
-			padding-top: rem(24);
+			padding-bottom: to-rem(24);
+			padding-inline-end: to-rem(8);
+			padding-inline-start: to-rem(24);
+			padding-top: to-rem(24);
 			border-style: solid;
 			border-width: 2px;
 		}
@@ -47,7 +47,7 @@
 			background-color: var(--color-white);
 
 			@at-root #{$root}--variant-card & {
-				gap: rem(8);
+				gap: to-rem(8);
 			}
 		}
 
@@ -64,7 +64,7 @@
 
 			.kol-icon {
 				@at-root #{$root}--variant-card & {
-					font-size: rem(32);
+					font-size: to-rem(32);
 				}
 			}
 		}
@@ -78,13 +78,13 @@
 			}
 
 			@at-root #{$root}--variant-card & {
-				font-size: rem(32);
+				font-size: to-rem(32);
 			}
 		}
 
 		&__content {
 			@at-root #{$root}--variant-card & {
-				margin-left: rem(40);
+				margin-left: to-rem(40);
 			}
 		}
 	}

--- a/packages/themes/ecl/src/ecl-eu/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/button.scss
@@ -1,9 +1,9 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-button($block-classname) {
 	.#{$block-classname} {
 		$root: &;
-		--kolibri-spacing: #{rem(4)};
+		--kolibri-spacing: #{to-rem(4)};
 		--text-focus-outline-color: var(--color-white);
 
 		appearance: none;
@@ -71,11 +71,11 @@
 			min-width: var(--a11y-min-size);
 			border-radius: 4px;
 			font:
-				normal normal 400 rem(16) / rem(20) arial,
+				normal normal 400 to-rem(16) / to-rem(20) arial,
 				sans-serif;
 			font-weight: 400;
 			margin: 0;
-			padding: rem(12);
+			padding: to-rem(12);
 			line-height: 1.2;
 
 			background-color: var(--text-background-color);
@@ -85,24 +85,24 @@
 			&:active,
 			&:not(:disabled):hover {
 				box-shadow:
-					0 rem(2) rem(4) rgb(9 49 142 / 8%),
-					0 0 rem(10) rgb(9 49 142 / 4%),
-					0 rem(4) rem(5) rgb(9 49 142 / 4%),
-					0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+					0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+					0 0 to-rem(10) rgb(9 49 142 / 4%),
+					0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+					0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 			}
 
 			@at-root #{$root}--secondary & {
-				padding: calc(rem(12) - rem(2)) calc(rem(16) - rem(2));
+				padding: calc(to-rem(12) - to-rem(2)) calc(to-rem(16) - to-rem(2));
 				border: 2px solid #0e47cb;
 			}
 
 			@at-root #{$root}--secondary.button:focus-visible & {
-				box-shadow: inset 0 0 0 rem(4) #0e47cb;
+				box-shadow: inset 0 0 0 to-rem(4) #0e47cb;
 			}
 
 			@at-root #{$root}:focus-visible & {
 				outline-offset: -4px;
-				outline: var(--text-focus-outline-color) solid rem(2);
+				outline: var(--text-focus-outline-color) solid to-rem(2);
 			}
 
 			@at-root #{$root}--hide-label & {

--- a/packages/themes/ecl/src/ecl-eu/mixins/custom-suggestions-option.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/custom-suggestions-option.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-option-theme($option-height) {
 	.kol-custom-suggestions-option {
@@ -6,7 +6,7 @@
 		align-items: center;
 		min-height: $option-height;
 		line-height: 1.2;
-		padding: rem(10) rem(12);
+		padding: to-rem(10) to-rem(12);
 
 		&[aria-selected] {
 			color: var(--color-blue);

--- a/packages/themes/ecl/src/ecl-eu/mixins/custom-suggestions-options-group.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/custom-suggestions-options-group.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-options-group-theme($option-height, $visible-options) {
 	.kol-custom-suggestions-options-group {
@@ -8,8 +8,8 @@
 		border-color: var(--color-subtle);
 		overflow-y: auto;
 		overflow-x: hidden;
-		max-height: calc($option-height * $visible-options + rem(2));
-		left: rem(-8);
-		right: rem(-8);
+		max-height: calc($option-height * $visible-options + to-rem(2));
+		left: to-rem(-8);
+		right: to-rem(-8);
 	}
 }

--- a/packages/themes/ecl/src/ecl-eu/mixins/custom-suggestions-toggle.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/custom-suggestions-toggle.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-custom-suggestions-toggle-theme {
 	.kol-custom-suggestions-toggle {

--- a/packages/themes/ecl/src/ecl-eu/mixins/form-field.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/form-field.scss
@@ -1,6 +1,6 @@
 @use './required' as *;
 @use '../mixins/alert-wc' as *;
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-form-field-theme {
 	.kol-form-field {
@@ -16,7 +16,7 @@
 		}
 
 		&__hint {
-			font-size: rem(14);
+			font-size: to-rem(14);
 		}
 
 		&__msg {

--- a/packages/themes/ecl/src/ecl-eu/mixins/indented-text.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/indented-text.scss
@@ -1,13 +1,13 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin indented-text {
-	-webkit-border-start: rem(8) solid #0e47cb;
-	-webkit-padding-start: rem(24);
-	border-end-start-radius: rem(4);
-	border-inline-start: rem(8) solid #0e47cb;
-	border-start-start-radius: rem(4);
+	-webkit-border-start: to-rem(8) solid #0e47cb;
+	-webkit-padding-start: to-rem(24);
+	border-end-start-radius: to-rem(4);
+	border-inline-start: to-rem(8) solid #0e47cb;
+	border-start-start-radius: to-rem(4);
 	display: inline-block;
-	padding-bottom: rem(16);
-	padding-inline-start: rem(24);
-	padding-top: rem(16);
+	padding-bottom: to-rem(16);
+	padding-inline-start: to-rem(24);
+	padding-top: to-rem(16);
 }

--- a/packages/themes/ecl/src/ecl-eu/mixins/input-container.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/input-container.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-input-container-theme {
 	.kol-input-container {
@@ -7,12 +7,12 @@
 		color: var(--color-grey);
 		order: 4;
 		align-items: center;
-		padding: rem(1) 0.5em;
+		padding: to-rem(1) 0.5em;
 
 		&:focus-within {
 			box-shadow:
-				inset rem(1) rem(1) var(--color-blue),
-				inset rem(-1) rem(-1) var(--color-blue);
+				inset to-rem(1) to-rem(1) var(--color-blue),
+				inset to-rem(-1) to-rem(-1) var(--color-blue);
 			outline: none;
 		}
 

--- a/packages/themes/ecl/src/ecl-eu/mixins/input-text.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/input-text.scss
@@ -1,11 +1,11 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-input-text-theme {
 	.kol-input,
 	.kol-select,
 	.kol-textarea {
 		border: none;
-		margin: rem(1);
+		margin: to-rem(1);
 		outline: none;
 	}
 

--- a/packages/themes/ecl/src/ecl-eu/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/kol-table-stateless-wc.scss
@@ -1,4 +1,4 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 @use './alert-wc' as *;
 @use './pagination-mixin' as *;
 
@@ -32,7 +32,7 @@
 			width: 100%;
 			border-spacing: 0;
 			border-width: 0;
-			border-bottom-width: rem(2);
+			border-bottom-width: to-rem(2);
 			border-style: solid;
 			border-color: var(--color-ice);
 		}
@@ -44,14 +44,14 @@
 			&--header {
 				@at-root #{$root}__head-row:first-child & {
 					border-width: 0;
-					border-top-width: rem(2);
+					border-top-width: to-rem(2);
 					border-style: solid;
 					border-color: var(--color-ice);
 				}
 
 				@at-root #{$root}__head-row:last-child & {
 					border-width: 0;
-					border-bottom-width: rem(2);
+					border-bottom-width: to-rem(2);
 					border-style: solid;
 					border-color: var(--color-ice);
 				}

--- a/packages/themes/ecl/src/ecl-eu/mixins/pagination-mixin.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/pagination-mixin.scss
@@ -1,18 +1,18 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-pagination-styles {
 	.kol-table-stateful {
 		&__pagination,
 		&__pagination-wrapper {
 			@media (min-width: 1024px) {
-				gap: rem(16);
+				gap: to-rem(16);
 			}
 		}
 	}
 
 	.kol-pagination {
 		.kol-button {
-			--kolibri-spacing: #{rem(4)};
+			--kolibri-spacing: #{to-rem(4)};
 			border-radius: 4px;
 
 			&:focus {
@@ -29,10 +29,10 @@
 				background-color: #fc0;
 				border-color: #fc0;
 				box-shadow:
-					0 rem(2) rem(4) rgb(9 49 142 / 8%),
-					0 0 rem(10) rgb(9 49 142 / 4%),
-					0 rem(4) rem(5) rgb(9 49 142 / 4%),
-					0 rem(-4) rem(4) rgb(9 49 142 / 4%);
+					0 to-rem(2) to-rem(4) rgb(9 49 142 / 8%),
+					0 0 to-rem(10) rgb(9 49 142 / 4%),
+					0 to-rem(4) to-rem(5) rgb(9 49 142 / 4%),
+					0 to-rem(-4) to-rem(4) rgb(9 49 142 / 4%);
 			}
 
 			&:disabled .kol-button__text {
@@ -45,9 +45,9 @@
 				min-width: var(--a11y-min-size);
 				border-radius: 4px;
 				font:
-					normal normal 400 rem(16) / rem(20) Arial,
+					normal normal 400 to-rem(16) / to-rem(20) Arial,
 					sans-serif;
-				padding: rem(12);
+				padding: to-rem(12);
 				background-color: #fc0;
 				color: #171a22;
 			}

--- a/packages/themes/ecl/src/ecl-eu/mixins/typography.scss
+++ b/packages/themes/ecl/src/ecl-eu/mixins/typography.scss
@@ -1,41 +1,41 @@
-@use '../../mixins/rem' as *;
+@use '../../mixins/to-rem' as *;
 
 @mixin kol-typography-body {
-	font-size: rem(16);
+	font-size: to-rem(16);
 	line-height: 1.5;
 }
 
 @mixin kol-typography-h1 {
-	font-size: rem(42);
+	font-size: to-rem(42);
 	line-height: 3.25;
 }
 
 @mixin kol-typography-h2 {
-	font-size: rem(36);
+	font-size: to-rem(36);
 	line-height: 2.755;
 }
 
 @mixin kol-typography-h3 {
-	font-size: rem(32);
+	font-size: to-rem(32);
 	line-height: 2.5;
 }
 
 @mixin kol-typography-h4 {
-	font-size: rem(28);
+	font-size: to-rem(28);
 	line-height: 2;
 }
 
 @mixin kol-typography-h5 {
-	font-size: rem(24);
+	font-size: to-rem(24);
 	line-height: 1.75;
 }
 
 @mixin kol-typography-h6 {
-	font-size: rem(20);
+	font-size: to-rem(20);
 	line-height: 1.75;
 }
 
 @mixin kol-typography-hint {
-	font-size: rem(14.4);
+	font-size: to-rem(14.4);
 	font-style: italic;
 }

--- a/packages/themes/ecl/src/mixins/to-rem.scss
+++ b/packages/themes/ecl/src/mixins/to-rem.scss
@@ -1,3 +1,3 @@
-@function rem($size) {
+@function to-rem($size) {
 	@return calc(#{$size}rem / var(--kolibri-root-font-size, 16));
 }


### PR DESCRIPTION
## Summary
Renames the `rem()` CSS utility function to `to-rem()` for clearer semantics.

## Changes
- Renamed `rem()` function to `to-rem()` across the codebase

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
CSS-Hilfsfunktion `rem()` für klarere Semantik in `to-rem()` umbenannt.

## Änderungen
- Funktion `rem()` überall im Code in `to-rem()` umbenannt

</details>