### PR TITLE
fix(input): fix counter not updating when value is set to empty string

### DIFF
--- a/packages/components/src/components/input-password/controller.ts
+++ b/packages/components/src/components/input-password/controller.ts
@@ -17,7 +17,7 @@ export class InputPasswordController extends InputIconController implements Inpu
 	}
 
 	protected afterSyncCharCounter = () => {
-		if (typeof this.component._value === 'string' && this.component._value.length > 0) {
+		if (typeof this.component._value === 'string') {
 			this.component.state._currentLength = this.component._value.length;
 			this.component.state._currentLengthDebounced = this.component._value.length;
 		}

--- a/packages/components/src/components/textarea/controller.ts
+++ b/packages/components/src/components/textarea/controller.ts
@@ -25,7 +25,7 @@ export class TextareaController extends InputIconController implements TextareaW
 	}
 
 	private afterSyncCharCounter = () => {
-		if (typeof this.component._value === 'string' && this.component._value.length > 0) {
+		if (typeof this.component._value === 'string') {
 			this.component.state._currentLength = this.component._value.length;
 			this.component.state._currentLengthDebounced = this.component._value.length;
 		}


### PR DESCRIPTION
## Summary
Fixes a bug where the input counter did not update when the value was programmatically set to an empty string.

## Changes
- Fixed counter update when value is set to empty string

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Fehler behoben, bei dem der Eingabe-Zähler nicht aktualisiert wurde, wenn der Wert programmatisch auf eine leere Zeichenkette gesetzt wurde.

## Änderungen
- Zähler-Aktualisierung bei Setzen auf leeren String korrigiert

</details>