### PR TITLE
feat(toolbar): use container queries for responsive layout

### DIFF
--- a/packages/components/src/components/toolbar/style.scss
+++ b/packages/components/src/components/toolbar/style.scss
@@ -10,8 +10,9 @@
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
+		container-type: inline-size;
 
-		&--orientation-vertical {
+		@container (max-width: to-rem(480)) {
 			flex-direction: column;
 			align-items: stretch;
 		}

--- a/packages/themes/default/src/components/toolbar.scss
+++ b/packages/themes/default/src/components/toolbar.scss
@@ -13,31 +13,32 @@
 	.kol-link__text,
 	.kol-button__text {
 		border-radius: 0;
+		border-right: 0;
 
-		.kol-toolbar--orientation-horizontal & {
-			border-right: 0;
-		}
-
-		.kol-toolbar--orientation-vertical & {
-			border-bottom: 0;
-		}
-
-		.kol-toolbar--orientation-vertical .kol-toolbar__item:first-child & {
-			border-radius: var(--border-radius) var(--border-radius) 0 0;
-		}
-
-		.kol-toolbar--orientation-horizontal .kol-toolbar__item:first-child & {
+		.kol-toolbar__item:first-child & {
 			border-radius: var(--border-radius) 0 0 var(--border-radius);
 		}
 
-		.kol-toolbar--orientation-vertical .kol-toolbar__item:last-child & {
-			border-radius: 0 0 var(--border-radius) var(--border-radius);
-			border-bottom: var(--border-width) solid var(--text-border-color);
-		}
-
-		.kol-toolbar--orientation-horizontal .kol-toolbar__item:last-child & {
+		.kol-toolbar__item:last-child & {
 			border-radius: 0 var(--border-radius) var(--border-radius) 0;
 			border-right: var(--border-width) solid var(--text-border-color);
+		}
+	}
+
+	@container (max-width: to-rem(480)) {
+		.kol-link__text,
+		.kol-button__text {
+			border-bottom: 0;
+			border-right: var(--border-width) solid var(--text-border-color);
+
+			.kol-toolbar__item:first-child & {
+				border-radius: var(--border-radius) var(--border-radius) 0 0;
+			}
+
+			.kol-toolbar__item:last-child & {
+				border-radius: 0 0 var(--border-radius) var(--border-radius);
+				border-bottom: var(--border-width) solid var(--text-border-color);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- declare toolbar container and swap to column layout with container query
- adjust default theme styles to match container-based orientation

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test` *(fails: inputs-get-value e2e tests for KolInputNumber/KolSelect)*

------
https://chatgpt.com/codex/tasks/task_e_68b687f2e360832b853abe54f4ed3720