### PR TITLE
fix(input-radio): fix value key mapping

### DIFF
--- a/packages/components/src/components/input-radio/controller.ts
+++ b/packages/components/src/components/input-radio/controller.ts
@@ -80,7 +80,18 @@ export class InputRadioController extends InputCheckboxRadioController implement
 		const options = nextState.has('_options') ? nextState.get('_options') : this.component.state._options;
 		if (Array.isArray(options) && options.length > 0) {
 			this.keyOptionMap.clear();
-			fillKeyOptionMap(this.keyOptionMap, options as SelectOption<StencilUnknown>[]);
+
+			const normalizedOptions = options.map((option: RadioOption<StencilUnknown> | string) => {
+				if (typeof option === 'object' && option !== null && typeof option.label === 'string') {
+					return {
+						...option,
+						value: option.value ?? option.label,
+					};
+				}
+				return option;
+			});
+
+			fillKeyOptionMap(this.keyOptionMap, normalizedOptions as SelectOption<StencilUnknown>[]);
 		}
 	};
 


### PR DESCRIPTION
## Summary
Fixes incorrect value key mapping in the `input-radio` component.

## Changes
- Corrected value key mapping logic in `input-radio`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Fehlerhafte Wertzuordnung in der `input-radio`-Komponente behoben.

## Änderungen
- Wertzuordnungslogik in `input-radio` korrigiert

</details>