### PR TITLE
fix(single-select): onInput has no target

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -107,6 +107,24 @@ export class KolSingleSelect implements SingleSelectAPI {
 		this._hasOpened = false;
 	}
 
+	private createEventWithTarget(type: string, detail: EventDetail): CustomEvent<EventDetail> {
+		const event = new CustomEvent<EventDetail>(type, {
+			bubbles: true,
+			detail,
+		});
+
+		if (this.refInput) {
+			Object.defineProperty(event, 'target', {
+				value: this.refInput,
+			});
+
+			Object.defineProperty(event, 'currentTarget', {
+				value: this.refInput,
+			});
+		}
+		return event;
+	}
+
 	private clearSelection() {
 		if (this.state._disabled) {
 			return;
@@ -117,23 +135,36 @@ export class KolSingleSelect implements SingleSelectAPI {
 			this._inputValue = '';
 			this._filteredOptions = [...this.state._options];
 
-			this.controller.onFacade.onInput(
-				new CustomEvent<EventDetail>('input', { bubbles: true, detail: { name: this.state._name as string, value: emptyValue } }),
-				true,
-				{ value: emptyValue },
-			);
-			this.controller.onFacade.onChange(
-				new CustomEvent<EventDetail>('change', { bubbles: true, detail: { name: this.state._name as string, value: emptyValue } }),
-				{ value: emptyValue },
-			);
+			const inputEvent = this.createEventWithTarget('input', {
+				name: this.state._name as string,
+				value: emptyValue,
+			});
+			const changeEvent = this.createEventWithTarget('change', {
+				name: this.state._name as string,
+				value: emptyValue,
+			});
+
+			this.controller.onFacade.onInput(inputEvent, true, { value: emptyValue });
+			this.controller.onFacade.onChange(changeEvent, { value: emptyValue });
 		}
 	}
 
 	private selectOption(option: Option<string>) {
 		this._value = option.value;
 		this._inputValue = option.label as string;
-		this.controller.onFacade.onInput(new CustomEvent('input', { bubbles: true, detail: { name: this.state._name, value: option.value } }), false, option.value);
-		this.controller.onFacade.onChange(new CustomEvent('change', { bubbles: true, detail: { name: this.state._name, value: option.value } }), option.value);
+
+		const inputEvent = this.createEventWithTarget('input', {
+			name: this.state._name ?? '',
+			value: option.value,
+		});
+		const changeEvent = this.createEventWithTarget('change', {
+			name: this.state._name ?? '',
+			value: option.value,
+		});
+
+		this.controller.onFacade.onInput(inputEvent, false, option.value);
+		this.controller.onFacade.onChange(changeEvent, option.value);
+
 		this._filteredOptions = [...this.state._options];
 
 		this.controller.setFormAssociatedValue(this._value);


### PR DESCRIPTION
## Summary
Fixed the single-select component's `onInput` event handler to correctly provide the `target` property in v2.

## Changes
- Fix `onInput` event to include `target` in the single-select component

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Das `onInput`-Event-Handler der Single-Select-Komponente wurde in v2 korrigiert, um die `target`-Eigenschaft korrekt bereitzustellen.

## Änderungen
- `onInput`-Event um `target` in der Single-Select-Komponente korrigiert

</details>