### PR TITLE
refactor: deprecate _role prop in button components for semantic HTML

### DIFF
--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -49,8 +49,7 @@
 	/* option, */
 	/* select, */
 	/* textarea, */
-	[role='button'],
-	button:not([role='link']),
+	button,
 	.kol-input .input {
 		min-width: var(--a11y-min-size);
 		min-height: var(--a11y-min-size);

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -70,7 +70,6 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 				_linkVariant={this._variant}
 				_name={this._name}
 				_on={this._on}
-				_role="link"
 				_shortKey={this._shortKey}
 				_syncValueBySelector={this._syncValueBySelector}
 				_tooltipAlign={this._tooltipAlign}
@@ -154,6 +153,8 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/button-link/style.scss
+++ b/packages/components/src/components/button-link/style.scss
@@ -4,4 +4,8 @@
 
 @layer kol-component {
 	@include kol-link-styles('kol-button');
+
+	.kol-button--inline {
+		min-height: unset; // Inline links may have the height of the flowing text and do not necessarily have to be 44px high.
+	}
 }

--- a/packages/components/src/components/button-link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/button-link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-button-link should render with _label="Beschreibung" 1`] = `
 <kol-button-link>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-button-wc _label="Beschreibung" _linkvariant="inline" _role="link" _tooltipalign="top" _type="button">
+    <kol-button-wc _label="Beschreibung" _linkvariant="inline" _tooltipalign="top" _type="button">
       <slot name="expert" slot="expert"></slot>
     </kol-button-wc>
   </template>

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -69,7 +69,6 @@ export class KolButton implements ButtonProps, FocusableElement {
 				_label={this._label}
 				_name={this._name}
 				_on={this._on}
-				_role={this._role}
 				_shortKey={this._shortKey}
 				_syncValueBySelector={this._syncValueBySelector}
 				_tooltipAlign={this._tooltipAlign}
@@ -151,6 +150,8 @@ export class KolButton implements ButtonProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -59,7 +59,6 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 				_icons={this._icons}
 				_label={this._label}
 				_on={this._on}
-				_role="button"
 				_shortKey={this._shortKey}
 				_target={this._target}
 				_tooltipAlign={this._tooltipAlign}
@@ -129,6 +128,8 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/link-button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link-button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="bottom" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="bottom">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="bottom">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -13,7 +13,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="left" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="left">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="left">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -23,7 +23,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="right" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="right">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="right">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -33,7 +33,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="top" _hideLabel=true 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _hidelabel="" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="top">
+    <kol-link-wc _buttonvariant="normal" _hidelabel="" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="top">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -43,7 +43,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="top" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="top">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="top">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -53,7 +53,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _role="button" _target="self" _tooltipalign="right">
+    <kol-link-wc _buttonvariant="normal" _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipalign="right">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>
@@ -63,7 +63,7 @@ exports[`kol-link-button should render with _href="https://example.com" _icons="
 exports[`kol-link-button should render with _label="Label" _href="" _download="download-file.zip" _target="blank" 1`] = `
 <kol-link-button>
   <template shadowrootmode="open" shadowrootdelegatesfocus>
-    <kol-link-wc _buttonvariant="normal" _download="download-file.zip" _href="" _label="Label" _role="button" _target="blank" _tooltipalign="right">
+    <kol-link-wc _buttonvariant="normal" _download="download-file.zip" _href="" _label="Label" _target="blank" _tooltipalign="right">
       <slot name="expert" slot="expert"></slot>
     </kol-link-wc>
   </template>

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -165,7 +165,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 						'kol-link--disabled': this.state._disabled === true,
 						'kol-link--external-link': isExternal,
 						'kol-link--hide-label': this.state._hideLabel === true,
-						[`kol-link--${this.state._buttonVariant as string}`]: this.state._role === 'button' && this.state._buttonVariant !== 'custom',
+						[`kol-link--${this.state._buttonVariant as string}`]: this.state._buttonVariant !== 'custom',
 						[`kol-link--${this.state._linkVariant as string}`]: this.state._linkVariant,
 						[this.state._customClass as string]:
 							this.state._buttonVariant === 'custom' && typeof this.state._customClass === 'string' && this.state._customClass.length > 0,

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -59,7 +59,6 @@ export class KolLink implements LinkProps, FocusableElement {
 				_label={this._label}
 				_linkVariant={this._variant}
 				_on={this._on}
-				_role={this._role}
 				_shortKey={this._shortKey}
 				_target={this._target}
 				_tooltipAlign={this._tooltipAlign}
@@ -132,6 +131,8 @@ export class KolLink implements LinkProps, FocusableElement {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-link-wc>
       <!---->
-      <a class="kol-link kol-link--external-link kol-link--inline" href="https://example.com" rel="noopener" target="self">
+      <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
             <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -30,7 +30,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-link-wc>
       <!---->
-      <a class="kol-link kol-link--external-link kol-link--inline" href="https://example.com" rel="noopener" target="self">
+      <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
             <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -55,7 +55,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-link-wc>
       <!---->
-      <a class="kol-link kol-link--external-link kol-link--inline" href="https://example.com" rel="noopener" target="self">
+      <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
             <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -80,7 +80,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-link-wc>
       <!---->
-      <a aria-label="Label (kol-open-link-in-tab)" class="kol-link kol-link--external-link kol-link--hide-label kol-link--inline" href="https://example.com" rel="noopener" target="self">
+      <a aria-label="Label (kol-open-link-in-tab)" class="kol-link kol-link--external-link kol-link--hide-label kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span kol-span--hide-label">
           <span class="kol-span__container">
             <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -102,7 +102,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-link-wc>
       <!---->
-      <a class="kol-link kol-link--external-link kol-link--inline" href="https://example.com" rel="noopener" target="self">
+      <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
             <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -127,7 +127,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-link-wc>
       <!---->
-      <a class="kol-link kol-link--external-link kol-link--inline" href="https://example.com" rel="noopener" target="self">
+      <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
             <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
@@ -152,7 +152,7 @@ exports[`kol-link should render with _label="Label" _href="" _download="download
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-link-wc>
       <!---->
-      <a class="kol-link kol-link--external-link kol-link--inline" download="download-file.zip" href="javascript:void(0);" rel="noopener" target="blank">
+      <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" download="download-file.zip" href="javascript:void(0);" rel="noopener" target="blank">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
             <span class="kol-span__label">

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -41,10 +41,14 @@ export class KolPopoverButton implements PopoverButtonProps {
 		void this.ref?.hidePopover();
 	}
 
+	private catchRef = (ref?: HTMLKolPopoverButtonWcElement) => {
+		this.ref = ref;
+	};
+
 	public render(): JSX.Element {
 		return (
 			<KolPopoverButtonWcTag
-				ref={(element) => (this.ref = element)}
+				ref={this.catchRef}
 				_accessKey={this._accessKey}
 				_ariaControls={this._ariaControls}
 				_ariaDescription={this._ariaDescription}
@@ -58,7 +62,6 @@ export class KolPopoverButton implements PopoverButtonProps {
 				_name={this._name}
 				_on={this._on}
 				_popoverAlign={this._popoverAlign}
-				_role={this._role}
 				_shortKey={this._shortKey}
 				_syncValueBySelector={this._syncValueBySelector}
 				_tabIndex={this._tabIndex}
@@ -142,6 +145,8 @@ export class KolPopoverButton implements PopoverButtonProps {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -107,7 +107,6 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 						_label={this._label}
 						_name={this._name}
 						_on={this.clickButtonHandler}
-						_role={this._role}
 						_shortKey={this._shortKey}
 						_syncValueBySelector={this._syncValueBySelector}
 						_tooltipAlign={this._tooltipAlign}
@@ -211,6 +210,8 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 
 	/**
 	 * Defines the role of the components primary element.
+	 *
+	 * @deprecated We prefer the semantic role of the HTML element and do not allow for customization. We will remove this prop in the future.
 	 */
 	@Prop() public _role?: AlternativeButtonLinkRolePropType;
 

--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -39,7 +39,7 @@ export class KolToolbar implements ToolbarAPI {
 		};
 
 		return '_href' in element ? (
-			<KolLinkWcTag {...element} {...props} ref={catchRef} _role="button"></KolLinkWcTag>
+			<KolLinkWcTag {...element} {...props} ref={catchRef}></KolLinkWcTag>
 		) : (
 			<KolButtonWcTag {...element} {...props} ref={catchRef}></KolButtonWcTag>
 		);

--- a/packages/components/src/components/toolbar/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/toolbar/test/__snapshots__/snapshot.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`kol-toolbar should render with _label="Label horizontal" _items=[{"_lab
   <template shadowrootmode="open">
     <div aria-label="Label horizontal" class="kol-toolbar kol-toolbar--orientation-horizontal" role="toolbar">
       <kol-button-wc _label="Button" _tabindex="0" class="button kol-toolbar__item normal"></kol-button-wc>
-      <kol-link-wc _href="#" _label="Link" _role="button" _tabindex="-1" class="button kol-toolbar__item normal"></kol-link-wc>
+      <kol-link-wc _href="#" _label="Link" _tabindex="-1" class="button kol-toolbar__item normal"></kol-link-wc>
     </div>
   </template>
 </kol-toolbar>
@@ -16,7 +16,7 @@ exports[`kol-toolbar should render with _label="Label vertical" _items=[{"_label
   <template shadowrootmode="open">
     <div aria-label="Label vertical" class="kol-toolbar kol-toolbar--orientation-vertical" role="toolbar">
       <kol-button-wc _label="Button" _tabindex="0" class="button kol-toolbar__item normal"></kol-button-wc>
-      <kol-link-wc _href="#" _label="Link" _role="button" _tabindex="-1" class="button kol-toolbar__item normal"></kol-link-wc>
+      <kol-link-wc _href="#" _label="Link" _tabindex="-1" class="button kol-toolbar__item normal"></kol-link-wc>
     </div>
   </template>
 </kol-toolbar>

--- a/packages/components/src/schema/props/alternative-button-link-role.ts
+++ b/packages/components/src/schema/props/alternative-button-link-role.ts
@@ -2,7 +2,7 @@
 import type { Generic } from 'adopted-style-sheets';
 import { watchValidator } from '../utils';
 
-const alternativeButtonLinkRolePropTypeOptions = ['button', 'link', 'tab', 'treeitem'] as const;
+const alternativeButtonLinkRolePropTypeOptions = ['tab', 'treeitem'] as const;
 export type AlternativeButtonLinkRolePropType = (typeof alternativeButtonLinkRolePropTypeOptions)[number];
 
 /**


### PR DESCRIPTION
## Summary
Deprecates the `_role` prop in button components, encouraging the use of semantic HTML elements instead.

## Changes
- Deprecated `_role` property in button components
- Marked `_role` as deprecated to encourage semantic HTML usage

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Das `_role`-Prop in Button-Komponenten wird als veraltet markiert, um die Verwendung semantischer HTML-Elemente zu fördern.

## Änderungen
- `_role`-Eigenschaft in Button-Komponenten als veraltet markiert
- Semantische HTML-Verwendung wird empfohlen

</details>