### PR TITLE
build(visual-tests): add playwright test peer dependency

### DIFF
--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -32,7 +32,6 @@
 		"kolibri-visual-test": "src/index.js"
 	},
 	"dependencies": {
-		"@playwright/test": "1.53.0",
 		"@public-ui/sample-react": "workspace:*",
 		"axe-playwright": "2.1.0",
 		"portfinder": "1.0.37",
@@ -42,9 +41,13 @@
 		"@babel/eslint-parser": "7.27.5",
 		"@babel/plugin-syntax-import-attributes": "7.27.1",
 		"@babel/preset-env": "7.27.2",
+		"@playwright/test": "1.53.0",
 		"eslint": "8.57.1",
 		"knip": "5.61.0",
 		"prettier": "3.5.3"
+	},
+	"peerDependencies": {
+		"@playwright/test": "1.53.0"
 	},
 	"files": [
 		"playwright.config.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1253,9 +1253,6 @@ importers:
 
   packages/tools/visual-tests:
     dependencies:
-      '@playwright/test':
-        specifier: 1.53.0
-        version: 1.53.0
       '@public-ui/sample-react':
         specifier: workspace:*
         version: link:../../samples/react
@@ -1278,6 +1275,9 @@ importers:
       '@babel/preset-env':
         specifier: 7.27.2
         version: 7.27.2(@babel/core@7.27.4)
+      '@playwright/test':
+        specifier: 1.53.0
+        version: 1.53.0
       eslint:
         specifier: 8.57.1
         version: 8.57.1


### PR DESCRIPTION
## Summary
Internal build improvement adding `@playwright/test` as a peer dependency for the v2 visual tests package.

## Changes
- Add `@playwright/test` as peer dependency in v2 visual tests package

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Build-Verbesserung: `@playwright/test` als Peer-Dependency im v2-Visual-Tests-Paket hinzugefügt.

## Änderungen
- `@playwright/test` als Peer-Dependency im v2-Visual-Tests-Paket hinzugefügt

</details>