### PR TITLE
fix(tooltip): remove contain layout to fix edge-case positioning

### DIFF
--- a/packages/components/src/components/tooltip/style.scss
+++ b/packages/components/src/components/tooltip/style.scss
@@ -12,7 +12,6 @@
 	}
 	.kol-tooltip {
 		display: contents;
-		contain: layout;
 
 		&__floating {
 			display: none;

--- a/packages/samples/react/src/scenarios/tooltip-positioning.tsx
+++ b/packages/samples/react/src/scenarios/tooltip-positioning.tsx
@@ -14,7 +14,12 @@ export const TooltipPositioning: FC = () => {
 				</p>
 			</SampleDescription>
 
-			<div style={{ container: 'test / size' }}>
+			<div
+				style={{
+					container: 'test / size',
+					contain: 'layout',
+				}}
+			>
 				<KolPopoverButton _label="Sample PopoverButton—Click for Popover" _icons="codicon codicon-info" _tooltipAlign="right" _hideLabel>
 					This is an explanation shown on click.
 				</KolPopoverButton>


### PR DESCRIPTION
## Summary
Removed `contain: layout` from tooltip styles to fix edge-case positioning issues, and fixed the related container query issue in the sample instead.

## Changes
- Remove `contain: layout` from tooltip styles
- Fix container query issue in tooltip sample

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`contain: layout` aus den Tooltip-Styles entfernt, um Randfall-Positionierungsprobleme zu beheben, und das zugehörige Container-Query-Problem im Beispiel korrigiert.

## Änderungen
- `contain: layout` aus Tooltip-Styles entfernt
- Container-Query-Problem im Tooltip-Beispiel korrigiert

</details>