### PR TITLE
docs: note CSS property collision risks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -573,6 +573,9 @@ THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test --update-snapshots=ch
 - ✅ Use `pnpm dev` for watch mode during theme development
 - ✅ Test themes with visual tests: `pnpm test`
 - ✅ Copy assets from components: `pnpm prepare` (in theme directory)
+- ⚠️ Expose only prefixed CSS custom properties that must be themed externally
+  and rely on SASS variables for internal calculations to avoid collisions with
+  host-page styles.
 
 **Component Development Rules:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,13 @@ In the theme component layer, you can set what ever you need to realize your own
 }
 ```
 
+### CSS Custom Properties and SASS Variables
+
+CSS custom properties remain part of the global cascade and are not isolated by the Shadow DOM.
+Overusing them in theme files can collide with variables defined on a host page.
+Expose only well‑prefixed design tokens as custom properties and rely on SASS variables for
+internal calculations to keep components robust and avoid unintended style leaks.
+
 ### General rules for custom themes
 
 - Do not use `!important` in your styles, as this will override the styles of the basis global and component layers.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ KoliBri is always actively working on improvements, new features and future-orie
 | ------: | :----------: | :------: | :----: | :------------: |
 |     1.x |     LTS      | Dec 2021 |   3y   |    Dec 2024    |
 |     2.x |     LTS      | Dec 2023 |   3y   |    Dec 2026    |
-|     3.x |     STS      | Dec 2024 |   15m   |    Dec 2025    |
+|     3.x |     STS      | Dec 2024 |  15m   |    Dec 2025    |
 |     4.x |     LTS      | Dec 2025 |   3y   |    Dec 2028    |
-|     5.x |     STS      | Dec 2026 |   15m   |    Dec 2027    |
+|     5.x |     STS      | Dec 2026 |  15m   |    Dec 2027    |
 
 ```mermaid
 gantt
@@ -78,6 +78,16 @@ import { DEFAULT } from '@public-ui/theme-default';
 
 register(DEFAULT, defineCustomElements);
 ```
+
+### Avoid CSS Custom Property Collisions
+
+KoliBri themes expose a few CSS custom properties so consumers can adapt the look and feel.
+Because these properties remain global—even inside a Shadow DOM—using too many of them can
+clash with variables defined on the host page.
+
+Use namespaced custom properties only for values that must be overridden from the outside.
+For internal calculations rely on SASS variables instead of additional CSS properties.
+This keeps components robust and prevents unexpected style leaks.
 
 ## Collaboration and cooperation
 

--- a/docs/HOWTO_KOLIBRI_WEB_COMPONENTS.de.md
+++ b/docs/HOWTO_KOLIBRI_WEB_COMPONENTS.de.md
@@ -29,6 +29,11 @@ KoliBri setzt auf ein mehrschichtiges Theming mit klaren Verantwortlichkeiten:
 
 Dieses System ermöglicht es, ein Corporate Design konsistent umzusetzen und dennoch flexibel zu bleiben.
 
+> **Hinweis:** CSS-Custom-Properties sind global und durchdringen auch den Shadow DOM.
+> Verwende sie nur für öffentliche Design-Tokens und statte sie mit einem eindeutigen Prefix aus.
+> Für interne Berechnungen und Zwischenergebnisse setze stattdessen auf SASS-Variablen,
+> um Kollisionen mit Variablen auf der Host-Seite zu vermeiden.
+
 ## Mindset für KoliBri-Nutzer:innen
 
 - **Accessibility first**: Barrierefreiheit ist kein Add-on, sondern Kernbestandteil jeder Komponente.

--- a/docs/STYLELINT.md
+++ b/docs/STYLELINT.md
@@ -108,3 +108,10 @@ The configuration enforces a specific order of CSS properties:
 5. **Everything Else** (Typography, Content)
 
 This improves readability and consistency of CSS code.
+
+## CSS Custom Properties and SASS Variables
+
+Custom properties (`--*`) remain in the global CSS cascade, even inside a Shadow DOM.
+Use them sparingly and prefix them clearly for values that external themes should override.
+For internal calculations prefer SASS variables so that unused properties do not leak and collide
+with variables from host applications.


### PR DESCRIPTION
## Summary
Internal documentation update noting CSS property collision risks and guidance for component styling.

## Changes
- Add documentation notes about CSS property collision risks in markdown files

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Dokumentationsaktualisierung: Hinweise zu CSS-Eigenschaftskollisionsrisiken und Anleitungen für Komponenten-Styling hinzugefügt.

## Änderungen
- Dokumentationshinweise zu CSS-Eigenschaftskollisionsrisiken in Markdown-Dateien hinzugefügt

</details>