### PR TITLE
fix(modal): remove position relative

### DIFF
--- a/packages/components/src/components/modal/style.scss
+++ b/packages/components/src/components/modal/style.scss
@@ -4,7 +4,6 @@
 
 @layer kol-component {
 	.kol-modal {
-		position: relative;
 		min-height: var(--a11y-min-size);
 		padding: 0;
 		border: 0;


### PR DESCRIPTION
## Summary
Removes the `position: relative` rule from the modal component styles to fix layout issues.

## Changes
- Removed `position: relative` from modal component CSS

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Die `position: relative`-Regel aus den Modal-Komponenten-Styles entfernt, um Layout-Probleme zu beheben.

## Änderungen
- `position: relative` aus dem Modal-Komponenten-CSS entfernt

</details>