### PR TITLE
fix: use web component as single label source

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -1,6 +1,5 @@
 import type { CountPropType } from '../../schema/props/count';
 import { normalizeCount, validateCount } from '../../schema/props/count';
-import type { LabelPropType } from '../../schema/props/label';
 import type { NamePropType } from '../../schema/props/name';
 import { normalizeName, validateName } from '../../schema/props/name';
 import { BaseController } from '../base-controller';
@@ -12,8 +11,6 @@ export class SkeletonController
 	extends BaseController<SkeletonRenderProps, SkeletonRenderStates>
 	implements ControllerInterface<SkeletonRenderProps, SkeletonCallbacks, SkeletonRefs, SkeletonMethods, SkeletonListeners>
 {
-	public label: LabelPropType = 'Label';
-
 	public constructor(
 		component: WebComponentInterface<Record<never, never>, SkeletonRenderStates>,
 		private readonly clickButtonController: ClickButtonController,
@@ -29,7 +26,7 @@ export class SkeletonController
 		this.watchCount(count);
 		this.watchName(name);
 		this.clickButtonController.componentWillLoad({
-			label: this.label,
+			label: this.component.label,
 		});
 	}
 

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -80,15 +80,16 @@ export class KolSkeleton implements WebComponentInterface<SkeletonRenderProps, S
 
 	public render(): JSX.Element {
 		const { count, name } = this.controller.getProps();
+		const { label, show } = this;
 		return (
 			<Host>
 				<SkeletonFC
 					count={count}
-					label={this.label}
+					label={label}
 					name={name}
 					handleClick={this.controller.handleClick}
 					onLoaded={this.loaded}
-					show={this.show}
+					show={show}
 					refButton={this.controller.setButtonRef}
 				/>
 			</Host>


### PR DESCRIPTION
## Summary
Refactors label state management so the web component acts as the single source of truth for labels.

## Changes
- Centralised label state to web component

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Label-Zustandsverwaltung überarbeitet, sodass die Web-Komponente als einzige Quelle für Labels gilt.

## Änderungen
- Label-Zustand in der Web-Komponente zentralisiert

</details>