### PR TITLE
ci: extend CLI test timeout

### DIFF
--- a/packages/tools/kolibri-cli/test/cli-interface.spec.ts
+++ b/packages/tools/kolibri-cli/test/cli-interface.spec.ts
@@ -9,7 +9,8 @@ import migrate from '../src/migrate';
 import { getRemoveMode, setRemoveMode } from '../src/migrate/shares/reuse';
 import { TaskRunner } from '../src/migrate/runner/task-runner';
 
-describe('CLI interface', () => {
+describe('CLI interface', function () {
+       this.timeout(5000);
        it('runs generate-scss command', async () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
 		const cwd = process.cwd();


### PR DESCRIPTION
## Summary
Extends the timeout for CLI tests to prevent false failures on slow machines.

## Changes
- Increased CLI test timeout to 5 seconds

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Timeout für CLI-Tests verlängert, um falsche Fehler auf langsamen Maschinen zu verhindern.

## Änderungen
- CLI-Test-Timeout auf 5 Sekunden erhöht

</details>