### PR TITLE
test: fix indentation in remove-msg-props spec

### DIFF
--- a/packages/tools/kolibri-cli/test/remove-msg-props.spec.ts
+++ b/packages/tools/kolibri-cli/test/remove-msg-props.spec.ts
@@ -15,13 +15,13 @@ describe('RemoveMsgPropsTask', () => {
 		const task = RemoveMsgPropsTask.getInstance('^4');
 		task.run(tmpDir);
 
-const tsxContent = fs.readFileSync(tsxPath, 'utf8');
-const htmlContent = fs.readFileSync(htmlPath, 'utf8');
-assert.ok(!tsxContent.includes('_label'));
-assert.ok(!tsxContent.includes('_variant'));
-assert.match(tsxContent, /_msg=\{\{\s*_type:\s*'error',\s*_description:\s*'Oops'\s*\}\}/);
-assert.ok(!htmlContent.includes('_label'));
-assert.ok(!htmlContent.includes('_variant'));
-assert.match(htmlContent, /_msg='\{"_type":"error","_description":"Oops"\}'/);
-});
+		const tsxContent = fs.readFileSync(tsxPath, 'utf8');
+		const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+		assert.ok(!tsxContent.includes('_label'));
+		assert.ok(!tsxContent.includes('_variant'));
+		assert.match(tsxContent, /_msg=\{\{\s*_type:\s*'error',\s*_description:\s*'Oops'\s*\}\}/);
+		assert.ok(!htmlContent.includes('_label'));
+		assert.ok(!htmlContent.includes('_variant'));
+		assert.match(htmlContent, /_msg='\{"_type":"error","_description":"Oops"\}'/);
+	});
 });


### PR DESCRIPTION
## Summary
Internal test maintenance fixing indentation in the `remove-msg-props` spec file.

## Changes
- Fix indentation of `fs.readFileSync` and assert lines in the `remove-msg-props` test

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Test-Wartung: Einrückung in der `remove-msg-props`-Spezifikationsdatei korrigiert.

## Änderungen
- Einrückung von `fs.readFileSync`- und Assert-Zeilen im `remove-msg-props`-Test korrigiert

</details>