### PR TITLE
feat(components): add tab-index prop schema

### DIFF
--- a/packages/components/src/components/@deprecated/input/controller.ts
+++ b/packages/components/src/components/@deprecated/input/controller.ts
@@ -31,10 +31,10 @@ import {
 	validateMsg,
 	validateHint,
 	validateShortKey,
-	validateTabIndex,
 	validateTooltipAlign,
 	watchString,
 } from '../../../schema';
+import { validateTabIndex } from '../../../schema/props/tab-index';
 
 import { dispatchDomEvent, KolEvent } from '../../../utils/events';
 import { ControlledInputController } from '../../input-adapter-leanup/controller';

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -43,10 +43,10 @@ import {
 	validateIcons,
 	validateLabelWithExpertSlot,
 	validateShortKey,
-	validateTabIndex,
 	validateTooltipAlign,
 	watchString,
 } from '../../schema';
+import { validateTabIndex } from '../../schema/props/tab-index';
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
 

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -45,9 +45,9 @@ import {
 	validateLinkCallbacks,
 	validateLinkTarget,
 	validateShortKey,
-	validateTabIndex,
 	validateTooltipAlign,
 } from '../../schema';
+import { validateTabIndex } from '../../schema/props/tab-index';
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
 import type { UnsubscribeFunction } from './ariaCurrentService';

--- a/packages/components/src/schema/props/index.ts
+++ b/packages/components/src/schema/props/index.ts
@@ -73,6 +73,7 @@ export * from './spell-check';
 export * from './suggestions';
 export * from './sync-value-by-selector';
 export * from './tab-behavior';
+export * from './tab-index';
 export * from './table-callbacks';
 export * from './table-data';
 export * from './table-data-foot';

--- a/packages/components/src/schema/props/tab-index.ts
+++ b/packages/components/src/schema/props/tab-index.ts
@@ -3,11 +3,18 @@ import type { Generic } from 'adopted-style-sheets';
 import type { WatchNumberOptions } from '../utils';
 import { a11yHint, watchNumber } from '../utils';
 
-/**
- * Accessibility hints
- * - https://adrianroselli.com/2014/11/dont-use-tabindex-greater-than-0.html
- */
+/* types */
+export type TabIndexPropType = number;
 
+/**
+ * Defines which tab-index the primary element of the component has.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
+ */
+export type PropTabIndex = {
+	tabIndex: TabIndexPropType;
+};
+
+/* constants */
 const options: WatchNumberOptions = {
 	hooks: {
 		afterPatch: (value) => {
@@ -18,9 +25,7 @@ const options: WatchNumberOptions = {
 	},
 };
 
-/**
- * Diese Methode validiert das Property und setzt den State, wenn es valide ist.
- */
-export const validateTabIndex = (component: Generic.Element.Component, value?: number): void => {
+/* validator */
+export const validateTabIndex = (component: Generic.Element.Component, value?: TabIndexPropType): void => {
 	watchNumber(component, '_tabIndex', value, options);
 };

--- a/packages/components/src/schema/validators/index.ts
+++ b/packages/components/src/schema/validators/index.ts
@@ -1,5 +1,4 @@
 export * from './alignment';
 export * from './common';
 export * from './options';
-export * from './tab-index';
 // export * from './window';


### PR DESCRIPTION
## Summary
Adds a prop schema for tab-index to enable validation and type safety.

## Changes
- Added tab-index prop type and validator

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Prop-Schema für Tab-Index hinzugefügt.

## Änderungen
- Tab-Index-Prop-Typ und -Validator hinzugefügt

</details>