### PR TITLE
fix: limit drawer dimensions to viewport units

### DIFF
--- a/packages/components/src/components/drawer/style.scss
+++ b/packages/components/src/components/drawer/style.scss
@@ -11,38 +11,32 @@
 		&__wrapper {
 			background-color: white;
 			position: fixed;
-			width: auto;
 			overflow: auto;
 
-			&--left {
+			&--left,
+			&--right {
 				top: 0;
-				left: 0;
+				max-width: 100vw;
 				height: 100vh;
-				max-height: 100%;
 
 				.drawer__content {
 					height: 100%;
 				}
+			}
+
+			&--left {
+				left: 0;
 			}
 
 			&--right {
-				top: 0;
 				right: 0;
-				height: 100vh;
-				max-height: 100%;
-
-				.drawer__content {
-					height: 100%;
-				}
 			}
 
+			&--bottom,
 			&--top {
-				top: 0;
 				left: 0;
 				width: 100vw;
-				max-width: 100%;
 				max-height: 100vh;
-				overflow: auto;
 
 				.drawer__content {
 					width: 100%;
@@ -51,15 +45,10 @@
 
 			&--bottom {
 				bottom: 0;
-				left: 0;
-				width: 100vw;
-				max-width: 100%;
-				max-height: 100vh;
-				overflow: auto;
+			}
 
-				.drawer__content {
-					width: 100%;
-				}
+			&--top {
+				top: 0;
 			}
 		}
 

--- a/packages/samples/react/src/components/drawer/basic.tsx
+++ b/packages/samples/react/src/components/drawer/basic.tsx
@@ -1,10 +1,9 @@
 import type { FC } from 'react';
-import React, { useRef, useState, useContext, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { HideMenusContext } from '../../shares/HideMenusContext';
 import type { AlignPropType } from '@public-ui/components';
-import { KolDrawer, KolButton, KolBadge } from '@public-ui/react-v19';
+import { KolButton, KolDrawer } from '@public-ui/react-v19';
 import { SampleDescription } from '../SampleDescription';
 
 import { DrawerRadioAlign } from './partials/align';
@@ -12,7 +11,6 @@ import { DrawerRadioAlign } from './partials/align';
 export const DrawerBasic: FC = () => {
 	const [searchParams] = useSearchParams();
 	const defaultAlign = searchParams.get('align') as AlignPropType;
-	const hideMenus = useContext(HideMenusContext);
 	const drawerElement = useRef<HTMLKolDrawerElement>(null);
 	const drawerModalElement = useRef<HTMLKolDrawerElement>(null);
 	const [align, setAlign] = useState<AlignPropType>(defaultAlign || 'left');
@@ -23,7 +21,6 @@ export const DrawerBasic: FC = () => {
 	}, [defaultAlign]);
 	return (
 		<>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 			<SampleDescription>
 				<p>
 					KolDrawer shows a dialog attached to one of the sides of the viewport, when opened. This sample illustrates the four alignments and the modal- and

--- a/packages/samples/react/src/components/drawer/controlled.tsx
+++ b/packages/samples/react/src/components/drawer/controlled.tsx
@@ -1,10 +1,9 @@
 import type { FC } from 'react';
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-import { HideMenusContext } from '../../shares/HideMenusContext';
 import type { AlignPropType } from '@public-ui/components';
-import { KolDrawer, KolButton, KolBadge } from '@public-ui/react-v19';
+import { KolButton, KolDrawer } from '@public-ui/react-v19';
 import { SampleDescription } from '../SampleDescription';
 
 import { DrawerRadioAlign } from './partials/align';
@@ -12,13 +11,11 @@ import { DrawerRadioAlign } from './partials/align';
 export const DrawerControlled: FC = () => {
 	const [searchParams] = useSearchParams();
 	const defaultAlign = searchParams.get('align') as AlignPropType;
-	const hideMenus = useContext(HideMenusContext);
 	const [open, setOpen] = useState(false);
 	const [modalOpen, setModalOpen] = useState(false);
 	const [align, setAlign] = useState<AlignPropType>(defaultAlign || 'left');
 	return (
 		<div>
-			{!hideMenus && <KolBadge className="block mb-3" _label="Component is a DRAFT - Don't use in production yet." _color="#db5461" />}
 			<SampleDescription>
 				<p>
 					This sample shows the KolDrawer controlled by the property <code>_open</code> instead of methods.

--- a/packages/samples/react/src/components/drawer/scrolled.tsx
+++ b/packages/samples/react/src/components/drawer/scrolled.tsx
@@ -1,24 +1,131 @@
+import type { AlignPropType } from '@public-ui/components';
+import { KolButton, KolDrawer, KolInputCheckbox } from '@public-ui/react-v19';
 import type { FC } from 'react';
-import React, { useRef, useContext } from 'react';
-import { KolDrawer, KolButton } from '@public-ui/react-v19';
-import { HideMenusContext } from '../../shares/HideMenusContext';
+import React, { useRef, useState } from 'react';
+import { SampleDescription } from '../SampleDescription';
+import { DrawerRadioAlign } from './partials/align';
 
 export const DrawerScrolled: FC = () => {
 	const drawerElement = useRef<HTMLKolDrawerElement>(null);
-	const hideMenus = useContext(HideMenusContext);
+	const [align, setAlign] = useState<AlignPropType>('bottom');
+	const [useOverflowHandling, setUseOverflowHandling] = useState(false);
 
 	return (
-		!hideMenus && (
-			<div className="h-[95vh] w-[95vw]" style={{ border: '1px solid black' }}>
-				<KolDrawer ref={drawerElement} _label="Drawer" _align="bottom">
-					{/* großer Inhalt, um Scrollbar-Bug sichtbar zu machen */}
-					<div className="h-[2000px] bg-red/10" />
-					<KolButton _label="Close" _on={{ onClick: () => drawerElement.current?.close() }} />
+		<>
+			<SampleDescription>
+				<p>
+					This sample demonstrates how KolDrawer handles content that exceeds the drawer dimensions and shows the correct way to handle overflow. Use the
+					&#34;Enable Overflow Handling&#34; toggle to see the difference between problematic behavior (content exceeding drawer bounds) and the proper solution
+					(overflow handling within the slot content).
+				</p>
+			</SampleDescription>
+
+			<div className="flex flex-col gap-4 mb-4">
+				<DrawerRadioAlign value={align} onChange={(_, value) => setAlign(value as AlignPropType)} />
+				<KolInputCheckbox
+					_label="Enable Overflow Handling (Recommended)"
+					_checked={useOverflowHandling}
+					_on={{ onChange: (_, value) => setUseOverflowHandling(!!value) }}
+				/>
+			</div>
+			<div className="flex flex-wrap gap-4">
+				<KolDrawer ref={drawerElement} _label="Scrollable Drawer" _align={align}>
+					{useOverflowHandling ? (
+						// ✅ Correct approach: Outer container with fixed dimensions and overflow handling
+						<div
+							style={{
+								width: align === 'left' || align === 'right' ? '90vw' : undefined,
+								height: align === 'top' || align === 'bottom' ? '90vh' : undefined,
+								overflow: 'auto',
+								padding: '0',
+								border: '1px solid #999',
+							}}
+						>
+							<div
+								style={{
+									width: align === 'left' || align === 'right' ? '150vw' : undefined,
+									height: align === 'top' || align === 'bottom' ? '150vh' : undefined,
+									background:
+										'linear-gradient(45deg, #f0f0f0 25%, transparent 25%), linear-gradient(-45deg, #f0f0f0 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f0f0f0 75%), linear-gradient(-45deg, transparent 75%, #f0f0f0 75%)',
+									backgroundSize: '20px 20px',
+									backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0px',
+									border: '2px dashed #ccc',
+									padding: '20px',
+									display: 'flex',
+									flexDirection: 'column',
+									gap: '20px',
+								}}
+							>
+								<p>✅ Content with proper overflow handling - scrollable within drawer bounds</p>
+								<div>
+									<h3>Large Content Area (Scrollable)</h3>
+									<p>
+										Container: {align === 'left' || align === 'right' ? '400px wide' : '90vw wide'} ×{' '}
+										{align === 'top' || align === 'bottom' ? '90vh high' : '400px high'}
+									</p>
+									<p>
+										Content: {align === 'left' || align === 'right' ? '150vw wide' : '400px wide'} ×{' '}
+										{align === 'top' || align === 'bottom' ? '150vh high' : '400px high'}
+									</p>
+									<p>
+										<strong>Overflow Handling:</strong> Enabled - Container has fixed size with overflow: auto
+									</p>
+									<p>
+										Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+										diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+										dolor sit amet.
+									</p>
+									<p>
+										With overflow handling enabled, this content scrolls properly within the drawer container. You can scroll horizontally/vertically to see all
+										content.
+									</p>
+									<div style={{ marginTop: 'auto', paddingTop: '40px' }}>
+										<KolButton _label="Close drawer" _on={{ onClick: () => drawerElement.current?.close() }} />
+									</div>
+								</div>
+							</div>
+						</div>
+					) : (
+						// ❌ Problematic approach: Content directly exceeds drawer bounds
+						<div
+							style={{
+								width: align === 'left' || align === 'right' ? '150vw' : '400px',
+								height: align === 'top' || align === 'bottom' ? '150vh' : '400px',
+								background:
+									'linear-gradient(45deg, #f0f0f0 25%, transparent 25%), linear-gradient(-45deg, #f0f0f0 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f0f0f0 75%), linear-gradient(-45deg, transparent 75%, #f0f0f0 75%)',
+								backgroundSize: '20px 20px',
+								backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0px',
+								border: '2px dashed #ccc',
+								padding: '20px',
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '20px',
+							}}
+						>
+							<p>❌ Content exceeding drawer bounds - problematic behavior</p>
+							<div>
+								<h3>Large Content Area</h3>
+								<p>Width: {align === 'left' || align === 'right' ? '150vw (exceeds drawer width)' : '400px'}</p>
+								<p>Height: {align === 'top' || align === 'bottom' ? '150vh (exceeds drawer height)' : '400px'}</p>
+								<p>
+									<strong>Overflow Handling:</strong> Disabled - Content extends beyond drawer boundaries
+								</p>
+								<p>
+									Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+									diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+									dolor sit amet.
+								</p>
+								<p>Without overflow handling, this content may extend beyond the drawer boundaries, causing layout issues.</p>
+								<div style={{ marginTop: 'auto', paddingTop: '40px' }}>
+									<KolButton _label="Close drawer" _on={{ onClick: () => drawerElement.current?.close() }} />
+								</div>
+							</div>
+						</div>
+					)}
 				</KolDrawer>
 
-				<p>Some content outside the drawer</p>
-				<KolButton _label="Open drawer" _on={{ onClick: () => drawerElement.current?.open() }} />
+				<KolButton _label="Open scrollable drawer" _on={{ onClick: () => drawerElement.current?.open() }} />
 			</div>
-		)
+		</>
 	);
 };

--- a/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
+++ b/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
@@ -54,7 +54,13 @@ function TableHorizontalScrollbarAdvanced() {
 
 	return (
 		<>
-			<SampleDescription></SampleDescription>
+			<SampleDescription>
+				<p>
+					This advanced scenario demonstrates a complex layout with KolTable featuring horizontal scrollbar within a tab-based navigation system. The table
+					automatically calculates its minimum width based on column definitions and provides smooth horizontal scrolling when content exceeds the container
+					width. This example showcases real-world usage in a dashboard-like interface with sidebar navigation and tabbed content areas.
+				</p>
+			</SampleDescription>
 			<div className="mainlayout">
 				<aside className="nav-area">
 					<KolNav _label="Main navigation" _links={LINKS} _hasCompactButton _hasIconsWhenExpanded />


### PR DESCRIPTION
## Summary
Internal fix updating drawer styles to use viewport units for dimensional constraints.

## Changes
- Update drawer styles to use viewport units

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix: Drawer-Styles aktualisiert, um Viewport-Einheiten für Dimensionsbeschränkungen zu verwenden.

## Änderungen
- Drawer-Styles auf Viewport-Einheiten aktualisiert

</details>