### PR TITLE
feat(tabs): responsive layout with container queries

### DIFF
--- a/packages/components/src/components/tabs/style.scss
+++ b/packages/components/src/components/tabs/style.scss
@@ -8,6 +8,7 @@
 		display: var(--display);
 		grid-template-columns: var(--grid-template-columns);
 		grid-template-rows: var(--grid-template-rows);
+		container-type: inline-size;
 
 		&--align-right {
 			--display: grid;
@@ -55,6 +56,18 @@
 
 		&__panel {
 			height: 100%;
+		}
+
+		@container (max-width: to-rem(480)) {
+			&,
+			&--align-right,
+			&--align-left,
+			&--align-bottom,
+			&__tabs-align-top {
+				--button-group-flex-direction: row;
+				--grid-template-columns: 1fr;
+				--grid-template-rows: auto 1fr;
+			}
 		}
 	}
 }

--- a/packages/components/src/components/tabs/tabs.e2e.ts
+++ b/packages/components/src/components/tabs/tabs.e2e.ts
@@ -57,9 +57,9 @@ test.describe('kol-tabs', () => {
 	test.describe('Dynamic Tabs', () => {
 		test('should update tabs when _tabs prop changes', async ({ page }) => {
 			await page.setContent(`<kol-tabs _tabs='${JSON.stringify(TABS)}' _label="Tabs">
-				<div slot="tab-0">Contents of Tab 1</div>
-				<div slot="tab-1">Contents of Tab 2</div>
-			</kol-tabs>`);
+                                <div slot="tab-0">Contents of Tab 1</div>
+                                <div slot="tab-1">Contents of Tab 2</div>
+                        </kol-tabs>`);
 			const initialTabs = [{ _label: 'First tab' }, { _label: 'Second Tab' }];
 			await page.setContent(`<kol-tabs _tabs='${JSON.stringify(initialTabs)}' _label="Tabs"> <div>Content 1</div> <div>Content 2</div> </kol-tabs>`);
 			const kolTabs = page.locator('kol-tabs');
@@ -72,6 +72,26 @@ test.describe('kol-tabs', () => {
 			await expect(kolTabs.getByRole('tab', { name: 'Updated Tab B' })).toBeVisible();
 			await expect(kolTabs.getByRole('tab', { name: 'Updated Tab C' })).toBeVisible();
 			await expect(kolTabs.getByRole('tab', { name: 'First tab' })).toHaveCount(0);
+		});
+	});
+
+	test.describe('Responsive layout', () => {
+		test('uses column layout when wide', async ({ page }) => {
+			await page.setContent(`<kol-tabs style="display:block;width:800px" _align="right" _tabs='${JSON.stringify(TABS)}' _label="Tabs"></kol-tabs>`);
+			const kolTabs = page.locator('kol-tabs');
+			const flexDirection = await kolTabs.locator('.kol-tabs__button-group').evaluate((el) => getComputedStyle(el).flexDirection);
+			expect(flexDirection).toBe('column');
+			const gridTemplateColumns = await kolTabs.locator('.kol-tabs').evaluate((el) => getComputedStyle(el).gridTemplateColumns);
+			expect(gridTemplateColumns.trim()).not.toBe('1fr');
+		});
+
+		test('switches to row layout when narrow', async ({ page }) => {
+			await page.setContent(`<kol-tabs style="display:block;width:400px" _align="right" _tabs='${JSON.stringify(TABS)}' _label="Tabs"></kol-tabs>`);
+			const kolTabs = page.locator('kol-tabs');
+			const flexDirection = await kolTabs.locator('.kol-tabs__button-group').evaluate((el) => getComputedStyle(el).flexDirection);
+			expect(flexDirection).toBe('row');
+			const gridTemplateColumns = await kolTabs.locator('.kol-tabs').evaluate((el) => getComputedStyle(el).gridTemplateColumns);
+			expect(gridTemplateColumns.trim()).toBe('1fr');
 		});
 	});
 

--- a/packages/components/src/components/tabs/test/responsive.spec.ts
+++ b/packages/components/src/components/tabs/test/responsive.spec.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('kol-tabs responsive styles', () => {
+	const style = readFileSync(join(__dirname, '../style.scss'), 'utf8');
+
+	it('declares container-type inline-size', () => {
+		expect(style).toContain('container-type: inline-size');
+	});
+
+	it('contains a container query for narrow widths', () => {
+		expect(style).toMatch(/@container\s*\(max-width:/);
+		expect(style).toContain('--button-group-flex-direction');
+	});
+});


### PR DESCRIPTION
## Summary
- enable `kol-tabs` to act as a size container and react to inline-size
- add responsive container query adjusting grid and button layout when narrow
- cover compact and wide tabs with unit and Playwright tests

## Testing
- `pnpm --filter @public-ui/components build`
- `pnpm --filter @public-ui/components lint:stylelint`
- `pnpm --filter @public-ui/components lint:tsc`
- `pnpm --filter @public-ui/components test`


------
https://chatgpt.com/codex/tasks/task_e_68b687edacf8832baab10b024089d3ad