### PR TITLE
refactor: use the correct prop types

### DIFF
--- a/packages/components/src/components/@deprecated/input/controller.ts
+++ b/packages/components/src/components/@deprecated/input/controller.ts
@@ -4,7 +4,10 @@ import type {
 	AccessKeyPropType,
 	AdjustHeightPropType,
 	ButtonProps,
+	HideLabelPropType,
 	HideMsgPropType,
+	HintPropType,
+	DisabledPropType,
 	InputTypeOnDefault,
 	LabelWithExpertSlotPropType,
 	MsgPropType,
@@ -62,7 +65,7 @@ export class InputController extends ControlledInputController implements Watche
 		validateAdjustHeight(this.component, value);
 	}
 
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		watchBoolean(this.component, '_disabled', value);
 		if (value === true) {
 			a11yHintDisabled();
@@ -84,7 +87,7 @@ export class InputController extends ControlledInputController implements Watche
 		});
 	}
 
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		validateHideLabel(this.component, value, {
 			hooks: {
 				afterPatch: () => {
@@ -96,7 +99,7 @@ export class InputController extends ControlledInputController implements Watche
 		});
 	}
 
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		watchString(this.component, '_hint', value);
 	}
 

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -2,12 +2,15 @@ import type {
 	AccessKeyPropType,
 	AlternativeButtonLinkRolePropType,
 	AriaDescriptionPropType,
+	AriaExpandedPropType,
+	AriaSelectedPropType,
 	ButtonCallbacksPropType,
 	ButtonStates,
 	ButtonTypePropType,
 	ButtonVariantPropType,
 	CustomClassPropType,
 	DisabledPropType,
+	HideLabelPropType,
 	FocusableElement,
 	IconsPropType,
 	InternalButtonAPI,
@@ -336,12 +339,12 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	}
 
 	@Watch('_ariaExpanded')
-	public validateAriaExpanded(value?: boolean): void {
+	public validateAriaExpanded(value?: AriaExpandedPropType): void {
 		validateAriaExpanded(this, value);
 	}
 
 	@Watch('_ariaSelected')
-	public validateAriaSelected(value?: boolean): void {
+	public validateAriaSelected(value?: AriaSelectedPropType): void {
 		validateAriaSelected(this, value);
 	}
 
@@ -356,7 +359,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		validateHideLabel(this, value);
 	}
 

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -15,6 +15,9 @@ import type {
 	SuggestionsPropType,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 	W3CInputValue,
 } from '../../schema';
 import clsx from 'clsx';
@@ -497,7 +500,7 @@ export class KolCombobox implements ComboboxAPI {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -507,12 +510,12 @@ export class KolCombobox implements ComboboxAPI {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -23,6 +23,9 @@ import type {
 	Stringified,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import { nonce } from '../../utils/dev.utils';
@@ -291,7 +294,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -301,12 +304,12 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -18,6 +18,9 @@ import type {
 	SuggestionsPropType,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper';
@@ -286,7 +289,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -296,12 +299,12 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -24,6 +24,9 @@ import type {
 	SuggestionsPropType,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 import { deprecatedHint } from '../../schema';
 
@@ -332,7 +335,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -342,12 +345,12 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -22,6 +22,10 @@ import type {
 	SuggestionsPropType,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HasCounterPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper';
@@ -298,7 +302,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -308,17 +312,17 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hasCounter')
-	public validateHasCounter(value?: boolean): void {
+	public validateHasCounter(value?: HasCounterPropType): void {
 		this.controller.validateHasCounter(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -18,6 +18,9 @@ import type {
 	Stringified,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import { nonce } from '../../utils/dev.utils';
@@ -241,7 +244,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -251,12 +254,12 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -21,6 +21,9 @@ import type {
 	SuggestionsPropType,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import { nonce } from '../../utils/dev.utils';
@@ -313,7 +316,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -323,12 +326,12 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-password/controller.ts
+++ b/packages/components/src/components/input-password/controller.ts
@@ -1,4 +1,4 @@
-import type { AutoCompletePropType, InputPasswordProps, InputPasswordWatches, MaxLengthBehaviorPropType } from '../../schema';
+import type { AutoCompletePropType, HasCounterPropType, InputPasswordProps, InputPasswordWatches, MaxLengthBehaviorPropType } from '../../schema';
 import { validateHasCounter, watchBoolean, watchNumber, watchString } from '../../schema';
 import { validateAutoComplete } from '../../schema/props/auto-complete';
 import { validateMaxLengthBehavior } from '../../schema/props/max-length-behavior';
@@ -28,7 +28,7 @@ export class InputPasswordController extends InputIconController implements Inpu
 		validateAutoComplete(this.component, value);
 	}
 
-	public validateHasCounter(value?: boolean): void {
+	public validateHasCounter(value?: HasCounterPropType): void {
 		validateHasCounter(this.component, value);
 	}
 

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -20,6 +20,10 @@ import type {
 	Stringified,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HasCounterPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 import { devHint } from '../../schema';
 
@@ -328,7 +332,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 	@Watch('_variant')
@@ -342,17 +346,17 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hasCounter')
-	public validateHasCounter(value?: boolean): void {
+	public validateHasCounter(value?: HasCounterPropType): void {
 		this.controller.validateHasCounter(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -18,6 +18,9 @@ import type {
 	Stringified,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import { nonce } from '../../utils/dev.utils';
@@ -263,12 +266,12 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
@@ -278,7 +281,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -20,6 +20,9 @@ import type {
 	SuggestionsPropType,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import { nonce } from '../../utils/dev.utils';
@@ -354,7 +357,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -364,12 +367,12 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -19,6 +19,10 @@ import type {
 	MsgPropType,
 	NamePropType,
 	ShortKeyPropType,
+	DisabledPropType,
+	HasCounterPropType,
+	HideLabelPropType,
+	HintPropType,
 	SpellCheckPropType,
 	Stringified,
 	SuggestionsPropType,
@@ -326,7 +330,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -336,17 +340,17 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hasCounter')
-	public validateHasCounter(value?: boolean): void {
+	public validateHasCounter(value?: HasCounterPropType): void {
 		this.controller.validateHasCounter(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -8,6 +8,7 @@ import type {
 	ButtonVariantPropType,
 	CustomClassPropType,
 	DisabledPropType,
+	HideLabelPropType,
 	DownloadPropType,
 	FocusableElement,
 	HrefPropType,
@@ -365,7 +366,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		validateHideLabel(this, value);
 	}
 

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -16,6 +16,9 @@ import type {
 	SelectAPI,
 	SelectStates,
 	ShortKeyPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 	StencilUnknown,
 	Stringified,
 	SyncValueBySelectorPropType,
@@ -255,7 +258,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -265,12 +268,12 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -18,6 +18,9 @@ import type {
 	Stringified,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import clsx from 'clsx';
@@ -590,7 +593,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -600,12 +603,12 @@ export class KolSingleSelect implements SingleSelectAPI {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/components/textarea/controller.ts
+++ b/packages/components/src/components/textarea/controller.ts
@@ -10,6 +10,7 @@ import {
 	watchString,
 	watchValidator,
 } from '../../schema';
+import type { HasCounterPropType } from '../../schema';
 
 import { InputIconController } from '../@deprecated/input/controller-icon';
 
@@ -30,7 +31,7 @@ export class TextareaController extends InputIconController implements TextareaW
 		}
 	};
 
-	public validateHasCounter(value?: boolean): void {
+	public validateHasCounter(value?: HasCounterPropType): void {
 		validateHasCounter(this.component, value);
 	}
 

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -22,6 +22,10 @@ import type {
 	TextareaAPI,
 	TextareaStates,
 	TooltipAlignPropType,
+	DisabledPropType,
+	HasCounterPropType,
+	HideLabelPropType,
+	HintPropType,
 } from '../../schema';
 
 import { nonce } from '../../utils/dev.utils';
@@ -295,7 +299,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	}
 
 	@Watch('_disabled')
-	public validateDisabled(value?: boolean): void {
+	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
 
@@ -305,17 +309,17 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	}
 
 	@Watch('_hideLabel')
-	public validateHideLabel(value?: boolean): void {
+	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
 
 	@Watch('_hasCounter')
-	public validateHasCounter(value?: boolean): void {
+	public validateHasCounter(value?: HasCounterPropType): void {
 		this.controller.validateHasCounter(value);
 	}
 
 	@Watch('_hint')
-	public validateHint(value?: string): void {
+	public validateHint(value?: HintPropType): void {
 		this.controller.validateHint(value);
 	}
 

--- a/packages/components/src/schema/components/combobox.ts
+++ b/packages/components/src/schema/components/combobox.ts
@@ -6,6 +6,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -21,7 +22,6 @@ import type { InputTypeOnDefault, KoliBriHIcons, Stringified, W3CInputValue } fr
 
 type RequiredProps = PropLabelWithExpertSlot & PropSuggestions;
 type OptionalProps = {
-	hint: string;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	placeholder: string;
@@ -30,6 +30,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropName &
 	PropRequired &
@@ -45,12 +46,12 @@ type RequiredStates = {
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	on: InputTypeOnDefault;
 	placeholder: string;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropId &
 	PropName &

--- a/packages/components/src/schema/components/input-checkbox.ts
+++ b/packages/components/src/schema/components/input-checkbox.ts
@@ -6,6 +6,7 @@ import type {
 	PropDisabled,
 	PropHideMsg,
 	PropHideLabel,
+	PropHint,
 	PropIndeterminate,
 	PropLabelAlign,
 	PropLabelWithExpertSlot,
@@ -47,7 +48,6 @@ export type InputCheckboxIconsState = {
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	icons: Stringified<InputCheckboxIconsProp>;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
@@ -58,6 +58,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropIndeterminate &
 	PropName &
 	PropRequired &
@@ -76,11 +77,11 @@ type RequiredStates = {
 	PropIndeterminate &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	on: InputTypeOnDefault;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	PropMsg &
 	PropName &
 	PropRequired &

--- a/packages/components/src/schema/components/input-color.ts
+++ b/packages/components/src/schema/components/input-color.ts
@@ -7,6 +7,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropLabelWithExpertSlot,
 	PropMsg,
@@ -21,7 +22,6 @@ import type { ButtonProps } from './button';
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	smartButton: Stringified<ButtonProps>;
@@ -29,8 +29,9 @@ type OptionalProps = {
 } & PropAccessKey &
 	PropAutoComplete &
 	PropDisabled &
-	PropHideMsg &
 	PropHideLabel &
+	PropHideMsg &
+	PropHint &
 	PropHorizontalIcons &
 	PropName &
 	PropShortKey &
@@ -44,7 +45,6 @@ type RequiredStates = {
 } & PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	on: InputTypeOnDefault;
 	smartButton: ButtonProps;
 	value: string;
@@ -52,6 +52,7 @@ type OptionalStates = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropMsg &
 	PropName &

--- a/packages/components/src/schema/components/input-date.ts
+++ b/packages/components/src/schema/components/input-date.ts
@@ -7,6 +7,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -27,7 +28,6 @@ export type InputDateType = (typeof inputDateTypeOptions)[number];
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	max: Iso8601 | Date;
 	min: Iso8601 | Date;
 	msg: Stringified<MsgPropType>;
@@ -41,6 +41,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideLabel &
 	PropHideMsg &
+	PropHint &
 	PropHorizontalIcons &
 	PropName &
 	PropReadOnly &
@@ -57,7 +58,6 @@ type RequiredStates = {
 	PropId;
 
 type OptionalStates = {
-	hint: string;
 	max: Iso8601;
 	min: Iso8601;
 	on: InputTypeOnDefault;
@@ -67,6 +67,7 @@ type OptionalStates = {
 	value: Iso8601 | null;
 } & PropAccessKey &
 	PropAutoComplete &
+	PropHint &
 	PropSyncValueBySelector &
 	PropDisabled &
 	PropHideLabel &

--- a/packages/components/src/schema/components/input-email.ts
+++ b/packages/components/src/schema/components/input-email.ts
@@ -7,6 +7,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -26,7 +27,6 @@ import type { ButtonProps } from './button';
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	maxLength: number;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
@@ -39,6 +39,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropMaxLengthBehavior &
 	PropMultiple &
@@ -60,7 +61,6 @@ type RequiredStates = {
 	PropLabelWithExpertSlot;
 
 type OptionalStates = {
-	hint: string;
 	maxLength: number;
 	on: InputTypeOnDefault;
 	pattern: string;
@@ -71,6 +71,7 @@ type OptionalStates = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropMaxLengthBehavior &
 	PropMsg &

--- a/packages/components/src/schema/components/input-file.ts
+++ b/packages/components/src/schema/components/input-file.ts
@@ -6,6 +6,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -23,7 +24,6 @@ import type { ButtonProps } from './button';
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
 	accept: string;
-	hint: string;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	smartButton: Stringified<ButtonProps>;
@@ -31,6 +31,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropMultiple &
 	PropName &
@@ -42,12 +43,12 @@ type OptionalProps = {
 type RequiredStates = PropId & PropLabelWithExpertSlot & PropHideMsg;
 type OptionalStates = {
 	accept: string;
-	hint: string;
 	on: InputTypeOnDefault;
 	smartButton: ButtonProps;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropMsg &
 	PropMultiple &

--- a/packages/components/src/schema/components/input-number.ts
+++ b/packages/components/src/schema/components/input-number.ts
@@ -7,6 +7,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -24,7 +25,6 @@ import type { ButtonProps } from './button';
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	max: number | NumberString;
 	min: number | NumberString;
 	msg: Stringified<MsgPropType>;
@@ -38,6 +38,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideLabel &
 	PropHideMsg &
+	PropHint &
 	PropHorizontalIcons &
 	PropName &
 	PropReadOnly &
@@ -53,7 +54,6 @@ type RequiredStates = {
 	PropLabelWithExpertSlot;
 
 type OptionalStates = {
-	hint: string;
 	max: number;
 	min: number;
 	on: InputTypeOnDefault;
@@ -65,6 +65,7 @@ type OptionalStates = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropMsg &
 	PropName &

--- a/packages/components/src/schema/components/input-password.ts
+++ b/packages/components/src/schema/components/input-password.ts
@@ -8,6 +8,7 @@ import type {
 	PropHasCounter,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -26,7 +27,6 @@ import type { ButtonProps } from './button';
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	maxLength: number;
 	on: InputTypeOnDefault;
 	pattern: string;
@@ -41,6 +41,7 @@ type OptionalProps = {
 	PropHasCounter &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropMaxLengthBehavior &
 	PropName &
@@ -58,7 +59,6 @@ type RequiredStates = {
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	maxLength: number;
 	on: InputTypeOnDefault;
 	pattern: string;
@@ -71,6 +71,7 @@ type OptionalStates = {
 	PropDisabled &
 	PropHasCounter &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropMaxLengthBehavior &
 	PropMsg &
@@ -78,6 +79,7 @@ type OptionalStates = {
 	PropReadOnly &
 	PropRequired &
 	PropShortKey &
+	PropSyncValueBySelector &
 	PropTouched;
 
 export type InputPasswordProps = Generic.Element.Members<RequiredProps, OptionalProps>;

--- a/packages/components/src/schema/components/input-radio.ts
+++ b/packages/components/src/schema/components/input-radio.ts
@@ -4,6 +4,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropId,
 	PropLabelWithExpertSlot,
 	PropMsg,
@@ -19,13 +20,13 @@ import type { PropOrientation } from '../props/orientation';
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	value: StencilUnknown;
 } & PropDisabled &
 	PropHideLabel &
 	PropHideMsg &
+	PropHint &
 	PropName &
 	PropOrientation &
 	PropRadioOptions & // PropRadioOptions becomes required with 2.0
@@ -41,11 +42,11 @@ type RequiredStates = {
 	PropLabelWithExpertSlot &
 	PropOrientation;
 type OptionalStates = {
-	hint: string;
 	on: InputTypeOnDefault;
 	value: StencilUnknown;
 } & PropDisabled &
 	PropHideLabel &
+	PropHint &
 	PropMsg &
 	PropName &
 	PropRequired &

--- a/packages/components/src/schema/components/input-range.ts
+++ b/packages/components/src/schema/components/input-range.ts
@@ -7,6 +7,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -21,7 +22,6 @@ import type { InputTypeOnDefault, KoliBriHIcons, NumberString, Stringified, W3CI
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	max: number | NumberString;
 	min: number | NumberString;
 	msg: Stringified<MsgPropType>;
@@ -33,6 +33,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropName &
 	PropSuggestions &
@@ -46,7 +47,6 @@ type RequiredStates = {
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	max: number;
 	min: number;
 	on: InputTypeOnDefault;
@@ -56,6 +56,7 @@ type OptionalStates = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropMsg &
 	PropName &

--- a/packages/components/src/schema/components/input-text.ts
+++ b/packages/components/src/schema/components/input-text.ts
@@ -21,6 +21,7 @@ import type {
 	PropSuggestions,
 	PropSyncValueBySelector,
 	PropTouched,
+	PropHint,
 } from '../props';
 import type { InputTypeOnDefault, KoliBriHIcons, Stringified, W3CInputValue } from '../types';
 import type { ButtonProps } from './button';
@@ -30,7 +31,6 @@ export type InputTextType = (typeof inputTextTypeOptions)[number];
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	maxLength: number;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
@@ -45,6 +45,7 @@ type OptionalProps = {
 	PropHasCounter &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropId &
 	PropMaxLengthBehavior &
@@ -67,7 +68,6 @@ type RequiredStates = {
 	PropId &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	maxLength: number;
 	on: InputTypeOnDefault;
 	pattern: string;
@@ -79,6 +79,7 @@ type OptionalStates = {
 	PropDisabled &
 	PropHasCounter &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropMaxLengthBehavior &
 	PropMsg &

--- a/packages/components/src/schema/components/select.ts
+++ b/packages/components/src/schema/components/select.ts
@@ -6,6 +6,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -23,7 +24,6 @@ import type { InputTypeOnDefault, KoliBriHIcons, SelectOption, StencilUnknown, S
 
 type RequiredProps = PropLabelWithExpertSlot & PropOptionsWithOptgroup;
 type OptionalProps = {
-	hint: string;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	tabIndex: number;
@@ -32,6 +32,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropMultiple &
 	PropName &
@@ -50,12 +51,12 @@ type RequiredStates = {
 	PropMultiple &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	on: InputTypeOnDefault;
 	tabIndex: number;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideLabel &
+	PropHint &
 	KoliBriHIcons &
 	PropId &
 	PropName &

--- a/packages/components/src/schema/components/single-select.ts
+++ b/packages/components/src/schema/components/single-select.ts
@@ -6,6 +6,7 @@ import type {
 	PropDisabled,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -22,7 +23,6 @@ import type { InputTypeOnDefault, KoliBriHIcons, Option, StencilUnknown, Stringi
 
 type RequiredProps = PropLabelWithExpertSlot & PropOptions;
 type OptionalProps = {
-	hint: string;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	placeholder: string;
@@ -32,6 +32,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHideMsg &
 	PropHideLabel &
+	PropHint &
 	PropHorizontalIcons &
 	PropName &
 	PropRequired &
@@ -46,7 +47,6 @@ type RequiredStates = {
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
-	hint: string;
 	on: InputTypeOnDefault;
 	placeholder: string;
 	hideClearButton: boolean;
@@ -54,6 +54,7 @@ type OptionalStates = {
 	PropDisabled &
 	PropHideLabel &
 	KoliBriHIcons &
+	PropHint &
 	PropId &
 	PropName &
 	PropRequired &

--- a/packages/components/src/schema/components/textarea.ts
+++ b/packages/components/src/schema/components/textarea.ts
@@ -8,6 +8,7 @@ import type {
 	PropHasCounter,
 	PropHideLabel,
 	PropHideMsg,
+	PropHint,
 	PropHorizontalIcons,
 	PropId,
 	PropLabelWithExpertSlot,
@@ -29,7 +30,6 @@ export type CSSResize = (typeof cssResizeOptions)[number];
 
 type RequiredProps = PropLabelWithExpertSlot;
 type OptionalProps = {
-	hint: string;
 	maxLength: number;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
@@ -42,6 +42,7 @@ type OptionalProps = {
 	PropHasCounter &
 	PropHideLabel &
 	PropHideMsg &
+	PropHint &
 	PropHorizontalIcons &
 	PropId &
 	PropMaxLengthBehavior &
@@ -66,7 +67,6 @@ type RequiredStates = {
 	PropLabelWithExpertSlot;
 
 type OptionalStates = {
-	hint: string;
 	maxLength: number;
 	on: InputTypeOnDefault;
 	placeholder: string;
@@ -76,6 +76,7 @@ type OptionalStates = {
 	PropDisabled &
 	PropHasCounter &
 	PropHideLabel &
+	PropHint &
 	PropMaxLengthBehavior &
 	PropMsg &
 	PropName &

--- a/packages/components/src/schema/props/aria-selected.ts
+++ b/packages/components/src/schema/props/aria-selected.ts
@@ -3,7 +3,7 @@ import type { Generic } from 'adopted-style-sheets';
 import { watchBoolean } from '../utils';
 
 /* types */
-type AriaSelectedPropType = boolean;
+export type AriaSelectedPropType = boolean;
 
 /**
  * Marks this element as selected.

--- a/packages/components/src/schema/props/hint.ts
+++ b/packages/components/src/schema/props/hint.ts
@@ -1,0 +1,18 @@
+import type { Generic } from 'adopted-style-sheets';
+
+import { watchString } from '../utils';
+
+/* types */
+export type HintPropType = string;
+
+/**
+ * Provides additional guidance below the form field.
+ */
+export type PropHint = {
+	hint: HintPropType;
+};
+
+/* validator */
+export const validateHint = (component: Generic.Element.Component, value?: HintPropType): void => {
+	watchString(component, '_hint', value);
+};

--- a/packages/components/src/schema/props/index.ts
+++ b/packages/components/src/schema/props/index.ts
@@ -31,6 +31,7 @@ export * from './has-counter';
 export * from './has-icons-when-expanded';
 export * from './hide-label';
 export * from './hide-msg';
+export * from './hint';
 export * from './href';
 export * from './icons';
 export * from './id';


### PR DESCRIPTION
## Summary
Replaces incorrect prop types with the correct typed versions for improved type safety.

## Changes
- Updated prop type references to use the correct typed versions

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Falsche Prop-Typen durch korrekte typisierte Versionen ersetzt.

## Änderungen
- Prop-Typ-Referenzen auf korrekte typisierte Versionen aktualisiert

</details>