### PR TITLE
fix(split-button): adjust button layout

### DIFF
--- a/packages/components/src/components/split-button/style.scss
+++ b/packages/components/src/components/split-button/style.scss
@@ -14,8 +14,11 @@
 		}
 
 		&__button {
-			flex-grow: 1;
 			text-align: left;
+		}
+
+		&__secondary-button {
+			width: var(--a11y-min-size);
 		}
 
 		.kol-popover {

--- a/packages/components/src/components/split-button/style.scss
+++ b/packages/components/src/components/split-button/style.scss
@@ -17,10 +17,6 @@
 			text-align: left;
 		}
 
-		&__secondary-button {
-			width: var(--a11y-min-size);
-		}
-
 		.kol-popover {
 			&__content {
 				margin-top: to-rem(2);

--- a/packages/themes/default/src/components/split-button.scss
+++ b/packages/themes/default/src/components/split-button.scss
@@ -50,13 +50,17 @@
 		@include kol-button('kol-button');
 
 		&__button {
+			width: auto;
+
 			.kol-button__text {
+				width: auto;
 				border-top-right-radius: 0;
 				border-bottom-right-radius: 0;
 			}
 		}
 
 		&__secondary-button {
+			width: var(--a11y-min-size);
 			.kol-button__text {
 				border-top-left-radius: 0;
 				border-bottom-left-radius: 0;


### PR DESCRIPTION
## Summary
- make the primary part of split-button auto width
- keep the dropdown button square

## Related issues
- fixes https://github.com/public-ui/kolibri/issues/8136

------
https://chatgpt.com/codex/tasks/task_e_6883bc83f354832b95a24555a35f6b6f