### PR TITLE
fix(drawer): limit drawer dimensions to viewport units

### DIFF
--- a/packages/components/src/components/drawer/style.scss
+++ b/packages/components/src/components/drawer/style.scss
@@ -16,36 +16,32 @@
 
 		&__wrapper {
 			position: fixed;
-			width: auto;
 			overflow: auto;
 
-			&--left {
+			&--left,
+			&--right {
 				top: 0;
-				left: 0;
+				max-width: 100vw;
 				height: 100vh;
-				max-height: 100%;
 
 				#{$root}__content {
 					height: 100%;
 				}
+			}
+
+			&--left {
+				left: 0;
 			}
 
 			&--right {
-				top: 0;
 				right: 0;
-				height: 100vh;
-				max-height: 100%;
-
-				#{$root}__content {
-					height: 100%;
-				}
 			}
 
+			&--bottom,
 			&--top {
-				top: 0;
 				left: 0;
 				width: 100vw;
-				max-width: 100%;
+				max-height: 100vh;
 
 				#{$root}__content {
 					width: 100%;
@@ -54,13 +50,10 @@
 
 			&--bottom {
 				bottom: 0;
-				left: 0;
-				width: 100vw;
-				max-width: 100%;
+			}
 
-				#{$root}__content {
-					width: 100%;
-				}
+			&--top {
+				top: 0;
 			}
 		}
 

--- a/packages/samples/react/src/components/drawer/routes.ts
+++ b/packages/samples/react/src/components/drawer/routes.ts
@@ -1,10 +1,12 @@
 import { Routes } from '../../shares/types';
 import { DrawerBasic } from './basic';
 import { DrawerControlled } from './controlled';
+import { DrawerScrolled } from './scrolled';
 
 export const DRAWER_ROUTES: Routes = {
 	drawer: {
 		basic: DrawerBasic,
 		controlled: DrawerControlled,
+		scrolled: DrawerScrolled,
 	},
 };

--- a/packages/samples/react/src/components/drawer/scrolled.tsx
+++ b/packages/samples/react/src/components/drawer/scrolled.tsx
@@ -10,7 +10,7 @@ import { DrawerRadioAlign } from './partials/align';
 export const DrawerScrolled: FC = () => {
 	const drawerElement = useRef<HTMLKolDrawerElement>(null);
 	const [align, setAlign] = useState<AlignPropType>('bottom');
-	const [useOverflowHandling, setUseOverflowHandling] = useState(false);
+	const [useOverflowHandling, setUseOverflowHandling] = useState(true);
 
 	return (
 		<>

--- a/packages/samples/react/src/components/drawer/scrolled.tsx
+++ b/packages/samples/react/src/components/drawer/scrolled.tsx
@@ -1,0 +1,133 @@
+// DrawerScrolled Class
+
+import type { AlignPropType } from '@public-ui/components';
+import { KolButton, KolDrawer, KolInputCheckbox } from '@public-ui/react-v19';
+import type { FC } from 'react';
+import React, { useRef, useState } from 'react';
+import { SampleDescription } from '../SampleDescription';
+import { DrawerRadioAlign } from './partials/align';
+
+export const DrawerScrolled: FC = () => {
+	const drawerElement = useRef<HTMLKolDrawerElement>(null);
+	const [align, setAlign] = useState<AlignPropType>('bottom');
+	const [useOverflowHandling, setUseOverflowHandling] = useState(false);
+
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					This sample demonstrates how KolDrawer handles content that exceeds the drawer dimensions and shows the correct way to handle overflow. Use the
+					&#34;Enable Overflow Handling&#34; toggle to see the difference between problematic behavior (content exceeding drawer bounds) and the proper solution
+					(overflow handling within the slot content).
+				</p>
+			</SampleDescription>
+
+			<div className="flex flex-col gap-4 mb-4">
+				<DrawerRadioAlign value={align} onChange={(_, value) => setAlign(value as AlignPropType)} />
+				<KolInputCheckbox
+					_label="Enable Overflow Handling (Recommended)"
+					_checked={useOverflowHandling}
+					_on={{ onChange: (_, value) => setUseOverflowHandling(!!value) }}
+				/>
+			</div>
+			<div className="flex flex-wrap gap-4">
+				<KolDrawer ref={drawerElement} _label="Scrollable Drawer" _align={align}>
+					{useOverflowHandling ? (
+						// ✅ Correct approach: Outer container with fixed dimensions and overflow handling
+						<div
+							style={{
+								width: align === 'left' || align === 'right' ? '90vw' : undefined,
+								height: align === 'top' || align === 'bottom' ? '90vh' : undefined,
+								overflow: 'auto',
+								padding: '0',
+								border: '1px solid #999',
+							}}
+						>
+							<div
+								style={{
+									width: align === 'left' || align === 'right' ? '150vw' : undefined,
+									height: align === 'top' || align === 'bottom' ? '150vh' : undefined,
+									background:
+										'linear-gradient(45deg, #f0f0f0 25%, transparent 25%), linear-gradient(-45deg, #f0f0f0 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f0f0f0 75%), linear-gradient(-45deg, transparent 75%, #f0f0f0 75%)',
+									backgroundSize: '20px 20px',
+									backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0px',
+									border: '2px dashed #ccc',
+									padding: '20px',
+									display: 'flex',
+									flexDirection: 'column',
+									gap: '20px',
+								}}
+							>
+								<p>✅ Content with proper overflow handling - scrollable within drawer bounds</p>
+								<div>
+									<h3>Large Content Area (Scrollable)</h3>
+									<p>
+										Container: {align === 'left' || align === 'right' ? '400px wide' : '90vw wide'} ×{' '}
+										{align === 'top' || align === 'bottom' ? '90vh high' : '400px high'}
+									</p>
+									<p>
+										Content: {align === 'left' || align === 'right' ? '150vw wide' : '400px wide'} ×{' '}
+										{align === 'top' || align === 'bottom' ? '150vh high' : '400px high'}
+									</p>
+									<p>
+										<strong>Overflow Handling:</strong> Enabled - Container has fixed size with overflow: auto
+									</p>
+									<p>
+										Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+										diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+										dolor sit amet.
+									</p>
+									<p>
+										With overflow handling enabled, this content scrolls properly within the drawer container. You can scroll horizontally/vertically to see all
+										content.
+									</p>
+									<div style={{ marginTop: 'auto', paddingTop: '40px' }}>
+										<KolButton _label="Close drawer" _on={{ onClick: () => drawerElement.current?.close() }} />
+									</div>
+								</div>
+							</div>
+						</div>
+					) : (
+						// ❌ Problematic approach: Content directly exceeds drawer bounds
+						<div
+							style={{
+								width: align === 'left' || align === 'right' ? '150vw' : '400px',
+								height: align === 'top' || align === 'bottom' ? '150vh' : '400px',
+								background:
+									'linear-gradient(45deg, #f0f0f0 25%, transparent 25%), linear-gradient(-45deg, #f0f0f0 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f0f0f0 75%), linear-gradient(-45deg, transparent 75%, #f0f0f0 75%)',
+								backgroundSize: '20px 20px',
+								backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0px',
+								border: '2px dashed #ccc',
+								padding: '20px',
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '20px',
+							}}
+						>
+							<p>❌ Content exceeding drawer bounds - problematic behavior</p>
+							<div>
+								<h3>Large Content Area</h3>
+								<p>Width: {align === 'left' || align === 'right' ? '150vw (exceeds drawer width)' : '400px'}</p>
+								<p>Height: {align === 'top' || align === 'bottom' ? '150vh (exceeds drawer height)' : '400px'}</p>
+								<p>
+									<strong>Overflow Handling:</strong> Disabled - Content extends beyond drawer boundaries
+								</p>
+								<p>
+									Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+									diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+									dolor sit amet.
+								</p>
+								<p>Without overflow handling, this content may extend beyond the drawer boundaries, causing layout issues.</p>
+								<div style={{ marginTop: 'auto', paddingTop: '40px' }}>
+									<KolButton _label="Close drawer" _on={{ onClick: () => drawerElement.current?.close() }} />
+								</div>
+							</div>
+						</div>
+					)}
+				</KolDrawer>
+
+				<KolButton _label="Open scrollable drawer" _on={{ onClick: () => drawerElement.current?.open() }} />
+			</div>
+		</>
+	);
+};

--- a/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
+++ b/packages/samples/react/src/scenarios/horizontal-scrollbar-advanced/TableHorizontalScrollbarAdvanced.tsx
@@ -54,7 +54,13 @@ function TableHorizontalScrollbarAdvanced() {
 
 	return (
 		<>
-			<SampleDescription></SampleDescription>
+			<SampleDescription>
+				<p>
+					This advanced scenario demonstrates a complex layout with KolTable featuring horizontal scrollbar within a tab-based navigation system. The table
+					automatically calculates its minimum width based on column definitions and provides smooth horizontal scrolling when content exceeds the container
+					width. This example showcases real-world usage in a dashboard-like interface with sidebar navigation and tabbed content areas.
+				</p>
+			</SampleDescription>
 			<div className="mainlayout">
 				<aside className="nav-area">
 					<KolNav _label="Main navigation" _links={LINKS} _hasCompactButton _hasIconsWhenExpanded />


### PR DESCRIPTION
## Summary
Fixed the drawer component to limit its dimensions to viewport units, preventing it from exceeding the visible screen area.

## Changes
- Limit drawer dimensions using viewport units
- Show scrollbar when drawer content exceeds viewport height

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Die Drawer-Komponente wurde korrigiert, um ihre Abmessungen auf Viewport-Einheiten zu begrenzen und zu verhindern, dass sie den sichtbaren Bildschirmbereich überschreitet.

## Änderungen
- Drawer-Abmessungen durch Viewport-Einheiten begrenzt
- Scrollleiste wird angezeigt, wenn der Drawer-Inhalt die Viewport-Höhe überschreitet

</details>