### PR TITLE
ci: handle PR labels

### DIFF
--- a/.github/workflows/handle-pr-labels.yml
+++ b/.github/workflows/handle-pr-labels.yml
@@ -1,0 +1,40 @@
+name: Handle PR-Labels
+
+on:
+  pull_request_target:
+    types: [opened, labeled]
+
+concurrency:
+  group: workflow-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  handle-labels:
+    if: >-
+      github.repository == 'public-ui/kolibri' &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'codex') ||
+        (github.event.action == 'opened' && contains(github.event.pull_request.labels.*.name, 'codex'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: prNumber,
+              labels: ['agent:codex'],
+            });
+
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: prNumber,
+              name: 'codex',
+            });


### PR DESCRIPTION
## Summary
Adds a CI pipeline for handling PR label changes automatically.

## Changes
- Added CI pipeline for PR label management

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
CI-Pipeline für die automatische Verwaltung von PR-Labels hinzugefügt.

## Änderungen
- CI-Pipeline für die PR-Label-Verwaltung hinzugefügt

</details>