### PR TITLE
fix: avoid double unescaping in hashing script

### DIFF
--- a/packages/components/scripts/hashing.js
+++ b/packages/components/scripts/hashing.js
@@ -125,13 +125,13 @@ function genArtifactHashes(dir) {
 			if (typeof css === 'string') {
 				css = css
 					.replace(/";$/, '')
-					.replace(/\\"/g, '"')
-					.replace(/\\\\/g, `\\`)
 					.replace(
 						/\\n/g,
 						`
-  `
-					);
+  `,
+					)
+					.replace(/\\"/g, '"')
+					.replace(/\\\\/g, `\\`);
 				sha = genShaAsHashAndApostrophe(css);
 				console.log(css, sha);
 				fs.writeFileSync(fullPath.replace(/.js$/, '.css'), css, 'utf-8');


### PR DESCRIPTION
## Summary
Internal fix preventing double unescaping in the hashing script used during the release process.

## Changes
- Fix double escaping and unescaping issue in hashing script

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix: Doppeltes Unescaping im Hashing-Skript des Release-Prozesses verhindert.

## Änderungen
- Doppeltes Escaping/Unescaping-Problem im Hashing-Skript behoben

</details>