### PR TITLE
ci: add ref fallback to concurrency groups

### DIFF
--- a/.github/workflows/benchmark.baseline.yml
+++ b/.github/workflows/benchmark.baseline.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/benchmark.monitoring.yml
+++ b/.github/workflows/benchmark.monitoring.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/benchmark.pr-check.yml
+++ b/.github/workflows/benchmark.pr-check.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
     - cron: '23 1 * * 6'
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/handle-pr-labels.yml
+++ b/.github/workflows/handle-pr-labels.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, labeled]
 
 concurrency:
-  group: workflow-${{ github.workflow }}-${{ github.ref }}
+  group: workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,7 +7,7 @@ on:
       - 'release/*'
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
Internal CI fix adding a `ref` fallback to concurrency groups to prevent workflow failures for non-PR triggers.

## Changes
- Add `ref` fallback to concurrency group configuration

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner CI-Fix: `ref`-Fallback zu Concurrency-Groups hinzugefügt, um Workflow-Fehler bei Nicht-PR-Triggern zu verhindern.

## Änderungen
- `ref`-Fallback zur Concurrency-Group-Konfiguration hinzugefügt

</details>