### PR TITLE
feat(breadcrumb): stack items when wrapping

### DIFF
--- a/packages/components/src/components/breadcrumb/style.scss
+++ b/packages/components/src/components/breadcrumb/style.scss
@@ -6,15 +6,29 @@
 	@include kol-link-styles('kol-link');
 
 	.kol-breadcrumb {
-		&__list,
-		&__list-element {
+		&__list {
 			display: flex;
 			margin: 0;
 			padding: 0;
 			gap: 0.5em;
 			flex-wrap: wrap;
 			place-items: center;
+			container-type: size;
 			list-style: none;
+		}
+
+		&__list-element {
+			display: flex;
+			gap: 0.5em;
+			place-items: center;
+		}
+
+		@container (min-height: calc(2lh + 0.5em)) {
+			&__list {
+				flex-direction: column;
+				flex-wrap: nowrap;
+				align-items: flex-start;
+			}
 		}
 
 		&__icon {

--- a/packages/samples/react/src/components/breadcrumb/basic.tsx
+++ b/packages/samples/react/src/components/breadcrumb/basic.tsx
@@ -42,20 +42,22 @@ export const BreadcrumbBasic: FC = () => (
 					},
 				]}
 			></KolBreadcrumb>
-			<KolBreadcrumb
-				_label="Breadcrumb from icons and text links"
-				_links={[
-					{ _label: 'Homepage', _icons: 'codicon codicon-home', _href: '#/back-page' },
-					{
-						_label: 'Subpage of the main page and I_am_a_really_long_compound_word_trying_to_break_the_layout',
-						_href: '#/back-page',
-					},
-					{
-						_label: 'Underside of the underside',
-						_href: '#/back-page',
-					},
-				]}
-			></KolBreadcrumb>
+			<div style={{ width: '10rem' }}>
+				<KolBreadcrumb
+					_label="Breadcrumb from icons and text links"
+					_links={[
+						{ _label: 'Homepage', _icons: 'codicon codicon-home', _href: '#/back-page' },
+						{
+							_label: 'Subpage of the main page and I_am_a_really_long_compound_word_trying_to_break_the_layout',
+							_href: '#/back-page',
+						},
+						{
+							_label: 'Underside of the underside',
+							_href: '#/back-page',
+						},
+					]}
+				></KolBreadcrumb>
+			</div>
 		</div>
 	</>
 );


### PR DESCRIPTION
## Summary
- mark breadcrumb list as a container and switch to column layout when items wrap
- constrain breadcrumb sample width to demonstrate vertical stacking

## Testing
- `pnpm build` *(fails: Command failed)*
- `pnpm lint` *(fails: lint errors in themes)*
- `pnpm --filter @public-ui/components lint`
- `pnpm --filter @public-ui/sample-react lint` *(fails: unsafe member access warnings)*
- `pnpm test` *(fails: SIGTERM)*
- `pnpm --filter @public-ui/components test:unit` *(fails: SIGTERM)*

------
https://chatgpt.com/codex/tasks/task_e_68b687d882f4832b985393d08cbfe2aa