### PR TITLE
fix: remove unnecessary regex replacement in docs folder readme modification

### DIFF
--- a/packages/components/scripts/autogen.doc.js
+++ b/packages/components/scripts/autogen.doc.js
@@ -44,7 +44,7 @@ const modifyReadmeContent = (contents) =>
 /**
  * Readme content modifications only for the docs folder
  */
-const modifyReadmeContentForDocsFolder = (contents) => contents.replace('style="color:red"', 'class="text-red-500"').replace(/ \\\| /g, '` \\| `');
+const modifyReadmeContentForDocsFolder = (contents) => contents.replace('style="color:red"', 'class="text-red-500"');
 
 rimraf('doc/*.md', { glob: true }).then(() => {
 	README_PATHS.forEach((readmePath) => {


### PR DESCRIPTION
## Summary
Fixes the documentation auto-generation script by removing an unnecessary regex replacement that modified the docs folder readme.

## Changes
- Removed unnecessary regex replacement in docs readme auto-generation

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Skript zur automatischen Dokumentationsgenerierung korrigiert: überflüssige Regex-Ersetzung entfernt.

## Änderungen
- Unnötige Regex-Ersetzung in der Docs-Readme-Autogenerierung entfernt

</details>