### PR TITLE
docs: add rule against overflow hidden in theming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ In the theme component layer, you can set what ever you need to realize your own
 - Do not `inherit` styles over the `:host` element, as this will override the styles of the basis global and component layers. This makes your component less robust from outside environment styles. Only the `kol-icon` inherits some specific styles, like `color`, `font-size`, `font-family` and `line-height`, as these are needed for the icon to be displayed correctly inline to this neighbored elements.
 - Do not set the default `font-family`, `font-size` or `box-sizing` in the basis or theme component layer (redundant), as these are already set in the basis global layers. If you need to set a different font-family or font-size, you can do this in the theme global layer.
 - Do not set `margin` or `padding` in the basis global and component layers. If you need to set a different margin or padding, you can do this in the theme global or component layers.
+- Do not use `overflow: hidden` in styling or theming, as it often causes issues for reuse and should be avoided.
 
 ## Samples
 


### PR DESCRIPTION
## Summary
Adds a theming documentation rule advising against the use of `overflow: hidden`.

## Changes
- Added rule against `overflow: hidden` in theming documentation

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Dokumentationsregel gegen die Verwendung von `overflow: hidden` im Theming hinzugefügt.

## Änderungen
- Regel gegen `overflow: hidden` in die Theming-Dokumentation aufgenommen

</details>