### PR TITLE
docs: recommend pnpm filter downstream for faster builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ We have a monorepo structure with multiple packages, each with its own `package.
   - You need to run `pnpm i` at the root level. This updates the lockfile and ensures all packages are using the correct versions.
 - Avoid that branch name may contain hidden characters.
 - If something does not work, check in the event of an error whether all dependent submodules have been built.
+- To build a single package faster, run commands with downstream dependents using `pnpm --filter ...<package>` (e.g., `pnpm --filter ...@public-ui/sample-react build`).
 
 ## Semantic Versioning
 


### PR DESCRIPTION
## Summary
Internal documentation update recommending `pnpm --filter` for downstream-only builds to speed up the development workflow.

## Changes
- Add `pnpm --filter` recommendation for faster downstream-only builds to `AGENTS.md`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Dokumentationsaktualisierung: `pnpm --filter`-Empfehlung für schnellere Downstream-only-Builds zu `AGENTS.md` hinzugefügt.

## Änderungen
- `pnpm --filter`-Empfehlung für schnellere Downstream-only-Builds in `AGENTS.md` hinzugefügt

</details>