### PR TITLE
fix: announce alerts via live regions

### DIFF
--- a/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,11 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`kol-alert should render with _label="Überschrift" _alert=false _level=0 _type="default" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=false _level=0 _type="error" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=false _level=0 _type="info" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=false _level=0 _type="success" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=false _level=0 _type="warning" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
 exports[`kol-alert should render with _label="Überschrift" _alert=false _level=1 _type="default" 1`] = `
 <kol-alert>
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -31,7 +161,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -57,7 +187,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -83,7 +213,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -109,7 +239,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -135,7 +265,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -161,7 +291,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -187,7 +317,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -213,7 +343,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -239,7 +369,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -265,7 +395,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -291,7 +421,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -317,7 +447,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -343,7 +473,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -369,7 +499,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -395,7 +525,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -421,7 +551,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -447,7 +577,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -473,7 +603,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -499,7 +629,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -525,7 +655,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -551,7 +681,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -577,7 +707,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -603,7 +733,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -629,7 +759,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -655,7 +785,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -681,7 +811,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -707,7 +837,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -733,7 +863,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -759,7 +889,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="polite" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="status">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -780,12 +910,142 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
 </kol-alert>
 `;
 
+exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0 _type="default" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-message
+          </span>
+          <kol-icon _icons="codicon codicon-comment" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0 _type="error" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-error
+          </span>
+          <kol-icon _icons="codicon codicon-error" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0 _type="info" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-info
+          </span>
+          <kol-icon _icons="codicon codicon-info" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0 _type="success" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-success
+          </span>
+          <kol-icon _icons="codicon codicon-pass" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
+exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0 _type="warning" 1`] = `
+<kol-alert>
+  <template shadowrootmode="open">
+    <kol-alert-wc>
+      <!---->
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
+        <div class="kol-alert__container">
+          <span class="visually-hidden">
+            kol-warning
+          </span>
+          <kol-icon _icons="codicon codicon-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <div class="kol-alert__container-content">
+            <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
+              Überschrift
+            </strong>
+            <span aria-describedby="heading" class="kol-alert__content">
+              <slot></slot>
+            </span>
+          </div>
+        </div>
+      </div>
+    </kol-alert-wc>
+  </template>
+</kol-alert>
+`;
+
 exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1 _type="default" 1`] = `
 <kol-alert>
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -811,7 +1071,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -837,7 +1097,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -863,7 +1123,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -889,7 +1149,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -915,7 +1175,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -941,7 +1201,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -967,7 +1227,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -993,7 +1253,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -1019,7 +1279,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -1045,7 +1305,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -1071,7 +1331,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -1097,7 +1357,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -1123,7 +1383,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -1149,7 +1409,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -1175,7 +1435,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -1201,7 +1461,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -1227,7 +1487,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -1253,7 +1513,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -1279,7 +1539,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -1305,7 +1565,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -1331,7 +1591,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -1357,7 +1617,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -1383,7 +1643,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -1409,7 +1669,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning
@@ -1435,7 +1695,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-message
@@ -1461,7 +1721,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-error kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-error
@@ -1487,7 +1747,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-info kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-info
@@ -1513,7 +1773,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-success kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-success
@@ -1539,7 +1799,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div aria-live="assertive" class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
+      <div class="kol-alert kol-alert--type-warning kol-alert--variant-msg" data-testid="alert" role="alert">
         <div class="kol-alert__container">
           <span class="visually-hidden">
             kol-warning

--- a/packages/components/src/components/alert/test/snapshot.spec.tsx
+++ b/packages/components/src/components/alert/test/snapshot.spec.tsx
@@ -1,17 +1,20 @@
 import { KolAlertTag } from '../../../core/component-names';
-import type { AlertProps } from '../../../schema';
+import type { AlertProps, AlertType } from '../../../schema';
 import { executeSnapshotTests } from '../../../utils/testing';
 
 import { KolAlert } from '../shadow';
 import { KolAlertWc } from '../component';
 
 const baseObject = { _label: 'Überschrift' };
-const baseArray = [true, false].map((_alert) => ({ ...baseObject, _alert }));
 
-function buildByType(_type: 'default' | 'error' | 'info' | 'success' | 'warning') {
+function buildByType(_type: AlertType) {
 	const nextArray: AlertProps[] = [];
-	[1, 2, 3, 4, 5, 6].forEach((_level) => {
-		nextArray.push(...baseArray.map((o) => ({ ...o, _level, _type }) as AlertProps));
+	const alertVariants = [true, false];
+
+	[0, 1, 2, 3, 4, 5, 6].forEach((_level) => {
+		alertVariants.forEach((_alert) => {
+			nextArray.push({ ...baseObject, _alert, _level, _type } as AlertProps);
+		});
 	});
 
 	return nextArray;

--- a/packages/components/src/components/spin/shadow.tsx
+++ b/packages/components/src/components/spin/shadow.tsx
@@ -38,19 +38,20 @@ export class KolSpin implements SpinAPI {
 
 	public render(): JSX.Element {
 		return (
-			<Host class="kol-spin" aria-live="polite">
-				{this.state._label && (this.state._show || this.showToggled) && <span class="visually-hidden">{this.state._label}</span>}
+			<Host class="kol-spin">
 				{this.state._show ? (
-					<span
-						aria-busy="true"
-						aria-label={this.state._label ?? this.translateActionRunning}
-						class={clsx('kol-spin__spinner', `kol-spin__spinner--${this.state._variant}`)}
-						role="alert"
-					>
-						{renderSpin(this.state._variant)}
-					</span>
+					<Fragment>
+						<span class={clsx('kol-spin__spinner', `kol-spin__spinner--${this.state._variant}`)}>{renderSpin(this.state._variant)}</span>
+						<span aria-busy="true" class="visually-hidden" role="alert">
+							{this.state._label ?? this.translateActionRunning}
+						</span>
+					</Fragment>
 				) : (
-					this.showToggled && <span aria-label={this.state._label ?? this.translateActionDone} aria-busy="false" role="alert"></span>
+					this.showToggled && (
+						<span aria-busy="false" class="visually-hidden" role="alert">
+							{this.state._label ?? this.translateActionDone}
+						</span>
+					)
 				)}
 			</Host>
 		);

--- a/packages/components/src/components/spin/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/spin/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,35 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`kol-spin should render with _show=false 1`] = `
-<kol-spin aria-live="polite" class="kol-spin">
+<kol-spin class="kol-spin">
   <template shadowrootmode="open"></template>
 </kol-spin>
 `;
 
 exports[`kol-spin should render with _show=true _label="Loading" 1`] = `
-<kol-spin _show="" aria-live="polite" class="kol-spin">
+<kol-spin _show="" class="kol-spin">
   <template shadowrootmode="open">
-    <span class="visually-hidden">
-      Loading
-    </span>
-    <span aria-busy="true" aria-label="Loading" class="kol-spin__spinner kol-spin__spinner--dot" role="alert">
+    <span class="kol-spin__spinner kol-spin__spinner--dot">
       <span class="kol-spin__spinner-element kol-spin__spinner-element--1"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--2"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--3"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--neutral"></span>
+    </span>
+    <span aria-busy="true" class="visually-hidden" role="alert">
+      Loading
     </span>
   </template>
 </kol-spin>
 `;
 
 exports[`kol-spin should render with _show=true 1`] = `
-<kol-spin _show="" aria-live="polite" class="kol-spin">
+<kol-spin _show="" class="kol-spin">
   <template shadowrootmode="open">
-    <span aria-busy="true" aria-label="kol-action-running" class="kol-spin__spinner kol-spin__spinner--dot" role="alert">
+    <span class="kol-spin__spinner kol-spin__spinner--dot">
       <span class="kol-spin__spinner-element kol-spin__spinner-element--1"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--2"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--3"></span>
       <span class="kol-spin__spinner-element kol-spin__spinner-element--neutral"></span>
+    </span>
+    <span aria-busy="true" class="visually-hidden" role="alert">
+      kol-action-running
     </span>
   </template>
 </kol-spin>

--- a/packages/components/src/functional-components/Alert/Alert.tsx
+++ b/packages/components/src/functional-components/Alert/Alert.tsx
@@ -82,7 +82,7 @@ const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 	};
 
 	return (
-		<div aria-live={alert ? 'assertive' : 'polite'} role={alert ? 'alert' : 'status'} {...rootProps} data-testid="alert">
+		<div role={alert ? 'alert' : undefined} {...rootProps} data-testid="alert">
 			<div class="kol-alert__container">
 				<AlertIcon label={label} type={type} />
 				<div class="kol-alert__container-content">

--- a/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KolAlertFc should render 1`] = `
-<div aria-live="polite" class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert" role="status">
+<div class="kol-alert kol-alert--type-default kol-alert--variant-msg" data-testid="alert">
   <div class="kol-alert__container">
     <span class="visually-hidden">
       kol-message

--- a/packages/components/src/functional-components/FormField/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/FormField/tests/__snapshots__/snapshot.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`KolFormFieldFc should render with error message 1`] = `
     </span>
   </label>
   <div class="kol-form-field__input"></div>
-  <div aria-live="polite" class="kol-alert kol-alert--type-error kol-alert--variant-msg kol-form-field__msg" data-testid="alert" id="test-id-msg" role="status">
+  <div class="kol-alert kol-alert--type-error kol-alert--variant-msg kol-form-field__msg" data-testid="alert" id="test-id-msg">
     <div class="kol-alert__container">
       <span class="visually-hidden">
         kol-error

--- a/packages/components/src/functional-components/FormFieldMsg/tests/__snapshots__/snapshort.test.tsx.snap
+++ b/packages/components/src/functional-components/FormFieldMsg/tests/__snapshots__/snapshort.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormFieldMsgFc should render with all props 1`] = `
-<div aria-live="assertive" class="custom-class kol-alert kol-alert--type-error kol-alert--variant-msg kol-form-field__msg" data-testid="alert" id="test-id-msg" role="alert">
+<div class="custom-class kol-alert kol-alert--type-error kol-alert--variant-msg kol-form-field__msg" data-testid="alert" id="test-id-msg" role="alert">
   <div class="kol-alert__container">
     <span class="visually-hidden">
       kol-error

--- a/packages/components/src/functional-components/ToastItem/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/ToastItem/tests/__snapshots__/snapshot.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ToastItemFc should render with basic props and status 1`] = `
 <div class="kol-toast-item kol-toast-item--settled">
-  <div aria-live="assertive" class="kol-alert kol-alert--hasCloser kol-alert--type-info kol-alert--variant-card kol-toast-item__alert" data-testid="alert" role="alert">
+  <div class="kol-alert kol-alert--hasCloser kol-alert--type-info kol-alert--variant-card kol-toast-item__alert" data-testid="alert" role="alert">
     <div class="kol-alert__container">
       <span class="visually-hidden">
         kol-info


### PR DESCRIPTION
## Summary
Fixed alert announcements by using ARIA live regions to ensure screen readers properly announce alert messages.

## Changes
- Fix screen reader role toggling to use ARIA live regions for alert announcement

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Alert-Ankündigungen behoben: ARIA-Live-Regionen werden nun verwendet, damit Screenreader Alert-Nachrichten korrekt ankündigen.

## Änderungen
- Screenreader-Rollen-Umschalten korrigiert, um ARIA-Live-Regionen für Alert-Ankündigungen zu verwenden

</details>