### PR TITLE
docs: restore AGENTS guidelines from develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,16 +228,21 @@ The samples are located in `packages/samples/react` and demonstrate how to use t
 
 - Formatting is enforced via **Prettier** with settings defined in `prettier.config.js` (print width 160, single quotes, tabs).
 - `.editorconfig` sets `indent_style = tab` and `max_line_length = 160` for code files. Markdown and YAML files use spaces.
-- ESLint and Stylelint are run using `pnpm lint`. Pre‑commit hooks run `lint-staged` which formats and lints changed files.
+- ESLint and Stylelint are run using `pnpm lint`. Pre‑commit hooks run `lint-staged` which formats and lints changed files. Lint rules should **not** be disabled via inline comments. Instead, describe the problem and work towards a clean solution.
 - Lists and enumerations in code should be kept in alphanumeric order. This also applies to import specifiers and union type literals.
 - Commit messages follow the **Conventional Commits** specification.
 - See also the [Contributing Guide](CONTRIBUTING.md) for more details on coding conventions and best practices.
+- Spell "KoliBri" with this casing in all documentation and code. The only exception is the component named KolKolibri.
+- Use ESM import syntax in browser code and scripts whenever supported, instead of `require` imports.
+- Do not create barrel files (e.g. `index.ts` that re-export modules). Import modules directly instead.
+- Do not place constant declarations before import statements; imports must always be at the very top of the file.
 
 ## Linting and Formatting
 
 - Run `pnpm lint` to check for linting errors across all packages. This script runs ESLint, Stylelint and TypeScript checks. You can try to automatically fix linting issues with `pnpm lint:eslint --fix`, but this may not resolve all issues.
 - Ensure all packages are built by running `pnpm build` before executing `pnpm lint` or `pnpm test`. Some packages rely on generated artifacts that linting and testing depend on.
 - Run `pnpm format` to format all code files using Prettier. You can try to automatically fix linting issues with `pnpm format -w`, but this may not resolve all issues.
+- If your pull request only modifies Markdown files, skip `pnpm build`, `pnpm lint` and `pnpm test`. Just format the Markdown using `pnpm format` or Prettier.
 
 ## Testing
 

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -47,3 +47,32 @@ updating texts when the component is rerendered. Cache the value in a class
 property whose name starts with `translate` followed by the translation
 identifier, for example `translateSort` for `kol-sort` or `translateOrderBy`
 for `kol-order-by`.
+
+### Properties
+
+To make the components easier to learn, property names and their descriptions should be consistent across components. Therefore you should:
+
+- Use the same property name for attributes that serve the same purpose.
+- Whenever possible, use identical descriptions for identical property names.
+- Whenever possible, keep the types of identical property names the same.
+- Minimize the number of different properties, descriptions and types.
+
+#### Props Handling
+
+Every property lives in a dedicated file under `src/schema/props`. The file
+contains the prop type, the prop schema and a validator function. Components and
+their controllers must import these validators instead of implementing custom
+logic. Always use the validator exported from the prop schema to keep behaviour
+consistent across components.
+
+#### Open vs Show
+
+Use `_open` when the component renders an element on demand, for example a drawer or popover that appears from nothing. Use `_show` when the element already exists in the DOM and you only toggle its visibility.
+
+#### Alignment properties
+
+The `align` prop controls the orientation of the component itself. When aligning an inner element, such as a tooltip or popover inside a component, specialized props like `tooltipAlign` or `popoverAlign` may be used instead of `align`.
+
+### BEM
+
+In release 2 we does not use the BEM styling concept. It will be introduced in a future release.


### PR DESCRIPTION
## Summary
Internal documentation update restoring missing AGENTS.md guidelines from the develop branch to release/2.

## Changes
- Restore AGENTS.md guidelines from develop to release/2

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Dokumentationsaktualisierung: Fehlende AGENTS.md-Richtlinien aus dem develop-Branch in release/2 wiederhergestellt.

## Änderungen
- AGENTS.md-Richtlinien aus develop in release/2 wiederhergestellt

</details>