### PR TITLE
feat(components): export NormalizedMsg type

### DIFF
--- a/packages/components/src/functional-components/FormFieldMsg/FormFieldMsg.tsx
+++ b/packages/components/src/functional-components/FormFieldMsg/FormFieldMsg.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { AlertPropType, AlertProps, IdPropType, MsgPropType } from '../../schema';
+import type { AlertPropType, IdPropType, MsgPropType, NormalizedMsg } from '../../schema';
 import type { FunctionalComponent } from '@stencil/core';
 import { h } from '@stencil/core';
 import KolAlertFc from '../Alert';
@@ -10,8 +10,6 @@ type FormFieldMsgProps = JSXBase.HTMLAttributes<HTMLDivElement> & {
 	msg?: MsgPropType;
 	id: IdPropType;
 };
-
-type NormalizedMsg = Omit<AlertProps, '_label' | '_variant'> & { _description: string };
 
 const FormFieldMsgFc: FunctionalComponent<FormFieldMsgProps> = ({ alert, msg, id, class: classNames, ...other }) => {
 	const message: NormalizedMsg | undefined = typeof msg === 'string' ? { _description: msg, _type: 'error' } : msg;

--- a/packages/components/src/schema/props/msg.ts
+++ b/packages/components/src/schema/props/msg.ts
@@ -5,11 +5,8 @@ import { objectObjectHandler, parseJson, watchValidator } from '../utils';
 import { isObject, isString } from '../validators';
 
 /* types */
-export type MsgPropType =
-	| (Omit<AlertProps, '_label' | '_variant'> & {
-			_description: string;
-	  })
-	| string;
+export type NormalizedMsg = Omit<AlertProps, '_label' | '_variant'> & { _description: string };
+export type MsgPropType = NormalizedMsg | string;
 
 /**
  * Defines the properties for a message rendered as Alert component.
@@ -41,7 +38,7 @@ export const validateMsg = (component: Generic.Element.Component, value?: String
 				}
 				// Allow object values with proper structure
 				if (isObject(value) && value !== null) {
-					const objValue = value as AlertProps & { _description: string };
+					const objValue = value as NormalizedMsg;
 					return isString(objValue._description, 1);
 				}
 


### PR DESCRIPTION
## Summary
Internal addition exporting the `NormalizedMsg` type from the components schema for use across packages.

## Changes
- Export `NormalizedMsg` type and update imports accordingly

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Zusatz: `NormalizedMsg`-Typ aus dem Komponenten-Schema exportiert und Imports entsprechend aktualisiert.

## Änderungen
- `NormalizedMsg`-Typ exportiert und Imports aktualisiert

</details>