### PR TITLE
feat(icon): add controller

### DIFF
--- a/packages/components/src/components/icon/controller.ts
+++ b/packages/components/src/components/icon/controller.ts
@@ -1,0 +1,24 @@
+import type { Generic } from 'adopted-style-sheets';
+import type { LabelPropType, IconProps } from '../../schema';
+import { validateLabel, watchString } from '../../schema';
+
+export class IconController {
+	protected readonly component: Generic.Element.Component & IconProps;
+
+	public constructor(component: Generic.Element.Component & IconProps) {
+		this.component = component;
+	}
+
+	public validateIcons(value?: string): void {
+		watchString(this.component, '_icons', value, { required: true });
+	}
+
+	public validateLabel(value?: LabelPropType): void {
+		validateLabel(this.component, value, { required: true });
+	}
+
+	public componentWillLoad(): void {
+		this.validateIcons(this.component._icons);
+		this.validateLabel(this.component._label);
+	}
+}

--- a/packages/components/src/components/icon/controller.ts
+++ b/packages/components/src/components/icon/controller.ts
@@ -1,11 +1,13 @@
 import type { Generic } from 'adopted-style-sheets';
-import type { LabelPropType, IconProps } from '../../schema';
+import type { LabelPropType, IconProps, IconWatches } from '../../schema';
 import { validateLabel, watchString } from '../../schema';
 
-export class IconController {
-	protected readonly component: Generic.Element.Component & IconProps;
+type Component = Generic.Element.Component & IconProps;
 
-	public constructor(component: Generic.Element.Component & IconProps) {
+export class IconController implements IconWatches {
+	protected readonly component: Component;
+
+	public constructor(component: Component) {
 		this.component = component;
 	}
 
@@ -14,7 +16,7 @@ export class IconController {
 	}
 
 	public validateLabel(value?: LabelPropType): void {
-		validateLabel(this.component, value, { required: true });
+		validateLabel(this.component, value, { required: true, defaultValue: '' });
 	}
 
 	public componentWillLoad(): void {

--- a/packages/components/src/components/icon/shadow.tsx
+++ b/packages/components/src/components/icon/shadow.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Host, Prop, State, Watch } from '@stencil/core';
 import type { IconAPI, IconStates, LabelPropType } from '../../schema';
-import { validateLabel, watchString } from '../../schema';
+import { IconController } from './controller';
 
 import type { JSX } from '@stencil/core';
 import clsx from 'clsx';
@@ -17,6 +17,7 @@ import { BEM_CLASS_ICON, BEM_CLASS_ICON__ICON } from './bem';
 	shadow: true,
 })
 export class KolIcon implements IconAPI {
+	private readonly controller: IconController;
 	public render(): JSX.Element {
 		const ariaShow = this.state._label.length > 0;
 		return (
@@ -53,22 +54,21 @@ export class KolIcon implements IconAPI {
 		_label: '', // ⚠ required
 	};
 
+	public constructor() {
+		this.controller = new IconController(this);
+	}
+
 	@Watch('_icons')
 	public validateIcons(value?: string): void {
-		watchString(this, '_icons', value, {
-			required: true,
-		});
+		this.controller.validateIcons(value);
 	}
 
 	@Watch('_label')
 	public validateLabel(value?: LabelPropType): void {
-		validateLabel(this, value, {
-			required: true,
-		});
+		this.controller.validateLabel(value);
 	}
 
 	public componentWillLoad(): void {
-		this.validateIcons(this._icons);
-		this.validateLabel(this._label);
+		this.controller.componentWillLoad();
 	}
 }

--- a/packages/components/src/schema/components/icon.ts
+++ b/packages/components/src/schema/components/icon.ts
@@ -11,6 +11,7 @@ type OptionalStates = OptionalProps;
 
 export type IconProps = Generic.Element.Members<RequiredProps, OptionalProps>;
 export type IconStates = Generic.Element.Members<RequiredStates, OptionalStates>;
+export type IconWatches = Generic.Element.Watchers<RequiredProps, OptionalProps>;
 export type IconAPI = Generic.Element.ComponentApi<RequiredProps, OptionalProps, RequiredStates, OptionalStates>;
 
 export type InternalIconProps = RequiredProps & OptionalProps;


### PR DESCRIPTION
## Summary
Adds a controller to the icon component to separate business logic from rendering.

## Changes
- Added controller to icon component

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Controller zur Icon-Komponente hinzugefügt, um Geschäftslogik von der Darstellung zu trennen.

## Änderungen
- Controller zur Icon-Komponente hinzugefügt

</details>