### PR TITLE
feat(input-range): add default range values

### DIFF
--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -310,12 +310,12 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	/**
 	 * Defines the largest possible input value.
 	 */
-	@Prop() public _max?: number;
+	@Prop() public _max?: number = 100;
 
 	/**
 	 * Defines the smallest possible input value.
 	 */
-	@Prop() public _min?: number;
+	@Prop() public _min?: number = 0;
 
 	/**
 	 * Defines the properties for a message rendered as Alert component.


### PR DESCRIPTION
## Summary
Adds sensible default values for the `input-range` component's min, max, and step properties.

## Changes
- Added default values for range input min, max, and step

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Sinnvolle Standardwerte für die Min-, Max- und Step-Eigenschaften der `input-range`-Komponente hinzugefügt.

## Änderungen
- Standardwerte für Range-Input-Min, Max und Step hinzugefügt

</details>