### PR TITLE
Apply typed BEM to additional components

### DIFF
--- a/packages/components/src/components/abbr/bem.ts
+++ b/packages/components/src/components/abbr/bem.ts
@@ -1,0 +1,27 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-abbr': {
+		elements: {
+			abbr: { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-abbr': {
+		elements: {
+			abbr: { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_ABBR = bem('kol-abbr');
+const BEM_CLASS_ABBR__ABBR = bem('kol-abbr', 'abbr');
+
+export { bem as genBemAbbr, BEM as BEM_ABBR };
+export { BEM_CLASS_ABBR, BEM_CLASS_ABBR__ABBR };

--- a/packages/components/src/components/abbr/shadow.tsx
+++ b/packages/components/src/components/abbr/shadow.tsx
@@ -3,6 +3,7 @@ import { Component, h, Host, Prop, State, Watch } from '@stencil/core';
 import type { AbbrAPI, AbbrStates, LabelPropType } from '../../schema';
 import { validateLabel } from '../../schema';
 import { KolTooltipWcTag } from '../../core/component-names';
+import { BEM_CLASS_ABBR, BEM_CLASS_ABBR__ABBR } from './bem';
 
 /**
  * @slot - The abbreviation (short form).
@@ -17,9 +18,9 @@ import { KolTooltipWcTag } from '../../core/component-names';
 export class KolAbbr implements AbbrAPI {
 	public render(): JSX.Element {
 		return (
-			<Host class="kol-abbr">
+			<Host class={BEM_CLASS_ABBR}>
 				{/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-				<abbr tabIndex={this.state._label ? 0 : undefined}>
+				<abbr class={BEM_CLASS_ABBR__ABBR} tabIndex={this.state._label ? 0 : undefined}>
 					<slot />
 				</abbr>
 				{this.state._label ? <KolTooltipWcTag aria-hidden="true" _label={this.state._label}></KolTooltipWcTag> : null}

--- a/packages/components/src/components/abbr/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/abbr/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-abbr should render with _label="Text" 1`] = `
 <kol-abbr class="kol-abbr">
   <template shadowrootmode="open">
-    <abbr tabindex="0">
+    <abbr class="kol-abbr__abbr" tabindex="0">
       <slot></slot>
     </abbr>
     <kol-tooltip-wc _label="Text" aria-hidden="true"></kol-tooltip-wc>

--- a/packages/components/src/components/accordion/bem.ts
+++ b/packages/components/src/components/accordion/bem.ts
@@ -1,0 +1,46 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-accordion': {
+		elements: {
+			heading: { modifiers: null };
+			'heading-button': { modifiers: null };
+			content: { modifiers: null };
+			wrapper: { modifiers: null };
+			'wrapper-animation': { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-accordion': {
+		elements: {
+			heading: { modifiers: null },
+			'heading-button': { modifiers: null },
+			content: { modifiers: null },
+			wrapper: { modifiers: null },
+			'wrapper-animation': { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_ACCORDION = bem('kol-accordion');
+const BEM_CLASS_ACCORDION__HEADING = bem('kol-accordion', 'heading');
+const BEM_CLASS_ACCORDION__HEADING_BUTTON = bem('kol-accordion', 'heading-button');
+const BEM_CLASS_ACCORDION__CONTENT = bem('kol-accordion', 'content');
+const BEM_CLASS_ACCORDION__WRAPPER = bem('kol-accordion', 'wrapper');
+const BEM_CLASS_ACCORDION__WRAPPER_ANIMATION = bem('kol-accordion', 'wrapper-animation');
+
+export { bem as genBemAccordion, BEM as BEM_ACCORDION };
+export {
+	BEM_CLASS_ACCORDION,
+	BEM_CLASS_ACCORDION__HEADING,
+	BEM_CLASS_ACCORDION__HEADING_BUTTON,
+	BEM_CLASS_ACCORDION__CONTENT,
+	BEM_CLASS_ACCORDION__WRAPPER,
+	BEM_CLASS_ACCORDION__WRAPPER_ANIMATION,
+};

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -16,6 +16,14 @@ import { nonce } from '../../utils/dev.utils';
 import { watchHeadingLevel } from '../heading/validation';
 import KolCollapsibleFc, { type CollapsibleProps } from '../../functional-components/Collapsible';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
+import {
+	BEM_CLASS_ACCORDION,
+	BEM_CLASS_ACCORDION__CONTENT,
+	BEM_CLASS_ACCORDION__HEADING,
+	BEM_CLASS_ACCORDION__HEADING_BUTTON,
+	BEM_CLASS_ACCORDION__WRAPPER,
+	BEM_CLASS_ACCORDION__WRAPPER_ANIMATION,
+} from './bem';
 
 featureHint(`[KolAccordion] Anfrage nach einer KolAccordionGroup bei dem immer nur ein Accordion geöffnet ist.
 
@@ -69,7 +77,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 
 	public render(): JSX.Element {
 		const { _open, _label, _disabled, _level } = this.state;
-		const rootClass = 'kol-accordion';
+		const rootClass = BEM_CLASS_ACCORDION;
 
 		const props: CollapsibleProps = {
 			id: this.nonce,
@@ -79,15 +87,15 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 			level: _level,
 			onClick: this.handleOnClick,
 			class: rootClass,
-			HeadingProps: { class: `${rootClass}__heading` },
+			HeadingProps: { class: BEM_CLASS_ACCORDION__HEADING },
 			HeadingButtonProps: {
 				ref: this.catchRef,
-				class: `${rootClass}__heading-button`,
+				class: BEM_CLASS_ACCORDION__HEADING_BUTTON,
 			},
 			ContentProps: {
-				class: `${rootClass}__content`,
-				wrapperClass: `${rootClass}__wrapper`,
-				animationClass: `${rootClass}__wrapper-animation`,
+				class: BEM_CLASS_ACCORDION__CONTENT,
+				wrapperClass: BEM_CLASS_ACCORDION__WRAPPER,
+				animationClass: BEM_CLASS_ACCORDION__WRAPPER_ANIMATION,
 			},
 		};
 

--- a/packages/components/src/components/avatar/bem.ts
+++ b/packages/components/src/components/avatar/bem.ts
@@ -1,0 +1,30 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-avatar': {
+		elements: {
+			image: { modifiers: null };
+			initials: { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-avatar': {
+		elements: {
+			image: { modifiers: null },
+			initials: { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_AVATAR = bem('kol-avatar');
+const BEM_CLASS_AVATAR__IMAGE = bem('kol-avatar', 'image');
+const BEM_CLASS_AVATAR__INITIALS = bem('kol-avatar', 'initials');
+
+export { bem as genBemAvatar, BEM as BEM_AVATAR };
+export { BEM_CLASS_AVATAR, BEM_CLASS_AVATAR__IMAGE, BEM_CLASS_AVATAR__INITIALS };

--- a/packages/components/src/components/avatar/component.tsx
+++ b/packages/components/src/components/avatar/component.tsx
@@ -4,6 +4,7 @@ import { Component, h, Prop, State, Watch } from '@stencil/core';
 
 import { translate } from '../../i18n';
 import { formatLabelAsInitials } from './controller';
+import { BEM_CLASS_AVATAR, BEM_CLASS_AVATAR__IMAGE, BEM_CLASS_AVATAR__INITIALS } from './bem';
 
 import type { AvatarAPI, AvatarStates, ImageSourcePropType, LabelPropType } from '../../schema';
 
@@ -17,11 +18,11 @@ import type { AvatarAPI, AvatarStates, ImageSourcePropType, LabelPropType } from
 export class KolAvatarWc implements AvatarAPI {
 	public render(): JSX.Element {
 		return (
-			<div aria-label={translate('kol-avatar-alt', { placeholders: { name: this.state._label } })} class="kol-avatar" role="img">
+			<div aria-label={translate('kol-avatar-alt', { placeholders: { name: this.state._label } })} class={BEM_CLASS_AVATAR} role="img">
 				{this.state._src ? (
-					<img alt="" aria-hidden="true" class="kol-avatar__image" src={this.state._src} />
+					<img alt="" aria-hidden="true" class={BEM_CLASS_AVATAR__IMAGE} src={this.state._src} />
 				) : (
-					<span aria-hidden="true" class="kol-avatar__initials">
+					<span aria-hidden="true" class={BEM_CLASS_AVATAR__INITIALS}>
 						{formatLabelAsInitials(this.state._label.trim())}
 					</span>
 				)}

--- a/packages/components/src/components/badge/bem.ts
+++ b/packages/components/src/components/badge/bem.ts
@@ -1,0 +1,30 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-badge': {
+		elements: {
+			label: { modifiers: null };
+			'smart-button': { modifiers: null };
+		};
+		modifiers: Set<'has-smart-button'>;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-badge': {
+		elements: {
+			label: { modifiers: null },
+			'smart-button': { modifiers: null },
+		},
+		modifiers: new Set(['has-smart-button']),
+	},
+};
+
+const BEM_CLASS_BADGE = bem('kol-badge');
+const BEM_CLASS_BADGE__LABEL = bem('kol-badge', 'label');
+const BEM_CLASS_BADGE__SMART_BUTTON = bem('kol-badge', 'smart-button');
+
+export { bem as genBemBadge, BEM as BEM_BADGE };
+export { BEM_CLASS_BADGE, BEM_CLASS_BADGE__LABEL, BEM_CLASS_BADGE__SMART_BUTTON };

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -7,7 +7,7 @@ import { nonce } from '../../utils/dev.utils';
 
 import type { JSX } from '@stencil/core';
 import { KolButtonWcTag } from '../../core/component-names';
-import clsx from 'clsx';
+import { BEM_CLASS_BADGE__LABEL, BEM_CLASS_BADGE__SMART_BUTTON, genBemBadge } from './bem';
 featureHint(`[KolBadge] Optimierung des _color-Properties (rgba, rgb, hex usw.).`);
 
 @Component({
@@ -25,7 +25,7 @@ export class KolBadge implements BadgeAPI {
 	private renderSmartButton(props: ButtonProps): JSX.Element {
 		return (
 			<KolButtonWcTag
-				class="kol-badge__smart-button"
+				class={BEM_CLASS_BADGE__SMART_BUTTON}
 				_ariaControls={this.id}
 				_customClass={props._customClass}
 				_disabled={props._disabled}
@@ -45,15 +45,15 @@ export class KolBadge implements BadgeAPI {
 
 		return (
 			<span
-				class={clsx('kol-badge', {
-					'kol-badge--has-smart-button': typeof this.state._smartButton === 'object' && this.state._smartButton !== null,
+				class={genBemBadge('kol-badge', {
+					'has-smart-button': hasSmartButton,
 				})}
 				style={{
 					backgroundColor: this.bgColorStr,
 					color: this.colorStr,
 				}}
 			>
-				<KolSpanFc class="kol-badge__label" id={hasSmartButton ? this.id : undefined} allowMarkdown icons={this.state._icons} label={this._label} />
+				<KolSpanFc class={BEM_CLASS_BADGE__LABEL} id={hasSmartButton ? this.id : undefined} allowMarkdown icons={this.state._icons} label={this._label} />
 				{hasSmartButton && this.renderSmartButton(this.state._smartButton as ButtonProps)}
 			</span>
 		);

--- a/packages/components/src/components/breadcrumb/bem.ts
+++ b/packages/components/src/components/breadcrumb/bem.ts
@@ -1,0 +1,46 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-breadcrumb': {
+		elements: {
+			list: { modifiers: null };
+			'list-element': { modifiers: null };
+			'list-element-span': { modifiers: null };
+			link: { modifiers: null };
+			icon: { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-breadcrumb': {
+		elements: {
+			list: { modifiers: null },
+			'list-element': { modifiers: null },
+			'list-element-span': { modifiers: null },
+			link: { modifiers: null },
+			icon: { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_BREADCRUMB = bem('kol-breadcrumb');
+const BEM_CLASS_BREADCRUMB__LIST = bem('kol-breadcrumb', 'list');
+const BEM_CLASS_BREADCRUMB__LIST_ELEMENT = bem('kol-breadcrumb', 'list-element');
+const BEM_CLASS_BREADCRUMB__LIST_ELEMENT_SPAN = bem('kol-breadcrumb', 'list-element-span');
+const BEM_CLASS_BREADCRUMB__LINK = bem('kol-breadcrumb', 'link');
+const BEM_CLASS_BREADCRUMB__ICON = bem('kol-breadcrumb', 'icon');
+
+export { bem as genBemBreadcrumb, BEM as BEM_BREADCRUMB };
+export {
+	BEM_CLASS_BREADCRUMB,
+	BEM_CLASS_BREADCRUMB__LIST,
+	BEM_CLASS_BREADCRUMB__LIST_ELEMENT,
+	BEM_CLASS_BREADCRUMB__LIST_ELEMENT_SPAN,
+	BEM_CLASS_BREADCRUMB__LINK,
+	BEM_CLASS_BREADCRUMB__ICON,
+};

--- a/packages/components/src/components/breadcrumb/shadow.tsx
+++ b/packages/components/src/components/breadcrumb/shadow.tsx
@@ -7,6 +7,14 @@ import { watchNavLinks } from '../nav/validation';
 
 import type { JSX } from '@stencil/core';
 import { KolIconTag, KolLinkWcTag } from '../../core/component-names';
+import {
+	BEM_CLASS_BREADCRUMB,
+	BEM_CLASS_BREADCRUMB__ICON,
+	BEM_CLASS_BREADCRUMB__LINK,
+	BEM_CLASS_BREADCRUMB__LIST,
+	BEM_CLASS_BREADCRUMB__LIST_ELEMENT,
+	BEM_CLASS_BREADCRUMB__LIST_ELEMENT_SPAN,
+} from './bem';
 
 @Component({
 	tag: 'kol-breadcrumb',
@@ -19,13 +27,13 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 	private readonly renderLink = (link: BreadcrumbLinkProps, index: number): JSX.Element => {
 		const lastIndex = this.state._links.length - 1;
 		return (
-			<li class="kol-breadcrumb__list-element" key={index}>
-				{index !== 0 && <KolIconTag class="kol-breadcrumb__icon" _label="" _icons="codicon codicon-chevron-right" />}
+			<li class={BEM_CLASS_BREADCRUMB__LIST_ELEMENT} key={index}>
+				{index !== 0 && <KolIconTag class={BEM_CLASS_BREADCRUMB__ICON} _label="" _icons="codicon codicon-chevron-right" />}
 				{index === lastIndex ? (
-					<span class="kol-breadcrumb__list-element-span">
+					<span class={BEM_CLASS_BREADCRUMB__LIST_ELEMENT_SPAN}>
 						{link._hideLabel ? (
 							<KolIconTag
-								class="kol-breadcrumb__icon"
+								class={BEM_CLASS_BREADCRUMB__ICON}
 								_label={link._label}
 								_icons={typeof link._icons === 'string' ? link._icons : 'codicon codicon-symbol-event'}
 							/>
@@ -34,7 +42,7 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 						)}
 					</span>
 				) : (
-					<KolLinkWcTag class="kol-breadcrumb__link" _linkVariant="standalone" {...link}></KolLinkWcTag>
+					<KolLinkWcTag class={BEM_CLASS_BREADCRUMB__LINK} _linkVariant="standalone" {...link}></KolLinkWcTag>
 				)}
 			</li>
 		);
@@ -42,8 +50,8 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 
 	public render(): JSX.Element {
 		return (
-			<nav class="kol-breadcrumb" aria-label={this.state._label}>
-				<ul class="kol-breadcrumb__list">
+			<nav class={BEM_CLASS_BREADCRUMB} aria-label={this.state._label}>
+				<ul class={BEM_CLASS_BREADCRUMB__LIST}>
 					{this.state._links.length === 0 && (
 						<li>
 							<KolIconTag class="kol-breadcrumb_icon" _label="" _icons="codicon codicon-home" />…

--- a/packages/components/src/components/card/bem.ts
+++ b/packages/components/src/components/card/bem.ts
@@ -1,0 +1,36 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-card': {
+		elements: {
+			header: { modifiers: null };
+			headline: { modifiers: null };
+			content: { modifiers: null };
+			'close-button': { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-card': {
+		elements: {
+			header: { modifiers: null },
+			headline: { modifiers: null },
+			content: { modifiers: null },
+			'close-button': { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_CARD = bem('kol-card');
+const BEM_CLASS_CARD__HEADER = bem('kol-card', 'header');
+const BEM_CLASS_CARD__HEADLINE = bem('kol-card', 'headline');
+const BEM_CLASS_CARD__CONTENT = bem('kol-card', 'content');
+const BEM_CLASS_CARD__CLOSE_BUTTON = bem('kol-card', 'close-button');
+
+export { bem as genBemCard, BEM as BEM_CARD };
+export { BEM_CLASS_CARD, BEM_CLASS_CARD__HEADER, BEM_CLASS_CARD__HEADLINE, BEM_CLASS_CARD__CONTENT, BEM_CLASS_CARD__CLOSE_BUTTON };

--- a/packages/components/src/components/card/component.tsx
+++ b/packages/components/src/components/card/component.tsx
@@ -9,6 +9,7 @@ import { watchHeadingLevel } from '../heading/validation';
 import { KolButtonWcTag } from '../../core/component-names';
 import { KolHeadingFc } from '../../functional-components';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
+import { BEM_CLASS_CARD, BEM_CLASS_CARD__CLOSE_BUTTON, BEM_CLASS_CARD__CONTENT, BEM_CLASS_CARD__HEADER, BEM_CLASS_CARD__HEADLINE } from './bem';
 
 /**
  * @slot - Ermöglicht das Einfügen beliebigen HTML's in den Inhaltsbereich der Card.
@@ -36,18 +37,18 @@ export class KolCard implements CardAPI {
 
 	public render(): JSX.Element {
 		return (
-			<div class="kol-card">
-				<div class="kol-card__header">
-					<KolHeadingFc class="kol-card__headline" level={this.state._level}>
+			<div class={BEM_CLASS_CARD}>
+				<div class={BEM_CLASS_CARD__HEADER}>
+					<KolHeadingFc class={BEM_CLASS_CARD__HEADLINE} level={this.state._level}>
 						{this.state._label}
 					</KolHeadingFc>
 				</div>
-				<div class="kol-card__content">
+				<div class={BEM_CLASS_CARD__CONTENT}>
 					<slot />
 				</div>
 				{this.state._hasCloser && (
 					<KolButtonWcTag
-						class="kol-card__close-button"
+						class={BEM_CLASS_CARD__CLOSE_BUTTON}
 						data-testid="card-close-button"
 						_hideLabel
 						_icons={{

--- a/packages/components/src/components/details/bem.ts
+++ b/packages/components/src/components/details/bem.ts
@@ -1,0 +1,46 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-details': {
+		elements: {
+			heading: { modifiers: null };
+			'heading-button': { modifiers: null };
+			content: { modifiers: null };
+			wrapper: { modifiers: null };
+			'wrapper-animation': { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-details': {
+		elements: {
+			heading: { modifiers: null },
+			'heading-button': { modifiers: null },
+			content: { modifiers: null },
+			wrapper: { modifiers: null },
+			'wrapper-animation': { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_DETAILS = bem('kol-details');
+const BEM_CLASS_DETAILS__HEADING = bem('kol-details', 'heading');
+const BEM_CLASS_DETAILS__HEADING_BUTTON = bem('kol-details', 'heading-button');
+const BEM_CLASS_DETAILS__CONTENT = bem('kol-details', 'content');
+const BEM_CLASS_DETAILS__WRAPPER = bem('kol-details', 'wrapper');
+const BEM_CLASS_DETAILS__WRAPPER_ANIMATION = bem('kol-details', 'wrapper-animation');
+
+export { bem as genBemDetails, BEM as BEM_DETAILS };
+export {
+	BEM_CLASS_DETAILS,
+	BEM_CLASS_DETAILS__HEADING,
+	BEM_CLASS_DETAILS__HEADING_BUTTON,
+	BEM_CLASS_DETAILS__CONTENT,
+	BEM_CLASS_DETAILS__WRAPPER,
+	BEM_CLASS_DETAILS__WRAPPER_ANIMATION,
+};

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -1,10 +1,19 @@
 import { Component, Element, h, type JSX, Method, Prop, State, Watch } from '@stencil/core';
+import clsx from 'clsx';
 import type { DetailsAPI, DetailsCallbacksPropType, DetailsStates, DisabledPropType, FocusableElement, HeadingLevel, LabelPropType } from '../../schema';
 import { validateDetailsCallbacks, validateDisabled, validateLabel, validateOpen } from '../../schema';
 import KolCollapsibleFc, { type CollapsibleProps } from '../../functional-components/Collapsible';
 import { nonce } from '../../utils/dev.utils';
 import { watchHeadingLevel } from '../heading/validation';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
+import {
+	BEM_CLASS_DETAILS,
+	BEM_CLASS_DETAILS__CONTENT,
+	BEM_CLASS_DETAILS__HEADING,
+	BEM_CLASS_DETAILS__HEADING_BUTTON,
+	BEM_CLASS_DETAILS__WRAPPER,
+	BEM_CLASS_DETAILS__WRAPPER_ANIMATION,
+} from './bem';
 
 /**
  * @slot - Der Inhalt, der in der Detailbeschreibung angezeigt wird.
@@ -57,8 +66,6 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	public render(): JSX.Element {
 		const { _open, _label, _disabled, _level } = this.state;
 
-		const rootClass = 'kol-details';
-
 		const props: CollapsibleProps = {
 			id: this.nonce,
 			label: _label,
@@ -66,17 +73,17 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 			disabled: _disabled,
 			level: _level,
 			onClick: this.handleOnClick,
-			class: rootClass,
-			HeadingProps: { class: `${rootClass}__heading` },
+			class: BEM_CLASS_DETAILS,
+			HeadingProps: { class: BEM_CLASS_DETAILS__HEADING },
 			HeadingButtonProps: {
 				ref: this.catchRef,
-				class: `${rootClass}__heading-button`,
+				class: BEM_CLASS_DETAILS__HEADING_BUTTON,
 				_icons: 'codicon codicon-chevron-right',
 			},
 			ContentProps: {
-				class: `${rootClass}__content indented-text`,
-				wrapperClass: `${rootClass}__wrapper`,
-				animationClass: `${rootClass}__wrapper-animation`,
+				class: clsx(BEM_CLASS_DETAILS__CONTENT, 'indented-text'),
+				wrapperClass: BEM_CLASS_DETAILS__WRAPPER,
+				animationClass: BEM_CLASS_DETAILS__WRAPPER_ANIMATION,
 			},
 		};
 

--- a/packages/components/src/components/drawer/bem.ts
+++ b/packages/components/src/components/drawer/bem.ts
@@ -1,0 +1,33 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-drawer': {
+		elements: {
+			dialog: { modifiers: null };
+			wrapper: { modifiers: Set<'left' | 'right' | 'top' | 'bottom' | 'open' | 'is-closing'> };
+			content: { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-drawer': {
+		elements: {
+			dialog: { modifiers: null },
+			wrapper: { modifiers: new Set(['left', 'right', 'top', 'bottom', 'open', 'is-closing']) },
+			content: { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_DRAWER = bem('kol-drawer');
+const BEM_CLASS_DRAWER__DIALOG = bem('kol-drawer', 'dialog');
+const BEM_CLASS_DRAWER__WRAPPER = bem('kol-drawer', 'wrapper');
+const BEM_CLASS_DRAWER__CONTENT = bem('kol-drawer', 'content');
+
+export { bem as genBemDrawer, BEM as BEM_DRAWER };
+export { BEM_CLASS_DRAWER, BEM_CLASS_DRAWER__DIALOG, BEM_CLASS_DRAWER__WRAPPER, BEM_CLASS_DRAWER__CONTENT };

--- a/packages/components/src/components/drawer/shadow.tsx
+++ b/packages/components/src/components/drawer/shadow.tsx
@@ -6,6 +6,7 @@ import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stenci
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import clsx from 'clsx';
 import { KolCardWcTag } from '../../core/component-names';
+import { genBemDrawer as bem, BEM_CLASS_DRAWER, BEM_CLASS_DRAWER__CONTENT, BEM_CLASS_DRAWER__DIALOG, BEM_CLASS_DRAWER__WRAPPER } from './bem';
 
 /**
  * @slot - The Content of drawer.
@@ -49,14 +50,17 @@ export class KolDrawer implements DrawerAPI {
 
 	private getWrapperRef = (el: HTMLKolCardWcElement | undefined) => (this.dialogWrapperElement = el as HTMLKolCardWcElement);
 	private renderDialogContent() {
-		const align = this.state._align as string;
+		const align = this.state._align as 'left' | 'right' | 'top' | 'bottom';
+		const wrapperClass = bem('kol-drawer', 'wrapper', {
+			[align]: true,
+			open: this.state._open,
+			'is-closing': this.state._open === false,
+		});
+
 		return (
 			<KolCardWcTag
 				ref={this.getWrapperRef}
-				class={clsx(`kol-drawer__wrapper`, `kol-drawer__wrapper--${align}`, {
-					'kol-drawer__wrapper--open': this.state._open,
-					'kol-drawer__wrapper--is-closing': this.state._open === false,
-				})}
+				class={clsx(BEM_CLASS_DRAWER__WRAPPER, wrapperClass)}
 				_label={this.state._label}
 				_hasCloser={this.state._hasCloser}
 				_on={{
@@ -65,7 +69,7 @@ export class KolDrawer implements DrawerAPI {
 					},
 				}}
 			>
-				<div class="kol-drawer__content">
+				<div class={BEM_CLASS_DRAWER__CONTENT}>
 					<slot />
 				</div>
 			</KolCardWcTag>
@@ -80,8 +84,8 @@ export class KolDrawer implements DrawerAPI {
 	};
 	public render(): JSX.Element {
 		return (
-			<Host class="kol-drawer">
-				<dialog aria-label={this.state._label} class="kol-drawer__dialog" ref={this.getRef}>
+			<Host class={BEM_CLASS_DRAWER}>
+				<dialog aria-label={this.state._label} class={BEM_CLASS_DRAWER__DIALOG} ref={this.getRef}>
 					{this.renderDialogContent()}
 				</dialog>
 			</Host>

--- a/packages/components/src/components/form/bem.ts
+++ b/packages/components/src/components/form/bem.ts
@@ -1,0 +1,33 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-form': {
+		elements: {
+			alert: { modifiers: null };
+			link: { modifiers: null };
+			'mandatory-fields-hint': { modifiers: null };
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-form': {
+		elements: {
+			alert: { modifiers: null },
+			link: { modifiers: null },
+			'mandatory-fields-hint': { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_FORM = bem('kol-form');
+const BEM_CLASS_FORM__ALERT = bem('kol-form', 'alert');
+const BEM_CLASS_FORM__LINK = bem('kol-form', 'link');
+const BEM_CLASS_FORM__MANDATORY_FIELDS_HINT = bem('kol-form', 'mandatory-fields-hint');
+
+export { bem as genBemForm, BEM as BEM_FORM };
+export { BEM_CLASS_FORM, BEM_CLASS_FORM__ALERT, BEM_CLASS_FORM__LINK, BEM_CLASS_FORM__MANDATORY_FIELDS_HINT };

--- a/packages/components/src/components/form/shadow.tsx
+++ b/packages/components/src/components/form/shadow.tsx
@@ -6,6 +6,7 @@ import { translate } from '../../i18n';
 
 import { KolLinkWcTag } from '../../core/component-names';
 import KolAlertFc from '../../functional-components/Alert';
+import { BEM_CLASS_FORM, BEM_CLASS_FORM__ALERT, BEM_CLASS_FORM__LINK, BEM_CLASS_FORM__MANDATORY_FIELDS_HINT } from './bem';
 import type { ErrorListPropType, FormAPI, FormStates, KoliBriFormCallbacks, Stringified } from '../../schema';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 
@@ -63,13 +64,13 @@ export class KolForm implements FormAPI {
 
 	private renderErrorList(errorList?: ErrorListPropType[]): JSX.Element {
 		return (
-			<KolAlertFc class="kol-form__alert" ref={this.setBlockElement} type="error" variant="card" label={this.translateErrorListMessage}>
+			<KolAlertFc class={BEM_CLASS_FORM__ALERT} ref={this.setBlockElement} type="error" variant="card" label={this.translateErrorListMessage}>
 				<nav aria-label={this.translateErrorList}>
 					<ul>
 						{errorList?.map((error, index) => (
 							<li key={index}>
 								<KolLinkWcTag
-									class="kol-form__link"
+									class={BEM_CLASS_FORM__LINK}
 									_href=""
 									_label={error.message}
 									_on={{ onClick: typeof error.selector === 'string' ? () => this.handleLinkClick(String(error.selector)) : error.selector }}
@@ -85,14 +86,14 @@ export class KolForm implements FormAPI {
 
 	private renderFormElement(): JSX.Element {
 		return (
-			<form class="kol-form" method="post" onSubmit={this.onSubmit} onReset={this.onReset} autoComplete="off" noValidate>
+			<form class={BEM_CLASS_FORM} method="post" onSubmit={this.onSubmit} onReset={this.onReset} autoComplete="off" noValidate>
 				{this.state._requiredText === true ? (
 					<p>
-						<div class="kol-form__mandatory-fields-hint">{this.translateFormDescription}</div>
+						<div class={BEM_CLASS_FORM__MANDATORY_FIELDS_HINT}>{this.translateFormDescription}</div>
 					</p>
 				) : typeof this.state._requiredText === 'string' && this.state._requiredText.length > 0 ? (
 					<p>
-						<div class="kol-form__mandatory-fields-hint">{this.state._requiredText}</div>
+						<div class={BEM_CLASS_FORM__MANDATORY_FIELDS_HINT}>{this.state._requiredText}</div>
 					</p>
 				) : null}
 				<slot />

--- a/packages/components/src/components/image/bem.ts
+++ b/packages/components/src/components/image/bem.ts
@@ -1,0 +1,19 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-image': {
+		elements: Record<string, never>;
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-image': { elements: {}, modifiers: null },
+};
+
+const BEM_CLASS_IMAGE = bem('kol-image');
+
+export { bem as genBemImage, BEM as BEM_IMAGE };
+export { BEM_CLASS_IMAGE };

--- a/packages/components/src/components/image/shadow.tsx
+++ b/packages/components/src/components/image/shadow.tsx
@@ -3,6 +3,7 @@ import { validateAlt, validateImageSizes, validateImageSrcset, validateImageSour
 import { Component, h, Prop, State, Watch } from '@stencil/core';
 
 import type { JSX } from '@stencil/core';
+import { BEM_CLASS_IMAGE } from './bem';
 @Component({
 	tag: 'kol-image',
 	styleUrls: {
@@ -80,7 +81,7 @@ export class KolImage implements ImageAPI {
 	public render(): JSX.Element {
 		return (
 			<img
-				class="kol-image"
+				class={BEM_CLASS_IMAGE}
 				alt={this.state._alt}
 				loading={this.state._loading}
 				sizes={this.state._sizes}

--- a/packages/components/src/functional-components/Heading/Heading.tsx
+++ b/packages/components/src/functional-components/Heading/Heading.tsx
@@ -1,5 +1,6 @@
 import { type FunctionalComponent as FC, h } from '@stencil/core';
 import clsx from 'clsx';
+import { genBemHeading as bem, BEM_CLASS_HEADLINE, BEM_CLASS_HEADING_GROUP } from './bem';
 import type { JSXBase } from '@stencil/core/internal';
 import type { HeadingLevel } from '../../schema';
 
@@ -58,7 +59,7 @@ const KolHeadlineFc: FC<HeadlineProps> = ({ class: classNames, level = MIN_HEADI
 	const HeadlineTag = getHeadlineTag(level);
 
 	return (
-		<HeadlineTag class={clsx('kol-headline', `kol-headline--${HeadlineTag}`, classNames)} {...other}>
+		<HeadlineTag class={clsx(BEM_CLASS_HEADLINE, bem('kol-headline', { [HeadlineTag]: true }), classNames)} {...other}>
 			{children}
 		</HeadlineTag>
 	);
@@ -72,7 +73,7 @@ const KolHeadlineFc: FC<HeadlineProps> = ({ class: classNames, level = MIN_HEADI
  */
 const KolSecondaryHeadlineFc: FC<SecondaryHeadlineProps> = ({ class: classNames, ...other }, children) => {
 	return (
-		<p class={clsx('kol-headline kol-headline--group kol-headline--secondary', classNames)} {...other}>
+		<p class={clsx(BEM_CLASS_HEADLINE, bem('kol-headline', { group: true, secondary: true }), classNames)} {...other}>
 			{children}
 		</p>
 	);
@@ -95,7 +96,7 @@ const KolHeadingFc: FC<HeadingProps> = (
 
 	if (!secondaryHeadline) {
 		return (
-			<KolHeadlineFc class={clsx(classNames, 'kol-headline--single')} {...headlineProps}>
+			<KolHeadlineFc class={clsx(classNames, bem('kol-headline', { single: true }))} {...headlineProps}>
 				{children}
 			</KolHeadlineFc>
 		);
@@ -103,13 +104,13 @@ const KolHeadingFc: FC<HeadingProps> = (
 
 	const { class: groupClassNames, ...groupOthers } = HeadingGroupProps;
 	const headlineGroupProps: HGroupProps = {
-		class: clsx('kol-heading-group', groupClassNames),
+		class: clsx(BEM_CLASS_HEADING_GROUP, groupClassNames),
 		...groupOthers,
 	};
 
 	return (
 		<hgroup {...headlineGroupProps}>
-			<KolHeadlineFc class={clsx(classNames, 'kol-headline--group', 'kol-headline--primary')} {...headlineProps}>
+			<KolHeadlineFc class={clsx(classNames, bem('kol-headline', { group: true, primary: true }))} {...headlineProps}>
 				{children}
 			</KolHeadlineFc>
 			<KolSecondaryHeadlineFc {...SecondaryHeadlineProps}>{secondaryHeadline}</KolSecondaryHeadlineFc>

--- a/packages/components/src/functional-components/Heading/bem.ts
+++ b/packages/components/src/functional-components/Heading/bem.ts
@@ -1,0 +1,28 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-headline': {
+		elements: Record<string, never>;
+		modifiers: Set<'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'strong' | 'group' | 'primary' | 'secondary' | 'single'>;
+	};
+	'kol-heading-group': {
+		elements: Record<string, never>;
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-headline': {
+		elements: {},
+		modifiers: new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong', 'group', 'primary', 'secondary', 'single']),
+	},
+	'kol-heading-group': { elements: {}, modifiers: null },
+};
+
+const BEM_CLASS_HEADLINE = bem('kol-headline');
+const BEM_CLASS_HEADING_GROUP = bem('kol-heading-group');
+
+export { bem as genBemHeading, BEM as BEM_HEADING };
+export { BEM_CLASS_HEADLINE, BEM_CLASS_HEADING_GROUP };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -27,3 +27,7 @@ export { BEM_AVATAR } from './components/avatar/bem';
 export { BEM_BADGE } from './components/badge/bem';
 export { BEM_BREADCRUMB } from './components/breadcrumb/bem';
 export { BEM_CARD } from './components/card/bem';
+export { BEM_DRAWER } from './components/drawer/bem';
+export { BEM_FORM } from './components/form/bem';
+export { BEM_HEADING } from './functional-components/Heading/bem';
+export { BEM_IMAGE } from './components/image/bem';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -20,3 +20,10 @@ export type {
 } from './schema';
 export { BEM_ALERT } from './functional-components/Alert/bem';
 export { BEM_ICON } from './components/icon/bem';
+export { BEM_DETAILS } from './components/details/bem';
+export { BEM_ABBR } from './components/abbr/bem';
+export { BEM_ACCORDION } from './components/accordion/bem';
+export { BEM_AVATAR } from './components/avatar/bem';
+export { BEM_BADGE } from './components/badge/bem';
+export { BEM_BREADCRUMB } from './components/breadcrumb/bem';
+export { BEM_CARD } from './components/card/bem';


### PR DESCRIPTION
This pull request introduces the use of the `typed-bem` library across multiple components to standardize BEM (Block Element Modifier) class name generation. The changes improve maintainability and consistency of class naming conventions. The most important updates involve defining schemas for BEM class names, integrating these schemas into components, and updating snapshots to reflect the new class names.

### Integration of `typed-bem` for BEM Class Name Generation:

#### Abbr Component:
- Added `bem.ts` file to define BEM schema and generate class names for `kol-abbr` and its elements (`abbr`). Updated `shadow.tsx` to use the new class names (`BEM_CLASS_ABBR`, `BEM_CLASS_ABBR__ABBR`). [[1]](diffhunk://#diff-be60e8555b7606188bdd95cdf589bb67e724299498c25c6d346474acfe51f5a1R1-R27) [[2]](diffhunk://#diff-526e53cd34821be2715e5ff13d9b1bbbefe4fa427e2c0f19d8f9e3994d61d5e2R6) [[3]](diffhunk://#diff-526e53cd34821be2715e5ff13d9b1bbbefe4fa427e2c0f19d8f9e3994d61d5e2L20-R23)
- Updated test snapshots to use the new class names.

#### Accordion Component:
- Added `bem.ts` file to define BEM schema for `kol-accordion` and its elements (`heading`, `heading-button`, `content`, `wrapper`, `wrapper-animation`). Updated `shadow.tsx` to use the new class names. [[1]](diffhunk://#diff-8f978f85534586eca222cb5c0c639d23767a978d5e66ee2834a2ad5bb8ef2590R1-R46) [[2]](diffhunk://#diff-6c08df88d508313db54cb7517171d0be461bd09b57ee1145c2b16ec8c3002f9aR19-R26) [[3]](diffhunk://#diff-6c08df88d508313db54cb7517171d0be461bd09b57ee1145c2b16ec8c3002f9aL72-R80) [[4]](diffhunk://#diff-6c08df88d508313db54cb7517171d0be461bd09b57ee1145c2b16ec8c3002f9aL82-R98)

#### Avatar Component:
- Added `bem.ts` file to define BEM schema for `kol-avatar` and its elements (`image`, `initials`). Updated `component.tsx` to use the new class names. [[1]](diffhunk://#diff-8c738346f8345a38f4bcef2b576e16df7d7e1d7e45bddc5b8e254c9ed81e5702R1-R30) [[2]](diffhunk://#diff-c455f6e456cd31db2f67f9e7e637256b08765f53f66d0cd46b3a8da42ec6a195R7) [[3]](diffhunk://#diff-c455f6e456cd31db2f67f9e7e637256b08765f53f66d0cd46b3a8da42ec6a195L20-R25)

#### Badge Component:
- Added `bem.ts` file to define BEM schema for `kol-badge`, including modifiers (`has-smart-button`) and elements (`label`, `smart-button`). Updated `shadow.tsx` to use the new class names. [[1]](diffhunk://#diff-c5f27b6d67337d5f2eb6efd75bc20b616c12e6a098db1e7620b6406da6d3912dR1-R30) [[2]](diffhunk://#diff-7722aa43999b268c1586cfb208e47b750a9b3047fd1a0b8ca8df8eb27747a7b6L10-R10) [[3]](diffhunk://#diff-7722aa43999b268c1586cfb208e47b750a9b3047fd1a0b8ca8df8eb27747a7b6L28-R28) [[4]](diffhunk://#diff-7722aa43999b268c1586cfb208e47b750a9b3047fd1a0b8ca8df8eb27747a7b6L48-R56)

#### Breadcrumb Component:
- Added `bem.ts` file to define BEM schema for `kol-breadcrumb` and its elements (`list`, `list-element`, `list-element-span`, `link`, `icon`). Updated `shadow.tsx` to use the new class names. [[1]](diffhunk://#diff-b68b5a83d17f408b9cc8feebe3489348e0794a8f55fe3b461bb5327d666e572cR1-R46) [[2]](diffhunk://#diff-343a84d5b3445dab79594defc57f4f343212bc7a2ddfe54a5ce2b08fef6911b0R10-R17) [[3]](diffhunk://#diff-343a84d5b3445dab79594defc57f4f343212bc7a2ddfe54a5ce2b08fef6911b0L22-R36) [[4]](diffhunk://#diff-343a84d5b3445dab79594defc57f4f343212bc7a2ddfe54a5ce2b08fef6911b0L37-R54)

#### Card Component:
- Added `bem.ts` file to define BEM schema for `kol-card` and its elements (`header`, `headline`, `content`, `close-button`). Updated `component.tsx` to use the new class names. [[1]](diffhunk://#diff-e96f629894394049fec777658c59c3a0f470ef3aa9c4eb15cb3326f5d13ece3bR1-R36) [[2]](diffhunk://#diff-a6c490195626b51c5d8f5fdf5b4116269a6ab6402826f9083304e79a09fade50R12) [[3]](diffhunk://#diff-a6c490195626b51c5d8f5fdf5b4116269a6ab6402826f9083304e79a09fade50L39-R51)

#### Details Component:
- Added `bem.ts` file to define BEM schema for `kol-details` and its elements (`heading`, `heading-button`, `content`, `wrapper`, `wrapper-animation`). Updated `shadow.tsx` to use the new class names. [[1]](diffhunk://#diff-abd710ef40b40abcaac585f4fee6426b31f21c3d74d57164089d3b656b58102fR1-R46) [[2]](diffhunk://#diff-bd72adaedf30e6eaa204c68073c2b1c03a89e33dfd7f6415b9679cae4c0bf08cR2-R16)
------
https://chatgpt.com/codex/tasks/task_e_687fe06549fc832bb8868ffe8d642704