### PR TITLE
fix(build): disable node type stripping for node 22.18.0 support

### DIFF
--- a/packages/tools/kolibri-cli/package.json
+++ b/packages/tools/kolibri-cli/package.json
@@ -31,7 +31,7 @@
 		"unused": "knip",
 		"watch": "nodemon --ignore package.json src/index.ts migrate --ignore-uncommitted-changes --test-tasks test",
 		"test": "pnpm test:unit",
-		"test:unit": "TS_NODE_PROJECT=tsconfig.test.json mocha --require ts-node/register test/**/*.ts"
+		"test:unit": "TS_NODE_PROJECT=tsconfig.test.json mocha --require ts-node/register test/**/*.ts --no-experimental-strip-types"
 	},
 	"type": "commonjs",
 	"dependencies": {


### PR DESCRIPTION
## Summary
Disables Node.js type stripping to restore compatibility with Node 22.18.0.

## Changes
- Disabled Node type stripping to support Node 22.18.0

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Node.js-Typ-Stripping deaktiviert, um Kompatibilität mit Node 22.18.0 wiederherzustellen.

## Änderungen
- Node-Typ-Stripping für Node-22.18.0-Unterstützung deaktiviert

</details>