### PR TITLE
fix(table): remove focus-element and make caption focusable

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -736,17 +736,10 @@ export class KolTableStateless implements TableStatelessAPI {
 							minWidth: this.state._deprecatedMinWidth || this.state._minWidth,
 						}}
 					>
-						{/*
-						 * The following element allows the table to receive focus without providing redundant content to screen readers.
-						 * The `div` is technically not allowed here. But any allowed element would mutate the table semantics. Additionally, the `&nbsp;` is necessary to
-						 * prevent screen readers from just reading "blank".
-						 */}
 						{/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-						<div class="focus-element" tabindex={this.tableDivElementHasScrollbar ? '0' : undefined} aria-describedby="caption">
-							&nbsp;
-						</div>
-
-						<caption id="caption">{this.state._label}</caption>
+						<caption id="caption" tabindex={this.tableDivElementHasScrollbar ? '0' : undefined}>
+							{this.state._label}
+						</caption>
 
 						{Array.isArray(this.state._headerCells.horizontal) && (
 							<thead>

--- a/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
@@ -4,7 +4,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with horizontal
 <kol-table-stateless-wc class="kol-table-stateless-wc">
   <div class="table">
     <table>
-      <div aria-describedby="caption" class="focus-element"></div>
       <caption id="caption">
         Table with horizontal and vertical headers
       </caption>
@@ -78,7 +77,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with only horiz
 <kol-table-stateless-wc class="kol-table-stateless-wc">
   <div class="table">
     <table>
-      <div aria-describedby="caption" class="focus-element"></div>
       <caption id="caption">
         Table with only horizontal headers
       </caption>
@@ -122,7 +120,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with two horizo
 <kol-table-stateless-wc class="kol-table-stateless-wc">
   <div class="table">
     <table>
-      <div aria-describedby="caption" class="focus-element"></div>
       <caption id="caption">
         Table with two horizontal header rows
       </caption>
@@ -181,7 +178,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with two spanne
 <kol-table-stateless-wc class="kol-table-stateless-wc">
   <div class="table">
     <table>
-      <div aria-describedby="caption" class="focus-element"></div>
       <caption id="caption">
         Table with two spanned horizontal and vertical headers
       </caption>


### PR DESCRIPTION
## Summary
Removes the dedicated focus element from the table component and makes the caption focusable instead, improving accessibility.

## Changes
- Removed focus-element from table component
- Made table caption focusable for improved accessibility

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Das dedizierte Fokus-Element aus der Tabellen-Komponente entfernt und stattdessen die Bildunterschrift fokussierbar gemacht, um die Barrierefreiheit zu verbessern.

## Änderungen
- Fokus-Element aus der Tabellen-Komponente entfernt
- Tabellenüberschrift für verbesserte Barrierefreiheit fokussierbar gemacht

</details>