### PR TITLE
8077 fix disabled radiobutton reacts on clicking

### DIFF
--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -49,6 +49,10 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 		this.inputRef = ref;
 	};
 
+	private preventLegendLabelFocus = (e: MouseEvent) => {
+		e.preventDefault();
+	};
+
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<StencilUnknown | undefined> {
@@ -75,6 +79,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 		const hasHint = typeof this._hint === 'string' && this._hint.length > 0;
 		return (
 			<Host class="kol-input-radio">
+				{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
 				<fieldset
 					class={{
 						fieldset: true,
@@ -84,8 +89,25 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 						'hidden-error': this._hideError === true,
 						[this.state._orientation]: true,
 					}}
+					onMouseDown={(e) => {
+						const target = e.target as HTMLElement;
+
+						// Prevent clicking on disabled radio/label
+						if (target.closest('label.is-disabled, input.is-disabled') || target.closest('.radio-input-wrapper')?.querySelector('input.is-disabled')) {
+							e.preventDefault();
+							e.stopPropagation();
+							return;
+						}
+
+						// Prevent clicking on non-interactive Elements
+						if (target.closest('.hint, .content, .input-slot')) {
+							e.preventDefault();
+							e.stopPropagation();
+						}
+					}}
 				>
-					<legend class="block w-full mb-1 leading-normal">
+					{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+					<legend class="block w-full mb-1 leading-normal" onMouseDown={this.preventLegendLabelFocus}>
 						{/* INFO: span is needed for css styling :after content like a star (*) or optional text ! */}
 						<span>
 							{/* INFO: label comes with any html tag or as plain text! */}
@@ -130,9 +152,11 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 										id={customId}
 										checked={selected}
 										name={this.state._name || this.state._id}
-										disabled={this.state._disabled || option.disabled}
+										class={{
+											'is-disabled': this.state._disabled || !!option.disabled,
+										}}
 										required={this.state._required}
-										tabIndex={this.state._tabIndex}
+										tabIndex={this.state._disabled || option.disabled ? -1 : this.state._tabIndex}
 										value={`-${index}`}
 										{...this.controller.onFacade}
 										onChange={this.onChange}
@@ -140,6 +164,11 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 										onInput={this.onInput}
 										onKeyDown={this.onKeyDown.bind(this)}
 										onFocus={(event) => {
+											if (this.state._disabled || option.disabled) {
+												event.preventDefault();
+												(event.target as HTMLElement).blur(); // Remove focus from disabled elements
+												return;
+											}
 											this.controller.onFacade.onFocus(event);
 											this.inputHasFocus = true;
 										}}
@@ -148,14 +177,19 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 											this.inputHasFocus = false;
 										}}
 									/>
+									{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
 									<label
-										class="radio-label"
+										class={{
+											'radio-label': true,
+											'is-disabled': this.state._disabled || !!option.disabled,
+											'hide-label': !!this.state._hideLabel,
+										}}
 										htmlFor={`${customId}`}
-										style={{
-											height: this.state._hideLabel ? '0' : undefined,
-											margin: this.state._hideLabel ? '0' : undefined,
-											padding: this.state._hideLabel ? '0' : undefined,
-											visibility: this.state._hideLabel ? 'hidden' : undefined,
+										onClick={(e) => {
+											if (this.state._disabled || option.disabled) {
+												e.preventDefault();
+												e.stopPropagation();
+											}
 										}}
 									>
 										<span>

--- a/packages/components/src/components/input-radio/style.scss
+++ b/packages/components/src/components/input-radio/style.scss
@@ -19,6 +19,10 @@
 		cursor: pointer;
 	}
 
+	label.radio-label.is-disabled {
+		cursor: not-allowed;
+	}
+
 	input {
 		appearance: none;
 		border-width: var(--border-width);
@@ -46,6 +50,13 @@
 		background-color: #000;
 	}
 
+	input.is-disabled {
+		pointer-events: none;
+		opacity: 0.5;
+		cursor: not-allowed !important;
+		background-color: var(--color-mute-variant);
+	}
+
 	@media (forced-colors: active) {
 		input:checked:before {
 			/* Give it a visible background in forced colors mode */
@@ -64,6 +75,18 @@
 	fieldset .input-slot {
 		align-items: center;
 		display: flex;
+	}
+
+	.radio-label.hide-label {
+		height: 0;
+		margin: 0;
+		padding: 0;
+		visibility: hidden;
+	}
+
+	.radio-label.is-disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	/* required star is on fieldset legend */

--- a/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
@@ -13,8 +13,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -65,8 +65,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -117,8 +117,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -129,8 +129,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _disabled="" _id="id-nonce-1" _label="Herr" _rendernolabel="" _slotname="radio-1" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-1">
-          <input disabled="" id="id-nonce-1" name="field" type="radio" value="-1">
-          <label class="radio-label" htmlfor="id-nonce-1">
+          <input class="is-disabled" id="id-nonce-1" name="field" tabindex="-1" type="radio" value="-1">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-1">
             <span>
               <span class="radio-label-span-inner">
                 Herr
@@ -141,8 +141,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _disabled="" _id="id-nonce-2" _label="Divers" _rendernolabel="" _slotname="radio-2" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-2">
-          <input disabled="" id="id-nonce-2" name="field" type="radio" value="-2">
-          <label class="radio-label" htmlfor="id-nonce-2">
+          <input class="is-disabled" id="id-nonce-2" name="field" tabindex="-1" type="radio" value="-2">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-2">
             <span>
               <span class="radio-label-span-inner">
                 Divers
@@ -169,8 +169,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input aria-describedby="id-nonce-hint" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input aria-describedby="id-nonce-hint" class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -224,8 +224,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -276,8 +276,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -328,8 +328,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -380,8 +380,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -432,8 +432,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -484,8 +484,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -536,8 +536,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -588,8 +588,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -600,8 +600,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _disabled="" _id="id-nonce-1" _label="Herr" _rendernolabel="" _slotname="radio-1" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-1">
-          <input disabled="" id="id-nonce-1" name="field" type="radio" value="-1">
-          <label class="radio-label" htmlfor="id-nonce-1">
+          <input class="is-disabled" id="id-nonce-1" name="field" tabindex="-1" type="radio" value="-1">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-1">
             <span>
               <span class="radio-label-span-inner">
                 Herr
@@ -612,8 +612,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _disabled="" _id="id-nonce-2" _label="Divers" _rendernolabel="" _slotname="radio-2" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-2">
-          <input disabled="" id="id-nonce-2" name="field" type="radio" value="-2">
-          <label class="radio-label" htmlfor="id-nonce-2">
+          <input class="is-disabled" id="id-nonce-2" name="field" tabindex="-1" type="radio" value="-2">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-2">
             <span>
               <span class="radio-label-span-inner">
                 Divers
@@ -640,8 +640,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input aria-describedby="id-nonce-hint" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input aria-describedby="id-nonce-hint" class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -695,8 +695,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -747,8 +747,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -799,8 +799,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -851,8 +851,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -903,8 +903,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -955,8 +955,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -1007,8 +1007,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -1059,8 +1059,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" _touched="" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -1111,8 +1111,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -1163,8 +1163,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -1215,8 +1215,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -1267,8 +1267,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" _touched="" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau
@@ -1319,8 +1319,8 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
-          <label class="radio-label" htmlfor="id-nonce-0">
+          <input class="is-disabled" id="id-nonce-0" name="field" tabindex="-1" type="radio" value="-0">
+          <label class="is-disabled radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
                 Frau


### PR DESCRIPTION
Ref: #8077 

### Fix: Fokus-Sprung bei deaktivierten Radio-Buttons behoben
**Problem**

Beim Klicken auf einen deaktivierten Radio-Button (sowohl Input als auch Label) setzt der Browser automatisch den Fokus auf den ersten nicht-deaktivierten Radio-Button der Gruppe, ändert aber nicht den ausgewählten Wert. Dies führt zu verwirrendem UX-Verhalten:

- Benutzer klickt auf deaktivierte Option
- Fokus springt zum ersten aktiven Radio-Button
- Wert ändert sich nicht
- Benutzer ist verwirrt, welche Option tatsächlich ausgewählt ist

**Lösung**

Mehrstufiger Schutz gegen ungewolltes Fokus-Verhalten bei deaktivierten Radio-Buttons implementiert:

**Durchgeführte Änderungen**

1.	**Fieldset-Ebene:** `onMouseDown` Handler verhindert Interaktion mit deaktivierten Elementen und nicht-interaktiven Bereichen (Hints, Error-Meldungen)
2.	**Input-Ebene:**
o	`tabIndex={-1}` für deaktivierte Inputs verhindert Tab-Navigation
o	`is-disabled` CSS-Klasse für bessere Styling-Kontrolle hinzugefügt
o	`onFocus` Handler erweitert, um aktiv Fokus von deaktivierten Elementen zu entfernen
3.	**Label-Ebene:** `onClick` Handler verhindert Label-Klicks auf deaktivierte Optionen
4.	**Legend-Schutz:** `onMouseDown` Handler verhindert Fokus-Probleme beim Klicken auf die Fieldset-Legende

**Technische Details**

- Verwendet `preventDefault()` und `stopPropagation()` um ungewollte Events zu blockieren
- Implementiert `blur()` als Fallback falls Fokus versehentlich gesetzt wird
- Erhält Accessibility-Standards mit korrekter `tabIndex` Behandlung
- Bewahrt alle bestehenden Funktionalitäten für aktivierte Radio-Buttons

**Testing**

- Klick auf deaktivierten Radio-Button verursacht keinen Fokus-Sprung mehr
- Klick auf deaktiviertes Label verursacht keinen Fokus-Sprung mehr
- Tab-Navigation überspringt deaktivierte Optionen
- Aktivierte Radio-Buttons funktionieren normal
- Tastatur-Navigation unbeeinträchtigt
