### PR TITLE
feat(themes): add autoprefixer

### DIFF
--- a/packages/themes/bwst/package.json
+++ b/packages/themes/bwst/package.json
@@ -67,6 +67,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"cross-env": "10.0.0",
 		"eslint": "8.57.1",

--- a/packages/themes/bwst/rollup.config.js
+++ b/packages/themes/bwst/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import autoprefixer from 'autoprefixer';
 import postcss from 'rollup-plugin-postcss';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -67,6 +67,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"cross-env": "10.0.0",
 		"eslint": "8.57.1",

--- a/packages/themes/default/rollup.config.js
+++ b/packages/themes/default/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import autoprefixer from 'autoprefixer';
 import postcss from 'rollup-plugin-postcss';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/packages/themes/ecl/package.json
+++ b/packages/themes/ecl/package.json
@@ -35,6 +35,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"cross-env": "10.0.0",
 		"eslint": "8.57.1",

--- a/packages/themes/ecl/rollup.config.js
+++ b/packages/themes/ecl/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import autoprefixer from 'autoprefixer';
 import postcss from 'rollup-plugin-postcss';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/packages/themes/itzbund/package.json
+++ b/packages/themes/itzbund/package.json
@@ -29,6 +29,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"cross-env": "10.0.0",
 		"eslint": "8.57.1",

--- a/packages/themes/itzbund/rollup.config.js
+++ b/packages/themes/itzbund/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import autoprefixer from 'autoprefixer';
 import postcss from 'rollup-plugin-postcss';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -62,6 +62,7 @@
 		"@rollup/plugin-typescript": "12.1.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
+		"autoprefixer": "10.4.21",
 		"cpy-cli": "6.0.0",
 		"eslint": "8.57.1",
 		"nodemon": "3.1.10",

--- a/packages/themes/rollup.config.js
+++ b/packages/themes/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import autoprefixer from 'autoprefixer';
 import postcss from 'rollup-plugin-postcss';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -22,7 +23,7 @@ export default {
 		nodeResolve(),
 		commonjs(),
 		postcss({
-			plugins: [],
+			plugins: [autoprefixer()],
 			inject: false,
 			use: {
 				sass: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -892,6 +895,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -949,6 +955,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -1006,6 +1015,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -1063,6 +1075,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.2)
+      autoprefixer:
+        specifier: 10.4.21
+        version: 10.4.21(postcss@8.5.6)
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
@@ -6400,9 +6415,6 @@ packages:
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
-
-  caniuse-lite@1.0.30001715:
-    resolution: {integrity: sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==}
 
   caniuse-lite@1.0.30001723:
     resolution: {integrity: sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==}
@@ -15445,7 +15457,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.27.5
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -20849,8 +20861,8 @@ snapshots:
 
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
-      browserslist: 4.24.4
-      caniuse-lite: 1.0.30001715
+      browserslist: 4.25.3
+      caniuse-lite: 1.0.30001737
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -21220,7 +21232,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001715
+      caniuse-lite: 1.0.30001737
       electron-to-chromium: 1.5.141
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.24.4)
@@ -21376,11 +21388,9 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.25.3
-      caniuse-lite: 1.0.30001723
+      caniuse-lite: 1.0.30001737
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
-
-  caniuse-lite@1.0.30001715: {}
 
   caniuse-lite@1.0.30001723: {}
 
@@ -21907,7 +21917,7 @@ snapshots:
 
   core-js-compat@3.41.0:
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
 
   core-js-compat@3.45.1:
     dependencies:
@@ -27673,7 +27683,7 @@ snapshots:
 
   postcss-colormin@5.3.1(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.6
@@ -27689,7 +27699,7 @@ snapshots:
 
   postcss-convert-values@5.1.3(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
@@ -27798,7 +27808,7 @@ snapshots:
 
   postcss-merge-rules@5.1.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -27838,7 +27848,7 @@ snapshots:
 
   postcss-minify-params@5.1.4(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       cssnano-utils: 3.1.0(postcss@8.5.6)
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
@@ -27965,7 +27975,7 @@ snapshots:
 
   postcss-normalize-unicode@5.1.1(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
@@ -28010,7 +28020,7 @@ snapshots:
 
   postcss-reduce-initial@5.1.2(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       caniuse-api: 3.0.0
       postcss: 8.5.6
 
@@ -29744,7 +29754,7 @@ snapshots:
 
   stylehacks@5.1.1(postcss@8.5.6):
     dependencies:
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
@@ -31105,7 +31115,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.14.1
       acorn-import-assertions: 1.9.0(acorn@8.14.1)
-      browserslist: 4.25.0
+      browserslist: 4.25.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
       es-module-lexer: 1.7.0


### PR DESCRIPTION
## Summary
Added autoprefixer to theme rollup builds to automatically add vendor CSS prefixes, improving cross-browser compatibility.

## Changes
- Add autoprefixer to theme rollup builds
- Declare autoprefixer dev dependency for theme packages
- Limit lint-staged in themes to lint only sources

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Autoprefixer wurde zu den Theme-Rollup-Builds hinzugefügt, um automatisch Vendor-CSS-Prefixes hinzuzufügen und die browserübergreifende Kompatibilität zu verbessern.

## Änderungen
- Autoprefixer zu Theme-Rollup-Builds hinzugefügt
- Autoprefixer als Dev-Abhängigkeit für Theme-Pakete deklariert
- lint-staged in Themes auf das Linting von nur Quelldateien beschränkt

</details>