### PR TITLE
test: Add reset e2e test for InputFile

### DIFF
--- a/packages/components/src/components/input-file/input-file.e2e.ts
+++ b/packages/components/src/components/input-file/input-file.e2e.ts
@@ -5,6 +5,7 @@ import { expect } from '@playwright/test';
 import { Callback } from '../../schema/enums';
 import { KolEvent } from '../../utils/events';
 import { testInputMessage } from '../../e2e/input-msg';
+import { translate } from '../../i18n';
 
 const COMPONENT_NAME = 'kol-input-file';
 const TEST_VALUE: [] = [];
@@ -81,13 +82,16 @@ test.describe(COMPONENT_NAME, () => {
 			await page.waitForChanges();
 
 			const component = page.locator(COMPONENT_NAME);
+			const filledFileList = await component.evaluate((element: HTMLKolInputFileElement) => element.getValue());
+			expect(filledFileList).not.toEqual({});
+
 			await component.evaluate((element: HTMLKolInputFileElement) => element.reset());
 			await page.waitForChanges();
 
 			const fileList = await component.evaluate((element: HTMLKolInputFileElement) => element.getValue());
-			expect(fileList).toBeNull();
+			expect(fileList).toEqual({});
 			await expect(page.locator('input')).toHaveValue('');
-			await expect(page.locator('.kol-input-container__filename')).toHaveText('kol-filename-text');
+			await expect(page.locator('.kol-input-container__filename')).toHaveText(translate('kol-filename-text'));
 		});
 	});
 });

--- a/packages/components/src/components/input-file/input-file.e2e.ts
+++ b/packages/components/src/components/input-file/input-file.e2e.ts
@@ -72,4 +72,22 @@ test.describe(COMPONENT_NAME, () => {
 			});
 		});
 	});
+
+	test.describe('reset()', () => {
+		test('should clear the selected files and filename text', async ({ page }) => {
+			await page.setContent(`<kol-input-file _label="Input"></kol-input-file>`);
+
+			await fillAction(page);
+			await page.waitForChanges();
+
+			const component = page.locator(COMPONENT_NAME);
+			await component.evaluate((element: HTMLKolInputFileElement) => element.reset());
+			await page.waitForChanges();
+
+			const fileList = await component.evaluate((element: HTMLKolInputFileElement) => element.getValue());
+			expect(fileList).toBeNull();
+			await expect(page.locator('input')).toHaveValue('');
+			await expect(page.locator('.kol-input-container__filename')).toHaveText('kol-filename-text');
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Adds end-to-end tests for the reset functionality of the `InputFile` component.

## Changes
- Added e2e test for input-file reset

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
End-to-End-Tests für die Reset-Funktionalität der `InputFile`-Komponente hinzugefügt.

## Änderungen
- E2E-Test für den Input-File-Reset hinzugefügt

</details>