### PR TITLE
feat: add accept prop validation

### DIFF
--- a/packages/components/src/components/input-file/controller.ts
+++ b/packages/components/src/components/input-file/controller.ts
@@ -1,7 +1,7 @@
 import type { Generic } from 'adopted-style-sheets';
 
-import type { InputFileProps, InputFileWatches, RequiredPropType } from '../../schema';
-import { validateRequired, watchBoolean, watchString } from '../../schema';
+import type { AcceptPropType, InputFileProps, InputFileWatches, RequiredPropType } from '../../schema';
+import { validateAccept, validateRequired, watchBoolean } from '../../schema';
 
 import { InputIconController } from '../@deprecated/input/controller-icon';
 
@@ -13,8 +13,8 @@ export class InputFileController extends InputIconController implements InputFil
 		this.component = component;
 	}
 
-	public validateAccept(value?: string): void {
-		watchString(this.component, '_accept', value);
+	public validateAccept(value?: AcceptPropType): void {
+		validateAccept(this.component, value);
 	}
 
 	public validateMultiple(value?: boolean): void {

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -22,6 +22,7 @@ import type {
 	Stringified,
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
+	AcceptPropType,
 } from '../../schema';
 
 import { KolButtonWcTag } from '../../core/component-names';
@@ -247,7 +248,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	}
 
 	@Watch('_accept')
-	public validateAccept(value?: string): void {
+	public validateAccept(value?: AcceptPropType): void {
 		this.controller.validateAccept(value);
 	}
 

--- a/packages/components/src/schema/index.ts
+++ b/packages/components/src/schema/index.ts
@@ -8,6 +8,7 @@ export const KoliBri = new Theme<'kol', keyof typeof KeyEnum, keyof typeof TagEn
 export * from './components';
 // export * from './enums'; // only for internal use
 export * from './props';
+export { AcceptPropType, PropAccept, validateAccept } from './props/accept';
 export * from './types';
 export * from './utils';
 export * from './validators';

--- a/packages/components/src/schema/props/accept.ts
+++ b/packages/components/src/schema/props/accept.ts
@@ -1,0 +1,19 @@
+import type { Generic } from 'adopted-style-sheets';
+
+import type { WatchStringOptions } from '../utils';
+import { watchString } from '../utils';
+
+/* types */
+export type AcceptPropType = string;
+
+/**
+ * Defines which file formats are accepted.
+ */
+export type PropAccept = {
+	accept: AcceptPropType;
+};
+
+/* validator */
+export const validateAccept = (component: Generic.Element.Component, value?: AcceptPropType, options: WatchStringOptions = {}): void => {
+	watchString(component, '_accept', value, options);
+};

--- a/packages/components/src/schema/props/index.ts
+++ b/packages/components/src/schema/props/index.ts
@@ -1,4 +1,5 @@
 export * from './access-key';
+export * from './accept';
 export * from './accordion-callbacks';
 export * from './active';
 export * from './adjust-height';


### PR DESCRIPTION
## Summary
Adds validation for the accept prop to ensure only valid MIME types and file extensions are accepted.

## Changes
- Added accept prop type and validation logic

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Validierung für das Accept-Prop hinzugefügt.

## Änderungen
- Accept-Prop-Typ und Validierungslogik hinzugefügt

</details>