### PR TITLE
feat(components): add allow-multi-sort prop

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -29,6 +29,7 @@ import {
 	objectObjectHandler,
 	parseJson,
 	setState,
+	validateAllowMultiSort,
 	validateLabel,
 	validatePaginationPosition,
 	validateTableData,
@@ -149,9 +150,7 @@ export class KolTableStateful implements TableAPI {
 
 	@Watch('_allowMultiSort')
 	public validateAllowMultiSort(value?: boolean): void {
-		watchValidator(this, '_allowMultiSort', () => true, new Set(['boolean']), value, {
-			defaultValue: false,
-		});
+		validateAllowMultiSort(this, value, { defaultValue: false });
 	}
 
 	@Watch('_data')

--- a/packages/components/src/schema/props/allow-multi-sort.ts
+++ b/packages/components/src/schema/props/allow-multi-sort.ts
@@ -1,0 +1,19 @@
+import type { Generic } from 'adopted-style-sheets';
+
+import type { WatchBooleanOptions } from '../utils';
+import { watchBoolean } from '../utils';
+
+/* types */
+export type AllowMultiSortPropType = boolean;
+
+/**
+ * Defines whether to allow multi sort.
+ */
+export interface PropAllowMultiSort {
+	allowMultiSort: AllowMultiSortPropType;
+}
+
+/* validator */
+export const validateAllowMultiSort = (component: Generic.Element.Component, value?: AllowMultiSortPropType, options: WatchBooleanOptions = {}): void => {
+	watchBoolean(component, '_allowMultiSort', value, { defaultValue: false, ...options });
+};

--- a/packages/components/src/schema/props/index.ts
+++ b/packages/components/src/schema/props/index.ts
@@ -6,6 +6,7 @@ export * from './alert';
 export * from './alert-type';
 export * from './alt';
 export * from './align';
+export * from './allow-multi-sort';
 export * from './alternative-button-link-role';
 export * from './aria-controls';
 export * from './aria-current-value';


### PR DESCRIPTION
## Summary
Adds an `allowMultiSort` prop with validator to enable multi-column sorting in tables.

## Changes
- Added `allowMultiSort` prop and validator

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`allowMultiSort`-Prop mit Validator hinzugefügt, um mehrspaltige Sortierung in Tabellen zu ermöglichen.

## Änderungen
- `allowMultiSort`-Prop und -Validator hinzugefügt

</details>