### PR TITLE
refactor: use solid h for skeleton components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -93,7 +93,7 @@
 		"typed-bem": "1.0.0-rc.7",
 		"wcag-contrast": "3.0.0"
 	},
-	"devDependencies": {
+    "devDependencies": {
 		"@playwright/test": "1.53.0",
 		"@public-ui/stencil-angular-output-target": "0.9.0",
 		"@public-ui/stencil-react-output-target": "0.6.0",
@@ -135,11 +135,12 @@
 		"stylelint": "16.20.0",
 		"stylelint-config-recommended-scss": "15.0.1",
 		"stylelint-config-standard": "38.0.0",
-		"stylelint-scss": "6.12.1",
-		"terser": "5.42.0",
-		"twig": "1.17.1",
-		"typescript": "5.8.3"
-	},
+        "stylelint-scss": "6.12.1",
+        "terser": "5.42.0",
+        "twig": "1.17.1",
+        "typescript": "5.8.3",
+        "solid-js": "1.9.7"
+    },
 	"peerDependencies": {
 		"adopted-style-sheets": "1.1.9-rc.19"
 	},

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
@@ -1,5 +1,6 @@
 import type { FunctionalComponent as FC } from '@stencil/core';
-import { h } from '@stencil/core';
+/** @jsxImportSource solid-js */
+import h from 'solid-js/h';
 import type { LabelProp } from '../../schema/props/label';
 import type { FunctionalComponentProps } from '../generic-types';
 

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
@@ -1,5 +1,6 @@
 import type { FunctionalComponent as FC } from '@stencil/core';
-import { h } from '@stencil/core';
+/** @jsxImportSource solid-js */
+import h from 'solid-js/h';
 import type { CountProp } from '../../schema/props/count';
 import type { LabelProp } from '../../schema/props/label';
 import type { NameProp } from '../../schema/props/name';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
       rimraf:
         specifier: 6.0.1
         version: 6.0.1
+      solid-js:
+        specifier: 1.9.7
+        version: 1.9.7
       stencil-awesome-test:
         specifier: 1.0.6
         version: 1.0.6(@stencil/core@4.36.0)


### PR DESCRIPTION
## Summary
- replace Stencil h with Solid h in skeleton functional components
- include solid-js dev dependency

## Testing
- `pnpm build` (fails: ELIFECYCLE Command failed)
- `pnpm lint` (fails: JSX element implicitly has type 'any')
- `pnpm test` (fails: Jest encountered an unexpected token)


------
https://chatgpt.com/codex/tasks/task_e_689242afe448832b84bee72b6dfdcf66