### PR TITLE
fix(table): remove focus-element and make caption focusable

### DIFF
--- a/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-table-stateless-mixin.scss
@@ -22,10 +22,6 @@
 			text-align: start;
 		}
 
-		.focus-element {
-			font-size: 0;
-		}
-
 		.focus-element:focus {
 			outline: 0 !important;
 		}


### PR DESCRIPTION
## Summary
Removes the dedicated focus element from the table component and makes the caption focusable instead, improving accessibility.

## Changes
- Removed focus-element from table component
- Made table caption focusable for improved accessibility

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Das dedizierte Fokus-Element aus der Tabellen-Komponente entfernt und stattdessen die Bildunterschrift fokussierbar gemacht, um die Barrierefreiheit zu verbessern.

## Änderungen
- Fokus-Element aus der Tabellen-Komponente entfernt
- Tabellenüberschrift für verbesserte Barrierefreiheit fokussierbar gemacht

</details>