### PR TITLE
fix(components): narrow secondary heading props to paragraph

### DIFF
--- a/packages/components/src/functional-components/Heading/Heading.tsx
+++ b/packages/components/src/functional-components/Heading/Heading.tsx
@@ -14,13 +14,13 @@ type BaseProps = JSXBase.HTMLAttributes<HTMLHeadingElement | HTMLElement> & {
 type HeadlineProps = BaseProps;
 
 // Define a type for the secondary headline props
-type SecondaryHeadlineProps = BaseProps;
+type SecondaryHeadlineProps = JSXBase.HTMLAttributes<HTMLParagraphElement>;
 
 // Define a type for the main Heading component props
 export type HeadingProps = HeadlineProps & {
 	secondaryHeadline?: string;
 	HeadingGroupProps?: HGroupProps;
-	SecondaryHeadlineProps?: JSXBase.HTMLAttributes<HTMLHeadingElement | HTMLElement>;
+	SecondaryHeadlineProps?: SecondaryHeadlineProps;
 };
 
 const MIN_HEADING_LEVEL = 1;

--- a/packages/components/src/functional-components/Heading/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Heading/test/__snapshots__/snapshot.test.tsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KolHeadingFc should apply SecondaryHeadlineProps to the secondary headline 1`] = `
+<hgroup class="kol-heading-group">
+  <h1 class="kol-headline kol-headline--group kol-headline--h1 kol-headline--primary">
+    Primary
+  </h1>
+  <p aria-label="secondary-label" class="kol-headline kol-headline--group kol-headline--secondary secondary-class">
+    Secondary
+  </p>
+</hgroup>
+`;
+
 exports[`KolHeadingFc should apply custom class names 1`] = `
 <h1 class="custom-class kol-headline kol-headline--h1 kol-headline--single">
   Custom Class Heading

--- a/packages/components/src/functional-components/Heading/test/snapshot.test.tsx
+++ b/packages/components/src/functional-components/Heading/test/snapshot.test.tsx
@@ -49,4 +49,18 @@ describe('KolHeadingFc', () => {
 		expect(page.root?.classList.contains('kol-headline')).toBe(true);
 		expect(page.root?.textContent).toContain('Custom Class Heading');
 	});
+
+	it('should apply SecondaryHeadlineProps to the secondary headline', async () => {
+		const page = await renderFunctionalComponentToSpecPage(() => (
+			<KolHeadingFc secondaryHeadline="Secondary" SecondaryHeadlineProps={{ class: 'secondary-class', 'aria-label': 'secondary-label' }}>
+				Primary
+			</KolHeadingFc>
+		));
+
+		expect(page.root).toBeDefined();
+		expect(page.root).toMatchSnapshot();
+		const secondary = page.root?.querySelector('p');
+		expect(secondary?.classList.contains('secondary-class')).toBe(true);
+		expect(secondary?.getAttribute('aria-label')).toBe('secondary-label');
+	});
 });


### PR DESCRIPTION
## Summary
Narrowed the secondary heading props type to accept only paragraph elements, improving type safety.

## Changes
- Narrow `SecondaryHeadlineProps` type to paragraph-only

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Der Typ der sekundären Überschriften-Props wurde auf Absatz-Elemente beschränkt, was die Typsicherheit verbessert.

## Änderungen
- `SecondaryHeadlineProps`-Typ auf Absatz-Elemente beschränkt

</details>