### PR TITLE
feat(components): add unit prop schema

### DIFF
--- a/packages/components/src/components/progress/shadow.tsx
+++ b/packages/components/src/components/progress/shadow.tsx
@@ -1,5 +1,5 @@
 import type { LabelPropType, ProgressAPI, ProgressStates, ProgressVariantPropType } from '../../schema';
-import { validateLabel, validateVariantProgress, watchNumber, watchString } from '../../schema';
+import { validateLabel, validateUnit, validateVariantProgress, watchNumber } from '../../schema';
 import { Component, h, Prop, State, Watch } from '@stencil/core';
 
 import type { JSX } from '@stencil/core';
@@ -166,7 +166,7 @@ export class KolProgress implements ProgressAPI {
 
 	@Watch('_unit')
 	public validateUnit(value?: string): void {
-		watchString(this, '_unit', value);
+		validateUnit(this, value);
 	}
 
 	@Watch('_value')

--- a/packages/components/src/schema/props/index.ts
+++ b/packages/components/src/schema/props/index.ts
@@ -83,6 +83,7 @@ export * from './tooltip-align';
 export * from './touched';
 export * from './type-input-date';
 export * from './type-input-text';
+export * from './unit';
 export * from './variant-alert';
 export * from './variant-input-checkbox';
 export * from './variant-progress';

--- a/packages/components/src/schema/props/unit.ts
+++ b/packages/components/src/schema/props/unit.ts
@@ -1,0 +1,18 @@
+import type { Generic } from 'adopted-style-sheets';
+
+import { watchString } from '../utils';
+
+/* types */
+export type UnitPropType = string;
+
+/**
+ * Defines the unit of the step values (not shown).
+ */
+export type PropUnit = {
+	unit: UnitPropType;
+};
+
+/* validator */
+export const validateUnit = (component: Generic.Element.Component, value?: UnitPropType): void => {
+	watchString(component, '_unit', value);
+};


### PR DESCRIPTION
## Summary
Adds a prop schema for the unit prop to enable type safety and validation.

## Changes
- Added unit prop type and validator

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Prop-Schema für das Unit-Prop hinzugefügt.

## Änderungen
- Unit-Prop-Typ und -Validator hinzugefügt

</details>