### PR TITLE
fix(basis-theme): update accessibility layer name and remove overwrites

### DIFF
--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -3,7 +3,7 @@
 /*
  * This file contains all rules for accessibility.
  */
-@layer kol-global {
+@layer kol-a11y {
 	:host {
 		/*
 		 * Minimum size of interactive elements.
@@ -79,20 +79,20 @@
 		 */
 		font-size: inherit;
 	}
-}
 
-/**
- * Sometimes we need the semantic element for accessibility reasons,
- * but we don't want to show it.
- *
- * - https://www.a11yproject.com/posts/how-to-hide-content/
- */
-.visually-hidden {
-	clip: rect(0 0 0 0);
-	clip-path: inset(50%);
-	height: 1px;
-	overflow: hidden;
-	position: absolute;
-	white-space: nowrap;
-	width: 1px;
+	/**
+	* Sometimes we need the semantic element for accessibility reasons,
+	* but we don't want to show it.
+	*
+	* - https://www.a11yproject.com/posts/how-to-hide-content/
+	*/
+	.visually-hidden {
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+	}
 }

--- a/packages/themes/bwst/src/mixins/_table-stateless.scss
+++ b/packages/themes/bwst/src/mixins/_table-stateless.scss
@@ -1,12 +1,6 @@
 @use '../rem' as *;
 
 @mixin kol-alert-table-stateless {
-	:host * {
-		hyphens: var(--hyphens);
-		line-height: var(--line-height);
-		word-break: break-word;
-	}
-
 	:host > div {
 		overflow-x: auto;
 		overflow-y: hidden;

--- a/packages/themes/default/src/components/table-stateful.scss
+++ b/packages/themes/default/src/components/table-stateful.scss
@@ -1,11 +1,6 @@
 @use '../mixins/kol-table-stateless-wc' as *;
 
 @layer kol-theme-component {
-	:host * {
-		line-height: var(--line-height);
-		word-break: break-word;
-	}
-
 	@media (min-width: 1024px) {
 		div.pagination .kol-pagination {
 			display: flex;

--- a/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
@@ -2,12 +2,6 @@
 
 @mixin kol-table-stateless-wc {
 	@layer kol-theme-component {
-		:host,
-		.kol-table-stateless-wc * {
-			line-height: var(--line-height);
-			word-break: break-word;
-		}
-
 		:host > div,
 		kol-table-stateless-wc > div {
 			overflow-x: auto;

--- a/packages/themes/ecl/src/ecl-ec/global.scss
+++ b/packages/themes/ecl/src/ecl-ec/global.scss
@@ -55,7 +55,7 @@
 		--font-size: #{to-rem(16)};
 		--font-weight: 400;
 		--font-weight-bold: 600;
-		--line-height: 1.5;
+		--line-height-regular: 1.5;
 		--line-height-heading: 1.2;
 		--spacing-4xl: #{to-rem(64)};
 		--spacing-3xl: #{to-rem(48)};


### PR DESCRIPTION
## Summary
Updates the accessibility CSS layer name in the basis theme and removes redundant overwrites.

## Changes
- Updated accessibility layer name in basis theme
- Removed unnecessary CSS overwrites

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Name des Barrierefreiheits-CSS-Layers im Basis-Theme aktualisiert und redundante Überschreibungen entfernt.

## Änderungen
- Barrierefreiheits-Layer-Name im Basis-Theme aktualisiert
- Unnötige CSS-Überschreibungen entfernt

</details>