### PR TITLE
fix(basis-theme): update accessibility layer name and remove overwrites

### DIFF
--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -3,7 +3,7 @@
 /*
  * This file contains all rules for accessibility.
  */
-@layer kol-global {
+@layer kol-a11y {
 	:host {
 		/*
 		 * Minimum size of interactive elements.
@@ -79,20 +79,20 @@
 		 */
 		font-size: inherit;
 	}
-}
 
-/**
- * Sometimes we need the semantic element for accessibility reasons,
- * but we don't want to show it.
- *
- * - https://www.a11yproject.com/posts/how-to-hide-content/
- */
-.visually-hidden {
-	clip: rect(0 0 0 0);
-	clip-path: inset(50%);
-	height: 1px;
-	overflow: hidden;
-	position: absolute;
-	white-space: nowrap;
-	width: 1px;
+	/**
+	* Sometimes we need the semantic element for accessibility reasons,
+	* but we don't want to show it.
+	*
+	* - https://www.a11yproject.com/posts/how-to-hide-content/
+	*/
+	.visually-hidden {
+		clip: rect(0 0 0 0);
+		clip-path: inset(50%);
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+	}
 }

--- a/packages/themes/default/src/components/table-stateful.scss
+++ b/packages/themes/default/src/components/table-stateful.scss
@@ -4,11 +4,6 @@
 	@include kol-table-stateless-theme;
 
 	.kol-table-stateful {
-		&__pagination {
-			line-height: var(--line-height);
-			word-break: break-word;
-		}
-
 		.kol-pagination {
 			@media (min-width: 1024px) {
 				display: flex;

--- a/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
+++ b/packages/themes/default/src/mixins/kol-table-stateless-wc.scss
@@ -11,9 +11,6 @@
 	.kol-table {
 		$root: &;
 
-		line-height: var(--line-height);
-		word-break: break-word;
-
 		overflow-x: auto;
 		overflow-y: hidden;
 		padding: to-rem(8);

--- a/packages/themes/ecl/README.md
+++ b/packages/themes/ecl/README.md
@@ -90,7 +90,7 @@ The token values are read from `src/ecl-ec/global.scss` and `src/ecl-eu/global.s
 | `--font-size`           | `#{to-rem(16)}`       | Base font size          |
 | `--font-weight`         | `400`                 | Regular font weight     |
 | `--font-weight-bold`    | `600`                 | Bold font               |
-| `--line-height`         | `1.5`                 | Line height text        |
+| `--line-height-regular` | `1.5`                 | Line height text        |
 | `--line-height-heading` | `1.2`                 | Line height headings    |
 | `--spacing-4xl`         | `#{to-rem(64)}`       | Largest spacing         |
 | `--spacing-3xl`         | `#{to-rem(48)}`       | Very large spacing      |

--- a/packages/themes/ecl/src/ecl-ec/global.scss
+++ b/packages/themes/ecl/src/ecl-ec/global.scss
@@ -54,7 +54,7 @@
 		--font-size: #{to-rem(16)};
 		--font-weight: 400;
 		--font-weight-bold: 600;
-		--line-height: 1.5;
+		--line-height-regular: 1.5;
 		--line-height-heading: 1.2;
 		--spacing-4xl: #{to-rem(64)};
 		--spacing-3xl: #{to-rem(48)};


### PR DESCRIPTION
## Summary
Updates the accessibility CSS layer name in the basis theme and removes redundant overwrites.

## Changes
- Updated accessibility layer name in basis theme
- Removed unnecessary CSS overwrites

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Name des Barrierefreiheits-CSS-Layers im Basis-Theme aktualisiert und redundante Überschreibungen entfernt.

## Änderungen
- Barrierefreiheits-Layer-Name im Basis-Theme aktualisiert
- Unnötige CSS-Überschreibungen entfernt

</details>