### PR TITLE
fix(components): promisify web component methods

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -46,6 +46,8 @@ type ComponentListeners<Listeners> = {
 	[K in keyof Listeners as `on${Capitalize<string & K>}`]: (event: Listeners[K]) => void;
 };
 
+// Ensure the Web Component contract always exposes asynchronous method signatures
+// without forcing controllers to refactor their synchronous implementations.
 type PromisifyMethod<Method> = Method extends (...args: infer Args) => infer Result
 	? (...args: Args) => Result extends Promise<unknown> ? Result : Promise<Result>
 	: Method;

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -46,8 +46,12 @@ type ComponentListeners<Listeners> = {
 	[K in keyof Listeners as `on${Capitalize<string & K>}`]: (event: Listeners[K]) => void;
 };
 
+type PromisifyMethod<Method> = Method extends (...args: infer Args) => infer Result
+	? (...args: Args) => Result extends Promise<unknown> ? Result : Promise<Result>
+	: Method;
+
 type ComponentMethods<Methods> = {
-	[K in keyof Methods]: Methods[K];
+	[K in keyof Methods]: PromisifyMethod<Methods[K]>;
 };
 
 type ComponentWatchers<Props> = {


### PR DESCRIPTION
## Summary
Internal fix to wrap web component methods in promises for the component architecture proposal.

## Changes
- Promisify web component methods for consistent async handling

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Fix zur Umwandlung von Web-Component-Methoden in Promises im Rahmen der Komponentenarchitektur-Proposal.

## Änderungen
- Web-Component-Methoden in Promises umgewandelt für konsistente asynchrone Behandlung

</details>