### PR TITLE
fix(tooltip): add layout containment to prevent container query positioning issues

### DIFF
--- a/packages/components/src/components/tooltip/style.scss
+++ b/packages/components/src/components/tooltip/style.scss
@@ -2,6 +2,7 @@
 
 @layer kol-component {
 	.kol-tooltip {
+		contain: layout;
 		display: contents;
 
 		&__floating {

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -3,24 +3,26 @@ import { ChangeTabindex } from './change-tabindex';
 import { CustomTooltipWidth } from './custom-tooltip-width';
 import { DisabledInteractiveElements } from './disabled-interactive-elements';
 import { FocusElements } from './focus-elements';
-import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
 import { InputGroupWithError } from './input-group-with-error';
 import { InputsGetValue } from './inputs-get-value';
 import { PerformanceTest } from './performance-test';
 import { SameHeightOfAllInteractiveElements } from './same-height-of-all-interactive-elements';
 import { StaticForm } from './static-form';
+import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
+import { TooltipPositioning } from './tooltip-positioning';
 
 export const SCENARIO_ROUTES: Routes = {
 	scenarios: {
+		'change-tabindex': ChangeTabindex,
 		'custom-tooltip-width': CustomTooltipWidth,
 		'disabled-interactive-scenario': DisabledInteractiveElements,
 		'focus-elements': FocusElements,
 		'input-group-with-error': InputGroupWithError,
 		'inputs-get-value': InputsGetValue,
+		'performance-test': PerformanceTest,
+		'same-height-of-all-interactive-elements': SameHeightOfAllInteractiveElements,
 		'static-form': StaticForm,
 		'table-horizontal-scrollbar-advanced': TableHorizontalScrollAdvanced,
-		'change-tabindex': ChangeTabindex,
-		'same-height-of-all-interactive-elements': SameHeightOfAllInteractiveElements,
-		'performance-test': PerformanceTest,
+		'tooltip-positioning': TooltipPositioning,
 	},
 };

--- a/packages/samples/react/src/scenarios/tooltip-positioning.tsx
+++ b/packages/samples/react/src/scenarios/tooltip-positioning.tsx
@@ -1,0 +1,24 @@
+import type { FC } from 'react';
+import React from 'react';
+import { KolPopoverButton } from '@public-ui/react';
+import { SampleDescription } from '../components/SampleDescription';
+
+export const TooltipPositioning: FC = () => {
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					This example demonstrates tooltip positioning within container query contexts. Container queries can interfere with fixed positioning, causing
+					tooltips to render incorrectly relative to the viewport. The layout containment fix ensures tooltips position properly even when their parent elements
+					use container-based sizing and layout rules.
+				</p>
+			</SampleDescription>
+
+			<div style={{ container: 'test / size' }}>
+				<KolPopoverButton _label="Sample PopoverButton—Click for Popover" _icons="codicon codicon-info" _tooltipAlign="right" _hideLabel>
+					This is an explanation shown on click.
+				</KolPopoverButton>
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
## Summary
Adds CSS layout containment to the tooltip component to prevent container query interference with tooltip positioning.

## Changes
- Added `contain: layout` to tooltip component CSS

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
CSS-Layout-Containment zur Tooltip-Komponente hinzugefügt, um Positionierungsprobleme durch Container Queries zu verhindern.

## Änderungen
- `contain: layout` zum Tooltip-Komponenten-CSS hinzugefügt

</details>