### PR TITLE
fix(singleselect): prevent onChange from firing on blur without value change

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -96,8 +96,10 @@ export class KolSingleSelect implements SingleSelectAPI {
 	private onBlur() {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 
-		if (matchingOption && matchingOption?.value !== this._value) {
-			this.selectOption(matchingOption as Option<string>);
+		if (matchingOption) {
+			if (matchingOption?.value !== this._value) {
+				this.selectOption(matchingOption as Option<string>);
+			}
 		} else {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -97,9 +97,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 
 		if (matchingOption) {
-			if (matchingOption?.value !== this._value) {
-				this.selectOption(matchingOption as Option<string>);
-			}
+			this.selectOption(matchingOption as Option<string>);
 		} else {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];
@@ -152,6 +150,12 @@ export class KolSingleSelect implements SingleSelectAPI {
 	}
 
 	private selectOption(option: Option<string>) {
+		if (option.value === this._value) {
+			this._inputValue = option.label as string;
+			this._filteredOptions = [...this.state._options];
+			return;
+		}
+
 		this._value = option.value;
 		this._inputValue = option.label as string;
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -96,7 +96,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 	private onBlur() {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 
-		if (matchingOption) {
+		if (matchingOption && matchingOption?.value !== this._value) {
 			this.selectOption(matchingOption as Option<string>);
 		} else {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -127,5 +127,69 @@ test.describe(COMPONENT_NAME, () => {
 			const noResult = page.getByText('Keine Ergebnisse gefunden.');
 			await expect(noResult).toBeVisible();
 		});
+
+		test('should only trigger onChange when the value actually changes', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
+
+			const input = page.getByTestId('single-select-input');
+			const singleSelect = page.locator('kol-single-select');
+
+			// Type definition for testing purposes
+			type TestElement = {
+				_onChangeCounter: number;
+				controller: {
+					onFacade: {
+						onChange: (event: CustomEvent, value: unknown) => void;
+					};
+				};
+			};
+
+			// Simulate counter: set _onChangeCounter on the component for testing purposes
+			await singleSelect.evaluate((el) => {
+				const testEl = el as unknown as TestElement;
+				testEl._onChangeCounter = 0;
+				const originalOnChange = testEl.controller.onFacade.onChange.bind(testEl.controller.onFacade);
+				testEl.controller.onFacade.onChange = (event: CustomEvent, value: unknown) => {
+					testEl._onChangeCounter++;
+					originalOnChange(event, value);
+				};
+			});
+
+			// Helper function to get counter
+			const getCounter = async () => {
+				return await singleSelect.evaluate((el) => {
+					const testEl = el as unknown as TestElement;
+					return testEl._onChangeCounter;
+				});
+			};
+
+			// 1) Select value -> onChange fires
+			await input.click();
+			await page.getByRole('listbox').getByText(TEST_LABEL).click({ force: true });
+			let counter = await getCounter();
+			expect(counter).toBe(1);
+
+			// 2) Click on free space -> onChange must not fire
+			await page.click('body', { position: { x: 0, y: 0 } });
+			counter = await getCounter();
+			expect(counter).toBe(1);
+
+			// 3) Add dummy button without destroying the component
+			await page.evaluate(() => {
+				const button = document.createElement('button');
+				button.id = 'dummyButton';
+				button.textContent = 'Dummy';
+				document.body.appendChild(button);
+			});
+			await page.locator('#dummyButton').click();
+			counter = await getCounter();
+			expect(counter).toBe(1);
+
+			// 4) Change selection again -> onChange fires again
+			await input.click();
+			await page.getByRole('listbox').getByText('North').click({ force: true });
+			counter = await getCounter();
+			expect(counter).toBe(2);
+		});
 	});
 });

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -134,62 +134,33 @@ test.describe(COMPONENT_NAME, () => {
 			const input = page.getByTestId('single-select-input');
 			const singleSelect = page.locator('kol-single-select');
 
-			// Type definition for testing purposes
-			type TestElement = {
-				_onChangeCounter: number;
-				controller: {
-					onFacade: {
-						onChange: (event: CustomEvent, value: unknown) => void;
-					};
-				};
-			};
+			// Setup simple change counter
+			await singleSelect.evaluate((element) => {
+				const el = element as HTMLElement & { _changeCount: number };
+				el._changeCount = 0;
 
-			// Simulate counter: set _onChangeCounter on the component for testing purposes
-			await singleSelect.evaluate((el) => {
-				const testEl = el as unknown as TestElement;
-				testEl._onChangeCounter = 0;
-				const originalOnChange = testEl.controller.onFacade.onChange.bind(testEl.controller.onFacade);
-				testEl.controller.onFacade.onChange = (event: CustomEvent, value: unknown) => {
-					testEl._onChangeCounter++;
-					originalOnChange(event, value);
+				(element as HTMLKolSelectElement)._on = {
+					onChange: () => {
+						el._changeCount++;
+					},
 				};
 			});
 
-			// Helper function to get counter
-			const getCounter = async () => {
+			// Helper to get counter
+			const getChangeCount = async () => {
 				return await singleSelect.evaluate((el) => {
-					const testEl = el as unknown as TestElement;
-					return testEl._onChangeCounter;
+					return (el as HTMLElement & { _changeCount: number })._changeCount || 0;
 				});
 			};
 
-			// 1) Select value -> onChange fires
+			// 1) Select value -> onChange should fire (counter = 1)
 			await input.click();
 			await page.getByRole('listbox').getByText(TEST_LABEL).click({ force: true });
-			let counter = await getCounter();
-			expect(counter).toBe(1);
+			expect(await getChangeCount()).toBe(1);
 
-			// 2) Click on free space -> onChange must not fire
-			await page.click('body', { position: { x: 0, y: 0 } });
-			counter = await getCounter();
-			expect(counter).toBe(1);
-
-			// 3) Add dummy button without destroying the component
-			await page.evaluate(() => {
-				const button = document.createElement('button');
-				button.id = 'dummyButton';
-				button.textContent = 'Dummy';
-				document.body.appendChild(button);
-			});
-			await page.locator('#dummyButton').click();
-			counter = await getCounter();
-			expect(counter).toBe(1);
-
-			// 4) Change selection again -> onChange fires again
-			await input.click();
-			await page.getByRole('listbox').getByText('North').click({ force: true });
-			counter = await getCounter();
-			expect(counter).toBe(2);
+			// 2) Click on free space -> onChange must NOT fire (counter stays 1)
+			await page.click('html', { position: { x: 0, y: 0 } });
+			expect(await getChangeCount()).toBe(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Fixed the single-select component to prevent the `onChange` callback from firing when the user blurs the field without changing the value.

## Changes
- Prevent `onChange` from firing on blur when the value has not changed in single-select

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Die Single-Select-Komponente wurde korrigiert, um zu verhindern, dass der `onChange`-Callback ausgelöst wird, wenn der Benutzer das Feld verlässt, ohne den Wert zu ändern.

## Änderungen
- `onChange` wird bei Blur nicht mehr ausgelöst, wenn sich der Wert nicht geändert hat

</details>