### PR TITLE
Add pig console animation

### DIFF
--- a/packages/components/src/global/devtools.ts
+++ b/packages/components/src/global/devtools.ts
@@ -83,6 +83,18 @@ export const initialize = (): void => {
 		metaModeLog('Experimental mode', getExperimentalMode());
 		metaModeLog('Color contrast analysis', getColorContrastAnalysis());
 
+		if (getDocument().body.textContent?.toLowerCase().includes('pig')) {
+			const frames = ['🐖     ', ' 🐖    ', '  🐖   ', '   🐖  ', '    🐖 ', '     🐖'];
+			let step = 0;
+			const interval = setInterval(() => {
+				Log.debug(frames[step % frames.length]);
+				step++;
+				if (step === frames.length * 3) {
+					clearInterval(interval);
+				}
+			}, 200);
+		}
+
 		if (getColorContrastAnalysis()) {
 			const timeout = setTimeout(() => {
 				clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- show a console animation of pigs if the page body contains the word `pig`

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test` *(fails: inputs-get-value e2e tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6880d318a1a8832b853c32b2999b767a