### PR TITLE
revert(table): revert table settings overflow changes

### DIFF
--- a/packages/components/src/components/@shared/_kol-table-settings-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-table-settings-mixin.scss
@@ -9,19 +9,15 @@
 			right: 0;
 			z-index: 1;
 
-			.kol-popover-button__popover {
-				overflow: unset !important; // reset browser default
-			}
-
 			&__columns-container {
 				max-height: to-rem(200);
 				margin-top: to-rem(16);
-				overflow-x: hidden;
-				overflow-y: auto;
+				overflow: auto;
 			}
 
 			&__columns {
 				display: grid;
+				overflow: hidden;
 				gap: to-rem(8);
 				align-items: center;
 				grid-auto-rows: min-content;


### PR DESCRIPTION
## Summary
Internal revert removing table settings overflow changes that caused unwanted whitespace issues.

## Changes
- Revert table settings overflow changes that caused whitespace issues

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Revert: Tabellen-Einstellungen-Overflow-Änderungen rückgängig gemacht, die unerwünschte Leerraumprobleme verursacht haben.

## Änderungen
- Tabellen-Einstellungen-Overflow-Änderungen rückgängig gemacht

</details>