### PR TITLE
fix(table): remove focus-element and make caption focusable

### DIFF
--- a/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
@@ -35,10 +35,6 @@
 				text-align: start;
 			}
 
-			&__focus-element {
-				font-size: 0;
-			}
-
 			&__sort-button {
 				.kol-button {
 					color: inherit;

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -922,17 +922,8 @@ export class KolTableStateless implements TableStatelessAPI {
 							minWidth: this.getTableMinWidth(),
 						}}
 					>
-						{/*
-						 * The following element allows the table to receive focus without providing redundant content to screen readers.
-						 * The `div` is technically not allowed here. But any allowed element would mutate the table semantics. Additionally, the `&nbsp;` is necessary to
-						 * prevent screen readers from just reading "blank".
-						 */}
 						{/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-						<div class="kol-table__focus-element" tabindex={this.tableDivElementHasScrollbar ? '0' : undefined} aria-describedby="caption">
-							&nbsp;
-						</div>
-
-						<caption class="kol-table__caption" id="caption">
+						<caption class="kol-table__caption" id="caption" tabindex={this.tableDivElementHasScrollbar ? '0' : undefined}>
 							{this.state._label}
 						</caption>
 

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -923,7 +923,7 @@ export class KolTableStateless implements TableStatelessAPI {
 						}}
 					>
 						{/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-						<caption class="kol-table__caption" id="caption" tabindex={this.tableDivElementHasScrollbar ? '0' : undefined}>
+						<caption class="kol-table__focus-element kol-table__caption" id="caption" tabindex={this.tableDivElementHasScrollbar ? '0' : undefined}>
 							{this.state._label}
 						</caption>
 

--- a/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`kol-table-stateless-wc should render with _label="Table with horizontal
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <caption class="kol-table__caption" id="caption">
+        <caption class="kol-table__caption kol-table__focus-element" id="caption">
           Table with horizontal and vertical headers
         </caption>
         <thead class="kol-table__head">
@@ -82,7 +82,7 @@ exports[`kol-table-stateless-wc should render with _label="Table with only horiz
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <caption class="kol-table__caption" id="caption">
+        <caption class="kol-table__caption kol-table__focus-element" id="caption">
           Table with only horizontal headers
         </caption>
         <thead class="kol-table__head">
@@ -128,7 +128,7 @@ exports[`kol-table-stateless-wc should render with _label="Table with two horizo
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <caption class="kol-table__caption" id="caption">
+        <caption class="kol-table__caption kol-table__focus-element" id="caption">
           Table with two horizontal header rows
         </caption>
         <thead class="kol-table__head">
@@ -189,7 +189,7 @@ exports[`kol-table-stateless-wc should render with _label="Table with two spanne
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <caption class="kol-table__caption" id="caption">
+        <caption class="kol-table__caption kol-table__focus-element" id="caption">
           Table with two spanned horizontal and vertical headers
         </caption>
         <thead class="kol-table__head">

--- a/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
@@ -6,7 +6,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with horizontal
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <div aria-describedby="caption" class="kol-table__focus-element"></div>
         <caption class="kol-table__caption" id="caption">
           Table with horizontal and vertical headers
         </caption>
@@ -83,7 +82,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with only horiz
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <div aria-describedby="caption" class="kol-table__focus-element"></div>
         <caption class="kol-table__caption" id="caption">
           Table with only horizontal headers
         </caption>
@@ -130,7 +128,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with two horizo
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <div aria-describedby="caption" class="kol-table__focus-element"></div>
         <caption class="kol-table__caption" id="caption">
           Table with two horizontal header rows
         </caption>
@@ -192,7 +189,6 @@ exports[`kol-table-stateless-wc should render with _label="Table with two spanne
     <kol-table-settings-wc></kol-table-settings-wc>
     <div class="kol-table__scroll-container">
       <table class="kol-table__table" style="min-width: max(400px, 0ch);">
-        <div aria-describedby="caption" class="kol-table__focus-element"></div>
         <caption class="kol-table__caption" id="caption">
           Table with two spanned horizontal and vertical headers
         </caption>


### PR DESCRIPTION
## Summary
Removes the dedicated focus element from the table component and makes the caption focusable instead, improving accessibility.

## Changes
- Removed focus-element from table component
- Made table caption focusable for improved accessibility

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Das dedizierte Fokus-Element aus der Tabellen-Komponente entfernt und stattdessen die Bildunterschrift fokussierbar gemacht, um die Barrierefreiheit zu verbessern.

## Änderungen
- Fokus-Element aus der Tabellen-Komponente entfernt
- Tabellenüberschrift für verbesserte Barrierefreiheit fokussierbar gemacht

</details>