### PR TITLE
feat(table): prevent hiding of fixed columns

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -488,6 +488,7 @@ export class KolTableStateless implements TableStatelessAPI {
 				label: header.label,
 				position: index,
 				visible: true,
+				hideable: header.hideable !== false,
 			}));
 	}
 

--- a/packages/components/src/components/table-stateless/table-settings.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-settings.e2e.ts
@@ -89,18 +89,21 @@ test.describe('kol-table-settings', () => {
 						label: 'ID',
 						position: 0,
 						visible: true,
+						hideable: true,
 					},
 					{
 						key: 'name',
 						label: 'Name',
 						position: 1,
 						visible: true,
+						hideable: true,
 					},
 					{
 						key: 'age',
 						label: 'Age',
 						position: 2,
 						visible: true,
+						hideable: true,
 					},
 				],
 			});
@@ -114,6 +117,35 @@ test.describe('kol-table-settings', () => {
 
 			const columnLabels = page.locator('.kol-table-settings__column > span');
 			await expect(columnLabels).toHaveText(['ID', 'Name', 'Age']);
+		});
+
+		test('it disables visibility toggle for columns marked as not hideable', async ({ page }) => {
+			const HEADERS_WITH_FIXED: TableHeaderCellsPropType = {
+				horizontal: [
+					[
+						{ key: 'id', label: 'ID', hideable: false },
+						{ key: 'name', label: 'Name' },
+					],
+				],
+			};
+			await page.setContent(`<kol-table-stateless
+      _label="Table with Settings"
+      _header-cells='${JSON.stringify(HEADERS_WITH_FIXED)}'
+      _data='${JSON.stringify(DATA)}'
+    />`);
+			await page.waitForChanges();
+
+			const settingsButton = page.getByTestId('popover-button').locator('button');
+			await settingsButton.click();
+
+			const idCheckbox = page.getByRole('checkbox', { name: 'ID' });
+			await idCheckbox.click();
+			await page.waitForChanges();
+			await expect(idCheckbox).toBeChecked();
+
+			const columnLabels = page.locator('.kol-table-settings__column > span');
+			await expect(columnLabels.first()).toHaveText('ID');
+			await expect(idCheckbox).toHaveAccessibleName(/nicht ausblendbar/);
 		});
 
 		test('it toggles visibility of individual columns', async ({ page }) => {

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -21,13 +21,19 @@ export class KolTableSettings {
 	private readonly translateTableSettingsCancel = translate('kol-table-settings-cancel');
 	private readonly translateTableSettingsApply = translate('kol-table-settings-apply');
 	private readonly translateErrorAllInvisible = translate('kol-table-settings-error-all-invisible');
+	private readonly translateColumnNotHideable = translate('kol-table-settings-column-not-hideable');
 	@Prop() _tableSettings: TableSettingsPropType = { columns: [] };
 
 	@Watch('_tableSettings')
 	handleTableSettingsChange(newValue: TableSettingsPropType) {
 		this.tableSettings = {
 			...newValue,
-			columns: this.sortColumnsByPosition(newValue.columns),
+			columns: this.sortColumnsByPosition(
+				newValue.columns.map((col) => ({
+					...col,
+					visible: col.hideable === false ? true : col.visible,
+				})),
+			),
 		};
 	}
 
@@ -66,7 +72,7 @@ export class KolTableSettings {
 	private handleVisibilityChange(key: string, visible: unknown): void {
 		this.tableSettings = {
 			...this.tableSettings,
-			columns: this.tableSettings.columns.map((col) => (col.key === key ? { ...col, visible: Boolean(visible) } : col)),
+			columns: this.tableSettings.columns.map((col) => (col.key === key && col.hideable !== false ? { ...col, visible: Boolean(visible) } : col)),
 		};
 	}
 
@@ -120,9 +126,13 @@ export class KolTableSettings {
 									<div key={column.key} class="kol-table-settings__column">
 										<KolInputCheckboxTag
 											_checked={column.visible}
-											_label={translate('kol-table-settings-show-column', { placeholders: { column: column.label } })}
+											_label={((): string => {
+												const baseLabel = translate('kol-table-settings-show-column', { placeholders: { column: column.label } });
+												return column.hideable === false ? `${baseLabel} (${this.translateColumnNotHideable})` : baseLabel;
+											})()}
 											_value={true}
 											_hideLabel
+											_disabled={column.hideable === false}
 											_on={{ onInput: (_, value: unknown) => this.handleVisibilityChange(column.key, value) }}
 										/>
 										<span>{column.label}</span>

--- a/packages/components/src/locales/de.ts
+++ b/packages/components/src/locales/de.ts
@@ -46,6 +46,7 @@ export default {
 	'table-settings-move-up': 'Spalte {{column}} nach oben verschieben',
 	'table-settings-move-down': 'Spalte {{column}} nach unten verschieben',
 	'table-settings-error-all-invisible': 'Mindestens eine Spalte muss sichtbar sein.',
+	'table-settings-column-not-hideable': 'nicht ausblendbar',
 	dropdown: 'Auswahlliste',
 	'nav-label-open': 'Untermenü zu {{label}} öffnen',
 	'nav-label-close': 'Untermenü zu {{label}} schließen',

--- a/packages/components/src/locales/en.ts
+++ b/packages/components/src/locales/en.ts
@@ -46,6 +46,7 @@ export default {
 	'table-settings-move-up': 'Move {{column}} column up',
 	'table-settings-move-down': 'Move {{column}} column down',
 	'table-settings-error-all-invisible': 'At least one column must be visible.',
+	'table-settings-column-not-hideable': 'cannot be hidden',
 	dropdown: 'Dropdown',
 	'nav-label-open': 'Submenu for {{label}} open',
 	'nav-label-close': 'Submenu for {{label}} close',

--- a/packages/components/src/schema/types/table-settings.ts
+++ b/packages/components/src/schema/types/table-settings.ts
@@ -1,8 +1,9 @@
 export interface ColumnSettings {
+	hideable?: boolean;
 	key: string;
 	label: string;
-	visible: boolean;
 	position: number;
+	visible: boolean;
 	width?: number;
 }
 

--- a/packages/components/src/schema/types/table.ts
+++ b/packages/components/src/schema/types/table.ts
@@ -18,6 +18,7 @@ export type KoliBriTableCell = {
 export type KoliBriTableHeaderCell = KoliBriTableCell & {
 	key?: string;
 	sortDirection?: KoliBriSortDirection;
+	hideable?: boolean;
 };
 
 export type KoliBriTableSelection = {


### PR DESCRIPTION
## Summary
- allow table columns to be marked as not hideable
- prevent toggling visibility for fixed columns and show hint in table settings
- add tests and translations for non-hideable table columns
- include non-hideable notice in checkbox label to avoid expanding the settings menu

## Testing
- `pnpm --filter @public-ui/components lint`
- `pnpm --filter @public-ui/components test`
- `pnpm --filter @public-ui/components test:e2e -- src/components/table-stateless/table-settings.e2e.ts --grep "disables visibility toggle for columns marked as not hideable"` *(fails: Column Visibility Management > it disables visibility toggle for columns marked as not hideable)*

------
https://chatgpt.com/codex/tasks/task_e_689b59465038832bb96cf4565e26a367