### PR TITLE
fix: wrap alert styles in component layer

### DIFF
--- a/packages/components/src/components/alert/style.scss
+++ b/packages/components/src/components/alert/style.scss
@@ -1,4 +1,6 @@
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 
-@include kol-alert;
+@layer kol-component {
+	@include kol-alert;
+}


### PR DESCRIPTION
## Summary
Internal fix wrapping alert component styles in a CSS `@layer` block to prevent style specificity conflicts.

## Changes
- Wrap alert component styles in CSS component layer

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix: Alert-Komponenten-Styles in einen CSS-`@layer`-Block eingebettet, um Stil-Spezifizitätskonflikte zu verhindern.

## Änderungen
- Alert-Komponenten-Styles in CSS-Komponentenlayer eingebettet

</details>