### PR TITLE
fix(theme): add gap between table and pagination

### DIFF
--- a/packages/themes/default/src/components/table-stateful.scss
+++ b/packages/themes/default/src/components/table-stateful.scss
@@ -1,9 +1,23 @@
+@use '../mixins/to-rem' as *;
 @use '../mixins/kol-table-stateless-wc' as *;
 
 @layer kol-theme-component {
 	@include kol-table-stateless-theme;
 
 	.kol-table-stateful {
+		.kol-table {
+			margin-bottom: 0;
+		}
+
+		&__pagination {
+			margin-top: to-rem(8);
+
+			&:first-child {
+				margin-top: 0;
+				margin-bottom: to-rem(8);
+			}
+		}
+
 		.kol-pagination {
 			@media (min-width: 1024px) {
 				display: flex;

--- a/packages/themes/ecl/src/ecl-ec/components/table-stateful.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/table-stateful.scss
@@ -7,6 +7,10 @@
 	.kol-table-stateful {
 		$root: &;
 
+		.kol-table {
+			margin-bottom: 0;
+		}
+
 		&__pagination-wrapper {
 			@media (min-width: 1024px) {
 				grid-auto-flow: column;
@@ -17,6 +21,12 @@
 			overflow-x: auto;
 			overflow-y: hidden;
 			grid-auto-flow: column;
+			margin-top: to-rem(8);
+
+			&:first-child {
+				margin-top: 0;
+				margin-bottom: to-rem(8);
+			}
 		}
 
 		.kol-pagination {

--- a/packages/themes/ecl/src/ecl-eu/components/table-stateful.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/table-stateful.scss
@@ -7,6 +7,10 @@
 	.kol-table-stateful {
 		$root: &;
 
+		.kol-table {
+			margin-bottom: 0;
+		}
+
 		&__pagination-wrapper {
 			@media (min-width: 1024px) {
 				grid-auto-flow: column;
@@ -18,6 +22,12 @@
 			overflow-y: hidden;
 			gap: to-rem(16);
 			grid-auto-flow: column;
+			margin-top: to-rem(8);
+
+			&:first-child {
+				margin-top: 0;
+				margin-bottom: to-rem(8);
+			}
 		}
 
 		.kol-pagination {


### PR DESCRIPTION
## Summary
- ensure table-stateful components leave an 8px gap before pagination using `to-rem`
- apply spacing fix across default and ECL themes

## Testing
- `pnpm --filter @public-ui/theme-default build`
- `pnpm --filter @public-ui/theme-ecl build`
- `pnpm --filter @public-ui/theme-default lint` *(fails: Unsafe assignment in theme index)*
- `pnpm --filter @public-ui/theme-ecl lint` *(fails: Unsafe assignment in theme index)*
- `pnpm --filter @public-ui/theme-default test` *(fails: failed to build React sample app)*
- `pnpm --filter @public-ui/theme-ecl test:ecl-ec` *(fails: failed to build React sample app)*
- `pnpm --filter @public-ui/theme-ecl test:ecl-eu` *(fails: failed to build React sample app)*

------
https://chatgpt.com/codex/tasks/task_e_689e41b3d090832b9c5e78d2f2cf73e9