### PR TITLE
feat(components): require minWidth for table header cells

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -43,6 +43,8 @@ import type { ColumnSettings } from '../../schema/types';
 import { nonce } from '../../utils/dev.utils';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 
+const EMPTY_CELL_MIN_WIDTH = 'auto';
+
 /**
  * @internal
  */
@@ -456,7 +458,7 @@ export class KolTableStateless implements TableStatelessAPI {
 			const emptyCell = {
 				colSpan: colspan,
 				label: this.translateNoEntries,
-				minWidth: 'auto',
+				minWidth: EMPTY_CELL_MIN_WIDTH,
 				render: undefined,
 				rowSpan: Math.max(rowspan, 1),
 			};
@@ -491,10 +493,14 @@ export class KolTableStateless implements TableStatelessAPI {
 			.map((header, index) => ({
 				key: header.key ?? nonce(),
 				label: header.label,
-				minWidth: header.minWidth ?? header.width ?? 'auto',
+				minWidth: this.getHeaderMinWidth(header),
 				position: index,
 				visible: true,
 			}));
+	}
+
+	private getHeaderMinWidth(header: KoliBriTableHeaderCell): string {
+		return header.minWidth ?? header.width ?? EMPTY_CELL_MIN_WIDTH;
 	}
 
 	public componentWillLoad(): void {
@@ -645,7 +651,7 @@ export class KolTableStateless implements TableStatelessAPI {
 		}
 
 		if ((cell as KoliBriTableHeaderCellWithLogic).headerCell) {
-			return this.renderHeadingCell(cell, rowIndex, colIndex, isVertical);
+			return this.renderHeadingCell(cell as KoliBriTableHeaderCell, rowIndex, colIndex, isVertical);
 		} else {
 			return (
 				<td
@@ -708,17 +714,22 @@ export class KolTableStateless implements TableStatelessAPI {
 		const visibleColumns = this.state._tableSettings?.columns.filter((col) => col.visible) ?? [];
 
 		if (visibleColumns.length === 0) {
-			return this._minWidth || 'auto';
+			return this._minWidth || EMPTY_CELL_MIN_WIDTH;
 		}
 
-		const nonAutoWidths = visibleColumns.map((col) => col.minWidth).filter((width) => width !== 'auto');
+		const nonAutoWidths = visibleColumns.map((col) => col.minWidth).filter((width) => width !== EMPTY_CELL_MIN_WIDTH);
 
 		if (nonAutoWidths.length === 0) {
-			return this._minWidth || 'auto';
+			return this._minWidth || EMPTY_CELL_MIN_WIDTH;
 		}
 
 		if (nonAutoWidths.length === 1) {
 			return nonAutoWidths[0];
+		}
+
+		const units = nonAutoWidths.map((width) => width.match(/[a-z%]+$/)?.[0] ?? '');
+		if (new Set(units).size > 1) {
+			return this._minWidth || EMPTY_CELL_MIN_WIDTH;
 		}
 
 		return `calc(${nonAutoWidths.join(' + ')})`;

--- a/packages/components/src/components/table-stateless/table-settings.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-settings.e2e.ts
@@ -12,9 +12,9 @@ const DATA = [
 const HEADERS: TableHeaderCellsPropType = {
 	horizontal: [
 		[
-			{ key: 'id', label: 'ID' },
-			{ key: 'name', label: 'Name' },
-			{ key: 'age', label: 'Age' },
+			{ key: 'id', label: 'ID', minWidth: 'auto' },
+			{ key: 'name', label: 'Name', minWidth: 'auto' },
+			{ key: 'age', label: 'Age', minWidth: 'auto' },
 		],
 	],
 };

--- a/packages/components/src/components/table-stateless/table-stateless.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-stateless.e2e.ts
@@ -5,7 +5,7 @@ import { KolEvent } from '../../utils/events';
 
 const DATA = [{ id: '1001' }, { id: '1002' }, { id: '1003' }, { id: '1004' }];
 const HEADERS: TableHeaderCellsPropType = {
-	horizontal: [[{ key: 'id', label: 'ID', sortDirection: 'ASC' }]],
+	horizontal: [[{ key: 'id', label: 'ID', minWidth: 'auto', sortDirection: 'ASC' }]],
 };
 
 type Data = (typeof DATA)[0];

--- a/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`kol-table-stateless-wc should render with _label="Table with horizontal and vertical headers" _minWidth="400px" _headerCells={"horizontal":[[{"key":"header1","label":"Header1","minWidth":"auto","textAlign":"left"},{"key":"header2","label":"Header2","minWidth":"auto","textAlign":"center"},{"key":"header3","label":"Header3","minWidth":"auto","textAlign":"right"}]],"vertical":[[{"key":"row1","label":"Row 1","minWidth":"auto","textAlign":"left"},{"key":"row2","label":"Row 2","minWidth":"auto","textAlign":"center"},{"key":"row3","label":"Row 3","minWidth":"auto","textAlign":"right"}]]} _data=[{"header1":"Cell 1.1","header2":"Cell 1.2","header3":"Cell 1.3"},{"header1":"Cell 2.1","header2":"Cell 2.2","header3":"Cell 2.3"},{"header1":"Cell 3.1","header2":"Cell 3.2","header3":"Cell 3.3"}] 1`] = `
+<kol-table-stateless-wc>
+  <div class="kol-table">
+    <kol-table-settings-wc></kol-table-settings-wc>
+    <div class="kol-table__scroll-container">
+      <table class="kol-table__table" style="min-width: 400px;">
+        <div aria-describedby="caption" class="kol-table__focus-element"></div>
+        <caption class="kol-table__caption" id="caption">
+          Table with horizontal and vertical headers
+        </caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <td aria-hidden="true" colspan="1" rowspan="1"></td>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Header1
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-center kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Header2
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-right kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Header3
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="4"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="row" style="min-width: auto;">
+              Row 1
+            </th>
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="min-width: auto; text-align: left;">
+              Cell 1.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="min-width: auto; text-align: center;">
+              Cell 1.2
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-right kol-table__cell--body" style="min-width: auto; text-align: right;">
+              Cell 1.3
+            </td>
+          </tr>
+          <tr class="kol-table__row kol-table__row--body">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-center kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="row" style="min-width: auto;">
+              Row 2
+            </th>
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="min-width: auto; text-align: left;">
+              Cell 2.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="min-width: auto; text-align: center;">
+              Cell 2.2
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-right kol-table__cell--body" style="min-width: auto; text-align: right;">
+              Cell 2.3
+            </td>
+          </tr>
+          <tr class="kol-table__row kol-table__row--body">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-right kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="row" style="min-width: auto;">
+              Row 3
+            </th>
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="min-width: auto; text-align: left;">
+              Cell 3.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="min-width: auto; text-align: center;">
+              Cell 3.2
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-right kol-table__cell--body" style="min-width: auto; text-align: right;">
+              Cell 3.3
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;
+
 exports[`kol-table-stateless-wc should render with _label="Table with horizontal and vertical headers" _minWidth="400px" _headerCells={"horizontal":[[{"key":"header1","label":"Header1","textAlign":"left"},{"key":"header2","label":"Header2","textAlign":"center"},{"key":"header3","label":"Header3","textAlign":"right"}]],"vertical":[[{"key":"row1","label":"Row 1","textAlign":"left"},{"key":"row2","label":"Row 2","textAlign":"center"},{"key":"row3","label":"Row 3","textAlign":"right"}]]} _data=[{"header1":"Cell 1.1","header2":"Cell 1.2","header3":"Cell 1.3"},{"header1":"Cell 2.1","header2":"Cell 2.2","header3":"Cell 2.3"},{"header1":"Cell 3.1","header2":"Cell 3.2","header3":"Cell 3.3"}] 1`] = `
 <kol-table-stateless-wc>
   <div class="kol-table">
@@ -77,6 +154,53 @@ exports[`kol-table-stateless-wc should render with _label="Table with horizontal
 </kol-table-stateless-wc>
 `;
 
+exports[`kol-table-stateless-wc should render with _label="Table with only horizontal headers" _minWidth="400px" _headerCells={"horizontal":[[{"key":"header1","label":"Header 1","minWidth":"auto","textAlign":"left"},{"key":"header2","label":"Header 2","minWidth":"auto","textAlign":"center"}]],"vertical":[]} _data=[{"header1":"Cell 1.1","header2":"Cell 1.2"},{"header1":"Cell 2.1","header2":"Cell 2.2"}] 1`] = `
+<kol-table-stateless-wc>
+  <div class="kol-table">
+    <kol-table-settings-wc></kol-table-settings-wc>
+    <div class="kol-table__scroll-container">
+      <table class="kol-table__table" style="min-width: 400px;">
+        <div aria-describedby="caption" class="kol-table__focus-element"></div>
+        <caption class="kol-table__caption" id="caption">
+          Table with only horizontal headers
+        </caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Header 1
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-center kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Header 2
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="2"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="min-width: auto; text-align: left;">
+              Cell 1.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="min-width: auto; text-align: center;">
+              Cell 1.2
+            </td>
+          </tr>
+          <tr class="kol-table__row kol-table__row--body">
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="min-width: auto; text-align: left;">
+              Cell 2.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="min-width: auto; text-align: center;">
+              Cell 2.2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;
+
 exports[`kol-table-stateless-wc should render with _label="Table with only horizontal headers" _minWidth="400px" _headerCells={"horizontal":[[{"key":"header1","label":"Header 1","textAlign":"left"},{"key":"header2","label":"Header 2","textAlign":"center"}]],"vertical":[]} _data=[{"header1":"Cell 1.1","header2":"Cell 1.2"},{"header1":"Cell 2.1","header2":"Cell 2.2"}] 1`] = `
 <kol-table-stateless-wc>
   <div class="kol-table">
@@ -114,6 +238,68 @@ exports[`kol-table-stateless-wc should render with _label="Table with only horiz
               Cell 2.1
             </td>
             <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="text-align: center;">
+              Cell 2.2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;
+
+exports[`kol-table-stateless-wc should render with _label="Table with two horizontal header rows" _minWidth="400px" _headerCells={"horizontal":[[{"label":"Header 1","minWidth":"auto","textAlign":"left"},{"label":"Header 2","minWidth":"auto","textAlign":"center"}],[{"key":"header1","label":"Sub Header 1","minWidth":"auto","textAlign":"left"},{"key":"header2","label":"Sub Header 2","minWidth":"auto","textAlign":"center"}]],"vertical":[[{"key":"row-1","label":"Row 1","minWidth":"auto","textAlign":"left"},{"key":"row-2","label":"Row 2","minWidth":"auto","textAlign":"center"}]]} _data=[{"header1":"Cell 1.1","header2":"Cell 1.2"},{"header1":"Cell 2.1","header2":"Cell 2.2"}] 1`] = `
+<kol-table-stateless-wc>
+  <div class="kol-table">
+    <kol-table-settings-wc></kol-table-settings-wc>
+    <div class="kol-table__scroll-container">
+      <table class="kol-table__table" style="min-width: 400px;">
+        <div aria-describedby="caption" class="kol-table__focus-element"></div>
+        <caption class="kol-table__caption" id="caption">
+          Table with two horizontal header rows
+        </caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <td aria-hidden="true" colspan="1" rowspan="2"></td>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Header 1
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-center kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Header 2
+            </th>
+          </tr>
+          <tr class="kol-table__head-row">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Sub Header 1
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-center kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Sub Header 2
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="3"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="row" style="min-width: auto;">
+              Row 1
+            </th>
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="min-width: auto; text-align: left;">
+              Cell 1.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="min-width: auto; text-align: center;">
+              Cell 1.2
+            </td>
+          </tr>
+          <tr class="kol-table__row kol-table__row--body">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-center kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="row" style="min-width: auto;">
+              Row 2
+            </th>
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="min-width: auto; text-align: left;">
+              Cell 2.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="min-width: auto; text-align: center;">
               Cell 2.2
             </td>
           </tr>
@@ -176,6 +362,68 @@ exports[`kol-table-stateless-wc should render with _label="Table with two horizo
               Cell 2.1
             </td>
             <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="text-align: center;">
+              Cell 2.2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;
+
+exports[`kol-table-stateless-wc should render with _label="Table with two spanned horizontal and vertical headers" _minWidth="400px" _headerCells={"horizontal":[[{"label":"H-Header","colSpan":2,"minWidth":"auto"}],[{"key":"header1","label":"Sub H-Header 1","minWidth":"auto"},{"key":"header2","label":"Sub H-Header 2","minWidth":"auto"}]],"vertical":[[{"label":"V-Header","rowSpan":2,"minWidth":"auto"}],[{"label":"Sub V-Header 1","minWidth":"auto"},{"label":"Sub V-Header 2","minWidth":"auto"}]]} _data=[{"header1":"Cell 1.1","header2":"Cell 1.2"},{"header1":"Cell 2.1","header2":"Cell 2.2"}] 1`] = `
+<kol-table-stateless-wc>
+  <div class="kol-table">
+    <kol-table-settings-wc></kol-table-settings-wc>
+    <div class="kol-table__scroll-container">
+      <table class="kol-table__table" style="min-width: 400px;">
+        <div aria-describedby="caption" class="kol-table__focus-element"></div>
+        <caption class="kol-table__caption" id="caption">
+          Table with two spanned horizontal and vertical headers
+        </caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <td aria-hidden="true" colspan="2" rowspan="2"></td>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" colspan="2" data-sort="sort-undefined" scope="colgroup" style="min-width: auto;">
+              H-Header
+            </th>
+          </tr>
+          <tr class="kol-table__head-row">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Sub H-Header 1
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col" style="min-width: auto;">
+              Sub H-Header 2
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="4"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" rowspan="2" scope="row" style="min-width: auto;">
+              V-Header
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="row" style="min-width: auto;">
+              Sub V-Header 1
+            </th>
+            <td class="kol-table__cell kol-table__cell--body" style="min-width: auto;">
+              Cell 1.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--body" style="min-width: auto;">
+              Cell 1.2
+            </td>
+          </tr>
+          <tr class="kol-table__row kol-table__row--body">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="row" style="min-width: auto;">
+              Sub V-Header 2
+            </th>
+            <td class="kol-table__cell kol-table__cell--body" style="min-width: auto;">
+              Cell 2.1
+            </td>
+            <td class="kol-table__cell kol-table__cell--body" style="min-width: auto;">
               Cell 2.2
             </td>
           </tr>

--- a/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
+++ b/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
@@ -14,16 +14,16 @@ executeSnapshotTests<TableStatelessProps>(
 			_headerCells: {
 				horizontal: [
 					[
-						{ key: 'header1', label: 'Header1', textAlign: 'left' },
-						{ key: 'header2', label: 'Header2', textAlign: 'center' },
-						{ key: 'header3', label: 'Header3', textAlign: 'right' },
+						{ key: 'header1', label: 'Header1', minWidth: 'auto', textAlign: 'left' },
+						{ key: 'header2', label: 'Header2', minWidth: 'auto', textAlign: 'center' },
+						{ key: 'header3', label: 'Header3', minWidth: 'auto', textAlign: 'right' },
 					],
 				],
 				vertical: [
 					[
-						{ key: 'row1', label: 'Row 1', textAlign: 'left' },
-						{ key: 'row2', label: 'Row 2', textAlign: 'center' },
-						{ key: 'row3', label: 'Row 3', textAlign: 'right' },
+						{ key: 'row1', label: 'Row 1', minWidth: 'auto', textAlign: 'left' },
+						{ key: 'row2', label: 'Row 2', minWidth: 'auto', textAlign: 'center' },
+						{ key: 'row3', label: 'Row 3', minWidth: 'auto', textAlign: 'right' },
 					],
 				],
 			},
@@ -39,8 +39,8 @@ executeSnapshotTests<TableStatelessProps>(
 			_headerCells: {
 				horizontal: [
 					[
-						{ key: 'header1', label: 'Header 1', textAlign: 'left' },
-						{ key: 'header2', label: 'Header 2', textAlign: 'center' },
+						{ key: 'header1', label: 'Header 1', minWidth: 'auto', textAlign: 'left' },
+						{ key: 'header2', label: 'Header 2', minWidth: 'auto', textAlign: 'center' },
 					],
 				],
 				vertical: [],
@@ -56,18 +56,18 @@ executeSnapshotTests<TableStatelessProps>(
 			_headerCells: {
 				horizontal: [
 					[
-						{ label: 'Header 1', textAlign: 'left' },
-						{ label: 'Header 2', textAlign: 'center' },
+						{ label: 'Header 1', minWidth: 'auto', textAlign: 'left' },
+						{ label: 'Header 2', minWidth: 'auto', textAlign: 'center' },
 					],
 					[
-						{ key: 'header1', label: 'Sub Header 1', textAlign: 'left' },
-						{ key: 'header2', label: 'Sub Header 2', textAlign: 'center' },
+						{ key: 'header1', label: 'Sub Header 1', minWidth: 'auto', textAlign: 'left' },
+						{ key: 'header2', label: 'Sub Header 2', minWidth: 'auto', textAlign: 'center' },
 					],
 				],
 				vertical: [
 					[
-						{ key: 'row-1', label: 'Row 1', textAlign: 'left' },
-						{ key: 'row-2', label: 'Row 2', textAlign: 'center' },
+						{ key: 'row-1', label: 'Row 1', minWidth: 'auto', textAlign: 'left' },
+						{ key: 'row-2', label: 'Row 2', minWidth: 'auto', textAlign: 'center' },
 					],
 				],
 			},
@@ -81,13 +81,19 @@ executeSnapshotTests<TableStatelessProps>(
 			_minWidth: '400px',
 			_headerCells: {
 				horizontal: [
-					[{ label: 'H-Header', colSpan: 2 }],
+					[{ label: 'H-Header', colSpan: 2, minWidth: 'auto' }],
 					[
-						{ key: 'header1', label: 'Sub H-Header 1' },
-						{ key: 'header2', label: 'Sub H-Header 2' },
+						{ key: 'header1', label: 'Sub H-Header 1', minWidth: 'auto' },
+						{ key: 'header2', label: 'Sub H-Header 2', minWidth: 'auto' },
 					],
 				],
-				vertical: [[{ label: 'V-Header', rowSpan: 2 }], [{ label: 'Sub V-Header 1' }, { label: 'Sub V-Header 2' }]],
+				vertical: [
+					[{ label: 'V-Header', rowSpan: 2, minWidth: 'auto' }],
+					[
+						{ label: 'Sub V-Header 1', minWidth: 'auto' },
+						{ label: 'Sub V-Header 2', minWidth: 'auto' },
+					],
+				],
 			},
 			_data: [
 				{ header1: 'Cell 1.1', header2: 'Cell 1.2' },

--- a/packages/components/src/schema/props/min-width.ts
+++ b/packages/components/src/schema/props/min-width.ts
@@ -1,6 +1,6 @@
 import type { Generic } from 'adopted-style-sheets';
 import type { WatchStringOptions } from '../utils';
-import { watchValidator } from '../utils';
+import { Log, watchValidator } from '../utils';
 
 /**
  * MinWidthPropType is a type alias for a string that represents the minimum width of a whole table.
@@ -27,6 +27,9 @@ const HEADER_CELL_WIDTH_VALIDATOR = /^\d+(\.\d+)?([a-z]+|%)?$/;
  * @deprecated Will be calculated by minWidth of each header column definition.
  */
 export const validateMinWidth = (component: Generic.Element.Component, value?: MinWidthPropType, options?: WatchStringOptions): void => {
+	Log.warn(
+		'[DEPRECATED] validateMinWidth is deprecated and will be removed in the next major version. Min width will be calculated by minWidth of each header column definition.',
+	);
 	watchValidator(
 		component,
 		'_minWidth',

--- a/packages/components/src/schema/types/table.ts
+++ b/packages/components/src/schema/types/table.ts
@@ -19,10 +19,11 @@ export type KoliBriTableCell = {
 	width?: string;
 };
 
-export type KoliBriTableHeaderCell = KoliBriTableCell & {
-	key?: string;
-	sortDirection?: KoliBriSortDirection;
-};
+export type KoliBriTableHeaderCell = KoliBriTableCell &
+	Required<Pick<KoliBriTableCell, 'minWidth'>> & {
+		key?: string;
+		sortDirection?: KoliBriSortDirection;
+	};
 
 export type KoliBriTableSelection = {
 	label: (row: KoliBriTableDataType) => string;

--- a/packages/samples/react/src/components/button/short-key.tsx
+++ b/packages/samples/react/src/components/button/short-key.tsx
@@ -83,11 +83,13 @@ export const ButtonShortKey: FC = () => {
 					label: 'Label',
 					key: 'label',
 					textAlign: 'left',
+					minWidth: 'auto',
 				},
 				{
 					label: 'Actions',
 					key: 'actions',
 					textAlign: 'left',
+					minWidth: 'auto',
 
 					render: (el, cell) => {
 						getRoot(createReactRenderElement(el)).render(<RowActions label={(cell.data as Data).label} />);

--- a/packages/samples/react/src/components/handout/basic.tsx
+++ b/packages/samples/react/src/components/handout/basic.tsx
@@ -56,16 +56,19 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 			{
 				label: 'Workdays',
 				colSpan: 5,
+				minWidth: 'auto',
 			},
 			{
 				label: 'Weekend',
 				colSpan: 2,
+				minWidth: 'auto',
 			},
 		],
 		[
 			{
 				key: 'monday',
 				label: 'Monday',
+				minWidth: 'auto',
 				render: (el, cell) => {
 					const renderElement = document.createElement('div');
 					renderElement.setAttribute('role', 'presentation');
@@ -88,6 +91,7 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 			{
 				key: 'tuesday',
 				label: 'Tuesday',
+				minWidth: 'auto',
 				render: (el, cell) => {
 					const renderElement = document.createElement('div');
 					renderElement.setAttribute('role', 'presentation');
@@ -109,6 +113,7 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 			{
 				key: 'wednesday',
 				label: 'Wednesday',
+				minWidth: 'auto',
 				render: (el, cell) => {
 					const renderElement = document.createElement('div');
 					renderElement.setAttribute('role', 'presentation');
@@ -120,6 +125,7 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 			{
 				key: 'thursday',
 				label: 'Thursday',
+				minWidth: 'auto',
 				render: (el, cell) => {
 					const renderElement = document.createElement('div');
 					renderElement.setAttribute('role', 'presentation');
@@ -131,6 +137,7 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 			{
 				key: 'friday',
 				label: 'Friday',
+				minWidth: 'auto',
 				render: (el, cell) => {
 					const renderElement = document.createElement('div');
 					renderElement.setAttribute('role', 'presentation');
@@ -142,6 +149,7 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 			{
 				key: 'saturday',
 				label: 'Saturday',
+				minWidth: 'auto',
 				render: (el, cell) => {
 					const renderElement = document.createElement('div');
 					renderElement.setAttribute('role', 'presentation');
@@ -153,6 +161,7 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 			{
 				key: 'sunday',
 				label: 'Sunday',
+				minWidth: 'auto',
 				render: (el, cell) => {
 					const renderElement = document.createElement('div');
 					renderElement.setAttribute('role', 'presentation');
@@ -167,15 +176,19 @@ const TABLE_HEADERS: KoliBriTableHeaders = {
 		[
 			{
 				label: 'Early',
+				minWidth: 'auto',
 			},
 			{
 				label: 'Noon',
+				minWidth: 'auto',
 			},
 			{
 				label: 'Evening',
+				minWidth: 'auto',
 			},
 			{
 				label: 'Night',
+				minWidth: 'auto',
 			},
 		],
 	],

--- a/packages/samples/react/src/components/input-text/text-formatter.tsx
+++ b/packages/samples/react/src/components/input-text/text-formatter.tsx
@@ -77,11 +77,11 @@ export function InputTextFormatterDemo() {
 													_touched={form.touched.iban}
 													_required
 													_on={{
-														onInput: (event, value: unknown) => {
-															if (event.target) {
-																const parsed_value = formatter.parse((value as string) ?? '');
-
-																void form.setFieldValue('iban', parsed_value, true);
+														onInput: (event: Event, value: unknown) => {
+															const target = event.target as HTMLInputElement | null;
+															if (target) {
+																const parsedValue = formatter.parse((value as string) ?? '');
+																void form.setFieldValue('iban', parsedValue, true);
 															}
 														},
 													}}

--- a/packages/samples/react/src/components/table/column-alignment.tsx
+++ b/packages/samples/react/src/components/table/column-alignment.tsx
@@ -22,9 +22,9 @@ export const TableColumnAlignment: FC = () => (
 				_headers={{
 					horizontal: [
 						[
-							{ label: 'left', key: 'left', textAlign: 'left' },
-							{ label: 'center', key: 'center', textAlign: 'center' },
-							{ label: 'right', key: 'right', textAlign: 'right' },
+							{ label: 'left', key: 'left', textAlign: 'left', minWidth: 'auto' },
+							{ label: 'center', key: 'center', textAlign: 'center', minWidth: 'auto' },
+							{ label: 'right', key: 'right', textAlign: 'right', minWidth: 'auto' },
 						],
 					],
 				}}
@@ -40,9 +40,9 @@ export const TableColumnAlignment: FC = () => (
 				_headers={{
 					horizontal: [
 						[
-							{ label: 'left', key: 'left', textAlign: 'left', compareFn: genericNonSorter },
-							{ label: 'center', key: 'center', textAlign: 'center', compareFn: genericNonSorter },
-							{ label: 'right', key: 'right', textAlign: 'right', compareFn: genericNonSorter },
+							{ label: 'left', key: 'left', textAlign: 'left', compareFn: genericNonSorter, minWidth: 'auto' },
+							{ label: 'center', key: 'center', textAlign: 'center', compareFn: genericNonSorter, minWidth: 'auto' },
+							{ label: 'right', key: 'right', textAlign: 'right', compareFn: genericNonSorter, minWidth: 'auto' },
 						],
 					],
 				}}
@@ -58,9 +58,9 @@ export const TableColumnAlignment: FC = () => (
 				_headers={{
 					horizontal: [
 						[
-							{ label: 'left', key: 'left', textAlign: 'left', compareFn: genericNonSorter },
-							{ label: 'center', key: 'center', textAlign: 'center', compareFn: genericNonSorter },
-							{ label: 'right', key: 'right', textAlign: 'right' },
+							{ label: 'left', key: 'left', textAlign: 'left', compareFn: genericNonSorter, minWidth: 'auto' },
+							{ label: 'center', key: 'center', textAlign: 'center', compareFn: genericNonSorter, minWidth: 'auto' },
+							{ label: 'right', key: 'right', textAlign: 'right', minWidth: 'auto' },
 						],
 					],
 				}}
@@ -76,12 +76,12 @@ export const TableColumnAlignment: FC = () => (
 				_headers={{
 					horizontal: [
 						[
-							{ label: 'left', key: 'left', textAlign: 'left' },
-							{ label: 'center', key: 'center', textAlign: 'center' },
-							{ label: 'right', key: 'right', textAlign: 'right' },
+							{ label: 'left', key: 'left', textAlign: 'left', minWidth: 'auto' },
+							{ label: 'center', key: 'center', textAlign: 'center', minWidth: 'auto' },
+							{ label: 'right', key: 'right', textAlign: 'right', minWidth: 'auto' },
 						],
 					],
-					vertical: [[{ label: 'Vertical' }]],
+					vertical: [[{ label: 'Vertical', minWidth: 'auto' }]],
 				}}
 				_data={DATA}
 				className="block"

--- a/packages/samples/react/src/components/table/complex-headers.tsx
+++ b/packages/samples/react/src/components/table/complex-headers.tsx
@@ -45,9 +45,11 @@ export const TableComplexHeaders: FC = () => (
 							{
 								label: 'Berlin',
 								rowSpan: 2,
+								minWidth: 'auto',
 							},
 							{
 								label: 'München',
+								minWidth: 'auto',
 							},
 						],
 					],
@@ -57,44 +59,54 @@ export const TableComplexHeaders: FC = () => (
 								label: 'District',
 								rowSpan: 2,
 								key: 'asp',
+								minWidth: 'auto',
 							},
 							{
 								label: 'Workdays',
 								colSpan: 5,
+								minWidth: 'auto',
 							},
 							{
 								label: 'Weekend',
 								colSpan: 2,
+								minWidth: 'auto',
 							},
 						],
 						[
 							{
 								label: 'Monday',
 								key: 'monday',
+								minWidth: 'auto',
 							},
 							{
 								label: 'Tuesday',
 								key: 'tuesday',
+								minWidth: 'auto',
 							},
 							{
 								label: 'Wednesday',
 								key: 'wednesday',
+								minWidth: 'auto',
 							},
 							{
 								label: 'Thursday',
 								key: 'thursday',
+								minWidth: 'auto',
 							},
 							{
 								label: 'Friday',
 								key: 'friday',
+								minWidth: 'auto',
 							},
 							{
 								label: 'Saturday',
 								key: 'saturday',
+								minWidth: 'auto',
 							},
 							{
 								label: 'Sunday',
 								key: 'sunday',
+								minWidth: 'auto',
 							},
 						],
 					],

--- a/packages/samples/react/src/components/table/horizontal-scrollbar.tsx
+++ b/packages/samples/react/src/components/table/horizontal-scrollbar.tsx
@@ -11,10 +11,10 @@ const DATA = [{ small: 'Small Example', large: 'Larger Example' }];
 const HEADERS: KoliBriTableHeaders = {
 	horizontal: [
 		[
-			{ label: 'Large Column', key: 'large', textAlign: 'left', width: '300px' },
-			{ label: 'Small Column', key: 'small', textAlign: 'left', width: '200px' },
-			{ label: 'Larger Column', key: 'large', textAlign: 'left', width: '400px' },
-			{ label: 'Larger Column', key: 'large', textAlign: 'left', width: '400px' },
+			{ label: 'Large Column', key: 'large', textAlign: 'left', width: '300px', minWidth: '300px' },
+			{ label: 'Small Column', key: 'small', textAlign: 'left', width: '200px', minWidth: '200px' },
+			{ label: 'Larger Column', key: 'large', textAlign: 'left', width: '400px', minWidth: '400px' },
+			{ label: 'Larger Column', key: 'large', textAlign: 'left', width: '400px', minWidth: '400px' },
 		],
 	],
 };

--- a/packages/samples/react/src/components/table/interactive-child-elements.tsx
+++ b/packages/samples/react/src/components/table/interactive-child-elements.tsx
@@ -22,6 +22,7 @@ const getButtonHeaderCell = (variant: ButtonVariantPropType): KoliBriTableHeader
 		label: capitalizedVariant,
 		key: variant,
 		textAlign: 'left',
+		minWidth: 'auto',
 		render: (element: HTMLElement, cell: KoliBriTableCell) => {
 			const commonProps = {
 				_label: capitalizedVariant,
@@ -57,7 +58,12 @@ export const InteractiveChildElements: FC = () => (
 							getButtonHeaderCell('ghost'),
 						],
 					],
-					vertical: [[{ label: 'Button' }, { label: 'Link-Button' }]],
+					vertical: [
+						[
+							{ label: 'Button', minWidth: 'auto' },
+							{ label: 'Link-Button', minWidth: 'auto' },
+						],
+					],
 				}}
 				_data={[
 					{
@@ -88,6 +94,7 @@ export const InteractiveChildElements: FC = () => (
 								key: 'regular',
 								label: 'Regular',
 								textAlign: 'left',
+								minWidth: 'auto',
 								render: (element: HTMLElement, cell: KoliBriTableCell) => {
 									const commonProps = {
 										_label: cell.label,
@@ -100,7 +107,12 @@ export const InteractiveChildElements: FC = () => (
 							},
 						],
 					],
-					vertical: [[{ label: 'Link' }, { label: 'Button-Link' }]],
+					vertical: [
+						[
+							{ label: 'Link', minWidth: 'auto' },
+							{ label: 'Button-Link', minWidth: 'auto' },
+						],
+					],
 				}}
 				_data={[
 					{

--- a/packages/samples/react/src/components/table/multi-sort.tsx
+++ b/packages/samples/react/src/components/table/multi-sort.tsx
@@ -20,6 +20,7 @@ const HEADERS_HORIZONTAL: KoliBriTableHeaders = {
 				label: 'order',
 				key: 'order',
 				textAlign: 'center',
+				minWidth: 'auto',
 				compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) => {
 					if ((data0 as Data).order < (data1 as Data).order) return -1;
 					else if ((data1 as Data).order < (data0 as Data).order) return 1;
@@ -30,6 +31,7 @@ const HEADERS_HORIZONTAL: KoliBriTableHeaders = {
 				label: 'date',
 				key: 'date',
 				textAlign: 'center',
+				minWidth: 'auto',
 				render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as Data).date),
 				compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) => {
 					if ((data0 as Data).date < (data1 as Data).date) return -1;
@@ -48,6 +50,7 @@ const HEADERS_VERTICAL: KoliBriTableHeaders = {
 				label: 'order',
 				key: 'order',
 				textAlign: 'center',
+				minWidth: 'auto',
 				compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) => {
 					if ((data0 as Data).order < (data1 as Data).order) return -1;
 					else if ((data1 as Data).order < (data0 as Data).order) return 1;
@@ -58,6 +61,7 @@ const HEADERS_VERTICAL: KoliBriTableHeaders = {
 				label: 'date',
 				key: 'date',
 				textAlign: 'center',
+				minWidth: 'auto',
 				render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as Data).date),
 				compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) => {
 					if ((data0 as Data).date < (data1 as Data).date) return -1;

--- a/packages/samples/react/src/components/table/pagination-position.tsx
+++ b/packages/samples/react/src/components/table/pagination-position.tsx
@@ -13,8 +13,8 @@ import type { KoliBriTableHeaders, KoliBriTablePaginationProps } from '@public-u
 const HEADERS: KoliBriTableHeaders = {
 	horizontal: [
 		[
-			{ label: 'Order', key: 'order' },
-			{ label: 'Date', key: 'date', render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as unknown as Data).date) },
+			{ label: 'Order', key: 'order', minWidth: 'auto' },
+			{ label: 'Date', key: 'date', render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as unknown as Data).date), minWidth: 'auto' },
 		],
 	],
 };

--- a/packages/samples/react/src/components/table/predefined-settings.tsx
+++ b/packages/samples/react/src/components/table/predefined-settings.tsx
@@ -18,17 +18,17 @@ export const PredefinedSettings: FC = () => {
 				_headers={{
 					horizontal: [
 						[
-							{ label: 'column A', key: 'columnA' },
-							{ label: 'column B', key: 'columnB' },
-							{ label: 'column C', key: 'columnC' },
+							{ label: 'column A', key: 'columnA', minWidth: 'auto' },
+							{ label: 'column B', key: 'columnB', minWidth: 'auto' },
+							{ label: 'column C', key: 'columnC', minWidth: 'auto' },
 						],
 					],
 				}}
 				_tableSettings={{
 					columns: [
-						{ key: 'columnA', visible: false, label: 'Column A', position: 2 },
-						{ key: 'columnB', visible: true, label: 'Column B', position: 1, width: 20 },
-						{ key: 'columnC', visible: true, label: 'Column C', position: 0, width: 45 },
+						{ key: 'columnA', visible: false, label: 'Column A', position: 2, minWidth: 'auto' },
+						{ key: 'columnB', visible: true, label: 'Column B', position: 1, minWidth: 'auto' },
+						{ key: 'columnC', visible: true, label: 'Column C', position: 0, minWidth: 'auto' },
 					],
 				}}
 				_data={DATA}

--- a/packages/samples/react/src/components/table/render-cell.tsx
+++ b/packages/samples/react/src/components/table/render-cell.tsx
@@ -51,6 +51,7 @@ const HEADERS: KoliBriTableHeaders = {
 				key: 'order',
 				textAlign: 'center',
 				width: '10em',
+				minWidth: '10em',
 
 				/* Example 1: Use render return value to format data */
 				render: (_el, cell) => `Index: ${cell.label}`,
@@ -60,6 +61,7 @@ const HEADERS: KoliBriTableHeaders = {
 				key: 'shipped',
 				textAlign: 'center',
 				width: '10em',
+				minWidth: '10em',
 
 				/* Example 2: Simple render function using textContent */
 				render: (el, cell) => {
@@ -75,6 +77,7 @@ const HEADERS: KoliBriTableHeaders = {
 				key: 'date',
 				width: '20em',
 				textAlign: 'center',
+				minWidth: '20em',
 
 				/* Example 3: Render function using innerHTML. ⚠️Make sure to sanitize data to avoid XSS. */
 				render: (el, cell) => {
@@ -85,6 +88,7 @@ const HEADERS: KoliBriTableHeaders = {
 			{
 				label: 'Action (react)',
 				width: '20em',
+				minWidth: '20em',
 
 				/* Example 4: Render function using React */
 				render: (el) => {

--- a/packages/samples/react/src/components/table/sort-data.tsx
+++ b/packages/samples/react/src/components/table/sort-data.tsx
@@ -16,7 +16,7 @@ const DATE_FORMATTER = Intl.DateTimeFormat('de-DE', {
 const HEADERS_HORIZONTAL: KoliBriTableHeaders = {
 	horizontal: [
 		[
-			{ label: 'order', key: 'order', textAlign: 'center' },
+			{ label: 'order', key: 'order', textAlign: 'center', minWidth: 'auto' },
 			{
 				label: 'date',
 				textAlign: 'center',
@@ -26,6 +26,7 @@ const HEADERS_HORIZONTAL: KoliBriTableHeaders = {
 					else if ((data1 as Data).date < (data0 as Data).date) return 1;
 					else return 0;
 				},
+				minWidth: 'auto',
 			},
 		],
 	],
@@ -34,7 +35,7 @@ const HEADERS_HORIZONTAL: KoliBriTableHeaders = {
 const HEADERS_VERTICAL: KoliBriTableHeaders = {
 	vertical: [
 		[
-			{ label: 'order', key: 'order', textAlign: 'center' },
+			{ label: 'order', key: 'order', textAlign: 'center', minWidth: 'auto' },
 			{
 				label: 'date',
 				textAlign: 'center',
@@ -44,6 +45,7 @@ const HEADERS_VERTICAL: KoliBriTableHeaders = {
 					else if ((data1 as Data).date < (data0 as Data).date) return 1;
 					else return 0;
 				},
+				minWidth: 'auto',
 			},
 		],
 	],

--- a/packages/samples/react/src/components/table/stateful-with-selection.tsx
+++ b/packages/samples/react/src/components/table/stateful-with-selection.tsx
@@ -76,9 +76,9 @@ export const TableStatefulWithSelection: FC = () => {
 					_headers={{
 						horizontal: [
 							[
-								{ key: 'id', label: '#ID', textAlign: 'left' },
-								{ key: 'name', label: 'Name', textAlign: 'left' },
-								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton },
+								{ key: 'id', label: '#ID', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'name', label: 'Name', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton, minWidth: 'auto' },
 							],
 						],
 					}}

--- a/packages/samples/react/src/components/table/stateful-with-single-selection.tsx
+++ b/packages/samples/react/src/components/table/stateful-with-single-selection.tsx
@@ -75,9 +75,9 @@ export const TableStatefulWithSingleSelection: FC = () => {
 					_headers={{
 						horizontal: [
 							[
-								{ key: 'id', label: '#ID', textAlign: 'left' },
-								{ key: 'name', label: 'Name', textAlign: 'left' },
-								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton },
+								{ key: 'id', label: '#ID', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'name', label: 'Name', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton, minWidth: 'auto' },
 							],
 						],
 					}}

--- a/packages/samples/react/src/components/table/stateless-with-selection.tsx
+++ b/packages/samples/react/src/components/table/stateless-with-selection.tsx
@@ -72,9 +72,9 @@ export const TableStatelessWithSelection: FC = () => {
 					_headerCells={{
 						horizontal: [
 							[
-								{ key: 'id', label: '#ID', textAlign: 'left' },
-								{ key: 'name', label: 'Name', textAlign: 'left' },
-								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton },
+								{ key: 'id', label: '#ID', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'name', label: 'Name', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton, minWidth: 'auto' },
 							],
 						],
 					}}

--- a/packages/samples/react/src/components/table/stateless-with-single-selection.tsx
+++ b/packages/samples/react/src/components/table/stateless-with-single-selection.tsx
@@ -72,9 +72,9 @@ export const TableStatelessWithSingleSelection: FC = () => {
 					_headerCells={{
 						horizontal: [
 							[
-								{ key: 'id', label: '#ID', textAlign: 'left' },
-								{ key: 'name', label: 'Name', textAlign: 'left' },
-								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton },
+								{ key: 'id', label: '#ID', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'name', label: 'Name', textAlign: 'left', minWidth: 'auto' },
+								{ key: 'action', label: 'Action', textAlign: 'left', render: renderButton, minWidth: 'auto' },
 							],
 						],
 					}}

--- a/packages/samples/react/src/components/table/stateless.tsx
+++ b/packages/samples/react/src/components/table/stateless.tsx
@@ -18,18 +18,18 @@ export const TableStateless: FC = () => (
 				_headerCells={{
 					horizontal: [
 						[
-							{ key: 'left', label: 'left', textAlign: 'left', sortDirection: 'ASC' },
-							{ key: 'center', label: 'center', textAlign: 'center', sortDirection: 'DESC' },
-							{ key: 'right', label: 'right', textAlign: 'right', sortDirection: 'NOS' },
-							{ key: 'nosort', label: 'no sort option' },
+							{ key: 'left', label: 'left', textAlign: 'left', sortDirection: 'ASC', minWidth: 'auto' },
+							{ key: 'center', label: 'center', textAlign: 'center', sortDirection: 'DESC', minWidth: 'auto' },
+							{ key: 'right', label: 'right', textAlign: 'right', sortDirection: 'NOS', minWidth: 'auto' },
+							{ key: 'nosort', label: 'no sort option', minWidth: 'auto' },
 						],
 					],
 					vertical: [
 						[
-							{ key: 'vertical-left', label: 'left', textAlign: 'left', sortDirection: 'ASC' },
-							{ key: 'vertical-center', label: 'center', textAlign: 'center', sortDirection: 'DESC' },
-							{ key: 'vertical-right', label: 'right', textAlign: 'right', sortDirection: 'NOS' },
-							{ key: 'vertical-nosort', label: 'no sort option' },
+							{ key: 'vertical-left', label: 'left', textAlign: 'left', sortDirection: 'ASC', minWidth: 'auto' },
+							{ key: 'vertical-center', label: 'center', textAlign: 'center', sortDirection: 'DESC', minWidth: 'auto' },
+							{ key: 'vertical-right', label: 'right', textAlign: 'right', sortDirection: 'NOS', minWidth: 'auto' },
+							{ key: 'vertical-nosort', label: 'no sort option', minWidth: 'auto' },
 						],
 					],
 				}}

--- a/packages/samples/react/src/components/table/with-footer.tsx
+++ b/packages/samples/react/src/components/table/with-footer.tsx
@@ -19,26 +19,32 @@ export const TableWithFooter: FC = () => (
 						{
 							label: 'District',
 							key: 'asp',
+							minWidth: 'auto',
 						},
 						{
 							label: 'Monday',
 							key: 'monday',
+							minWidth: 'auto',
 						},
 						{
 							label: 'Tuesday',
 							key: 'tuesday',
+							minWidth: 'auto',
 						},
 						{
 							label: 'Wednesday',
 							key: 'wednesday',
+							minWidth: 'auto',
 						},
 						{
 							label: 'Thursday',
 							key: 'thursday',
+							minWidth: 'auto',
 						},
 						{
 							label: 'Friday',
 							key: 'friday',
+							minWidth: 'auto',
 						},
 					],
 				],

--- a/packages/samples/react/src/components/table/with-pagination.tsx
+++ b/packages/samples/react/src/components/table/with-pagination.tsx
@@ -13,8 +13,8 @@ import type { KoliBriTableHeaders, KoliBriTablePaginationProps } from '@public-u
 const HEADERS: KoliBriTableHeaders = {
 	horizontal: [
 		[
-			{ label: 'Order', key: 'order' },
-			{ label: 'Date', key: 'date', render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as unknown as Data).date) },
+			{ label: 'Order', key: 'order', minWidth: 'auto' },
+			{ label: 'Date', key: 'date', render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as unknown as Data).date), minWidth: 'auto' },
 		],
 	],
 };

--- a/packages/samples/react/src/scenarios/appointment-form/DistrictForm.tsx
+++ b/packages/samples/react/src/scenarios/appointment-form/DistrictForm.tsx
@@ -73,10 +73,11 @@ export function DistrictForm() {
 								void form.setFieldTouched('district', true);
 							}}
 							_on={{
-								onChange: (event, values: unknown) => {
+								onChange: (event: Event, values: unknown) => {
 									setSectionSubmitted(false);
 									// Select und Radio setzen den Wert immer initial.
-									if (event.target) {
+									const target = event.target as HTMLElement | null;
+									if (target) {
 										const [value] = values as [FormValues['district']];
 										void form.setFieldValue('district', value, true);
 									}

--- a/packages/samples/react/src/scenarios/appointment-form/PersonalInformationForm.tsx
+++ b/packages/samples/react/src/scenarios/appointment-form/PersonalInformationForm.tsx
@@ -66,8 +66,9 @@ export function PersonalInformationForm() {
 							_options={[{ label: 'Please select…', value: '' }, ...SALUTATION_OPTIONS]}
 							_required
 							_on={{
-								onChange: (event, values: unknown) => {
-									if (event.target) {
+								onChange: (event: Event, values: unknown) => {
+									const target = event.target as HTMLElement | null;
+									if (target) {
 										const [value] = values as [FormValues['salutation']];
 										void form.setFieldValue('salutation', value, true);
 									}
@@ -95,8 +96,9 @@ export function PersonalInformationForm() {
 									_touched={form.touched.company}
 									_required
 									_on={{
-										onChange: (event, value: unknown) => {
-											if (event.target) {
+										onChange: (event: Event, value: unknown) => {
+											const target = event.target as HTMLElement | null;
+											if (target) {
 												void form.setFieldValue('company', value, true);
 											}
 										},
@@ -124,8 +126,9 @@ export function PersonalInformationForm() {
 								_touched={form.touched.name}
 								_required
 								_on={{
-									onChange: (event, value: unknown) => {
-										if (event.target) {
+									onChange: (event: Event, value: unknown) => {
+										const target = event.target as HTMLElement | null;
+										if (target) {
 											void form.setFieldValue('name', value, true);
 										}
 									},
@@ -152,8 +155,9 @@ export function PersonalInformationForm() {
 								_touched={form.touched.email}
 								_required
 								_on={{
-									onChange: (event, value: unknown) => {
-										if (event.target) {
+									onChange: (event: Event, value: unknown) => {
+										const target = event.target as HTMLElement | null;
+										if (target) {
 											void form.setFieldValue('email', value, true);
 										}
 									},
@@ -177,8 +181,9 @@ export function PersonalInformationForm() {
 								}}
 								_touched={form.touched.phone}
 								_on={{
-									onChange: (event, value: unknown) => {
-										if (event.target) {
+									onChange: (event: Event, value: unknown) => {
+										const target = event.target as HTMLElement | null;
+										if (target) {
 											void form.setFieldTouched('phone', true);
 											void form.setFieldValue('phone', value, true);
 										}

--- a/packages/samples/react/src/scenarios/disabled-interactive-elements.tsx
+++ b/packages/samples/react/src/scenarios/disabled-interactive-elements.tsx
@@ -19,7 +19,7 @@ import {
 	KolSelect,
 	KolTextarea,
 } from '@public-ui/react';
-import type { FC } from 'react';
+import type { ComponentType, FC } from 'react';
 import React from 'react';
 import { SampleDescription } from '../components/SampleDescription';
 import { useToasterService } from '../hooks/useToasterService';
@@ -120,13 +120,8 @@ export const DisabledInteractiveElements: FC = () => {
 					</div>
 				</KolCard>
 				{[KolInputCheckbox, KolInputColor, KolInputDate, KolInputEmail, KolInputFile, KolInputNumber, KolInputPassword, KolInputRange, KolInputText].map(
-					(Input) => {
-						const render = (
-							Input as typeof KolInputCheckbox & {
-								render: { displayName: string };
-							}
-						).render;
-						const name = render.displayName;
+					(Input: ComponentType<any> & { render?: { displayName: string } }) => {
+						const name = Input.render?.displayName ?? '';
 						return (
 							<KolCard key={name} _label={name} _level={0}>
 								<div className="grid gap-4">
@@ -139,13 +134,8 @@ export const DisabledInteractiveElements: FC = () => {
 						);
 					},
 				)}
-				{[KolInputRadio, KolSelect].map((Input) => {
-					const render = (
-						Input as typeof KolInputRadio & {
-							render: { displayName: string };
-						}
-					).render;
-					const name = render.displayName;
+				{[KolInputRadio, KolSelect].map((Input: ComponentType<any> & { render?: { displayName: string } }) => {
+					const name = Input.render?.displayName ?? '';
 					return (
 						<KolCard key={name} _label={name} _level={0}>
 							<div className="grid gap-4">

--- a/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
+++ b/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
@@ -32,11 +32,11 @@ const TABS: TabButtonProps[] = [
 const HEADERS: KoliBriTableHeaders = {
 	horizontal: [
 		[
-			{ key: 'name', label: 'Name', textAlign: 'left', width: '400px' },
-			{ key: 'species', label: 'Species', textAlign: 'left', width: '400px' },
-			{ key: 'habitat', label: 'Habitat', textAlign: 'left', width: '400px' },
-			{ key: 'diet', label: 'Diet', textAlign: 'left', width: '400px' },
-			{ key: 'lifespan', label: 'lifespan', textAlign: 'right', width: '400px' },
+			{ key: 'name', label: 'Name', textAlign: 'left', width: '400px', minWidth: '400px' },
+			{ key: 'species', label: 'Species', textAlign: 'left', width: '400px', minWidth: '400px' },
+			{ key: 'habitat', label: 'Habitat', textAlign: 'left', width: '400px', minWidth: '400px' },
+			{ key: 'diet', label: 'Diet', textAlign: 'left', width: '400px', minWidth: '400px' },
+			{ key: 'lifespan', label: 'lifespan', textAlign: 'right', width: '400px', minWidth: '400px' },
 		],
 	],
 };


### PR DESCRIPTION
## Summary
Requires a `minWidth` property for table header cells to support automatic horizontal scroll activation.

## Changes
- Added `minWidth` requirement for `KolibriTableHeaderCell` components

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`minWidth`-Eigenschaft für Tabellenüberschriften-Zellen als Pflichtfeld eingeführt.

## Änderungen
- `minWidth`-Pflicht für `KolibriTableHeaderCell`-Komponenten hinzugefügt

</details>