### PR TITLE
docs(components): explain secondary headline paragraph rendering

### DIFF
--- a/packages/components/src/functional-components/Heading/Heading.tsx
+++ b/packages/components/src/functional-components/Heading/Heading.tsx
@@ -66,6 +66,8 @@ const KolHeadlineFc: FC<HeadlineProps> = ({ class: classNames, level = MIN_HEADI
 
 /**
  * Functional component for rendering a secondary headline.
+ * The secondary text is rendered as a `<p>` because according to the HTML `hgroup`
+ * specification the subheading does not create its own outline level.
  * @param props - The properties for the secondary headline component.
  * @param children - The children to render inside the secondary headline.
  * @returns A VNode representing the secondary headline.


### PR DESCRIPTION
## Summary
Internal documentation update explaining how secondary headline props render as paragraph elements.

## Changes
- Document secondary headline paragraph rendering behavior in component docs

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Dokumentationsaktualisierung: Erklärt, wie sekundäre Überschriften-Props als Absatzelemente gerendert werden.

## Änderungen
- Rendering-Verhalten sekundärer Überschriften als Absatzelemente in der Komponentendokumentation dokumentiert

</details>