### PR TITLE
fix: keep camel case when mapping component props

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -35,7 +35,7 @@ type FunctionalComponentEmitters<Emitters> = {
 };
 
 type ComponentProps<Props> = {
-	[K in keyof Props as `_${Lowercase<string & K>}`]: Props[K];
+	[K in keyof Props as `_${Uncapitalize<string & K>}`]: Props[K];
 };
 
 type ComponentRefs<Refs> = {


### PR DESCRIPTION
## Summary
Internal fix to preserve camel case naming when mapping component properties in the architecture proposal.

## Changes
- Preserve camel case when mapping component props

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix zur Beibehaltung von camelCase-Benennung beim Mapping von Komponenten-Properties.

## Änderungen
- camelCase beim Mapping von Komponenten-Properties beibehalten

</details>