### PR TITLE
fix(samples-react): enable date column sorting

### DIFF
--- a/packages/samples/react/src/components/table/sort-data.tsx
+++ b/packages/samples/react/src/components/table/sort-data.tsx
@@ -19,6 +19,7 @@ const HEADERS_HORIZONTAL: KoliBriTableHeaders = {
 			{ label: 'order', key: 'order', textAlign: 'center' },
 			{
 				label: 'date',
+				key: 'date',
 				textAlign: 'center',
 				render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as Data).date),
 				compareFn: (data0, data1) => {
@@ -37,6 +38,7 @@ const HEADERS_VERTICAL: KoliBriTableHeaders = {
 			{ label: 'order', key: 'order', textAlign: 'center' },
 			{
 				label: 'date',
+				key: 'date',
 				textAlign: 'center',
 				render: (_el, _cell, tupel) => DATE_FORMATTER.format((tupel as Data).date),
 				compareFn: (data0, data1) => {


### PR DESCRIPTION
## Summary
Internal fix in the sample application to enable sorting on the date column by providing the missing `key` prop in horizontal and vertical table headers.

## Changes
- Add missing `key` to date column headers in horizontal and vertical table samples

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix in der Beispielanwendung: Fehlender `key` für die Datumsspalte in horizontalen und vertikalen Tabellenheadern hinzugefügt, um die Sortierung zu ermöglichen.

## Änderungen
- Fehlenden `key` für Datumsspalten-Header in horizontalen und vertikalen Tabellenbeispielen hinzugefügt

</details>