### PR TITLE
fix: align roles of button-link and link-button

### DIFF
--- a/packages/components/src/components/button-link/button-link.e2e.ts
+++ b/packages/components/src/components/button-link/button-link.e2e.ts
@@ -9,6 +9,12 @@ test.describe('kol-button-link', () => {
 		await expect(kolButton).toContainText('Test ButtonLink Element');
 	});
 
+	test('has button role', async ({ page }) => {
+		await page.setContent('<kol-button-link _label="Label"></kol-button-link>');
+		const role = await page.locator('kol-button-link').evaluate((el) => el.shadowRoot?.querySelector('kol-button-wc')?.getAttribute('role'));
+		expect(role).toBe('button');
+	});
+
 	test.describe('Callbacks', () => {
 		['onClick', 'onMouseDown'].forEach((callbackName) => {
 			test(`should call ${callbackName} callback when internal button emits`, async ({ page }) => {

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -1,6 +1,5 @@
 import type {
 	AccessKeyPropType,
-	AlternativeButtonLinkRolePropType,
 	AriaDescriptionPropType,
 	ButtonCallbacksPropType,
 	ButtonLinkProps,
@@ -70,7 +69,6 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 				_linkVariant={this._variant}
 				_name={this._name}
 				_on={this._on}
-				_role="link"
 				_shortKey={this._shortKey}
 				_syncValueBySelector={this._syncValueBySelector}
 				_tooltipAlign={this._tooltipAlign}
@@ -154,8 +152,8 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 * @deprecated Will be removed in release 2.
 	 */
-	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 
 	/**
 	 * Adds a visual short key hint to the component.

--- a/packages/components/src/components/button-link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/button-link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-button-link should render with _label="Beschreibung" 1`] = `
 <kol-button-link>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-button-wc _label="Beschreibung" _linkvariant="inline" _role="link" _tooltipalign="top" _type="button">
+    <kol-button-wc _label="Beschreibung" _linkvariant="inline" _tooltipalign="top" _type="button">
       <slot name="expert" slot="expert"></slot>
     </kol-button-wc>
   </template>

--- a/packages/components/src/components/link-button/link-button.e2e.ts
+++ b/packages/components/src/components/link-button/link-button.e2e.ts
@@ -3,6 +3,12 @@ import { test } from '@stencil/playwright';
 import { KolEvent } from '../../utils/events';
 
 test.describe('kol-link-button', () => {
+	test('has link role', async ({ page }) => {
+		await page.setContent('<kol-link-button _label="Link"></kol-link-button>');
+		const role = await page.locator('kol-link-button').evaluate((el) => el.shadowRoot?.querySelector('kol-link-wc')?.getAttribute('role'));
+		expect(role).toBe('link');
+	});
+
 	test.describe('Callbacks', () => {
 		test(`should call onClick callback when internal anchor emits click`, async ({ page }) => {
 			await page.setContent('<kol-link-button _label="Link"></kol-link-button>');

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -1,6 +1,5 @@
 import type {
 	AccessKeyPropType,
-	AlternativeButtonLinkRolePropType,
 	AriaCurrentValuePropType,
 	AriaDescriptionPropType,
 	ButtonVariantPropType,
@@ -59,7 +58,6 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 				_icons={this._icons}
 				_label={this._label}
 				_on={this._on}
-				_role="button"
 				_shortKey={this._shortKey}
 				_target={this._target}
 				_tooltipAlign={this._tooltipAlign}
@@ -129,8 +127,8 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 * @deprecated Will be removed in release 2.
 	 */
-	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 
 	/**
 	 * Adds a visual short key hint to the component.

--- a/packages/components/src/components/link-button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link-button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="bottom" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="bottom">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="bottom">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -13,7 +13,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="left" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="left">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="left">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -23,7 +23,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="right" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="right">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="right">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -33,7 +33,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="top" _hideLabel=true 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _hidelabel="" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="top">
+    <kol-link-wc _buttonvariant="normal" _hidelabel="" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="top">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -43,7 +43,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="top" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="top">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="top">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -53,7 +53,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="right">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="right">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -63,7 +63,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _label="Label" _href="" _download="download-file.zip" _target="blank" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _download="download-file.zip" _href="" _label="Label" _role="button" _target="blank" _tooltipalign="right">
+    <kol-link-wc _buttonvariant="normal" _download="download-file.zip" _href="" _label="Label" _target="blank" _tooltipalign="right">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>

--- a/packages/components/src/schema/components/button-link.ts
+++ b/packages/components/src/schema/components/button-link.ts
@@ -1,10 +1,10 @@
 import type { Generic } from 'adopted-style-sheets';
 
-import type { PropAlternativeButtonLinkRole, PropButtonVariant, PropLinkVariant } from '../props';
+import type { PropButtonVariant, PropLinkVariant } from '../props';
 import type { OptionalButtonProps, OptionalButtonStates, RequiredButtonProps, RequiredButtonStates } from './button';
 
 type RequiredProps = RequiredButtonProps;
-type OptionalProps = Omit<OptionalButtonProps, keyof PropAlternativeButtonLinkRole | keyof PropButtonVariant> & PropLinkVariant; // _role is fixed to "link"
+type OptionalProps = Omit<OptionalButtonProps, 'role' | keyof PropButtonVariant> & PropLinkVariant;
 
 export type ButtonLinkProps = Generic.Element.Members<RequiredProps, OptionalProps>;
 export type ButtonLinkStates = Generic.Element.Members<RequiredButtonStates, OptionalButtonStates>;

--- a/packages/components/src/schema/components/link-button.ts
+++ b/packages/components/src/schema/components/link-button.ts
@@ -1,9 +1,9 @@
 import type { Generic } from 'adopted-style-sheets';
 
-import type { PropAlternativeButtonLinkRole, PropButtonVariant, PropCustomClass, PropLinkVariant } from '../props';
+import type { PropButtonVariant, PropCustomClass, PropLinkVariant } from '../props';
 import type { OptionalProps as LinkOptionalProps, RequiredProps as LinkRequiredProps } from './link';
 
 type RequiredProps = LinkRequiredProps;
-type OptionalProps = Omit<LinkOptionalProps, keyof PropAlternativeButtonLinkRole | keyof PropLinkVariant> & PropButtonVariant & PropCustomClass; // _role is fixed to "button"
+type OptionalProps = Omit<LinkOptionalProps, 'role' | keyof PropLinkVariant> & PropButtonVariant & PropCustomClass;
 
 export type LinkButtonProps = Generic.Element.Members<RequiredProps, OptionalProps>;

--- a/packages/samples/react/src/components/button-link/basic.tsx
+++ b/packages/samples/react/src/components/button-link/basic.tsx
@@ -16,8 +16,9 @@ export const ButtonLinkBasic: FC = () => {
 		<>
 			<SampleDescription>
 				<p>
-					KolButtonLink shows an element, that behaves like a button but looks like a link. The sample illustrates KolButtonLink with different
-					display-properties such as <code>block</code>, <code>inline-block</code> and <code>inline</code>. It also demonstrates the disabled-state.
+					KolButtonLink shows an element, that behaves like a button but looks like a link. Screen readers announce it as a button. The sample illustrates
+					KolButtonLink with different display-properties such as <code>block</code>, <code>inline-block</code> and <code>inline</code>. It also demonstrates
+					the disabled-state.
 				</p>
 			</SampleDescription>
 			<section className="text-base">

--- a/packages/samples/react/src/components/link-button/basic.tsx
+++ b/packages/samples/react/src/components/link-button/basic.tsx
@@ -12,7 +12,7 @@ const ARGS = {
 export const LinkButtonBasic: FC = () => (
 	<>
 		<SampleDescription>
-			<p>KolLinkButton renders a link that looks like a button. The sample shows the different styling variants.</p>
+			<p>KolLinkButton renders a link that looks like a button. Screen readers announce a navigation. The sample shows the different styling variants.</p>
 		</SampleDescription>
 
 		<div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- remove `_role` prop from `kol-button-link` and `kol-link-button`
- drop `_role` from their schema definitions and tests
- tidy breaking changes doc for these components

## Testing
- `pnpm --filter @public-ui/components build`
- `pnpm lint` *(fails: Command failed)*
- `pnpm test` *(fails: Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f0ef1898832b9e4c7a4bb498dab1