### PR TITLE
test: re-enable modal variant close button tests

### DIFF
--- a/packages/components/src/components/modal/modal.e2e.ts
+++ b/packages/components/src/components/modal/modal.e2e.ts
@@ -135,6 +135,8 @@ test.describe('kol-modal', () => {
 			await kolModal.evaluate((element: HTMLKolModalElement) => element.openModal());
 			await expect(dialog).toBeVisible();
 			await expect(page.getByTestId('card-close-button')).toHaveCount(0);
+			await kolModal.evaluate((element: HTMLKolModalElement) => element.closeModal());
+			await expect(dialog).toBeHidden();
 		});
 	});
 });

--- a/packages/components/src/components/modal/modal.e2e.ts
+++ b/packages/components/src/components/modal/modal.e2e.ts
@@ -123,7 +123,7 @@ test.describe('kol-modal', () => {
 			await expect(dialog).toBeHidden();
 			await kolModal.evaluate((element: HTMLKolModalElement) => element.openModal());
 			await expect(dialog).toBeVisible();
-			const closeButton = page.locator('[data-testid="card-close-button"] button');
+			const closeButton = page.getByTestId('card-close-button').locator('button');
 			await expect(closeButton).toBeVisible();
 			await closeButton.evaluate((button) => (button as HTMLButtonElement).click());
 			await expect(dialog).toBeHidden();
@@ -134,7 +134,7 @@ test.describe('kol-modal', () => {
 			const dialog = page.locator('dialog');
 			await kolModal.evaluate((element: HTMLKolModalElement) => element.openModal());
 			await expect(dialog).toBeVisible();
-			await expect(page.locator('[data-testid="card-close-button"]')).toHaveCount(0);
+			await expect(page.getByTestId('card-close-button')).toHaveCount(0);
 		});
 	});
 });

--- a/packages/components/src/components/modal/modal.e2e.ts
+++ b/packages/components/src/components/modal/modal.e2e.ts
@@ -115,28 +115,26 @@ test.describe('kol-modal', () => {
 		});
 	});
 
-	// test.describe('kol-modal - variant', () => {
-	// 	test('it renders the close button in card variant', async ({ page }) => {
-	// 		await page.setContent('<kol-modal _variant="card" _label="">Modal content</kol-modal>');
-	// 		const kolModal = page.locator('kol-modal');
-	// 		const dialog = page.locator('dialog');
-	// 		await expect(dialog).toBeHidden();
-	// 		await kolModal.evaluate((element: HTMLKolModalElement) => element.openModal());
-	// 		await expect(dialog).toBeVisible();
-	// 		const closeButton = page.locator('.kol-modal__close-button');
-	// 		await expect(closeButton).toBeVisible();
-	// 		await closeButton.click();
-	// 		await expect(dialog).toBeHidden();
-	// 	});
-
-	// 	test('it does not render the close button in blank variant', async ({ page }) => {
-	// 		await page.setContent('<kol-modal _variant="blank" _label="">Modal content</kol-modal>');
-	// 		const kolModal = page.locator('kol-modal');
-	// 		const dialog = page.locator('dialog');
-	// 		const closeButton = page.locator('.kol-modal__close-button');
-	// 		await kolModal.evaluate((element: HTMLKolModalElement) => element.openModal());
-	// 		await expect(dialog).toBeVisible();
-	// 		await expect(closeButton).toBeHidden();
-	// 	});
-	// });
+	test.describe('kol-modal - variant', () => {
+		test('it renders the close button in card variant', async ({ page }) => {
+			await page.setContent('<kol-modal _variant="card" _label="">Modal content</kol-modal>');
+			const kolModal = page.locator('kol-modal');
+			const dialog = page.locator('dialog');
+			await expect(dialog).toBeHidden();
+			await kolModal.evaluate((element: HTMLKolModalElement) => element.openModal());
+			await expect(dialog).toBeVisible();
+			const closeButton = page.locator('[data-testid="card-close-button"] button');
+			await expect(closeButton).toBeVisible();
+			await closeButton.evaluate((button) => (button as HTMLButtonElement).click());
+			await expect(dialog).toBeHidden();
+		});
+		test('it does not render the close button in blank variant', async ({ page }) => {
+			await page.setContent('<kol-modal _variant="blank" _label="">Modal content</kol-modal>');
+			const kolModal = page.locator('kol-modal');
+			const dialog = page.locator('dialog');
+			await kolModal.evaluate((element: HTMLKolModalElement) => element.openModal());
+			await expect(dialog).toBeVisible();
+			await expect(page.locator('[data-testid="card-close-button"]')).toHaveCount(0);
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Re-enables previously disabled modal variant close button tests and refactors them for reliability.

## Changes
- Re-enabled modal variant close button tests
- Refactored tests for improved reliability

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Zuvor deaktivierte Schaltflächentests für Modal-Varianten wieder aktiviert und überarbeitet.

## Änderungen
- Modal-Varianten-Schließbutton-Tests wieder aktiviert
- Tests für verbesserte Zuverlässigkeit überarbeitet

</details>