### PR TITLE
feat(pagination): responsive flex layout

### DIFF
--- a/packages/components/src/components/pagination/style.scss
+++ b/packages/components/src/components/pagination/style.scss
@@ -6,7 +6,7 @@
 	:host {
 		align-items: center;
 		display: flex;
-		flex-wrap: wrap;
+		flex-direction: row;
 		gap: to-rem(16);
 	}
 
@@ -45,9 +45,12 @@
 	}
 
 	@media (max-width: 600px) {
+		:host {
+			flex-direction: column;
+		}
+
 		.range,
 		.page-size {
-			flex: 0 0 100%;
 			text-align: center;
 		}
 	}

--- a/packages/samples/react/src/scenarios/responsive-flex-layout.tsx
+++ b/packages/samples/react/src/scenarios/responsive-flex-layout.tsx
@@ -1,0 +1,38 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { KolInputRange, KolNav, KolSelect } from '@public-ui/react';
+
+import { SampleDescription } from '../components/SampleDescription';
+
+const LINKS = [
+	{ _label: 'Home', _href: '#home' },
+	{ _label: 'Docs', _href: '#docs' },
+];
+
+const OPTIONS = [
+	{ label: 'Option A', value: 'A' },
+	{ label: 'Option B', value: 'B' },
+];
+
+export const ResponsiveFlexLayout: FC = () => (
+	<>
+		<SampleDescription>
+			<p>
+				This scenario demonstrates a responsive flex layout where a range input, navigation and select are placed side by side on wide screens and stacked on
+				small screens.
+			</p>
+		</SampleDescription>
+		<div className="flex flex-col items-center gap-4 md:flex-row md:justify-between w-full">
+			<div className="flex flex-1 justify-center md:justify-start">
+				<KolInputRange _label="Range" _min={0} _max={100} />
+			</div>
+			<div className="flex flex-1 justify-center">
+				<KolNav _label="Main navigation" _links={LINKS} />
+			</div>
+			<div className="flex flex-1 justify-center md:justify-end">
+				<KolSelect _label="Select" _options={OPTIONS} />
+			</div>
+		</div>
+	</>
+);

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -6,6 +6,7 @@ import { DisabledInteractiveElements } from './disabled-interactive-elements';
 import { FocusElements } from './focus-elements';
 import { InputGroupWithError } from './input-group-with-error';
 import { InputsGetValue } from './inputs-get-value';
+import { ResponsiveFlexLayout } from './responsive-flex-layout';
 import { SameHeightOfAllInteractiveElements } from './same-height-of-all-interactive-elements';
 import { StaticForm } from './static-form';
 import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
@@ -20,6 +21,7 @@ export const SCENARIO_ROUTES: Routes = {
 		'focus-elements': FocusElements,
 		'input-group-with-error': InputGroupWithError,
 		'inputs-get-value': InputsGetValue,
+		'responsive-flex-layout': ResponsiveFlexLayout,
 		'same-height-of-all-interactive-elements': SameHeightOfAllInteractiveElements,
 		'static-form': StaticForm,
 		'table-horizontal-scrollbar-advanced': TableHorizontalScrollAdvanced,


### PR DESCRIPTION
## Summary
- add responsive scenario demonstrating range, nav and select alignment using flex
- update `kol-pagination` to switch flex direction for narrow screens

## Testing
- `pnpm --filter @public-ui/components format`
- `pnpm --filter @public-ui/components build`
- `pnpm --filter @public-ui/components lint`
- `pnpm --filter @public-ui/components test`


------
https://chatgpt.com/codex/tasks/task_e_68a2b04d6fa8832bac5a7911659d2b82