### PR TITLE
fix(cli): parse msg props with babel

### DIFF
--- a/packages/tools/kolibri-cli/package.json
+++ b/packages/tools/kolibri-cli/package.json
@@ -35,6 +35,8 @@
 	},
 	"type": "commonjs",
 	"dependencies": {
+		"@babel/generator": "7.28.3",
+		"@babel/parser": "7.28.3",
 		"chalk": "5.6.2",
 		"commander": "14.0.0",
 		"deepmerge": "4.3.1",

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/RemoveMsgPropsTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/RemoveMsgPropsTask.ts
@@ -1,4 +1,7 @@
 import fs from 'fs';
+import { parseExpression } from '@babel/parser';
+import generate from '@babel/generator';
+import type { ObjectExpression } from '@babel/types';
 
 import { MARKUP_EXTENSIONS } from '../../../../types';
 import { filterFilesByExt, MODIFIED_FILES } from '../../../shares/reuse';
@@ -23,12 +26,28 @@ export class RemoveMsgPropsTask extends AbstractTask {
 			let newContent = content;
 
 			newContent = newContent.replace(/_msg=\{\{([\s\S]*?)\}\}/g, (_match: string, body: string) => {
-				const updated: string = String(body)
-					.replace(/,?\s*_label:\s*[^,}]+/g, '')
-					.replace(/,?\s*_variant:\s*[^,}]+/g, '')
-					.replace(/,\s*}/g, ' }')
-					.replace(/\{\s*,/g, '{ ');
-				return `_msg={{${updated}}}`;
+				try {
+					const ast = parseExpression(body, { plugins: ['typescript'] });
+					if (ast.type === 'ObjectExpression') {
+						const obj = ast as ObjectExpression;
+						obj.properties = obj.properties.filter((prop) => {
+							if (prop.type === 'ObjectProperty') {
+								const { key } = prop;
+								if (key.type === 'Identifier') {
+									return key.name !== '_label' && key.name !== '_variant';
+								}
+								if (key.type === 'StringLiteral') {
+									return key.value !== '_label' && key.value !== '_variant';
+								}
+							}
+							return true;
+						});
+						return `_msg={{${generate(obj).code}}}`;
+					}
+				} catch {
+					/* ignore parsing errors */
+				}
+				return `_msg={{${body}}}`;
 			});
 
 			newContent = newContent.replace(/_msg=('([^']*)'|"([^"]*)")/g, (match: string, _p0: string, single: string, dbl: string) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1023,6 +1023,12 @@ importers:
 
   packages/tools/kolibri-cli:
     dependencies:
+      '@babel/generator':
+        specifier: 7.28.3
+        version: 7.28.3
+      '@babel/parser':
+        specifier: 7.28.3
+        version: 7.28.3
       chalk:
         specifier: 5.6.2
         version: 5.6.2
@@ -1521,10 +1527,6 @@ packages:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
 
-  '@babel/generator@7.28.0':
-    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.28.3':
     resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
     engines: {node: '>=6.9.0'}
@@ -1635,11 +1637,6 @@ packages:
   '@babel/helpers@7.28.3':
     resolution: {integrity: sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.0':
-    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.28.3':
     resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
@@ -14308,11 +14305,11 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
+      '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.23.9)
       '@babel/helpers': 7.28.2
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.4
@@ -14328,11 +14325,11 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
+      '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.25.2)
       '@babel/helpers': 7.28.2
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.4
@@ -14348,11 +14345,11 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
+      '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.26.9)
       '@babel/helpers': 7.28.2
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.4
@@ -14368,11 +14365,11 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.0
+      '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
       '@babel/helpers': 7.28.2
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.4
@@ -14411,14 +14408,6 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
-
-  '@babel/generator@7.28.0':
-    dependencies:
-      '@babel/parser': 7.28.0
-      '@babel/types': 7.28.4
-      '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
-      jsesc: 3.1.0
 
   '@babel/generator@7.28.3':
     dependencies:
@@ -14611,10 +14600,6 @@ snapshots:
   '@babel/helpers@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.4
-
-  '@babel/parser@7.28.0':
-    dependencies:
       '@babel/types': 7.28.4
 
   '@babel/parser@7.28.3':
@@ -15181,7 +15166,7 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.4
 
   '@babel/traverse@7.28.0':
@@ -15189,7 +15174,7 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.3
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
       debug: 4.4.1(supports-color@8.1.1)
@@ -15929,7 +15914,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/remapping@2.3.5':
@@ -15951,12 +15936,12 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.29':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
@@ -19789,7 +19774,7 @@ snapshots:
 
   constantinople@4.0.1:
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.4
 
   content-disposition@0.5.2: {}
@@ -22549,7 +22534,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -28792,7 +28777,7 @@ snapshots:
 
   with@7.0.2:
     dependencies:
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.4
       assert-never: 1.4.0
       babel-walk: 3.0.0-canary-5


### PR DESCRIPTION
## Summary
Internal fix updating the kolibri-cli to use Babel for parsing `_msg` props, improving reliability of the migration tool.

## Changes
- Replace regex-based parsing with Babel AST parsing for `_msg` props in kolibri-cli

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix: kolibri-cli verwendet nun Babel zum Parsen von `_msg`-Props, was die Zuverlässigkeit des Migrations-Tools verbessert.

## Änderungen
- Regex-basiertes Parsing durch Babel-AST-Parsing für `_msg`-Props in kolibri-cli ersetzt

</details>