### PR TITLE
test(table-stateful): ensure no caption with aria-labelledby

### DIFF
--- a/packages/components/src/components/table-stateful/table-stateful.e2e.ts
+++ b/packages/components/src/components/table-stateful/table-stateful.e2e.ts
@@ -59,4 +59,24 @@ test.describe('kol-table-stateful', () => {
 			await expect(callbackPromise).resolves.toEqual([DATA[0]]);
 		});
 	});
+
+	test('supports external caption via aria-labelledby', async ({ page }) => {
+		await page.setContent(
+			`<span id="external-caption">Caption</span><kol-table-stateful aria-labelledby="external-caption" _label="" _headers='${JSON.stringify(
+				HEADERS,
+			)}' _data='${JSON.stringify(DATA)}'></kol-table-stateful>`,
+		);
+		await page.waitForChanges();
+		const table = page.locator('kol-table-stateful kol-table-stateless table');
+		await expect(table.locator('caption')).toHaveCount(0);
+		const supportsInternals = await page.evaluate(() => {
+			return 'ElementInternals' in window && 'ariaLabelledByElements' in (ElementInternals.prototype as unknown as Record<string, unknown>);
+		});
+
+		if (supportsInternals) {
+			await expect(table).not.toHaveAttribute('aria-labelledby');
+		} else {
+			await expect(table).toHaveAttribute('aria-labelledby', 'external-caption');
+		}
+	});
 });


### PR DESCRIPTION
## Summary
Internal test addition ensuring that table-stateful renders no duplicate caption when `aria-labelledby` is used.

## Changes
- Add test to ensure no caption is rendered when `aria-labelledby` is present

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Test-Zusatz: Sicherstellt, dass table-stateful keine doppelte Caption rendert, wenn `aria-labelledby` verwendet wird.

## Änderungen
- Test hinzugefügt, der sicherstellt, dass kein Caption gerendert wird, wenn `aria-labelledby` vorhanden ist

</details>