### PR TITLE
refactor: deprecate _role prop in button components for semantic HTML

### DIFF
--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -48,8 +48,7 @@
 	/* option, */
 	/* select, */
 	/* textarea, */
-	[role='button'],
-	button:not([role='link']),
+	button,
 	.kol-input .input {
 		min-width: var(--a11y-min-size);
 		min-height: var(--a11y-min-size);

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -78,7 +78,6 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 					_label={this._label}
 					_name={this._name}
 					_on={this._on}
-					_role="link"
 					_shortKey={this._shortKey}
 					_syncValueBySelector={this._syncValueBySelector}
 					_tabIndex={this._tabIndex}
@@ -159,6 +158,8 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/button-link/style.scss
+++ b/packages/components/src/components/button-link/style.scss
@@ -1,2 +1,8 @@
 @use '../style' as *;
 @use '../link' as *;
+
+@layer kol-component {
+	button {
+		min-height: unset; // Inline links may have the height of the flowing text and do not necessarily have to be 44px high.
+	}
+}

--- a/packages/components/src/components/button-link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/button-link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-button-link should render with _label="Beschreibung" 1`] = `
 <kol-button-link class="kol-button-link">
   <template shadowrootmode="open">
-    <kol-button-wc _label="Beschreibung" _role="link" _tooltipalign="top" _type="button">
+    <kol-button-wc _label="Beschreibung" _tooltipalign="top" _type="button">
       <slot name="expert" slot="expert"></slot>
     </kol-button-wc>
   </template>

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -82,7 +82,6 @@ export class KolButton implements ButtonProps, FocusableElement {
 					_label={this._label}
 					_name={this._name}
 					_on={this._on}
-					_role={this._role}
 					_shortKey={this._shortKey}
 					_syncValueBySelector={this._syncValueBySelector}
 					_tabIndex={this._tabIndex}
@@ -166,6 +165,8 @@ export class KolButton implements ButtonProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -71,7 +71,6 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 					_icons={this._icons}
 					_label={this._label}
 					_on={this._on}
-					_role="button"
 					_shortKey={this._shortKey}
 					_tabIndex={this._tabIndex}
 					_target={this._target}
@@ -143,6 +142,8 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/link-button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link-button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="bottom" 1`] = `
 <kol-link-button class="kol-link-button">
   <template shadowrootmode="open">
-    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="bottom" _variant="normal" class="button">
+    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="bottom" _variant="normal" class="button">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -13,7 +13,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="left" 1`] = `
 <kol-link-button class="kol-link-button">
   <template shadowrootmode="open">
-    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="left" _variant="normal" class="button">
+    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="left" _variant="normal" class="button">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -23,7 +23,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="right" 1`] = `
 <kol-link-button class="kol-link-button">
   <template shadowrootmode="open">
-    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="right" _variant="normal" class="button">
+    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="right" _variant="normal" class="button">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -33,7 +33,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="top" _hideLabel=true 1`] = `
 <kol-link-button class="kol-link-button">
   <template shadowrootmode="open">
-    <kol-link-wc _hidelabel="" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="top" _variant="normal" class="button">
+    <kol-link-wc _hidelabel="" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="top" _variant="normal" class="button">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -43,7 +43,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="top" 1`] = `
 <kol-link-button class="kol-link-button">
   <template shadowrootmode="open">
-    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="top" _variant="normal" class="button">
+    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="top" _variant="normal" class="button">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -53,7 +53,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" 1`] = `
 <kol-link-button class="kol-link-button">
   <template shadowrootmode="open">
-    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="right" _variant="normal" class="button">
+    <kol-link-wc _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="right" _variant="normal" class="button">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -63,7 +63,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _label="Label" _href="" _download="download-file.zip" _target="blank" 1`] = `
 <kol-link-button class="kol-link-button">
   <template shadowrootmode="open">
-    <kol-link-wc _download="download-file.zip" _href="" _label="Label" _role="button" _target="blank" _tooltipalign="right" _variant="normal" class="button">
+    <kol-link-wc _download="download-file.zip" _href="" _label="Label" _target="blank" _tooltipalign="right" _variant="normal" class="button">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -66,7 +66,6 @@ export class KolLink implements LinkProps, FocusableElement {
 					_icons={this._icons}
 					_label={this._label}
 					_on={this._on}
-					_role={this._role}
 					_shortKey={this._shortKey}
 					_tabIndex={this._tabIndex}
 					_target={this._target}
@@ -136,6 +135,8 @@ export class KolLink implements LinkProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -132,7 +132,6 @@ export class KolPopoverButton implements PopoverButtonProps {
 							this._on?.onClick?.(event, value);
 						},
 					}}
-					_role={this._role}
 					_shortKey={this._shortKey}
 					_syncValueBySelector={this._syncValueBySelector}
 					_tabIndex={this._tabIndex}
@@ -223,6 +222,8 @@ export class KolPopoverButton implements PopoverButtonProps {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -24,12 +24,12 @@ import { buildBadgeTextString, showExpertSlot } from '../../schema';
 import clsx from 'clsx';
 import { KolIconTag, KolInputTag } from '../../core/component-names';
 import { translate } from '../../i18n';
+import type { EventDetail } from '../../schema/interfaces/EventDetail';
 import { nonce } from '../../utils/dev.utils';
 import { tryToDispatchKoliBriEvent } from '../../utils/events';
 import { getRenderStates } from '../input/controller';
 import { InternalUnderlinedBadgeText } from '../span/InternalUnderlinedBadgeText';
 import { SingleSelectController } from './controller';
-import { EventDetail } from '../../schema/interfaces/EventDetail';
 
 /**
  * @slot - The input field label.

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -73,7 +73,6 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 						_label={this._label}
 						_name={this._name}
 						_on={this.clickButtonHandler}
-						_role={this._role}
 						_syncValueBySelector={this._syncValueBySelector}
 						_tabIndex={this._tabIndex}
 						_tooltipAlign={this._tooltipAlign}
@@ -168,6 +167,8 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -38,7 +38,7 @@ export class KolToolbar implements ToolbarAPI {
 		};
 
 		return '_href' in element ? (
-			<KolLinkWcTag {...element} {...props} ref={catchRef} _role="button"></KolLinkWcTag>
+			<KolLinkWcTag {...element} {...props} ref={catchRef}></KolLinkWcTag>
 		) : (
 			<KolButtonWcTag {...element} {...props} ref={catchRef}></KolButtonWcTag>
 		);

--- a/packages/components/src/components/toolbar/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/toolbar/test/__snapshots__/snapshot.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`kol-toolbar should render with _label="Text" _items=[{"_label":"Button"
   <template shadowrootmode="open">
     <div aria-label="Text" class="toolbar" role="toolbar">
       <kol-button-wc _label="Button" _tabindex="0" class="button kol-toolbar-item normal"></kol-button-wc>
-      <kol-link-wc _href="#" _label="Link" _role="button" _tabindex="-1" class="button kol-toolbar-item normal"></kol-link-wc>
+      <kol-link-wc _href="#" _label="Link" _tabindex="-1" class="button kol-toolbar-item normal"></kol-link-wc>
     </div>
   </template>
 </kol-toolbar>

--- a/packages/components/src/schema/props/alternative-button-link-role.ts
+++ b/packages/components/src/schema/props/alternative-button-link-role.ts
@@ -2,7 +2,7 @@
 import type { Generic } from 'adopted-style-sheets';
 import { watchValidator } from '../utils';
 
-const alternativeButtonLinkRolePropTypeOptions = ['button', 'link', 'tab', 'treeitem'] as const;
+const alternativeButtonLinkRolePropTypeOptions = ['tab', 'treeitem'] as const;
 export type AlternativeButtonLinkRolePropType = (typeof alternativeButtonLinkRolePropTypeOptions)[number];
 
 /**


### PR DESCRIPTION
## Summary
Deprecates the `_role` prop in button components, encouraging the use of semantic HTML elements instead.

## Changes
- Deprecated `_role` property in button components
- Marked `_role` as deprecated to encourage semantic HTML usage

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Das `_role`-Prop in Button-Komponenten wird als veraltet markiert, um die Verwendung semantischer HTML-Elemente zu fördern.

## Änderungen
- `_role`-Eigenschaft in Button-Komponenten als veraltet markiert
- Semantische HTML-Verwendung wird empfohlen

</details>