### PR TITLE
fix(build): explicitly allow vite imports from THEME_MODULE path

### DIFF
--- a/packages/samples/react/vite.config.ts
+++ b/packages/samples/react/vite.config.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import react from '@vitejs/plugin-react-swc';
 import UnoCSS from '@unocss/vite';
 import process from 'process';
+import path from 'path';
 
 function getGitCommitHash(): string | null {
 	try {
@@ -29,5 +30,8 @@ export default defineConfig({
 	},
 	server: {
 		port: 9191,
+		fs: {
+			allow: [path.resolve(__dirname), ...(process.env.THEME_MODULE ? [path.resolve(process.env.THEME_MODULE)] : [])],
+		},
 	},
 });


### PR DESCRIPTION
## Summary
Configures the Vite dev server to explicitly allow imports from the `THEME_MODULE` path, fixing theme loading in development.

## Changes
- Added Vite server configuration to allow THEME_MODULE path imports

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Vite-Dev-Server so konfiguriert, dass Importe aus dem `THEME_MODULE`-Pfad explizit erlaubt sind.

## Änderungen
- Vite-Server-Konfiguration für THEME_MODULE-Pfad-Importe hinzugefügt

</details>