### PR TITLE
feat(table): support external caption via aria-labelledby

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -26,6 +26,7 @@ import type {
 import {
 	devHint,
 	emptyStringByArrayHandler,
+	Log,
 	objectObjectHandler,
 	parseJson,
 	setState,
@@ -49,6 +50,10 @@ const PAGINATION_OPTIONS = [10, 20, 50, 100];
 
 const paginationValidator = (value: unknown) => value === true || value === '' /* true */ || (typeof value === 'object' && value !== null);
 
+type HostInternals = {
+	ariaLabelledByElements: HTMLElement[];
+};
+
 type SortData = {
 	label: string;
 	key: string;
@@ -64,7 +69,37 @@ type SortData = {
 	shadow: true,
 })
 export class KolTableStateful implements TableAPI {
-	@Element() private readonly host?: HTMLKolTableStatelessWcElement;
+	@Element() private readonly host?: HTMLKolTableStatefulElement;
+
+	private internals?: HostInternals;
+
+	private resolveTargets(value?: string): HTMLElement[] {
+		const ids = (value ?? '').trim().split(/\s+/).filter(Boolean);
+		if (!ids.length) return [];
+		const root = this.host?.getRootNode({ composed: true }) as Document | ShadowRoot | undefined;
+		const getById = (id: string): HTMLElement | null => {
+			return (root as Document)?.getElementById?.(id) || document.getElementById(id);
+		};
+		return ids.map(getById).filter((el): el is HTMLElement => !!el);
+	}
+
+	/**
+	 * Allows labeling the table by referencing elements outside via `aria-labelledby`.
+	 */
+	@Prop() public ariaLabelledby?: string;
+
+	@Watch('ariaLabelledBy')
+	protected handleAriaLabelledBy(value?: string): void {
+		if (this.internals && 'ariaLabelledByElements' in this.internals) {
+			this.internals.ariaLabelledByElements = this.resolveTargets(value);
+			if (this.internals.ariaLabelledByElements.length) {
+				Log.info(['Experimental feature for linking aria-labelledby to an external caption.', this.host, this.internals.ariaLabelledByElements], {
+					forceLog: true,
+				});
+			}
+		}
+	}
+
 	private tableWcRef?: HTMLKolTableStatelessWcElement;
 
 	private readonly catchRef = (ref?: HTMLKolTableStatelessWcElement) => {
@@ -378,6 +413,11 @@ export class KolTableStateful implements TableAPI {
 	}
 
 	public componentWillLoad(): void {
+		if ((this.host as unknown as { attachInternals?: () => HostInternals }).attachInternals) {
+			this.internals = (this.host as unknown as { attachInternals: () => HostInternals }).attachInternals();
+			this.handleAriaLabelledBy(this.ariaLabelledby);
+		}
+
 		this.validateAllowMultiSort(this._allowMultiSort);
 		this.validateData(this._data);
 		this.validateDataFoot(this._dataFoot);
@@ -543,6 +583,8 @@ export class KolTableStateful implements TableAPI {
 		const paginationTop = this._paginationPosition === 'top' || this._paginationPosition === 'both' ? this.renderPagination('top') : null;
 		const paginationBottom = this._paginationPosition === 'bottom' || this._paginationPosition === 'both' ? this.renderPagination('bottom') : null;
 
+		const showCaption = this.internals?.ariaLabelledByElements?.length;
+
 		const headerCells: TableHeaderCells = {
 			horizontal: this.state._headers.horizontal?.map((row) => row.map((cell) => ({ ...cell, sortDirection: this.getHeaderCellSortState(cell) }))) ?? [],
 			vertical: this.state._headers.vertical?.map((column) => column.map((cell) => ({ ...cell, sortDirection: this.getHeaderCellSortState(cell) }))) ?? [],
@@ -551,6 +593,7 @@ export class KolTableStateful implements TableAPI {
 			<Host class="kol-table-stateful">
 				{this.pageEndSlice > 0 && this.showPagination && paginationTop}
 				<KolTableStatelessWcTag
+					aria-labelledby={showCaption ? this.ariaLabelledby : undefined}
 					ref={this.catchRef}
 					_data={displayedData}
 					_headerCells={headerCells}

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -85,6 +85,11 @@ export class KolTableStateless implements TableStatelessAPI {
 	private previousHeaderCells?: TableHeaderCellsPropType;
 
 	/**
+	 * Allows labeling the table by referencing elements outside via `aria-labelledby`.
+	 */
+	@Prop() public ariaLabelledby?: string;
+
+	/**
 	 * Defines the primary table data.
 	 */
 	@Prop() public _data!: TableDataPropType;
@@ -928,13 +933,20 @@ export class KolTableStateless implements TableStatelessAPI {
 						 * prevent screen readers from just reading "blank".
 						 */}
 						{/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-						<div class="kol-table__focus-element" tabindex={this.tableDivElementHasScrollbar ? '0' : undefined} aria-describedby="caption">
+						<div
+							aria-describedby={this.ariaLabelledby ?? 'caption'}
+							class="kol-table__focus-element"
+							// eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+							tabindex={this.tableDivElementHasScrollbar ? '0' : undefined}
+						>
 							&nbsp;
 						</div>
 
-						<caption class="kol-table__caption" id="caption">
-							{this.state._label}
-						</caption>
+						{this.ariaLabelledby ? null : (
+							<caption class="kol-table__caption" id="caption">
+								{this.state._label}
+							</caption>
+						)}
 
 						{Array.isArray(sortedHorizontalHeaders) && (
 							<thead class="kol-table__head">

--- a/packages/components/src/components/table-stateless/shadow.tsx
+++ b/packages/components/src/components/table-stateless/shadow.tsx
@@ -1,16 +1,21 @@
 import type { JSX } from '@stencil/core';
-import { Component, h, Prop } from '@stencil/core';
+import { Component, Element, h, Prop, Watch } from '@stencil/core';
 import { KolTableStatelessWcTag } from '../../core/component-names';
-import type {
-	TableCallbacksPropType,
-	TableDataFootPropType,
-	TableDataPropType,
-	TableHeaderCellsPropType,
-	TableSelectionPropType,
-	TableStatelessProps,
+import {
+	Log,
+	type TableCallbacksPropType,
+	type TableDataFootPropType,
+	type TableDataPropType,
+	type TableHeaderCellsPropType,
+	type TableSelectionPropType,
+	type TableStatelessProps,
 } from '../../schema';
 import type { MinWidthPropType } from '../../schema/props/min-width';
 import type { TableSettingsPropType } from '../../schema/props/table-settings';
+
+type HostInternals = {
+	ariaLabelledByElements: HTMLElement[];
+};
 
 @Component({
 	tag: 'kol-table-stateless',
@@ -20,6 +25,37 @@ import type { TableSettingsPropType } from '../../schema/props/table-settings';
 	shadow: true,
 })
 export class KolTableStateless implements TableStatelessProps {
+	@Element() private readonly host?: HTMLKolTableStatelessElement;
+
+	private internals?: HostInternals;
+
+	private resolveTargets(value?: string): HTMLElement[] {
+		const ids = (value ?? '').trim().split(/\s+/).filter(Boolean);
+		if (!ids.length) return [];
+		const root = this.host?.getRootNode({ composed: true }) as Document | ShadowRoot | undefined;
+		const getById = (id: string): HTMLElement | null => {
+			return (root as Document)?.getElementById?.(id) || document.getElementById(id);
+		};
+		return ids.map(getById).filter((el): el is HTMLElement => !!el);
+	}
+
+	/**
+	 * Allows labeling the table by referencing elements outside via `aria-labelledby`.
+	 */
+	@Prop() public ariaLabelledby?: string;
+
+	@Watch('ariaLabelledBy')
+	protected handleAriaLabelledBy(value?: string): void {
+		if (this.internals && 'ariaLabelledByElements' in this.internals) {
+			this.internals.ariaLabelledByElements = this.resolveTargets(value);
+			if (this.internals.ariaLabelledByElements.length) {
+				Log.info(['Experimental feature for linking aria-labelledby to an external caption.', this.host, this.internals.ariaLabelledByElements], {
+					forceLog: true,
+				});
+			}
+		}
+	}
+
 	/**
 	 * Defines the primary table data.
 	 */
@@ -60,9 +96,18 @@ export class KolTableStateless implements TableStatelessProps {
 	 */
 	@Prop() public _tableSettings?: TableSettingsPropType;
 
+	public componentWillLoad(): void {
+		if ((this.host as unknown as { attachInternals?: () => HostInternals }).attachInternals) {
+			this.internals = (this.host as unknown as { attachInternals: () => HostInternals }).attachInternals();
+			this.handleAriaLabelledBy(this.ariaLabelledby);
+		}
+	}
+
 	public render(): JSX.Element {
+		const showCaption = this.internals?.ariaLabelledByElements?.length;
 		return (
 			<KolTableStatelessWcTag
+				aria-labelledby={showCaption ? this.ariaLabelledby : undefined}
 				_data={this._data}
 				_dataFoot={this._dataFoot}
 				_headerCells={this._headerCells}

--- a/packages/components/src/components/table-stateless/table-stateless.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-stateless.e2e.ts
@@ -218,4 +218,32 @@ test.describe('kol-table-stateless', () => {
 			await expect(callbackPromise).resolves.toEqual(DATA[0].id);
 		});
 	});
+
+	test('supports external caption via aria-labelledby', async ({ page }) => {
+		await page.setContent(
+			`<span id="external-caption">Caption</span><kol-table-stateless aria-labelledby="external-caption" _label="" _header-cells='${JSON.stringify(HEADERS)}' _data='${JSON.stringify(DATA)}'></kol-table-stateless>`,
+		);
+		await page.waitForChanges();
+		const table = page.locator('kol-table-stateless table');
+		await expect(table.locator('caption')).toHaveCount(0);
+		const supportsInternals = await page.evaluate(() => {
+			return 'ElementInternals' in window && 'ariaLabelledByElements' in (ElementInternals.prototype as unknown as Record<string, unknown>);
+		});
+
+		if (supportsInternals) {
+			await expect(table).not.toHaveAttribute('aria-labelledby');
+		} else {
+			await expect(table).toHaveAttribute('aria-labelledby', 'external-caption');
+		}
+	});
+
+	test('renders internal caption when external target is missing', async ({ page }) => {
+		await page.setContent(
+			`<kol-table-stateless aria-labelledby="missing" _label="Internal" _header-cells='${JSON.stringify(HEADERS)}' _data='${JSON.stringify(DATA)}'></kol-table-stateless>`,
+		);
+		await page.waitForChanges();
+		const table = page.locator('kol-table-stateless table');
+		await expect(table).not.toHaveAttribute('aria-labelledby');
+		await expect(table.locator('caption')).toHaveText('Internal');
+	});
 });

--- a/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
@@ -247,3 +247,34 @@ exports[`kol-table-stateless-wc should render with _label="Table with two spanne
   </div>
 </kol-table-stateless-wc>
 `;
+
+exports[`kol-table-stateless-wc should render with ariaLabelledBy="external-caption" _label="" _data=[{"header1":"Cell 1.1"}] _headerCells={"horizontal":[[{"key":"header1","label":"Header 1","textAlign":"left"}]],"vertical":[]} _minWidth="400px" 1`] = `
+<kol-table-stateless-wc arialabelledby="external-caption">
+  <div class="kol-table">
+    <kol-table-settings-wc></kol-table-settings-wc>
+    <div class="kol-table__scroll-container">
+      <table class="kol-table__table" style="min-width: max(400px, 0ch);">
+        <div aria-describedby="caption" class="kol-table__focus-element"></div>
+        <caption class="kol-table__caption" id="caption"></caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col">
+              Header 1
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="1"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <td class="kol-table__cell kol-table__cell--align-left kol-table__cell--body" style="text-align: left;">
+              Cell 1.1
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;

--- a/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
+++ b/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
@@ -94,5 +94,15 @@ executeSnapshotTests<TableStatelessProps>(
 				{ header1: 'Cell 2.1', header2: 'Cell 2.2' },
 			],
 		},
+		{
+			ariaLabelledBy: 'external-caption',
+			_label: '',
+			_data: [{ header1: 'Cell 1.1' }],
+			_headerCells: {
+				horizontal: [[{ key: 'header1', label: 'Header 1', textAlign: 'left' }]],
+				vertical: [],
+			},
+			_minWidth: '400px',
+		} as unknown as TableStatelessProps,
 	],
 );

--- a/packages/samples/react/src/components/table/external-caption.tsx
+++ b/packages/samples/react/src/components/table/external-caption.tsx
@@ -1,0 +1,42 @@
+import type { FC } from 'react';
+import React from 'react';
+import { KolTableStateful, KolTableStateless } from '@public-ui/react';
+import { SampleDescription } from '../SampleDescription';
+
+const DATA = [{ city: 'Berlin', country: 'Germany' }];
+
+const HEADERS = {
+	horizontal: [
+		[
+			{ key: 'city', label: 'City' },
+			{ key: 'country', label: 'Country' },
+		],
+	],
+	vertical: [],
+};
+
+const PROPS = {
+	_data: DATA,
+	_headers: HEADERS,
+	_headerCells: HEADERS,
+	_label: 'Label should always be filled',
+	_minWidth: 'auto',
+};
+
+export const TableExternalCaption: FC = () => (
+	<>
+		<SampleDescription>
+			<p>This sample shows KolTableStateless with an external caption referenced via aria-labelledby.</p>
+		</SampleDescription>
+
+		<section className="w-full">
+			<span id="caption-ext">External table caption</span>
+			<br />
+			<KolTableStateless aria-labelledby="caption-ext" {...PROPS} />
+			<KolTableStateful aria-labelledby="caption-ext" {...PROPS} />
+			<hr aria-hidden="true" />
+			<KolTableStateless {...PROPS} />
+			<KolTableStateful {...PROPS} />
+		</section>
+	</>
+);

--- a/packages/samples/react/src/components/table/routes.ts
+++ b/packages/samples/react/src/components/table/routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '../../shares/types';
 import { PaginationPosition } from './pagination-position';
 import { TableColumnAlignment } from './column-alignment';
 import { TableComplexHeaders } from './complex-headers';
+import { TableExternalCaption } from './external-caption';
 import { TableHorizontalScrollbar } from './horizontal-scrollbar';
 import { TableRenderCell } from './render-cell';
 import { TableSortData } from './sort-data';
@@ -20,6 +21,7 @@ export const TABLE_ROUTES: Routes = {
 	table: {
 		'column-alignment': TableColumnAlignment,
 		'complex-headers': TableComplexHeaders,
+		'external-caption': TableExternalCaption,
 		'horizontal-scrollbar': TableHorizontalScrollbar,
 		'interactive-child-elements': InteractiveChildElements,
 		'multi-sort': MultiSortTable,


### PR DESCRIPTION
This pull request adds support for referencing external captions via the `aria-labelledby` attribute in both the `KolTableStateless` and `KolTableStateful` table components, improving accessibility by allowing tables to be labeled by elements outside the component. It includes updates to the components' logic, rendering, and documentation, as well as new tests and a React sample demonstrating the feature.

**Accessibility Improvements:**

* Added an `ariaLabelledby` prop to both `KolTableStateless` and `KolTableStateful` components, allowing tables to be labeled by external elements via the `aria-labelledby` attribute. The components resolve the referenced elements and update internal state for accessibility. [[1]](diffhunk://#diff-fe119f78e745e66aec0e2b7319b43f6570b18dd7525981c30f948b156c8394cdL67-R102) [[2]](diffhunk://#diff-d953b284febd555c7f5e6c4d38073bdbf1b3212d30edde125275afe3b7f8d0e4R87-R91) [[3]](diffhunk://#diff-3e914e99f0241804d16eb79d92060203abc30caefd4207449b9ae92d631dec09R28-R58)
* Modified rendering logic to conditionally set the `aria-labelledby` attribute and hide the internal `<caption>` element if an external label is provided and found. [[1]](diffhunk://#diff-fe119f78e745e66aec0e2b7319b43f6570b18dd7525981c30f948b156c8394cdR586-R587) [[2]](diffhunk://#diff-fe119f78e745e66aec0e2b7319b43f6570b18dd7525981c30f948b156c8394cdR596) [[3]](diffhunk://#diff-d953b284febd555c7f5e6c4d38073bdbf1b3212d30edde125275afe3b7f8d0e4L931-R949) [[4]](diffhunk://#diff-3e914e99f0241804d16eb79d92060203abc30caefd4207449b9ae92d631dec09R99-R110)

**Component Internals and Logging:**

* Introduced a `HostInternals` type and internal logic to track resolved `ariaLabelledByElements`, including logging for experimental feature usage. [[1]](diffhunk://#diff-fe119f78e745e66aec0e2b7319b43f6570b18dd7525981c30f948b156c8394cdR53-R56) [[2]](diffhunk://#diff-3e914e99f0241804d16eb79d92060203abc30caefd4207449b9ae92d631dec09L2-R19) [[3]](diffhunk://#diff-fe119f78e745e66aec0e2b7319b43f6570b18dd7525981c30f948b156c8394cdL67-R102) [[4]](diffhunk://#diff-3e914e99f0241804d16eb79d92060203abc30caefd4207449b9ae92d631dec09R28-R58)

**Testing:**

* Added end-to-end tests to verify correct behavior when using external captions, including fallback to internal captions when the external target is missing.
* Updated snapshot tests to cover the new `ariaLabelledBy` prop scenario. [[1]](diffhunk://#diff-409726ecf012647d039f6be72006ba70b11633c9fc2c442b8d67596a484da172R250-R280) [[2]](diffhunk://#diff-7cb8fd8ed2a589417a159cffc43ec5e2c1acff09a6f87278f142cc8c8173766dR97-R106)

**Documentation and Samples:**

* Added a React sample (`TableExternalCaption`) and updated routing to demonstrate the use of external captions with both table components. [[1]](diffhunk://#diff-9a3bada95b8c2898039a33110530c754aa23b4697322b9a35330bb058331d45aR1-R42) [[2]](diffhunk://#diff-358380e98497fed65462ca1ed1463cc6ce93b91c2d9363e663e75e475e36eaccR5) [[3]](diffhunk://#diff-358380e98497fed65462ca1ed1463cc6ce93b91c2d9363e663e75e475e36eaccR24)