### PR TITLE
fix(components): prioritize icons before disabled in toolbar

### DIFF
--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -4,6 +4,8 @@ import { Component, Element, h, Host, Listen, Prop, State, Watch } from '@stenci
 import type { LabelPropType, ToolbarAPI, ToolbarStates, ToolbarItemsPropType, ToolbarItemPropType } from '../../schema';
 import { validateLabel, validateToolbarItems } from '../../schema';
 import { KolButtonWcTag, KolLinkWcTag } from '../../core/component-names';
+import type { KolLinkWc } from '../link/component';
+import type { KolButtonWc } from '../button/component';
 
 const TOOLBAR_ITEM_TAG_NAME = 'kol-toolbar-item';
 
@@ -37,10 +39,12 @@ export class KolToolbar implements ToolbarAPI {
 			if (element) this.indexToElement.set(index, element);
 		};
 
+		const { _icons, _disabled, ...rest } = element;
+
 		return '_href' in element ? (
-			<KolLinkWcTag {...element} {...props} ref={catchRef} _role="button"></KolLinkWcTag>
+			<KolLinkWcTag {...(rest as KolLinkWc)} {...props} ref={catchRef} _icons={_icons} _disabled={_disabled} _role="button"></KolLinkWcTag>
 		) : (
-			<KolButtonWcTag {...element} {...props} ref={catchRef}></KolButtonWcTag>
+			<KolButtonWcTag {...(rest as KolButtonWc)} {...props} ref={catchRef} _icons={_icons} _disabled={_disabled}></KolButtonWcTag>
 		);
 	};
 

--- a/packages/components/src/components/toolbar/test/disabled.spec.tsx
+++ b/packages/components/src/components/toolbar/test/disabled.spec.tsx
@@ -1,0 +1,24 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolToolbar } from '../shadow';
+
+describe('KolToolbar _disabled toggle', () => {
+	it('re-enables toolbar items after timeout', async () => {
+		jest.useFakeTimers();
+		const page = await newSpecPage({ components: [KolToolbar], html: '<kol-toolbar></kol-toolbar>' });
+		const toolbar = page.root as HTMLKolToolbarElement;
+
+		toolbar._items = [{ _label: 'Button', _disabled: true }];
+		await page.waitForChanges();
+		let button = toolbar.shadowRoot?.querySelector('kol-button-wc');
+		expect(button?.hasAttribute('_disabled')).toBe(true);
+
+		setTimeout(() => {
+			toolbar._items = [{ _label: 'Button' }];
+		}, 50);
+		jest.runAllTimers();
+		await page.waitForChanges();
+		button = toolbar.shadowRoot?.querySelector('kol-button-wc');
+		expect(button?.hasAttribute('_disabled')).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- ensure toolbar item `_icons` prop overrides before `_disabled`
- add regression test covering `_disabled` toggling

## Testing
- `pnpm build` *(fails: Command failed)*
- `pnpm --filter @public-ui/components lint`
- `pnpm --filter @public-ui/components test:unit packages/components/src/components/toolbar/test/disabled.spec.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a765ef6558832ba0fa589e7084afde