### PR TITLE
style(components): wrap pagination styles in component layer

### DIFF
--- a/packages/components/src/components/pagination/style.scss
+++ b/packages/components/src/components/pagination/style.scss
@@ -3,4 +3,6 @@
 @use '../tooltip/style.scss' as *;
 @use '../@shared/kol-pagination-mixin' as *;
 
-@include kol-pagination-styles;
+@layer kol-component {
+	@include kol-pagination-styles;
+}


### PR DESCRIPTION
## Summary
Internal improvement wrapping pagination component styles in a CSS `@layer` block to prevent style specificity conflicts.

## Changes
- Wrap pagination component styles in CSS component layer

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Verbesserung: Paginierungs-Komponenten-Styles in einen CSS-Komponentenlayer eingebettet.

## Änderungen
- Paginierungs-Komponenten-Styles in CSS-Komponentenlayer eingebettet

</details>