### PR TITLE
8212 fix toolbar items order bug

### DIFF
--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -31,10 +31,10 @@ export class KolToolbar implements ToolbarAPI {
 		const props = {
 			key: index,
 			_tabIndex: tabIndex,
-			class: `button normal ${TOOLBAR_ITEM_TAG_NAME} `,
+			class: `button normal ${TOOLBAR_ITEM_TAG_NAME}`,
 		};
 		const catchRef = (element?: HTMLKolLinkWcElement | HTMLKolButtonWcElement) => {
-			element && this.indexToElement.set(index, element);
+			if (element) this.indexToElement.set(index, element);
 		};
 
 		return '_href' in element ? (
@@ -71,29 +71,31 @@ export class KolToolbar implements ToolbarAPI {
 	@Watch('_items')
 	public validateItems(value?: ToolbarItemsPropType): void {
 		validateToolbarItems(this, value);
+		this.state._items = value ?? [];
+		this.setFirstEnabledItemIndex();
 	}
 
-	/**
-	 * Retrieves the toolbar item by index if defined.
-	 * If not it use the current index of state.
-	 *
-	 * @returns An array of HTMLElements representing the toolbar items.
-	 */
-	private getCurrentToolbarItem(index?: number): ChildNode | undefined {
+	private getCurrentToolbarItem(index?: number) {
 		return typeof index === 'number' ? this.indexToElement.get(index) : undefined;
 	}
 
-	/**
-	 * Sets the index of the first enabled toolbar item.
-	 */
 	private setFirstEnabledItemIndex() {
-		this.currentIndex = this.state._items?.findIndex((item) => !item._disabled);
+		const items = this.state._items || [];
+		const firstEnabledIndex = items.findIndex((item) => !item._disabled);
+		this.currentIndex = firstEnabledIndex >= 0 ? firstEnabledIndex : 0;
+
+		// update all TabIndexes
+		items.forEach((item, index) => {
+			const element = this.indexToElement.get(index);
+			if (element) {
+				element._tabIndex = index === this.currentIndex && !item._disabled ? 0 : -1;
+			}
+		});
 	}
 
 	@Listen('keydown')
-	public handleKeyDown(event: KeyboardEvent) {
-		const isArrowKey = event.code === 'ArrowRight' || event.code === 'ArrowLeft';
-		if (!isArrowKey) return;
+	handleKeyDown(event: KeyboardEvent) {
+		if (event.code !== 'ArrowLeft' && event.code !== 'ArrowRight') return;
 		event.preventDefault();
 
 		const lastItemIndex = this._items?.length - 1;
@@ -111,7 +113,8 @@ export class KolToolbar implements ToolbarAPI {
 		if (currentIndex === nextIndex) return;
 
 		this.currentIndex = nextIndex;
-		void (this.getCurrentToolbarItem(nextIndex) as HTMLKolLinkElement | HTMLKolButtonElement | undefined)?.kolFocus();
+		const el = this.getCurrentToolbarItem(nextIndex);
+		if (el) void el.kolFocus();
 	}
 
 	/**

--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -71,26 +71,25 @@ export class KolToolbar implements ToolbarAPI {
 	@Watch('_items')
 	public validateItems(value?: ToolbarItemsPropType): void {
 		validateToolbarItems(this, value);
-		this.state._items = value ?? [];
-		this.setFirstEnabledItemIndex();
 	}
 
-	private getCurrentToolbarItem(index?: number) {
+	/**
+	 * Retrieves the toolbar item by index if defined.
+	 * If not it use the current index of state.
+	 *
+	 * @returns An array of HTMLElements representing the toolbar items.
+	 */
+	private getCurrentToolbarItem(index?: number): ChildNode | undefined {
 		return typeof index === 'number' ? this.indexToElement.get(index) : undefined;
 	}
 
+	/**
+	 * Sets the index of the first enabled toolbar item.
+	 */
 	private setFirstEnabledItemIndex() {
 		const items = this.state._items || [];
 		const firstEnabledIndex = items.findIndex((item) => !item._disabled);
 		this.currentIndex = firstEnabledIndex >= 0 ? firstEnabledIndex : 0;
-
-		// update all TabIndexes
-		items.forEach((item, index) => {
-			const element = this.indexToElement.get(index);
-			if (element) {
-				element._tabIndex = index === this.currentIndex && !item._disabled ? 0 : -1;
-			}
-		});
 	}
 
 	@Listen('keydown')
@@ -113,8 +112,7 @@ export class KolToolbar implements ToolbarAPI {
 		if (currentIndex === nextIndex) return;
 
 		this.currentIndex = nextIndex;
-		const el = this.getCurrentToolbarItem(nextIndex);
-		if (el) void el.kolFocus();
+		void (this.getCurrentToolbarItem(nextIndex) as HTMLKolLinkElement | HTMLKolButtonElement | undefined)?.kolFocus();
 	}
 
 	/**

--- a/packages/samples/react/e2e/toolbar-item-order.spec.ts
+++ b/packages/samples/react/e2e/toolbar-item-order.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('KolToolbar Button Reactivation', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('#/scenarios/toolbar-item-order?hideMenus');
+	});
+
+	test('KolToolbar A - All buttons disable immediately after click', async ({ page }) => {
+		const toolbar = page.getByRole('toolbar', { name: 'KolToolbar A' });
+		const buttons = toolbar.getByRole('button');
+
+		await buttons.nth(0).click();
+
+		const count = await buttons.count();
+		for (let i = 0; i < count; i++) {
+			await expect(buttons.nth(i)).toBeDisabled();
+		}
+	});
+
+	test('KolToolbar A - All buttons re-enable after 2 seconds', async ({ page }) => {
+		const toolbar = page.getByRole('toolbar', { name: 'KolToolbar A' });
+		const buttons = toolbar.getByRole('button');
+
+		await buttons.nth(0).click();
+		await page.waitForTimeout(2500);
+
+		const count = await buttons.count();
+		for (let i = 0; i < count; i++) {
+			await expect(buttons.nth(i)).toBeEnabled();
+		}
+	});
+
+	test('KolToolbar A - Clicking different buttons has same disable behavior', async ({ page }) => {
+		const toolbar = page.getByRole('toolbar', { name: 'KolToolbar A' });
+		const buttons = toolbar.getByRole('button');
+		const count = await buttons.count();
+
+		for (let buttonIndex = 0; buttonIndex < count; buttonIndex++) {
+			await page.waitForTimeout(100);
+
+			await buttons.nth(buttonIndex).click();
+
+			for (let i = 0; i < count; i++) {
+				await expect(buttons.nth(i)).toBeDisabled();
+			}
+
+			await page.waitForTimeout(2500);
+		}
+	});
+
+	test('KolToolbar B - All buttons disable immediately after click', async ({ page }) => {
+		const toolbar = page.getByRole('toolbar', { name: 'KolToolbar B' });
+		const buttons = toolbar.getByRole('button');
+
+		await buttons.nth(0).click();
+
+		const count = await buttons.count();
+		for (let i = 0; i < count; i++) {
+			await expect(buttons.nth(i)).toBeDisabled();
+		}
+	});
+
+	test('KolToolbar B - All buttons re-enable after 2 seconds', async ({ page }) => {
+		const toolbar = page.getByRole('toolbar', { name: 'KolToolbar B' });
+		const buttons = toolbar.getByRole('button');
+
+		await buttons.nth(0).click();
+		await page.waitForTimeout(2500);
+
+		const count = await buttons.count();
+		for (let i = 0; i < count; i++) {
+			await expect(buttons.nth(i)).toBeEnabled();
+		}
+	});
+
+	test('KolToolbar B - Clicking different buttons has same disable behavior', async ({ page }) => {
+		const toolbar = page.getByRole('toolbar', { name: 'KolToolbar B' });
+		const buttons = toolbar.getByRole('button');
+		const count = await buttons.count();
+
+		for (let buttonIndex = 0; buttonIndex < count; buttonIndex++) {
+			await page.waitForTimeout(100);
+
+			await buttons.nth(buttonIndex).click();
+
+			for (let i = 0; i < count; i++) {
+				await expect(buttons.nth(i)).toBeDisabled();
+			}
+
+			await page.waitForTimeout(2500);
+		}
+	});
+
+	test('Both toolbars - Buttons start in enabled state', async ({ page }) => {
+		const toolbarA = page.getByRole('toolbar', { name: 'KolToolbar A' });
+		const toolbarB = page.getByRole('toolbar', { name: 'KolToolbar B' });
+
+		const buttonsA = toolbarA.getByRole('button');
+		const buttonsB = toolbarB.getByRole('button');
+
+		// Prüfe initiale States
+		const countA = await buttonsA.count();
+		const countB = await buttonsB.count();
+
+		for (let i = 0; i < countA; i++) {
+			await expect(buttonsA.nth(i)).toBeEnabled();
+		}
+
+		for (let i = 0; i < countB; i++) {
+			await expect(buttonsB.nth(i)).toBeEnabled();
+		}
+	});
+
+	test('Cross-toolbar interaction - One toolbar click does not affect other toolbar', async ({ page }) => {
+		const toolbarA = page.getByRole('toolbar', { name: 'KolToolbar A' });
+		const toolbarB = page.getByRole('toolbar', { name: 'KolToolbar B' });
+
+		const buttonsA = toolbarA.getByRole('button');
+		const buttonsB = toolbarB.getByRole('button');
+
+		// Klick auf Toolbar A
+		await buttonsA.nth(0).click();
+
+		// Toolbar A sollte disabled sein
+		const countA = await buttonsA.count();
+		for (let i = 0; i < countA; i++) {
+			await expect(buttonsA.nth(i)).toBeDisabled();
+		}
+
+		// Toolbar B sollte weiterhin enabled sein
+		const countB = await buttonsB.count();
+		for (let i = 0; i < countB; i++) {
+			await expect(buttonsB.nth(i)).toBeEnabled();
+		}
+	});
+
+	test('Timing precision - Buttons are still disabled at 1.5 seconds', async ({ page }) => {
+		const toolbar = page.getByRole('toolbar', { name: 'KolToolbar A' });
+		const buttons = toolbar.getByRole('button');
+
+		await buttons.nth(0).click();
+		await page.waitForTimeout(1500); // Waiting only 1.5sec
+
+		const count = await buttons.count();
+		for (let i = 0; i < count; i++) {
+			await expect(buttons.nth(i)).toBeDisabled();
+		}
+	});
+});

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -9,6 +9,7 @@ import { InputsGetValue } from './inputs-get-value';
 import { SameHeightOfAllInteractiveElements } from './same-height-of-all-interactive-elements';
 import { StaticForm } from './static-form';
 import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
+import { ToolbarItemOrder } from './toolbar-item-order';
 import { TooltipPositioning } from './tooltip-positioning';
 
 export const SCENARIO_ROUTES: Routes = {
@@ -23,6 +24,7 @@ export const SCENARIO_ROUTES: Routes = {
 		'same-height-of-all-interactive-elements': SameHeightOfAllInteractiveElements,
 		'static-form': StaticForm,
 		'table-horizontal-scrollbar-advanced': TableHorizontalScrollAdvanced,
+		'toolbar-item-order': ToolbarItemOrder,
 		'tooltip-positioning': TooltipPositioning,
 	},
 };

--- a/packages/samples/react/src/scenarios/toolbar-item-order.tsx
+++ b/packages/samples/react/src/scenarios/toolbar-item-order.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { FC } from 'react';
+import type { ToolbarItemsPropType } from '@public-ui/components';
+import { KolHeading, KolToolbar } from '@public-ui/react-v19';
+
+export const ToolbarItemOrder: FC = () => {
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [isSubmitting2, setIsSubmitting2] = useState(false);
+
+	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout>;
+		if (isSubmitting) {
+			timer = setTimeout(() => {
+				setIsSubmitting(false);
+			}, 2000);
+		}
+		return () => clearTimeout(timer);
+	}, [isSubmitting]);
+
+	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout>;
+		if (isSubmitting2) {
+			timer = setTimeout(() => {
+				setIsSubmitting2(false);
+			}, 2000);
+		}
+		return () => clearTimeout(timer);
+	}, [isSubmitting2]);
+
+	const handleSubmit = () => setIsSubmitting(true);
+	const handleSubmit2 = () => setIsSubmitting2(true);
+
+	const toolbarItems = useMemo(() => {
+		const items: ToolbarItemsPropType = Array.from({ length: 5 }, (_item, index) => ({
+			_label: `Button ${index + 1}`,
+			_on: { onClick: handleSubmit },
+			_icons: isSubmitting ? 'codicon codicon-loading codicon-modifier-spin' : void 0,
+			_disabled: isSubmitting,
+		}));
+		return items;
+	}, [isSubmitting]);
+
+	const brokenToolbarItems = useMemo(() => {
+		const items: ToolbarItemsPropType = Array.from({ length: 5 }, (_item, index) => ({
+			_label: `Button ${index + 1}`,
+			_on: { onClick: handleSubmit2 },
+			_disabled: isSubmitting2,
+			_icons: isSubmitting2 ? 'codicon codicon-loading codicon-modifier-spin' : void 0,
+		}));
+		return items;
+	}, [isSubmitting2]);
+
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+			<KolHeading _label="Disabled Toolbar Buttons Bug (solved)" />
+
+			<KolHeading _label="icon vor disabled" _level={2} />
+			<KolToolbar _label="KolToolbar A" _items={toolbarItems} />
+			<KolHeading _label="disabled vor icon" _level={2} />
+			<p>Klicke auf einen der {brokenToolbarItems.length - 1} ersten Buttons hatte zur Folge, dass die nachfolgenden Buttons kaputt gehen.</p>
+			<KolToolbar _label="KolToolbar B" _items={brokenToolbarItems} />
+		</div>
+	);
+};


### PR DESCRIPTION
Ref.: #8212 

### Titel:
Fix Toolbar Button Activation and _disabled / _icons Handling

## Beschreibung:

## Fehlerhafte Aktivierung von Buttons:
- Buttons wurden nach Klick nicht korrekt reaktiviert, insbesondere abhängig von der Reihenfolge von _disabled und _icons. Nun werden alle Buttons nach Ablauf von z. B. 2 Sekunden korrekt wieder aktiv.

## TabIndex Handling:
- _tabIndex wird jetzt nach jedem Prop-Update korrekt gesetzt, sodass immer der erste aktive Button fokussierbar ist.

## State-Synchronisation:
- state._items wird bei Prop-Updates synchronisiert, wodurch die Reihenfolge von _disabled und _icons keine Rolle mehr spielt.


## Testing:

- Das Sample toolbar-item-order habe ich in den Scenarios platziert. Ich kann es nach der Review wieder entfernen.
- e2e Test ist erstellt 
- Sample mit 2 x 5 Buttons getestet: Buttons 1–5 deaktivieren sich korrekt nach Klick und reaktivieren sich nach 2 Sekunden.
  - Fehler trat in der 2 Button-Reihe auf, weil _disabled vor _icon kam
- Reihenfolge von _disabled und _icons beeinflusst jetzt nicht mehr das Verhalten.

## Update (refactored Bug Fix)

Ich habe folgende Anpassungen vorgenommen:
- `validateItems:`  wieder zurück auf die ursprüngliche Validation
- `setFirstEnabledItemIndex` Nur Index-Berechnung, keine DOM-Updates
- `renderItem` unverändert gelassen: Das deklarative Rendering macht seine Arbeit

## Begründung:

Das Problem lag nach m. M.  bei setFirstEnabledItemIdex:

**Ursprüngliche Version war:**
`this.currentIndex = this.state._items?.findIndex((item) => !item._disabled);`

**funktionierende Version:**
```
const items = this.state._items || [];
const firstEnabledIndex = items.findIndex((item) => !item._disabled);
this.currentIndex = firstEnabledIndex >= 0 ? firstEnabledIndex : 0;
```
**Das Problem mit der ursprünglichen Version:**
1.	findIndex() gibt -1 zurück, wenn kein Element gefunden wird (alle disabled)
2.	this.currentIndex = -1 führt zu einem ungültigen Index
3.	In renderItem: index === this.currentIndex && !element?._disabled ? 0 : -1 
o	Bei currentIndex = -1 ist kein Element aktiv (tabIndex = 0)
o	Buttons bekommen tabIndex = -1

**Das Timing-Problem:**
•	Wenn alle Buttons disabled werden (setIsSubmitting(true))
•	setFirstEnabledItemIndex() wird aufgerufen
•	findIndex() findet nichts → currentIndex = -1
•	Re-Render passiert mit currentIndex = -1
•	Wenn später setIsSubmitting(false) aufgerufen wird, ist der currentIndex immer noch -1
•	Button bekommt tabIndex = 0 → Focus/Aktivierung geht verloren

**Lösung:**
`this.currentIndex = firstEnabledIndex >= 0 ? firstEnabledIndex : 0;`

•	Fallback auf 0 statt -1
•	Sicherstellt, dass immer ein gültiger Index existiert
•	Beim Re-Enable bekommt mindestens der erste Button den Fokus

Das war der eigentliche Bug! Nicht die Props-Reihenfolge, sondern der ungültige currentIndex = -1 bei disabled Items.


