### PR TITLE
refactor: use solid h in skeleton component

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
@@ -1,5 +1,5 @@
-import type { FunctionalComponent as FC } from '@stencil/core';
-import { h } from '@stencil/core';
+import type { JSX } from 'solid-js';
+import h from 'solid-js/h';
 import type { LabelProp } from '../../schema/props/label';
 import type { FunctionalComponentProps } from '../generic-types';
 
@@ -18,7 +18,7 @@ export type ClickButtonRenderStates = Record<never, never>;
 
 type Props = FunctionalComponentProps<ClickButtonRenderProps, ClickButtonRenderStates, ClickButtonCallbacks, ClickButtonEmitters, ClickButtonRefs>;
 
-export const ClickButtonFC: FC<Props> = ({ label, handleClick, refButton }) => (
+export const ClickButtonFC = ({ label, handleClick, refButton }: Props): JSX.Element => (
 	<button ref={refButton} onClick={handleClick}>
 		{label}
 	</button>

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
@@ -1,5 +1,5 @@
-import type { FunctionalComponent as FC } from '@stencil/core';
-import { h } from '@stencil/core';
+import type { JSX } from 'solid-js';
+import h from 'solid-js/h';
 import type { CountProp } from '../../schema/props/count';
 import type { LabelProp } from '../../schema/props/label';
 import type { NameProp } from '../../schema/props/name';
@@ -43,7 +43,7 @@ export type SkeletonRenderStates = LabelProp & ShowProp;
 
 type Props = FunctionalComponentProps<SkeletonRenderProps, SkeletonRenderStates, SkeletonCallbacks, SkeletonEmitters, SkeletonRefs>;
 
-export const SkeletonFC: FC<Props> = ({ count, label, name, show, onLoaded, handleClick, refButton }) => {
+export const SkeletonFC = ({ count, label, name, show, onLoaded, handleClick, refButton }: Props): JSX.Element => {
 	setTimeout(() => {
 		onLoaded.emit(100);
 	}, 1000);

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from '@stencil/core';
-import { Component, h, Host, Prop, Watch } from '@stencil/core';
+import { Component, Host, Prop, Watch } from '@stencil/core';
+import h from 'solid-js/h';
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,5 +1,6 @@
 import type { EventEmitter, JSX } from '@stencil/core';
-import { Component, Event, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
+import { Component, Event, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
+import h from 'solid-js/h';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type {


### PR DESCRIPTION
## Summary
- replace Stencil `h` usage in skeleton blueprint with Solid's `h`
- adjust functional components to return `JSX.Element`
- update web component imports accordingly

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6892455b9e4c832b8dcc8704ccb4cbfd