### PR TITLE
fix: replace span with kbd for key hints

### DIFF
--- a/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -305,9 +305,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -9,9 +9,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
           <div class="kol-field-control__input">
@@ -273,9 +273,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
           <div class="kol-field-control__input">
@@ -358,9 +358,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -622,9 +622,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -701,9 +701,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -965,9 +965,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -1038,9 +1038,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
           <div class="kol-field-control__input">
@@ -1302,9 +1302,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
           <div class="kol-field-control__input">
@@ -1387,9 +1387,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -1651,9 +1651,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -1730,9 +1730,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -1994,9 +1994,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -2073,9 +2073,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -2337,9 +2337,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -2416,9 +2416,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 V
-              </span>
+              </kbd>
             </span>
           </label>
         </div>
@@ -2680,9 +2680,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           <label class="kol-field-control__label" htmlfor="id-nonce" id="id-nonce-label">
             <span class="kol-field-control__label-text">
               Label
-              <span aria-hidden="true" class="badge-text-hint">
+              <kbd aria-hidden="true" class="badge-text-hint">
                 S
-              </span>
+              </kbd>
             </span>
           </label>
         </div>

--- a/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -285,9 +285,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -342,9 +342,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -620,9 +620,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -255,9 +255,9 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -255,9 +255,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -306,9 +306,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -604,9 +604,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -295,9 +295,9 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -255,9 +255,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -306,9 +306,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -604,9 +604,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -255,9 +255,9 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -285,9 +285,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -312,9 +312,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -710,9 +710,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -255,9 +255,9 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -349,9 +349,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -727,9 +727,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -800,9 +800,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -1178,9 +1178,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -1359,9 +1359,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -1432,9 +1432,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -1810,9 +1810,9 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -305,9 +305,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
@@ -7,9 +7,9 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             V
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">
@@ -245,9 +245,9 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           Label
-          <span aria-hidden="true" class="badge-text-hint">
+          <kbd aria-hidden="true" class="badge-text-hint">
             S
-          </span>
+          </kbd>
         </span>
       </label>
       <div class="kol-form-field__input">

--- a/packages/components/src/functional-components/FormFieldLabel/FormFieldLabel.tsx
+++ b/packages/components/src/functional-components/FormFieldLabel/FormFieldLabel.tsx
@@ -42,9 +42,9 @@ const LabelFc: FC<LabelProps> = ({ hasExpertSlot, accessKey, shortKey, label, sh
 		<>
 			<InternalUnderlinedBadgeText badgeText={badgeText} label={label} />
 			&nbsp;
-			<span class="badge-text-hint" aria-hidden="true">
+			<kbd class="badge-text-hint" aria-hidden="true">
 				{badgeText}
-			</span>
+			</kbd>
 		</>
 	);
 };

--- a/packages/components/src/functional-components/FormFieldLabel/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/FormFieldLabel/tests/__snapshots__/snapshot.test.tsx.snap
@@ -24,9 +24,9 @@ exports[`KolFormFieldLabelFc should render with accessKey and shortKey 1`] = `
 <label class="kol-form-field__label" htmlfor="test-id" id="test-id-label">
   <span class="kol-form-field__label-text">
     Test Label
-    <span aria-hidden="true" class="badge-text-hint">
+    <kbd aria-hidden="true" class="badge-text-hint">
       A
-    </span>
+    </kbd>
   </span>
 </label>
 `;

--- a/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
+++ b/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
@@ -17,9 +17,9 @@ const KolSpanCoreHelperFc: FC<{ label: string; hideLabel?: boolean; badgeText?: 
 				{children}
 			</span>
 			{isString(badgeText) && badgeText.length > 0 && (
-				<span class="badge-text-hint" aria-hidden="true">
+				<kbd class="badge-text-hint" aria-hidden="true">
 					{badgeText}
-				</span>
+				</kbd>
 			)}
 		</>
 	);

--- a/packages/components/src/functional-components/Span/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Span/test/__snapshots__/snapshot.test.tsx.snap
@@ -31,9 +31,9 @@ exports[`KolSpanFc should render with badge text 1`] = `
       </u>
     </span>
     <span aria-hidden="true" class="kol-span__label" hidden=""></span>
-    <span aria-hidden="true" class="badge-text-hint">
+    <kbd aria-hidden="true" class="badge-text-hint">
       Badge
-    </span>
+    </kbd>
   </span>
 </span>
 `;


### PR DESCRIPTION
## Summary
Replaces `<span>` elements with semantically correct `<kbd>` elements for keyboard key hints.

## Changes
- Replaced `<span>` tags with `<kbd>` tags for key hint display

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`<span>`-Elemente durch semantisch korrekte `<kbd>`-Elemente für Tastaturhinweise ersetzt.

## Änderungen
- `<span>`-Tags durch `<kbd>`-Tags für die Anzeige von Tastaturhinweisen ersetzt

</details>