### PR TITLE
ci: remove concurrency in CLA checks

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,10 +6,6 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
-concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
-  cancel-in-progress: true
-
 jobs:
   cla:
     if: github.repository == 'public-ui/kolibri'


### PR DESCRIPTION
## Summary
Removes the concurrency setting from the CLA (Contributor License Agreement) check workflow.

## Changes
- Removed concurrency configuration from CLA check CI workflow

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Concurrency-Einstellung aus dem CLA-Prüf-Workflow entfernt.

## Änderungen
- Concurrency-Konfiguration aus dem CLA-CI-Workflow entfernt

</details>