### PR TITLE
feat(themes): add autoprefixer to theme packages

### DIFF
--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -66,6 +66,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"cross-env": "10.0.0",
 		"eslint": "8.57.1",

--- a/packages/themes/default/rollup.config.js
+++ b/packages/themes/default/rollup.config.js
@@ -1,5 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import postcss from 'rollup-plugin-postcss';
+import autoprefixer from 'autoprefixer';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/packages/themes/ecl/package.json
+++ b/packages/themes/ecl/package.json
@@ -72,6 +72,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"cross-env": "10.0.0",
 		"eslint": "8.57.1",

--- a/packages/themes/ecl/rollup.config.js
+++ b/packages/themes/ecl/rollup.config.js
@@ -1,5 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import postcss from 'rollup-plugin-postcss';
+import autoprefixer from 'autoprefixer';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -62,6 +62,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"eslint": "8.57.1",
 		"nodemon": "3.1.10",

--- a/packages/themes/rollup.config.js
+++ b/packages/themes/rollup.config.js
@@ -1,5 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import postcss from 'rollup-plugin-postcss';
+import autoprefixer from 'autoprefixer';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,6 +813,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -861,6 +864,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -921,6 +927,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0


### PR DESCRIPTION
## Summary
Added autoprefixer to the PostCSS pipeline for theme packages to automatically generate vendor CSS prefixes.

## Changes
- Add autoprefixer dependency to theme packages
- Include autoprefixer in the PostCSS pipeline for themes

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Autoprefixer wurde zur PostCSS-Pipeline der Theme-Pakete hinzugefügt, um automatisch Vendor-CSS-Prefixes zu generieren.

## Änderungen
- Autoprefixer-Abhängigkeit zu Theme-Paketen hinzugefügt
- Autoprefixer in die PostCSS-Pipeline für Themes integriert

</details>