### PR TITLE
fix(cli): restore tsconfig task

### DIFF
--- a/packages/tools/kolibri-cli/.knip.json
+++ b/packages/tools/kolibri-cli/.knip.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://unpkg.com/knip@5/schema.json",
 	"ignoreDependencies": ["@public-ui/components", "loglevel", "mocha"],
-	"project": ["src/**/*.ts"],
+	"project": ["src/**/*.ts", "test/**/*.ts"],
 	"rules": {
 		"classMembers": "warn"
 	}

--- a/packages/tools/kolibri-cli/Theme-Migration.md
+++ b/packages/tools/kolibri-cli/Theme-Migration.md
@@ -1,0 +1,50 @@
+# Theme-Migration
+
+This document outlines how KoliBri themes can be migrated together with the component library.
+
+## Goal
+
+Synchronise breaking changes in components with the styling of each theme package so that upgrades require minimal manual work.
+
+## Requirements
+
+- Components and themes follow the BEM naming convention via `typed-bem`.
+- Each theme lives under `packages/themes` and keeps its SCSS sources in `src/`.
+- The CLI migration tool can read and modify `.scss` files.
+
+## Concept
+
+1. **Central BEM schemas**
+
+   - Every component exports its BEM schema. These schemas are used by the CLI to generate SCSS files and by themes to reference selectors.
+   - When a selector changes, the same schema information allows the migration to update all theme packages consistently.
+
+2. **SCSS migration tasks**
+   The CLI runner will be extended with task types operating on SCSS. They behave like the existing property tasks and are idempotent.
+
+   - `RenameBlockTask` – rename a block selector everywhere in a theme.
+   - `RenameElementTask` – rename an element within a block.
+   - `RenameModifierTask` – rename or replace a modifier.
+   - `AddSelectorTask` and `RemoveSelectorTask` – insert or remove entire rule sets.
+   - `UpdateTokenTask` – adjust variable names or values when tokens change.
+   - `MoveRulesTask` – move declarations from one selector to another if the DOM structure changes.
+
+   Tasks scan the SCSS with regular expressions or an AST parser. If a pattern is missing the task logs a warning instead of failing.
+
+3. **Safe execution**
+   - Migrations abort when uncommitted changes are detected unless `--ignore-uncommitted-changes` is specified.
+   - Each task logs the files it touched. After completion Prettier can format them automatically.
+   - Because tasks are idempotent, rerunning the migration produces no new changes. To undo a run, reset the Git state.
+
+## Workflow Example
+
+```bash
+pnpm i -g @public-ui/kolibri-cli@2      # install the CLI matching the next version
+kolibri migrate path/to/project         # run all tasks for the upgrade
+pnpm format                             # format changed files
+git diff                                # review results and commit
+```
+
+## Outlook
+
+Using these tasks, theme packages remain aligned with component updates. Future breaking changes can be scripted and applied via the CLI so that projects can upgrade in a controlled and reproducible way.

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssAddSelectorTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssAddSelectorTask.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+
+import { SCSS_FILE_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, logAndCreateError, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+/**
+ * Escapes special characters for use in a regular expression.
+ * @param {string} str String to escape
+ * @returns {string} Escaped string
+ */
+function escapeRegExp(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export class ScssAddSelectorTask extends AbstractTask {
+	private readonly regExp: RegExp;
+
+	protected constructor(
+		identifier: string,
+		private readonly selector: string,
+		private readonly rules: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	) {
+		super(identifier, `Add selector "${selector}"`, SCSS_FILE_EXTENSIONS, versionRange, dependentTasks, options);
+
+		if (!selector.startsWith('.')) {
+			throw logAndCreateError(`Selector "${selector}" must start with a dot.`);
+		}
+
+		this.regExp = new RegExp(escapeRegExp(selector) + '\\s*{');
+	}
+
+	public static getInstance(
+		selector: string,
+		rules: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	): ScssAddSelectorTask {
+		const identifier = `add-selector-${selector}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new ScssAddSelectorTask(identifier, selector, rules, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as ScssAddSelectorTask;
+	}
+
+	public run(baseDir: string): void {
+		filterFilesByExt(baseDir, SCSS_FILE_EXTENSIONS).forEach((file) => {
+			let content = fs.readFileSync(file, 'utf8');
+			if (!this.regExp.test(content)) {
+				content += `\n${this.selector} {\n${this.rules}\n}\n`;
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, content);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRemoveSelectorTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRemoveSelectorTask.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+
+import { SCSS_FILE_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, logAndCreateError, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+/**
+ * Escapes special characters for use in a regular expression.
+ * @param {string} str String to escape
+ * @returns {string} Escaped string
+ */
+function escapeRegExp(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export class ScssRemoveSelectorTask extends AbstractTask {
+	private readonly regExp: RegExp;
+
+	protected constructor(
+		identifier: string,
+		private readonly selector: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	) {
+		super(identifier, `Remove selector "${selector}"`, SCSS_FILE_EXTENSIONS, versionRange, dependentTasks, options);
+
+		if (!selector.startsWith('.')) {
+			throw logAndCreateError(`Selector "${selector}" must start with a dot.`);
+		}
+
+		this.regExp = new RegExp(`${escapeRegExp(selector)}\\s*{[\\s\\S]*?}`, 'g');
+	}
+
+	public static getInstance(selector: string, versionRange: string, dependentTasks: AbstractTask[] = [], options: TaskOptions = {}): ScssRemoveSelectorTask {
+		const identifier = `remove-selector-${selector}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new ScssRemoveSelectorTask(identifier, selector, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as ScssRemoveSelectorTask;
+	}
+
+	public run(baseDir: string): void {
+		filterFilesByExt(baseDir, SCSS_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(this.regExp, `/* removed ${this.selector} */`);
+			if (content !== newContent) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRenameBlockTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRenameBlockTask.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+
+import { SCSS_FILE_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, isKebabCaseRegExp, logAndCreateError, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+export class ScssRenameBlockTask extends AbstractTask {
+	private readonly regExp: RegExp;
+
+	protected constructor(
+		identifier: string,
+		block: string,
+		private readonly newBlock: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	) {
+		super(identifier, `Rename block selector "${block}" to "${newBlock}"`, SCSS_FILE_EXTENSIONS, versionRange, dependentTasks, options);
+
+		if (!isKebabCaseRegExp.test(block)) {
+			throw logAndCreateError(`Block "${block}" is not in kebab case.`);
+		}
+		if (!isKebabCaseRegExp.test(newBlock)) {
+			throw logAndCreateError(`Block "${newBlock}" is not in kebab case.`);
+		}
+
+		this.regExp = new RegExp(`\\.${block}(?=(?:__|--|\\b))`, 'g');
+	}
+
+	public static getInstance(
+		block: string,
+		newBlock: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	): ScssRenameBlockTask {
+		const identifier = `${block}-rename-block-${newBlock}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new ScssRenameBlockTask(identifier, block, newBlock, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as ScssRenameBlockTask;
+	}
+
+	public run(baseDir: string): void {
+		filterFilesByExt(baseDir, SCSS_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(this.regExp, `.${this.newBlock}`);
+			if (content !== newContent) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRenameElementTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRenameElementTask.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+
+import { SCSS_FILE_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, isKebabCaseRegExp, logAndCreateError, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+export class ScssRenameElementTask extends AbstractTask {
+	private readonly regExp: RegExp;
+
+	protected constructor(
+		identifier: string,
+		private readonly block: string,
+		element: string,
+		private readonly newElement: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	) {
+		super(
+			identifier,
+			`Rename element selector "${block}__${element}" to "${block}__${newElement}"`,
+			SCSS_FILE_EXTENSIONS,
+			versionRange,
+			dependentTasks,
+			options,
+		);
+
+		if (!isKebabCaseRegExp.test(block)) {
+			throw logAndCreateError(`Block "${block}" is not in kebab case.`);
+		}
+		if (!isKebabCaseRegExp.test(element)) {
+			throw logAndCreateError(`Element "${element}" is not in kebab case.`);
+		}
+		if (!isKebabCaseRegExp.test(newElement)) {
+			throw logAndCreateError(`Element "${newElement}" is not in kebab case.`);
+		}
+
+		this.regExp = new RegExp(`\\.${block}__${element}(?=(?:--|\\b))`, 'g');
+	}
+
+	public static getInstance(
+		block: string,
+		element: string,
+		newElement: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	): ScssRenameElementTask {
+		const identifier = `${block}-rename-element-${element}-to-${newElement}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new ScssRenameElementTask(identifier, block, element, newElement, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as ScssRenameElementTask;
+	}
+
+	public run(baseDir: string): void {
+		filterFilesByExt(baseDir, SCSS_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(this.regExp, `.${this.block}__${this.newElement}`);
+			if (content !== newContent) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRenameModifierTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssRenameModifierTask.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+
+import { SCSS_FILE_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, isKebabCaseRegExp, logAndCreateError, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+export class ScssRenameModifierTask extends AbstractTask {
+	private readonly regExp: RegExp;
+
+	protected constructor(
+		identifier: string,
+		private readonly base: string,
+		modifier: string,
+		private readonly newModifier: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	) {
+		super(identifier, `Rename modifier "${modifier}" of "${base}" selector`, SCSS_FILE_EXTENSIONS, versionRange, dependentTasks, options);
+
+		if (!isKebabCaseRegExp.test(base)) {
+			throw logAndCreateError(`Base selector "${base}" is not in kebab case.`);
+		}
+		if (!isKebabCaseRegExp.test(modifier)) {
+			throw logAndCreateError(`Modifier "${modifier}" is not in kebab case.`);
+		}
+		if (!isKebabCaseRegExp.test(newModifier)) {
+			throw logAndCreateError(`Modifier "${newModifier}" is not in kebab case.`);
+		}
+
+		this.regExp = new RegExp(`\\.${base}--${modifier}(?=\\b)`, 'g');
+	}
+
+	public static getInstance(
+		base: string,
+		modifier: string,
+		newModifier: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	): ScssRenameModifierTask {
+		const identifier = `${base}-rename-modifier-${modifier}-to-${newModifier}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new ScssRenameModifierTask(identifier, base, modifier, newModifier, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as ScssRenameModifierTask;
+	}
+
+	public run(baseDir: string): void {
+		filterFilesByExt(baseDir, SCSS_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(this.regExp, `.${this.base}--${this.newModifier}`);
+			if (content !== newContent) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssUpdateTokenTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/ScssUpdateTokenTask.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+
+import { SCSS_FILE_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, logAndCreateError, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+/**
+ * Escapes special characters for use in a regular expression.
+ * @param {string} str String to escape
+ * @returns {string} Escaped string
+ */
+function escapeRegExp(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export class ScssUpdateTokenTask extends AbstractTask {
+	private readonly regExp: RegExp;
+
+	protected constructor(
+		identifier: string,
+		token: string,
+		private readonly newToken: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	) {
+		super(identifier, `Update token "${token}" to "${newToken}"`, SCSS_FILE_EXTENSIONS, versionRange, dependentTasks, options);
+
+		if (!token.startsWith('$')) {
+			throw logAndCreateError(`Token "${token}" must start with "$".`);
+		}
+		if (!newToken.startsWith('$')) {
+			throw logAndCreateError(`Token "${newToken}" must start with "$".`);
+		}
+
+		this.regExp = new RegExp(escapeRegExp(token) + '(?=\b)', 'g');
+	}
+
+	public static getInstance(
+		token: string,
+		newToken: string,
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		options: TaskOptions = {},
+	): ScssUpdateTokenTask {
+		const identifier = `update-token-${token}-to-${newToken}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new ScssUpdateTokenTask(identifier, token, newToken, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as ScssUpdateTokenTask;
+	}
+
+	public run(baseDir: string): void {
+		filterFilesByExt(baseDir, SCSS_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(this.regExp, this.newToken);
+			if (content !== newContent) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/types.ts
+++ b/packages/tools/kolibri-cli/src/types.ts
@@ -1,9 +1,11 @@
-export const FILE_EXTENSIONS = ['html', 'xhtml', 'js', 'json', 'jsx', 'ts', 'tsx', 'vue'] as const;
+export const FILE_EXTENSIONS = ['html', 'xhtml', 'js', 'json', 'jsx', 'ts', 'tsx', 'vue', 'css', 'sass', 'scss'] as const;
 export type FileExtension = (typeof FILE_EXTENSIONS)[number];
 
 export const COMPONENT_FILE_EXTENSIONS: FileExtension[] = ['jsx', 'tsx', 'vue'];
 export const CUSTOM_ELEMENT_FILE_EXTENSIONS: FileExtension[] = ['html', 'xhtml', 'jsx', 'tsx', 'vue'];
 export const MARKUP_EXTENSIONS: FileExtension[] = COMPONENT_FILE_EXTENSIONS.concat(CUSTOM_ELEMENT_FILE_EXTENSIONS);
+// treat plain CSS and SASS files like SCSS for migration tasks
+export const SCSS_FILE_EXTENSIONS: FileExtension[] = ['css', 'sass', 'scss'];
 
 export const WEB_TAG_REGEX = /\b<kol-[a-z-]+/i;
 export const REACT_TAG_REGEX = /\b<Kol[A-Z][A-Za-z]*/;

--- a/packages/tools/kolibri-cli/test/scss-tasks.spec.ts
+++ b/packages/tools/kolibri-cli/test/scss-tasks.spec.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ScssAddSelectorTask } from '../src/migrate/runner/tasks/common/ScssAddSelectorTask';
+import { ScssRemoveSelectorTask } from '../src/migrate/runner/tasks/common/ScssRemoveSelectorTask';
+import { ScssRenameBlockTask } from '../src/migrate/runner/tasks/common/ScssRenameBlockTask';
+import { ScssRenameElementTask } from '../src/migrate/runner/tasks/common/ScssRenameElementTask';
+import { ScssRenameModifierTask } from '../src/migrate/runner/tasks/common/ScssRenameModifierTask';
+import { ScssUpdateTokenTask } from '../src/migrate/runner/tasks/common/ScssUpdateTokenTask';
+
+describe('SCSS migration tasks', () => {
+	it('adds selectors when missing', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const scssPath = path.join(tmpDir, 'style.scss');
+		fs.writeFileSync(scssPath, '.block { color: red; }');
+
+		const task = ScssAddSelectorTask.getInstance('.new-block', 'color: blue;', '^1');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(scssPath, 'utf8');
+		assert.ok(content.includes('.new-block'));
+		assert.ok(content.includes('color: blue;'));
+	});
+
+	it('removes selectors', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const scssPath = path.join(tmpDir, 'style.scss');
+		fs.writeFileSync(scssPath, '.old { color: red; }');
+
+		const task = ScssRemoveSelectorTask.getInstance('.old', '^1');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(scssPath, 'utf8');
+		assert.ok(content.includes('/* removed .old */'));
+		assert.ok(!content.includes('.old {'));
+	});
+
+	it('renames block selectors', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const scssPath = path.join(tmpDir, 'style.scss');
+		fs.writeFileSync(scssPath, '.old-block { color: red; }');
+
+		const task = ScssRenameBlockTask.getInstance('old-block', 'new-block', '^1');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(scssPath, 'utf8');
+		assert.ok(content.includes('.new-block'));
+	});
+
+	it('renames element selectors', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const scssPath = path.join(tmpDir, 'style.scss');
+		fs.writeFileSync(scssPath, '.block__old { color: red; }');
+
+		const task = ScssRenameElementTask.getInstance('block', 'old', 'new', '^1');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(scssPath, 'utf8');
+		assert.ok(content.includes('.block__new'));
+	});
+
+	it('renames modifier selectors', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const scssPath = path.join(tmpDir, 'style.scss');
+		fs.writeFileSync(scssPath, '.block--old { color: red; }');
+
+		const task = ScssRenameModifierTask.getInstance('block', 'old', 'new', '^1');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(scssPath, 'utf8');
+		assert.ok(content.includes('.block--new'));
+	});
+
+	it('updates tokens', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const scssPath = path.join(tmpDir, 'style.scss');
+		fs.writeFileSync(scssPath, '$old-color: red; .btn { color: $old-color; }');
+
+		const task = ScssUpdateTokenTask.getInstance('$old-color', '$new-color', '^1');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(scssPath, 'utf8');
+		assert.ok(content.includes('$new-color'));
+		assert.ok(!content.includes('$old-color'));
+	});
+});


### PR DESCRIPTION
## Summary
Restores the tsconfig task in the CLI that was missing from the theme migration feature branch.

## Changes
- Restored tsconfig task in CLI

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Die tsconfig-Aufgabe in der CLI für den Theme-Migrations-Feature-Branch wiederhergestellt.

## Änderungen
- tsconfig-Task in der CLI wiederhergestellt

</details>