### PR TITLE
docs: add AGENTS instructions for themes

### DIFF
--- a/packages/themes/AGENTS.md
+++ b/packages/themes/AGENTS.md
@@ -18,7 +18,7 @@ This folder collects all official KoliBri themes. Each theme package under this 
 
 - Organise SCSS using `@layer kol-theme-global` and `@layer kol-theme-component`.
 - Follow BEM style class naming (`block__element--modifier`).
-- Reuse mixins from the `mixins/` folder and use the `rem()` helper for sizing.
+- Reuse mixins from the `mixins/` folder and use the `to-rem()` helper for sizing.
 - Place theme tokens (colors, fonts, spacing, etc.) in the global layer and reference them in component styles.
 - Avoid `!important` and only override properties that the theme actually customises.
 

--- a/packages/themes/AGENTS.md
+++ b/packages/themes/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Instructions
+
+This folder collects all official KoliBri themes. Each theme package under this directory (`default`, `ecl`, …) uses the same tool chain and follows the same coding rules.
+
+## Structure
+
+- `src/` – shared entry points and utilities used by all themes.
+- `<theme>/src` – theme specific sources containing `global.scss`, component styles and mixins.
+- Every theme exposes one or more theme objects via `KoliBri.createTheme` and exports them from `src/index.ts`.
+
+## Building
+
+- Use **pnpm** for all commands. Run `pnpm build` in the repository root or `pnpm --filter <package> build` to build a single theme.
+- The build stack is based on **Rollup**, **TypeScript** and **PostCSS**. Keep `rollup.config.js`, `tsconfig.json` and dependency versions identical across all theme packages.
+- Do not edit the generated `assets` folders. Modify the source files instead and rebuild.
+
+## Coding Guidelines
+
+- Organise SCSS using `@layer kol-theme-global` and `@layer kol-theme-component`.
+- Follow BEM style class naming (`block__element--modifier`).
+- Reuse mixins from the `mixins/` folder and use the `rem()` helper for sizing.
+- Place theme tokens (colors, fonts, spacing, etc.) in the global layer and reference them in component styles.
+- Avoid `!important` and only override properties that the theme actually customises.
+
+## Consistency
+
+All theme packages must share the same stack configuration, scripts and dependency versions. When updating one theme, ensure the others are kept in sync.


### PR DESCRIPTION
## Summary
Adds AGENTS.md documentation with instructions for AI agents working on theme packages.

## Changes
- Added AGENTS.md for theme packages

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
AGENTS.md-Dokumentation mit Anweisungen für KI-Agenten, die an Theme-Paketen arbeiten, hinzugefügt.

## Änderungen
- AGENTS.md für Theme-Pakete hinzugefügt

</details>