### PR TITLE
refactor(components): deprecate _id prop

### DIFF
--- a/MIGRATION.de.md
+++ b/MIGRATION.de.md
@@ -72,3 +72,9 @@ Mehr Informationen zu Breaking Changes finden Sie in der Dokumentation [BREAKING
    Das Projekt ist auf einer früheren Version, alle Abhängigkeiten sind installiert, das Projekt ist lauffähig und alle Änderungen sind eingecheckt und sicher gepusht.
 2. **Migration durchführen:**<br/>
    Führen Sie die Migration durch, indem Sie die Breaking Changes in der jeweiligen Dokumentation.
+
+## Migration von Version 3 auf Version 4
+
+### Entfernte `_id`-Property in allen Komponenten
+
+Die interne `_id`-Property aller Komponenten wurde als veraltet markiert und wird in der nächsten Major-Version entfernt. Entfernen Sie `_id` aus Ihrem Markup; die Komponenten erzeugen die eindeutige ID nun automatisch.

--- a/MIGRATION.de.md
+++ b/MIGRATION.de.md
@@ -52,6 +52,10 @@ Mehr Informationen zu Breaking Changes finden Sie in der Dokumentation [BREAKING
 
 Mehr Informationen zu Breaking Changes finden Sie in der Dokumentation [BREAKING_CHANGES.v3.md (EN)](https://github.com/public-ui/kolibri/blob/develop/docs/BREAKING_CHANGES.v3.md).
 
+### Breaking Changes für Version 4
+
+Mehr Informationen zu Breaking Changes finden Sie in der Dokumentation [BREAKING_CHANGES.v4.md (EN)](https://github.com/public-ui/kolibri/blob/develop/docs/BREAKING_CHANGES.v4.md).
+
 ## Migration durchführen
 
 > [!TIP]
@@ -72,9 +76,3 @@ Mehr Informationen zu Breaking Changes finden Sie in der Dokumentation [BREAKING
    Das Projekt ist auf einer früheren Version, alle Abhängigkeiten sind installiert, das Projekt ist lauffähig und alle Änderungen sind eingecheckt und sicher gepusht.
 2. **Migration durchführen:**<br/>
    Führen Sie die Migration durch, indem Sie die Breaking Changes in der jeweiligen Dokumentation.
-
-## Migration von Version 3 auf Version 4
-
-### Entfernte `_id`-Property in allen Komponenten
-
-Die interne `_id`-Property aller Komponenten wurde als veraltet markiert und wird in der nächsten Major-Version entfernt. Entfernen Sie `_id` aus Ihrem Markup; die Komponenten erzeugen die eindeutige ID nun automatisch.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -52,6 +52,10 @@ You can find more information about Breaking Changes in the documentation [BREAK
 
 You can find more information about Breaking Changes in the documentation [BREAKING_CHANGES.v3.md (EN)](https://github.com/public-ui/kolibri/blob/develop/docs/BREAKING_CHANGES.v3.md).
 
+### Breaking changes for version 4
+
+You can find more information about Breaking Changes in the documentation [BREAKING_CHANGES.v4.md (EN)](https://github.com/public-ui/kolibri/blob/develop/docs/BREAKING_CHANGES.v4.md).
+
 ## Perform migration
 
 > [!TIP]
@@ -72,9 +76,3 @@ You can find more information about Breaking Changes in the documentation [BREAK
    The project is on an earlier version, all dependencies are installed, the project is executable and all changes are checked in and safely pushed.
 2. **Perform migration:**<br/>
    Carry out the migration by making the breaking changes in the respective documentation.
-
-## Migration from version 3 to version 4
-
-### Removed `_id` property on all components
-
-The internal `_id` property of all components has been deprecated and will be removed in the next major release. Remove any `_id` attributes from your markup; components generate a stable internal ID automatically.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -72,3 +72,9 @@ You can find more information about Breaking Changes in the documentation [BREAK
    The project is on an earlier version, all dependencies are installed, the project is executable and all changes are checked in and safely pushed.
 2. **Perform migration:**<br/>
    Carry out the migration by making the breaking changes in the respective documentation.
+
+## Migration from version 3 to version 4
+
+### Removed `_id` property on all components
+
+The internal `_id` property of all components has been deprecated and will be removed in the next major release. Remove any `_id` attributes from your markup; components generate a stable internal ID automatically.

--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -10,4 +10,4 @@ For more information, see the [KoliBri Maintenance and Support Strategy](https:/
 
 ### All components
 
-- The internal `_id` property has been removed. Components now generate a stable ID internally and no longer expose `_id` as a public prop. Remove any `_id` attributes from your markup.
+- The `_id` prop has been removed from components that use Shadow DOM. IDs within a shadow tree are not visible outside, so each component now generates its own stable ID internally and manages all references. For tests or external lookups, set an `id` on the host element instead.

--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -1,0 +1,13 @@
+# Breaking Changes for version 4
+
+## Introduction
+
+New major versions of KoliBri are developed with the goal of simplifying maintenance and support and promoting further development.
+
+For more information, see the [KoliBri Maintenance and Support Strategy](https://github.com/public-ui/kolibri/blob/develop/MIGRATION.md).
+
+## Changed Components
+
+### All components
+
+- The internal `_id` property has been removed. Components now generate a stable ID internally and no longer expose `_id` as a public prop. Remove any `_id` attributes from your markup.

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -127,7 +127,7 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -127,7 +127,8 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -249,7 +249,8 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @internal
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -249,7 +249,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -129,7 +129,8 @@ export class KolButton implements ButtonProps, FocusableElement {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -129,7 +129,7 @@ export class KolButton implements ButtonProps, FocusableElement {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -415,7 +415,8 @@ export class KolCombobox implements ComboboxAPI {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -415,7 +415,7 @@ export class KolCombobox implements ComboboxAPI {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -193,7 +193,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Prop() public _icons?: Stringified<InputCheckboxIconsProp>;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -193,7 +193,8 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Prop() public _icons?: Stringified<InputCheckboxIconsProp>;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -206,7 +206,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -206,7 +206,8 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -222,7 +222,8 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -222,7 +222,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -187,7 +187,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -187,7 +187,8 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -175,7 +175,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -175,7 +175,8 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -203,7 +203,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -203,7 +203,8 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -214,7 +214,8 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -214,7 +214,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -186,7 +186,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@Prop() public _hint?: string = '';
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -186,7 +186,8 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@Prop() public _hint?: string = '';
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -264,7 +264,8 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -264,7 +264,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -204,7 +204,8 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -204,7 +204,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -200,7 +200,8 @@ export class KolPopoverButton implements PopoverButtonProps {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @internal
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -200,7 +200,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -119,7 +119,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -119,7 +119,8 @@ export class KolPopoverButton implements PopoverButtonProps {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -162,7 +162,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -162,7 +162,8 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -523,7 +523,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -523,7 +523,8 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -189,7 +189,7 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -189,7 +189,8 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	@Prop() public _icons?: IconsPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: string;
 

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -177,7 +177,8 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -177,7 +177,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Prop() public _icons?: IconsHorizontalPropType;
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -168,7 +168,8 @@ export class KolTooltipWc implements TooltipAPI {
 	@Prop() public _align?: AlignPropType = 'top';
 
 	/**
-	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+	 * Defines the internal ID of the primary component element.
+	 * @internal
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -168,7 +168,7 @@ export class KolTooltipWc implements TooltipAPI {
 	@Prop() public _align?: AlignPropType = 'top';
 
 	/**
-	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
 	 */
 	@Prop() public _id?: IdPropType;
 

--- a/packages/components/src/schema/props/id.ts
+++ b/packages/components/src/schema/props/id.ts
@@ -6,13 +6,14 @@ import { watchString } from '../utils';
 export type IdPropType = string;
 
 /**
- * Defines the internal ID of the primary component element.
+ * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
  */
 export type PropId = {
 	id: IdPropType;
 };
 
 /* validator */
+/** @deprecated Will be removed in the next major version. */
 export const validateId = (component: Generic.Element.Component, value?: IdPropType): void => {
 	watchString(component, '_id', value);
 };

--- a/packages/components/src/schema/props/id.ts
+++ b/packages/components/src/schema/props/id.ts
@@ -6,7 +6,8 @@ import { watchString } from '../utils';
 export type IdPropType = string;
 
 /**
- * @deprecated Will be removed in the next major version. Defines the internal ID of the primary component element.
+ * Defines the internal ID of the primary component element.
+ * @deprecated Will be removed in the next major version.
  */
 export type PropId = {
 	id: IdPropType;

--- a/packages/tools/kolibri-cli/src/migrate/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/index.ts
@@ -13,6 +13,7 @@ import { testTasks } from './runner/tasks/test';
 import { v1Tasks } from './runner/tasks/v1';
 import { v2Tasks } from './runner/tasks/v2';
 import { v3Tasks } from './runner/tasks/v3';
+import { v4Tasks } from './runner/tasks/v4';
 import { getAssetTasks } from './runner/tasks/v1/assets';
 import {
 	getContentOfProjectPkgJson,
@@ -120,6 +121,7 @@ Source folder to migrate: ${baseDir}
 				runner.registerTasks(v1Tasks);
 				runner.registerTasks(v2Tasks);
 				runner.registerTasks(v3Tasks);
+				runner.registerTasks(v4Tasks);
 				runner.registerTasks(getAssetTasks(baseDir));
 
 				if (options.testTasks) {

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/id.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/id.ts
@@ -1,0 +1,26 @@
+import { RemovePropertyNameTask } from '../common/RemovePropertyNameTask';
+import { AbstractTask } from '../../abstract-task';
+
+const ID_COMPONENTS = [
+	'kol-button',
+	'kol-button-link',
+	'kol-combobox',
+	'kol-input-checkbox',
+	'kol-input-color',
+	'kol-input-date',
+	'kol-input-email',
+	'kol-input-file',
+	'kol-input-number',
+	'kol-input-password',
+	'kol-input-radio',
+	'kol-input-range',
+	'kol-input-text',
+	'kol-popover-button',
+	'kol-select',
+	'kol-single-select',
+	'kol-split-button',
+	'kol-textarea',
+	'kol-tooltip',
+];
+
+export const RemoveIdPropTasks: AbstractTask[] = ID_COMPONENTS.map((componentName) => RemovePropertyNameTask.getInstance(componentName, '_id', '<4'));

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/index.ts
@@ -5,6 +5,7 @@ import { ModalRemovePropertyActiveElement } from './modal';
 import { InputFileRemovePropertyValue } from './input-file';
 import { AllInputTasks } from './all-input';
 import { ToasterRenameProperties } from './toaster';
+import { RemoveIdPropTasks } from './id';
 
 export const v3Tasks: AbstractTask[] = [];
 
@@ -13,5 +14,6 @@ v3Tasks.push(TextareaUpdatePropertyValue_Resize_Horizontal);
 v3Tasks.push(AbbrRemovePropertyTooltipAlign);
 v3Tasks.push(ModalRemovePropertyActiveElement);
 v3Tasks.push(InputFileRemovePropertyValue);
+v3Tasks.push(...RemoveIdPropTasks);
 v3Tasks.push(...AllInputTasks);
 v3Tasks.push(ToasterRenameProperties);

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v3/index.ts
@@ -5,7 +5,6 @@ import { ModalRemovePropertyActiveElement } from './modal';
 import { InputFileRemovePropertyValue } from './input-file';
 import { AllInputTasks } from './all-input';
 import { ToasterRenameProperties } from './toaster';
-import { RemoveIdPropTasks } from './id';
 
 export const v3Tasks: AbstractTask[] = [];
 
@@ -14,6 +13,5 @@ v3Tasks.push(TextareaUpdatePropertyValue_Resize_Horizontal);
 v3Tasks.push(AbbrRemovePropertyTooltipAlign);
 v3Tasks.push(ModalRemovePropertyActiveElement);
 v3Tasks.push(InputFileRemovePropertyValue);
-v3Tasks.push(...RemoveIdPropTasks);
 v3Tasks.push(...AllInputTasks);
 v3Tasks.push(ToasterRenameProperties);

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/id.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/id.ts
@@ -23,4 +23,4 @@ const ID_COMPONENTS = [
 	'kol-tooltip',
 ];
 
-export const RemoveIdPropTasks: AbstractTask[] = ID_COMPONENTS.map((componentName) => RemovePropertyNameTask.getInstance(componentName, '_id', '<4'));
+export const RemoveIdPropTasks: AbstractTask[] = ID_COMPONENTS.map((componentName) => RemovePropertyNameTask.getInstance(componentName, '_id', '^4'));

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,0 +1,6 @@
+import { AbstractTask } from '../../abstract-task';
+import { RemoveIdPropTasks } from './id';
+
+export const v4Tasks: AbstractTask[] = [];
+
+v4Tasks.push(...RemoveIdPropTasks);


### PR DESCRIPTION
## Summary
Deprecated the `_id` prop across components in favor of implicit ID management, reducing the risk of duplicate ID collisions.

## Changes
- Mark `_id` prop as deprecated across all affected components
- Locate and document all usages of `_id`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Der `_id`-Prop wurde in allen Komponenten als veraltet markiert, zugunsten der impliziten ID-Verwaltung, um Risiken durch doppelte IDs zu reduzieren.

## Änderungen
- `_id`-Prop in allen betroffenen Komponenten als veraltet markiert
- Alle Verwendungen von `_id` dokumentiert

</details>