### PR TITLE
Simplify InputDate copy-paste sample handling

### DIFF
--- a/packages/samples/react/src/components/input-date/copy-paste.tsx
+++ b/packages/samples/react/src/components/input-date/copy-paste.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { KolButton, KolInputDate, KolInputText } from '@public-ui/react-v19';
 import { SampleDescription } from '../SampleDescription';
 
-const DEFAULT_GERMAN_DATE = '31.12.2025';
+const DEFAULT_DOT_SEPARATED_DATE = '31.12.2025';
 
 const pad2 = (value: number): string => String(value).padStart(2, '0');
 
-const parseGermanDate = (value: string): string | null => {
+const parseDotSeparatedDate = (value: string): string | null => {
 	const match = value.trim().match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
 	if (!match) {
 		return null;
@@ -37,12 +37,12 @@ const toIsoValue = (value: unknown): string => {
 };
 
 export const InputDateCopyPaste: React.FC = () => {
-	const [germanDate, setGermanDate] = useState<string>(DEFAULT_GERMAN_DATE);
-	const [isoDate, setIsoDate] = useState<string>(() => parseGermanDate(DEFAULT_GERMAN_DATE) ?? '');
+	const [dotSeparatedDate, setDotSeparatedDate] = useState<string>(DEFAULT_DOT_SEPARATED_DATE);
+	const [isoDate, setIsoDate] = useState<string>(() => parseDotSeparatedDate(DEFAULT_DOT_SEPARATED_DATE) ?? '');
 	const [status, setStatus] = useState<string>('');
 	const dateFieldRef = useRef<HTMLKolInputDateElement | null>(null);
 
-	const isGermanDateValid = useMemo(() => parseGermanDate(germanDate) !== null, [germanDate]);
+	const isDotSeparatedDateValid = useMemo(() => parseDotSeparatedDate(dotSeparatedDate) !== null, [dotSeparatedDate]);
 
 	useEffect(() => {
 		const host = dateFieldRef.current;
@@ -53,10 +53,10 @@ export const InputDateCopyPaste: React.FC = () => {
 		const handlePaste: EventListener = (event) => {
 			const clipboardEvent = event as ClipboardEvent;
 			const raw = clipboardEvent.clipboardData?.getData('text') ?? '';
-			const iso = parseGermanDate(raw);
+			const iso = parseDotSeparatedDate(raw);
 
 			if (!iso) {
-				setStatus('Clipboard: unrecognized date. Use DD.MM.YYYY.');
+				setStatus('Clipboard: unrecognised date. Use the dot-separated DD.MM.YYYY format.');
 				return;
 			}
 
@@ -69,20 +69,20 @@ export const InputDateCopyPaste: React.FC = () => {
 		return () => host.removeEventListener('paste', handlePaste);
 	}, []);
 
-	const handleGermanInput = useCallback((_event: Event, value: unknown) => {
+	const handleDotSeparatedInput = useCallback((_event: Event, value: unknown) => {
 		setStatus('');
-		setGermanDate(typeof value === 'string' ? value : String(value ?? ''));
+		setDotSeparatedDate(typeof value === 'string' ? value : String(value ?? ''));
 	}, []);
 
 	const copyToClipboard = useCallback(async () => {
 		setStatus('');
 		try {
-			await navigator.clipboard.writeText(germanDate);
+			await navigator.clipboard.writeText(dotSeparatedDate);
 			setStatus('Copied.');
 		} catch {
 			setStatus('Copy failed. Your browser may block clipboard access.');
 		}
-	}, [germanDate]);
+	}, [dotSeparatedDate]);
 
 	const handleIsoInput = useCallback((_event: Event, value: unknown) => {
 		setStatus('');
@@ -93,35 +93,35 @@ export const InputDateCopyPaste: React.FC = () => {
 		<>
 			<SampleDescription>
 				<p>
-					Type a date in German format (<code>DD.MM.YYYY</code>), click <em>Copy to Clipboard</em>, then paste it into the date field below with <kbd>Ctrl</kbd>
-					+<kbd>V</kbd>. The ISO conversion happens internally.
+					Type a date in the dot-separated day-month-year format (<code>DD.MM.YYYY</code>) that many European locales use, click <em>Copy to Clipboard</em>,
+					then paste it into the date field below with <kbd>Ctrl</kbd>+<kbd>V</kbd>. The ISO conversion happens internally.
 				</p>
 			</SampleDescription>
 
 			<div className="grid gap-8" lang="en">
 				<section aria-labelledby="de-title">
 					<h3 id="de-title" className="text-lg font-semibold mb-2">
-						German date (DD.MM.YYYY)
+						Dot-separated date (DD.MM.YYYY)
 					</h3>
 
 					<div className="grid gap-3">
 						<KolInputText
 							className="w-full"
-							_label="German date (DD.MM.YYYY)"
+							_label="Dot-separated date (DD.MM.YYYY)"
 							_placeholder="e.g., 31.12.2025"
-							_value={germanDate}
+							_value={dotSeparatedDate}
 							_type="text"
 							_on={{
-								onInput: handleGermanInput,
-								onChange: handleGermanInput,
+								onInput: handleDotSeparatedInput,
+								onChange: handleDotSeparatedInput,
 							}}
 						/>
 
-						<small className="opacity-80">Click the button to copy the exact German date, then paste it into the date field below.</small>
+						<small className="opacity-80">Click the button to copy the characters exactly as typed, then paste them into the date field below.</small>
 
 						<div className="flex items-center gap-2">
-							<KolButton _label="Copy to Clipboard" _disabled={!isGermanDateValid} _on={{ onClick: copyToClipboard }} />
-							{!isGermanDateValid && <span className="text-red-600">Invalid date</span>}
+							<KolButton _label="Copy to Clipboard" _on={{ onClick: copyToClipboard }} />
+							{!isDotSeparatedDateValid && <span className="text-red-600">Invalid date (expected DD.MM.YYYY)</span>}
 						</div>
 
 						<KolInputDate

--- a/packages/samples/react/src/components/input-date/copy-paste.tsx
+++ b/packages/samples/react/src/components/input-date/copy-paste.tsx
@@ -2,126 +2,91 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { KolButton, KolInputDate, KolInputText } from '@public-ui/react-v19';
 import { SampleDescription } from '../SampleDescription';
 
-/** -----------------------------
- * Types & helpers
- * ----------------------------- */
-const pad2 = (n: number): string => String(n).padStart(2, '0');
+const DEFAULT_GERMAN_DATE = '31.12.2025';
 
-type Year = `${number}`;
-type Month = `${number}`;
-type Day = `${number}`;
-type IsoDate = `${Year}-${Month}-${Day}`;
+const pad2 = (value: number): string => String(value).padStart(2, '0');
 
-const isValidYmd = (y: number, m: number, d: number): boolean => {
-	const dt = new Date(y, m - 1, d);
-	return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
-};
-
-/** Parse ONLY German format DD.MM.YYYY to ISO (internal use) */
-function parseDeToIso(input: string): IsoDate | null {
-	const m = /^\s*(\d{1,2})\.(\d{1,2})\.(\d{4})\s*$/.exec(input);
-	if (!m) return null;
-	const d = +m[1];
-	const mo = +m[2];
-	const y = +m[3];
-	if (!isValidYmd(y, mo, d)) return null;
-	return `${y}-${pad2(mo)}-${pad2(d)}` as IsoDate;
-}
-
-/** -----------------------------
- * Typed Web Component bridge
- * ----------------------------- */
-type SetIsoValueMethod = (iso: IsoDate | null) => Promise<void>;
-
-type KolInputDateHost = HTMLKolInputDateElement & {
-	setIsoValue?: SetIsoValueMethod;
-	value?: string;
-	_value?: IsoDate | Date | null;
-};
-
-function isKolHost(n: EventTarget): n is KolInputDateHost {
-	return n instanceof HTMLElement && n.tagName === 'KOL-INPUT-DATE';
-}
-
-async function setKolInputDateValue(host: KolInputDateHost, iso: IsoDate): Promise<void> {
-	if (typeof host.setIsoValue === 'function') {
-		await host.setIsoValue(iso);
-	} else if (typeof host.value !== 'undefined') {
-		host.value = iso;
-	} else if (typeof host._value !== 'undefined') {
-		host._value = iso;
-	} else {
-		host.setAttribute('_value', iso);
+const parseGermanDate = (value: string): string | null => {
+	const match = value.trim().match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+	if (!match) {
+		return null;
 	}
 
-	host.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
-	host.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
-}
+	const day = Number(match[1]);
+	const month = Number(match[2]);
+	const year = Number(match[3]);
+	const candidate = new Date(year, month - 1, day);
 
-/** -----------------------------
- * React component
- * ----------------------------- */
+	if (candidate.getFullYear() !== year || candidate.getMonth() !== month - 1 || candidate.getDate() !== day) {
+		return null;
+	}
+
+	return `${year}-${pad2(month)}-${pad2(day)}`;
+};
+
+const formatDate = (value: Date): string => `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
+
+const toIsoValue = (value: unknown): string => {
+	if (typeof value === 'string') {
+		return value;
+	}
+	if (value instanceof Date) {
+		return formatDate(value);
+	}
+	return String(value ?? '');
+};
+
 export const InputDateCopyPaste: React.FC = () => {
-	const [deValue, setDeValue] = useState<string>('31.12.2025');
+	const [germanDate, setGermanDate] = useState<string>(DEFAULT_GERMAN_DATE);
+	const [isoDate, setIsoDate] = useState<string>(() => parseGermanDate(DEFAULT_GERMAN_DATE) ?? '');
 	const [status, setStatus] = useState<string>('');
-	const activeKolHostRef = useRef<KolInputDateHost | null>(null);
+	const dateFieldRef = useRef<HTMLKolInputDateElement | null>(null);
 
-	const isoFromDe = useMemo(() => parseDeToIso(deValue), [deValue]);
+	const isGermanDateValid = useMemo(() => parseGermanDate(germanDate) !== null, [germanDate]);
 
-	// Track focus target inside shadow DOM
 	useEffect(() => {
-		const ac = new AbortController();
-		const onFocusIn = (e: Event): void => {
-			const path = (e.composedPath?.() ?? []) as EventTarget[];
-			activeKolHostRef.current = path.find(isKolHost) ?? null;
-		};
-		document.addEventListener('focusin', onFocusIn, { capture: true, signal: ac.signal });
-		return () => ac.abort();
-	}, []);
+		const host = dateFieldRef.current;
+		if (!(host instanceof HTMLElement)) {
+			return;
+		}
 
-	// Global paste handler: read German date from clipboard, convert to ISO internally, inject into KolInputDate
-	useEffect(() => {
-		const ac = new AbortController();
-
-		const onPaste = (e: ClipboardEvent): void => {
-			const host = activeKolHostRef.current;
-			if (!host) return;
-
-			const raw = e.clipboardData?.getData('text') ?? '';
-			const iso = parseDeToIso(raw);
+		const handlePaste: EventListener = (event) => {
+			const clipboardEvent = event as ClipboardEvent;
+			const raw = clipboardEvent.clipboardData?.getData('text') ?? '';
+			const iso = parseGermanDate(raw);
 
 			if (!iso) {
 				setStatus('Clipboard: unrecognized date. Use DD.MM.YYYY.');
 				return;
 			}
 
-			e.preventDefault();
-			void setKolInputDateValue(host, iso);
+			clipboardEvent.preventDefault();
+			setIsoDate(iso);
 			setStatus('Pasted.');
 		};
 
-		document.addEventListener('paste', onPaste, { capture: true, signal: ac.signal });
-		return () => ac.abort();
+		host.addEventListener('paste', handlePaste);
+		return () => host.removeEventListener('paste', handlePaste);
 	}, []);
 
-	const copyToClipboard = useCallback(async (text: string): Promise<void> => {
+	const handleGermanInput = useCallback((_event: Event, value: unknown) => {
+		setStatus('');
+		setGermanDate(typeof value === 'string' ? value : String(value ?? ''));
+	}, []);
+
+	const copyToClipboard = useCallback(async () => {
 		setStatus('');
 		try {
-			await navigator.clipboard.writeText(text);
+			await navigator.clipboard.writeText(germanDate);
 			setStatus('Copied.');
 		} catch {
 			setStatus('Copy failed. Your browser may block clipboard access.');
 		}
-	}, []);
+	}, [germanDate]);
 
-	/** -----------------------------
-	 * KolInputText handlers (match signature: (event, value: unknown) => void)
-	 * ----------------------------- */
-	const handleDeInput = useCallback((event: Event, value: unknown) => {
-		if (event?.target) {
-			const next = typeof value === 'string' ? value : String(value ?? '');
-			setDeValue(next);
-		}
+	const handleIsoInput = useCallback((_event: Event, value: unknown) => {
+		setStatus('');
+		setIsoDate(toIsoValue(value));
 	}, []);
 
 	return (
@@ -144,22 +109,32 @@ export const InputDateCopyPaste: React.FC = () => {
 							className="w-full"
 							_label="German date (DD.MM.YYYY)"
 							_placeholder="e.g., 31.12.2025"
-							_value={deValue}
+							_value={germanDate}
 							_type="text"
 							_on={{
-								onInput: handleDeInput,
-								onChange: handleDeInput,
+								onInput: handleGermanInput,
+								onChange: handleGermanInput,
 							}}
 						/>
 
 						<small className="opacity-80">Click the button to copy the exact German date, then paste it into the date field below.</small>
 
 						<div className="flex items-center gap-2">
-							<KolButton _label="Copy to Clipboard" _disabled={!isoFromDe} _on={{ onClick: () => copyToClipboard(deValue) }} />
-							{!isoFromDe && <span className="text-red-600">Invalid date</span>}
+							<KolButton _label="Copy to Clipboard" _disabled={!isGermanDateValid} _on={{ onClick: copyToClipboard }} />
+							{!isGermanDateValid && <span className="text-red-600">Invalid date</span>}
 						</div>
 
-						<KolInputDate _type="date" _label="Date (paste here with Ctrl+V)" className="w-full" />
+						<KolInputDate
+							ref={dateFieldRef}
+							_type="date"
+							_label="Date (paste here with Ctrl+V)"
+							className="w-full"
+							_value={isoDate}
+							_on={{
+								onInput: handleIsoInput,
+								onChange: handleIsoInput,
+							}}
+						/>
 					</div>
 				</section>
 


### PR DESCRIPTION
## Summary
- refactor the InputDate copy-paste sample to use straightforward React state instead of global shadow DOM listeners
- add direct paste handling on the KolInputDate host and centralise conversion helpers for German date parsing
- update UI wiring to surface validation feedback and keep the KolInputDate value in sync

## Testing
- pnpm --filter @public-ui/sample-react lint:tsc *(fails: existing missing module/type errors in unrelated samples)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bf2ef8e4832bbf569dd4641998a5