### PR TITLE
fix(singleselect): prevent onChange from firing on blur without value change

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -102,8 +102,10 @@ export class KolSingleSelect implements SingleSelectAPI {
 	private onBlur() {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 
-		if (matchingOption && matchingOption?.value !== this._value) {
-			this.selectOption(matchingOption as Option<string>);
+		if (matchingOption) {
+			if (matchingOption?.value !== this._value) {
+				this.selectOption(matchingOption as Option<string>);
+			}
 		} else {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -157,9 +157,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 	}
 
 	private selectOption(option: Option<string>) {
-		// Nur weitermachen, wenn sich der Wert wirklich ändert
 		if (option.value === this._value) {
-			// trotzdem das Label und Filter zurücksetzen
 			this._inputValue = option.label as string;
 			this._filteredOptions = [...this.state._options];
 			return;

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -102,7 +102,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 	private onBlur() {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 
-		if (matchingOption) {
+		if (matchingOption && matchingOption?.value !== this._value) {
 			this.selectOption(matchingOption as Option<string>);
 		} else {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -103,9 +103,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 
 		if (matchingOption) {
-			if (matchingOption?.value !== this._value) {
-				this.selectOption(matchingOption as Option<string>);
-			}
+			this.selectOption(matchingOption as Option<string>);
 		} else {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];
@@ -159,6 +157,14 @@ export class KolSingleSelect implements SingleSelectAPI {
 	}
 
 	private selectOption(option: Option<string>) {
+		// Nur weitermachen, wenn sich der Wert wirklich ändert
+		if (option.value === this._value) {
+			// trotzdem das Label und Filter zurücksetzen
+			this._inputValue = option.label as string;
+			this._filteredOptions = [...this.state._options];
+			return;
+		}
+
 		this._value = option.value;
 		this._inputValue = option.label as string;
 

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -136,5 +136,40 @@ test.describe(COMPONENT_NAME, () => {
 			const noResult = page.getByText('Keine Ergebnisse gefunden.');
 			await expect(noResult).toBeVisible();
 		});
+
+		test('should only trigger onChange when the value actually changes', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
+
+			const input = page.locator('input.kol-single-select__input');
+			const singleSelect = page.locator('kol-single-select');
+
+			// Setup simple change counter
+			await singleSelect.evaluate((element) => {
+				const el = element as HTMLElement & { _changeCount: number };
+				el._changeCount = 0;
+
+				(element as HTMLKolSelectElement)._on = {
+					onChange: () => {
+						el._changeCount++;
+					},
+				};
+			});
+
+			// Helper to get counter
+			const getChangeCount = async () => {
+				return await singleSelect.evaluate((el) => {
+					return (el as HTMLElement & { _changeCount: number })._changeCount || 0;
+				});
+			};
+
+			// 1) Select value -> onChange should fire (counter = 1)
+			await input.click();
+			await page.getByRole('listbox').getByText(TEST_LABEL).click({ force: true });
+			expect(await getChangeCount()).toBe(1);
+
+			// 2) Click on free space -> onChange must NOT fire (counter stays 1)
+			await page.click('html', { position: { x: 0, y: 0 } });
+			expect(await getChangeCount()).toBe(1);
+		});
 	});
 });


### PR DESCRIPTION
## Summary
Fixed the single-select component to prevent the `onChange` callback from firing when the user blurs the field without changing the value.

## Changes
- Prevent `onChange` from firing on blur when the value has not changed in single-select

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Die Single-Select-Komponente wurde korrigiert, um zu verhindern, dass der `onChange`-Callback ausgelöst wird, wenn der Benutzer das Feld verlässt, ohne den Wert zu ändern.

## Änderungen
- `onChange` wird bei Blur nicht mehr ausgelöst, wenn sich der Wert nicht geändert hat

</details>