### PR TITLE
feat(sample): allow loading optional THEME_CSS

### DIFF
--- a/packages/samples/react/src/main.ts
+++ b/packages/samples/react/src/main.ts
@@ -1,5 +1,16 @@
 import 'uno.css'; // https://github.com/antfu/unocss
 // App style
 import './style.scss';
+
+/* Optional theme CSS (e.g. font-face declarations) */
+if (process.env.THEME_CSS) {
+	if (process.env.PLATFORM === 'win32') {
+		/* Add leading slash, required for ESBuild on Windows.
+			 Note: process.env.THEME_CSS must be used literally in the import(). Moving it to a constant breaks the import. */
+		process.env.THEME_CSS = `/${process.env.THEME_CSS}`;
+	}
+	import(/* @vite-ignore */ process.env.THEME_CSS);
+}
+
 // App
 import './react.main';

--- a/packages/samples/react/vite.config.ts
+++ b/packages/samples/react/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 	define: {
 		'process.env.THEME_MODULE': JSON.stringify(process.env.THEME_MODULE || ''),
 		'process.env.THEME_EXPORT': JSON.stringify(process.env.THEME_EXPORT || ''),
+		'process.env.THEME_CSS': JSON.stringify(process.env.THEME_CSS || ''),
 		'process.env.ENABLE_I18N_OVERWRITING': JSON.stringify(process.env.ENABLE_I18N_OVERWRITING || ''),
 		'process.env.ENABLE_TAG_NAME_TRANSFORMER': JSON.stringify(process.env.ENABLE_TAG_NAME_TRANSFORMER || ''),
 		'process.env.ENABLE_THEME_PATCHING': JSON.stringify(process.env.ENABLE_THEME_PATCHING || ''),
@@ -31,7 +32,11 @@ export default defineConfig({
 	server: {
 		port: 9191,
 		fs: {
-			allow: [path.resolve(__dirname), ...(process.env.THEME_MODULE ? [path.resolve(process.env.THEME_MODULE)] : [])],
+			allow: [
+				path.resolve(__dirname),
+				...(process.env.THEME_MODULE ? [path.resolve(process.env.THEME_MODULE)] : []),
+				...(process.env.THEME_CSS ? [path.resolve(process.env.THEME_CSS, '..')] : []),
+			],
 		},
 	},
 });


### PR DESCRIPTION
## Summary
Added support for loading an optional `THEME_CSS` environment variable in the v2 sample application to allow custom theme injection.

## Changes
- Allow sample app to load optional `THEME_CSS` at runtime

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Unterstützung für das Laden einer optionalen `THEME_CSS`-Umgebungsvariablen in der v2-Beispielanwendung hinzugefügt.

## Änderungen
- Beispielanwendung kann optionale `THEME_CSS` zur Laufzeit laden

</details>