### PR TITLE
chore: remove jsdoc for eslint

### DIFF
--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -64,7 +64,6 @@ const config = {
 		'@stencil-community/props-must-be-public': 'off',
 		'@stencil-community/props-must-be-readonly': 'off',
 		'@stencil-community/render-returns-host': 'off',
-		'@stencil-community/required-jsdoc': 'off',
 		'@stencil-community/reserved-member-names': 'off',
 		'@stencil-community/single-export': 'off',
 		'@stencil-community/strict-mutable': 'off',

--- a/packages/components/.knip.json
+++ b/packages/components/.knip.json
@@ -8,7 +8,6 @@
 		"@stencil/solid-output-target",
 		"@stencil/vue-output-target",
 		"eslint-plugin-html",
-		"eslint-plugin-jsdoc",
 		"eslint-plugin-react"
 	],
 	"project": ["src/**/*.ts"]

--- a/packages/tools/kolibri-cli/.eslintrc.cjs
+++ b/packages/tools/kolibri-cli/.eslintrc.cjs
@@ -16,12 +16,7 @@ module.exports = {
 		sourceType: 'module',
 		tsconfigRootDir: __dirname,
 	},
-	plugins: [
-		'html',
-		// 'json',
-		// 'jsx-a11y',
-		'react',
-	],
+	plugins: ['html', 'react'],
 	rules: {
 		eqeqeq: 'error',
 	},

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GenericUpdatePropertyValueTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GenericUpdatePropertyValueTask.ts
@@ -72,14 +72,6 @@ export class GenericUpdatePropertyValueTask extends AbstractTask {
 	}
 }
 
-// Helper function to update attribute values in HTML strings
-/**
- *
- * @param htmlString
- * @param tagRegExp
- * @param oldValue
- * @param newValue
- */
 function updateAttributeValue(htmlString: string, tagRegExp: RegExp, oldValue: string, newValue: string): string {
 	return htmlString.replace(tagRegExp, (match) => {
 		return match.replace(`="${oldValue}"`, `="${newValue}"`).replace(`='${oldValue}'`, `='${newValue}'`);

--- a/packages/tools/mcp/.eslintrc.cjs
+++ b/packages/tools/mcp/.eslintrc.cjs
@@ -20,7 +20,6 @@ module.exports = {
 		},
 		{
 			files: ['test/**/*.js'],
-			extends: [],
 			env: {
 				node: true,
 				es2022: true,

--- a/packages/tools/mcp/src/data.ts
+++ b/packages/tools/mcp/src/data.ts
@@ -41,6 +41,11 @@ interface SerializedSampleIndex {
 
 let cachedData: { entries: SampleEntry[]; metadata: SampleIndexMetadata } | undefined;
 
+/**
+ * Calculate counts of entries by kind
+ * @param entries - Array of sample entries
+ * @returns Object containing total counts and counts by kind
+ */
 function calculateCounts(entries: SampleEntry[]): SampleIndexCounts {
 	const byKind: Record<string, number> = {};
 
@@ -59,6 +64,11 @@ function calculateCounts(entries: SampleEntry[]): SampleIndexCounts {
 	};
 }
 
+/**
+ * Normalize a sample entry
+ * @param entry - The sample entry to normalize
+ * @returns Normalized sample entry
+ */
 function normalizeEntry(entry: SampleEntry): SampleEntry {
 	const normalizedKind: SampleEntry['kind'] = entry.kind === 'doc' ? 'doc' : entry.kind === 'scenario' ? 'scenario' : entry.kind === 'spec' ? 'spec' : 'sample';
 	const tags = Array.isArray(entry.tags) ? entry.tags.map((tag) => String(tag)).filter((tag) => tag.trim().length > 0) : undefined;
@@ -70,6 +80,12 @@ function normalizeEntry(entry: SampleEntry): SampleEntry {
 	};
 }
 
+/**
+ * Normalize sample index metadata
+ * @param metadata - The metadata to normalize
+ * @param entries - The sample entries for calculating counts
+ * @returns Normalized sample index metadata
+ */
 function normalizeMetadata(metadata: SerializedSampleIndex['metadata'], entries: SampleEntry[]): SampleIndexMetadata {
 	const counts = calculateCounts(entries);
 	const repo = metadata?.repo ?? { commit: null, branch: null, repoUrl: null };

--- a/packages/tools/mcp/src/mcp.ts
+++ b/packages/tools/mcp/src/mcp.ts
@@ -9,6 +9,11 @@ import { searchEntries, type SearchOptions } from './search.js';
 const KIND_OPTIONS = ['doc', 'sample', 'scenario', 'spec'] as const;
 type KindOption = (typeof KIND_OPTIONS)[number];
 
+/**
+ * Check if a value is a valid KindOption
+ * @param value - The value to check
+ * @returns True if value is a valid KindOption
+ */
 function isValidKind(value: unknown): value is KindOption {
 	return typeof value === 'string' && (KIND_OPTIONS as readonly string[]).includes(value);
 }
@@ -31,15 +36,28 @@ interface StructuredSearchResult {
 	results: StructuredSearchResultEntry[];
 }
 
+/**
+ * Normalize tags array, filtering empty values
+ * @param tags - The tags array to normalize
+ * @returns Normalized tags array
+ */
 function normalizeTags(tags?: string[]): string[] {
 	return Array.isArray(tags) ? tags : [];
 }
 
+/**
+ * Format tags array as comma-separated text
+ * @param tags - The tags array to format
+ * @returns Formatted tags string
+ */
 function formatTagsForText(tags?: string[]): string {
 	const normalized = normalizeTags(tags);
 	return normalized.length > 0 ? normalized.join(', ') : 'none';
 }
 
+/**
+ * Load package.json metadata for the MCP server
+ */
 const require = createRequire(import.meta.url);
 const {
 	version: PACKAGE_VERSION = '0.0.0',
@@ -56,6 +74,9 @@ const ENABLE_LOGGING = process.env.MCP_LOGGING === 'true' || process.env.MCP_LOG
 
 /**
  * Log a message if logging is enabled
+ * @param type - The log type (info, tool, resource, or error)
+ * @param message - The log message
+ * @param data - Optional data object to log as JSON
  */
 function log(type: 'info' | 'tool' | 'resource' | 'error', message: string, data?: unknown): void {
 	if (!ENABLE_LOGGING) return;
@@ -85,6 +106,8 @@ export function createKolibriMcpServer(): McpServer {
 
 /**
  * Configure the MCP server with tools and resources.
+ * @param server - The MCP server to configure
+ * @returns The configured MCP server
  */
 function configureServer(server: McpServer): McpServer {
 	// Add search tool for KoliBri samples and docs

--- a/packages/tools/mcp/src/search.ts
+++ b/packages/tools/mcp/src/search.ts
@@ -38,7 +38,9 @@ export function searchEntries(entries: SampleEntry[], query: string, options: Se
 		return filteredEntries.map((item) => ({ item, score: 1 }));
 	}
 
-	// Split query into words to determine search strategy
+	/**
+	 * Split query into words to determine search strategy
+	 */
 	const words = normalizedQuery.split(/\s+/).filter((w) => w.length > 0);
 	const isMultiWord = words.length > 1;
 

--- a/packages/tools/mcp/test/fuzzy-search.test.js
+++ b/packages/tools/mcp/test/fuzzy-search.test.js
@@ -53,6 +53,10 @@ const SAMPLE_ENTRIES = [
 		kind: 'scenario',
 	},
 ];
+
+/**
+ * Extract ids from search results
+ */
 function ids(result) {
 	return result.map((entry) => entry.item.id);
 }

--- a/packages/tools/mcp/test/search-fetch-consistency.test.js
+++ b/packages/tools/mcp/test/search-fetch-consistency.test.js
@@ -8,6 +8,9 @@ import { createKolibriMcpServer } from '../dist/mcp.mjs';
 
 const DEFAULT_LIMIT = 5;
 
+/**
+ * Create server with registered tools for testing
+ */
 function createServerWithRegisteredTools() {
 	const registeredTools = new Map();
 	const originalRegisterTool = McpServer.prototype.registerTool;
@@ -35,6 +38,9 @@ async function runSearch(tools, query = 'button', limit = DEFAULT_LIMIT) {
 	return response.structuredContent;
 }
 
+/**
+ * Verify consistent results across multiple calls
+ */
 test('search tool results stay consistent with fetch results', async () => {
 	const { registeredTools } = createServerWithRegisteredTools();
 	const structuredContent = await runSearch(registeredTools);


### PR DESCRIPTION
## Summary
Internal tooling cleanup removing JSDoc configuration for ESLint.

## Changes
- Remove JSDoc configuration from ESLint setup

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Internes Tooling-Cleanup: JSDoc-Konfiguration aus ESLint-Setup entfernt.

## Änderungen
- JSDoc-Konfiguration aus ESLint-Setup entfernt

</details>