### PR TITLE
fix: default msg alert props

### DIFF
--- a/packages/components/src/functional-components/FormFieldMsg/FormFieldMsg.tsx
+++ b/packages/components/src/functional-components/FormFieldMsg/FormFieldMsg.tsx
@@ -18,8 +18,8 @@ const FormFieldMsgFc: FunctionalComponent<FormFieldMsgProps> = ({ alert, msg, id
 		<KolAlertFc
 			id={`${id}-msg`}
 			alert={message?._alert ?? alert}
-			hasCloser={message?._hasCloser}
-			level={message?._level}
+			hasCloser={false}
+			level={0}
 			type={message?._type}
 			variant="msg"
 			class={clsx('kol-form-field__msg', classNames)}


### PR DESCRIPTION
## Summary
Internal fix ensuring `FormFieldMsg` always passes default `hasCloser` and `level` props to `KolAlertFc`.

## Changes
- Pass default `hasCloser` and `level` props from `FormFieldMsg` to `KolAlertFc`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix: `FormFieldMsg` übergibt nun immer Standard-`hasCloser`- und `level`-Props an `KolAlertFc`.

## Änderungen
- Standard-`hasCloser`- und `level`-Props von `FormFieldMsg` an `KolAlertFc` weitergegeben

</details>