### PR TITLE
fix(table-stateful): warn when sortable column lacks key

### DIFF
--- a/docs/BREAKING_CHANGES.v3.md
+++ b/docs/BREAKING_CHANGES.v3.md
@@ -49,6 +49,7 @@ The following components have been removed:
 - The property `_minWidth` becomes required. This is to ensure that the inner width of the table and columns are wide enough to display the content. If the table gets too narrow, then the table becomes
   automatically horizontally scrollbar.
 - The DOM event `kol-selection-change` has been renamed to `kolSelectionChange`.
+- Header cells with `compareFn` must include a `key` property to enable sorting.
 
 ### kol-table-stateless
 

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -242,6 +242,10 @@ export class KolTableStateful implements TableAPI {
 							const applySort = (headers: KoliBriTableHeaderCellWithLogic[]) => {
 								let hasSortedCells = false;
 								headers.forEach((cell) => {
+									if (typeof cell.compareFn === 'function' && !cell.key) {
+										devHint(`[KolTableStateful] A sortable column requires the 'key' property.`);
+										return;
+									}
 									const key = cell.key;
 									if (!key) {
 										return;

--- a/packages/components/src/components/table-stateful/test/validate-headers.spec.ts
+++ b/packages/components/src/components/table-stateful/test/validate-headers.spec.ts
@@ -1,0 +1,30 @@
+import type * as SchemaModule from '../../../schema';
+
+jest.mock('../../../schema', () => {
+	const actual: typeof SchemaModule = jest.requireActual('../../../schema');
+	return { ...actual, devHint: jest.fn() };
+});
+
+import * as Schema from '../../../schema';
+import type { KoliBriTableHeaders } from '../../../schema';
+import { setRuntimeMode } from '../../../schema/utils/dev.utils';
+import { KolTableStateful } from '../shadow';
+
+describe('KolTableStateful.validateHeaders', () => {
+	it('warns when compareFn is set without key', () => {
+		setRuntimeMode('development');
+		const table = new KolTableStateful();
+		const headers: KoliBriTableHeaders = {
+			horizontal: [
+				[
+					{
+						label: 'Foo',
+						compareFn: () => 0,
+					},
+				],
+			],
+		};
+		table.validateHeaders(headers);
+		expect(Schema.devHint).toHaveBeenCalledWith("[KolTableStateful] A sortable column requires the 'key' property.");
+	});
+});


### PR DESCRIPTION
## Summary
Added a warning when a sortable table column has a `compareFn` but no `key`, preventing silent sort failures and improving developer experience.

## Changes
- Warn when a table header uses `compareFn` without a `key`
- Add unit test for missing key on sortable header
- Document that sortable table headers require a `key`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Eine Warnung wird ausgegeben, wenn eine sortierbare Tabellenspalte eine `compareFn` hat, aber keinen `key`, um stille Sortierfehler zu verhindern.

## Änderungen
- Warnung wenn ein Tabellenheader `compareFn` ohne `key` verwendet
- Unit-Test für fehlenden Key bei sortierbarem Header hinzugefügt
- Dokumentiert, dass sortierbare Tabellenheader einen `key` benötigen

</details>