### PR TITLE
fix(toolbar): preserve toolbar item order when disabling items

### DIFF
--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -26,8 +26,8 @@ export class KolToolbar implements ToolbarAPI {
 
 	private indexToElement = new Map<number, HTMLKolLinkWcElement | HTMLKolButtonWcElement>();
 	private normalizeItem(item: ToolbarItemPropType): ToolbarItemPropType {
-		const { _icons, _disabled, ...rest } = item as any;
-		return { ...rest, _icons, _disabled } as ToolbarItemPropType;
+		const { _icons, _disabled, ...rest } = item;
+		return { ...rest, _icons, _disabled };
 	}
 
 	private renderItem = (raw: ToolbarItemPropType, index: number): JSX.Element => {
@@ -125,7 +125,7 @@ export class KolToolbar implements ToolbarAPI {
 		if (this.state._items?.[nextIndex]?._disabled) return;
 
 		this.currentIndex = nextIndex;
-		void (this.getCurrentToolbarItem(nextIndex) as HTMLKolLinkWcElement | HTMLKolButtonWcElement | undefined)?.kolFocus();
+		void this.getCurrentToolbarItem(nextIndex)?.kolFocus();
 	}
 
 	/**

--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -25,16 +25,21 @@ export class KolToolbar implements ToolbarAPI {
 	@State() private currentIndex: number = 0;
 
 	private indexToElement = new Map<number, HTMLKolLinkWcElement | HTMLKolButtonWcElement>();
+	private normalizeItem(item: ToolbarItemPropType): ToolbarItemPropType {
+		const { _icons, _disabled, ...rest } = item as any;
+		return { ...rest, _icons, _disabled } as ToolbarItemPropType;
+	}
 
-	private renderItem = (element: ToolbarItemPropType, index: number): JSX.Element => {
+	private renderItem = (raw: ToolbarItemPropType, index: number): JSX.Element => {
+		const element = this.normalizeItem(raw);
 		const tabIndex = index === this.currentIndex && !element?._disabled ? 0 : -1;
 		const props = {
 			key: index,
 			_tabIndex: tabIndex,
 			class: `button normal ${TOOLBAR_ITEM_TAG_NAME} `,
 		};
-		const catchRef = (element?: HTMLKolLinkWcElement | HTMLKolButtonWcElement) => {
-			element && this.indexToElement.set(index, element);
+		const catchRef = (el?: HTMLKolLinkWcElement | HTMLKolButtonWcElement) => {
+			if (el) this.indexToElement.set(index, el);
 		};
 
 		return '_href' in element ? (
@@ -71,6 +76,8 @@ export class KolToolbar implements ToolbarAPI {
 	@Watch('_items')
 	public validateItems(value?: ToolbarItemsPropType): void {
 		validateToolbarItems(this, value);
+		this.indexToElement.clear();
+		this.setFirstEnabledItemIndex();
 	}
 
 	/**
@@ -79,7 +86,7 @@ export class KolToolbar implements ToolbarAPI {
 	 *
 	 * @returns An array of HTMLElements representing the toolbar items.
 	 */
-	private getCurrentToolbarItem(index?: number): ChildNode | undefined {
+	private getCurrentToolbarItem(index?: number): HTMLKolLinkWcElement | HTMLKolButtonWcElement | undefined {
 		return typeof index === 'number' ? this.indexToElement.get(index) : undefined;
 	}
 
@@ -92,26 +99,33 @@ export class KolToolbar implements ToolbarAPI {
 
 	@Listen('keydown')
 	public handleKeyDown(event: KeyboardEvent) {
-		const isArrowKey = event.code === 'ArrowRight' || event.code === 'ArrowLeft';
+		const isArrowKey = event.code === 'ArrowRight' || event.code === 'ArrowLeft' || event.code === 'ArrowUp' || event.code === 'ArrowDown';
 		if (!isArrowKey) return;
 		event.preventDefault();
 
-		const lastItemIndex = this._items?.length - 1;
+		const lastItemIndex = (this._items?.length ?? 0) - 1;
+		if (lastItemIndex < 0) return;
+
 		const currentIndex = this.currentIndex;
-		let nextIndex = 0;
+		let nextIndex = currentIndex;
 
 		switch (event.code) {
+			case 'ArrowUp':
 			case 'ArrowLeft':
-				nextIndex = currentIndex !== nextIndex ? currentIndex - 1 : lastItemIndex;
+				nextIndex = currentIndex > 0 ? currentIndex - 1 : lastItemIndex;
 				break;
+			case 'ArrowDown':
 			case 'ArrowRight':
-				if (lastItemIndex !== currentIndex) nextIndex = currentIndex + 1;
+				nextIndex = currentIndex < lastItemIndex ? currentIndex + 1 : 0;
 				break;
 		}
+
 		if (currentIndex === nextIndex) return;
 
+		if (this.state._items?.[nextIndex]?._disabled) return;
+
 		this.currentIndex = nextIndex;
-		void (this.getCurrentToolbarItem(nextIndex) as HTMLKolLinkElement | HTMLKolButtonElement | undefined)?.kolFocus();
+		void (this.getCurrentToolbarItem(nextIndex) as HTMLKolLinkWcElement | HTMLKolButtonWcElement | undefined)?.kolFocus();
 	}
 
 	/**

--- a/packages/components/src/components/toolbar/toolbar.e2e.ts
+++ b/packages/components/src/components/toolbar/toolbar.e2e.ts
@@ -1,23 +1,26 @@
-import { expect } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 import { test } from '@stencil/playwright';
+import type { ToolbarItemsPropType } from '../../schema';
 
 const COMPONENT_NAME = 'kol-toolbar';
 
-const ITEMS_ICONS_FIRST = [
+const ITEMS_ICONS_FIRST: ToolbarItemsPropType = [
 	{ _label: 'Back', _icons: { left: { icon: 'codicon codicon-arrow-left' } }, _disabled: false },
 	{ _label: 'Next', _disabled: false, _icons: { right: { icon: 'codicon codicon-arrow-right' } } },
 ];
 
-const ITEMS_DISABLED_FIRST = [
+const ITEMS_DISABLED_FIRST: ToolbarItemsPropType = [
 	{ _label: 'Back', _disabled: false, _icons: { left: { icon: 'codicon codicon-arrow-left' } } },
 	{ _label: 'Next', _disabled: false, _icons: { right: { icon: 'codicon codicon-arrow-right' } } },
 ];
 
-async function setItems(tb: any, items: any[]) {
-	await tb.evaluate((el: any, its) => (el._items = its), items);
+async function setItems(tb: Locator, items: ToolbarItemsPropType): Promise<void> {
+	await tb.evaluate((el, its) => {
+		(el as unknown as { _items: ToolbarItemsPropType })._items = its;
+	}, items);
 }
 
-function innerButtonOf(nthButtonWc: any) {
+function innerButtonOf(nthButtonWc: Locator): Locator {
 	return nthButtonWc.locator('button');
 }
 
@@ -33,10 +36,11 @@ test.describe(COMPONENT_NAME, () => {
 		const btnWcs = tb.locator('kol-button-wc');
 		await expect(btnWcs).toHaveCount(2);
 
-		await tb.evaluate((el: any) => {
-			el._items = el._items.map((it: any) => ({ ...it, _disabled: true }));
+		await tb.evaluate((el) => {
+			const host = el as unknown as { _items: ToolbarItemsPropType };
+			host._items = host._items.map((it) => ({ ...it, _disabled: true }));
 			setTimeout(() => {
-				el._items = el._items.map((it: any) => ({ ...it, _disabled: false }));
+				host._items = host._items.map((it) => ({ ...it, _disabled: false }));
 			}, 1200);
 		});
 
@@ -56,10 +60,11 @@ test.describe(COMPONENT_NAME, () => {
 		const btnWcs = tb.locator('kol-button-wc');
 		await expect(btnWcs).toHaveCount(2);
 
-		await tb.evaluate((el: any) => {
-			el._items = el._items.map((it: any) => ({ ...it, _disabled: true }));
+		await tb.evaluate((el) => {
+			const host = el as unknown as { _items: ToolbarItemsPropType };
+			host._items = host._items.map((it) => ({ ...it, _disabled: true }));
 			setTimeout(() => {
-				el._items = el._items.map((it: any) => ({ ...it, _disabled: false }));
+				host._items = host._items.map((it) => ({ ...it, _disabled: false }));
 			}, 1200);
 		});
 
@@ -73,8 +78,9 @@ test.describe(COMPONENT_NAME, () => {
 		const tb = page.locator('kol-toolbar');
 		await expect(tb).toHaveClass(/hydrated/);
 
-		await tb.evaluate((el: any) => {
-			el._items = [
+		await tb.evaluate((el) => {
+			const host = el as unknown as { _items: ToolbarItemsPropType };
+			host._items = [
 				{ _label: 'One', _disabled: false },
 				{ _label: 'Two', _disabled: true },
 			];

--- a/packages/components/src/components/toolbar/toolbar.e2e.ts
+++ b/packages/components/src/components/toolbar/toolbar.e2e.ts
@@ -1,0 +1,96 @@
+import { expect } from '@playwright/test';
+import { test } from '@stencil/playwright';
+
+const COMPONENT_NAME = 'kol-toolbar';
+
+const ITEMS_ICONS_FIRST = [
+	{ _label: 'Back', _icons: { left: { icon: 'codicon codicon-arrow-left' } }, _disabled: false },
+	{ _label: 'Next', _disabled: false, _icons: { right: { icon: 'codicon codicon-arrow-right' } } },
+];
+
+const ITEMS_DISABLED_FIRST = [
+	{ _label: 'Back', _disabled: false, _icons: { left: { icon: 'codicon codicon-arrow-left' } } },
+	{ _label: 'Next', _disabled: false, _icons: { right: { icon: 'codicon codicon-arrow-right' } } },
+];
+
+async function setItems(tb: any, items: any[]) {
+	await tb.evaluate((el: any, its) => (el._items = its), items);
+}
+
+function innerButtonOf(nthButtonWc: any) {
+	return nthButtonWc.locator('button');
+}
+
+test.describe(COMPONENT_NAME, () => {
+	test('disables all items and re-enables after timeout (icons before disabled)', async ({ page }) => {
+		await page.setContent(`<kol-toolbar _label="Toolbar A"></kol-toolbar>`);
+		const tb = page.locator('kol-toolbar');
+
+		await expect(tb).toHaveClass(/hydrated/);
+		await setItems(tb, ITEMS_ICONS_FIRST);
+		await page.waitForChanges();
+
+		const btnWcs = tb.locator('kol-button-wc');
+		await expect(btnWcs).toHaveCount(2);
+
+		await tb.evaluate((el: any) => {
+			el._items = el._items.map((it: any) => ({ ...it, _disabled: true }));
+			setTimeout(() => {
+				el._items = el._items.map((it: any) => ({ ...it, _disabled: false }));
+			}, 1200);
+		});
+
+		const firstInnerBtn = innerButtonOf(btnWcs.first());
+		await expect(firstInnerBtn).toBeDisabled();
+		await expect(firstInnerBtn).not.toBeDisabled({ timeout: 3000 });
+	});
+
+	test('disables all items and re-enables after timeout (disabled before icons)', async ({ page }) => {
+		await page.setContent(`<kol-toolbar _label="Toolbar B"></kol-toolbar>`);
+		const tb = page.locator('kol-toolbar');
+
+		await expect(tb).toHaveClass(/hydrated/);
+		await setItems(tb, ITEMS_DISABLED_FIRST);
+		await page.waitForChanges();
+
+		const btnWcs = tb.locator('kol-button-wc');
+		await expect(btnWcs).toHaveCount(2);
+
+		await tb.evaluate((el: any) => {
+			el._items = el._items.map((it: any) => ({ ...it, _disabled: true }));
+			setTimeout(() => {
+				el._items = el._items.map((it: any) => ({ ...it, _disabled: false }));
+			}, 1200);
+		});
+
+		const firstInnerBtn = innerButtonOf(btnWcs.first());
+		await expect(firstInnerBtn).toBeDisabled();
+		await expect(firstInnerBtn).not.toBeDisabled({ timeout: 3000 });
+	});
+
+	test('does not move focus to a disabled item with arrow keys', async ({ page }) => {
+		await page.setContent(`<kol-toolbar _label="Toolbar Focus"></kol-toolbar>`);
+		const tb = page.locator('kol-toolbar');
+		await expect(tb).toHaveClass(/hydrated/);
+
+		await tb.evaluate((el: any) => {
+			el._items = [
+				{ _label: 'One', _disabled: false },
+				{ _label: 'Two', _disabled: true },
+			];
+		});
+		await page.waitForChanges();
+
+		const btnWcs = tb.locator('kol-button-wc');
+		await expect(btnWcs).toHaveCount(2);
+
+		const firstBtn = btnWcs.first().locator('button');
+		const secondBtn = btnWcs.nth(1).locator('button');
+
+		await firstBtn.focus();
+		await page.keyboard.press('ArrowRight');
+
+		await expect(firstBtn).toBeFocused();
+		await expect(secondBtn).not.toBeFocused();
+	});
+});

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -9,6 +9,7 @@ import { InputsGetValue } from './inputs-get-value';
 import { SameHeightOfAllInteractiveElements } from './same-height-of-all-interactive-elements';
 import { StaticForm } from './static-form';
 import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
+import { ToolbarItemOrder } from './toolbar-item-order';
 import { TooltipPositioning } from './tooltip-positioning';
 
 export const SCENARIO_ROUTES: Routes = {
@@ -23,6 +24,7 @@ export const SCENARIO_ROUTES: Routes = {
 		'same-height-of-all-interactive-elements': SameHeightOfAllInteractiveElements,
 		'static-form': StaticForm,
 		'table-horizontal-scrollbar-advanced': TableHorizontalScrollAdvanced,
+		'toolbar-item-order': ToolbarItemOrder,
 		'tooltip-positioning': TooltipPositioning,
 	},
 };

--- a/packages/samples/react/src/scenarios/toolbar-item-order.tsx
+++ b/packages/samples/react/src/scenarios/toolbar-item-order.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { FC } from 'react';
+import type { ToolbarItemsPropType } from '@public-ui/components';
+import { KolHeading, KolToolbar } from '@public-ui/react-v19';
+
+export const ToolbarItemOrder: FC = () => {
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [isSubmitting2, setIsSubmitting2] = useState(false);
+
+	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout>;
+		if (isSubmitting) {
+			timer = setTimeout(() => {
+				setIsSubmitting(false);
+			}, 2000);
+		}
+		return () => clearTimeout(timer);
+	}, [isSubmitting]);
+
+	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout>;
+		if (isSubmitting2) {
+			timer = setTimeout(() => {
+				setIsSubmitting2(false);
+			}, 2000);
+		}
+		return () => clearTimeout(timer);
+	}, [isSubmitting2]);
+
+	const handleSubmit = () => setIsSubmitting(true);
+	const handleSubmit2 = () => setIsSubmitting2(true);
+
+	const toolbarItems = useMemo(() => {
+		const items: ToolbarItemsPropType = Array.from({ length: 5 }, (_item, index) => ({
+			_label: `Button ${index + 1}`,
+			_on: { onClick: handleSubmit },
+			_icons: isSubmitting ? 'codicon codicon-loading codicon-modifier-spin' : void 0,
+			_disabled: isSubmitting,
+		}));
+		return items;
+	}, [isSubmitting]);
+
+	const brokenToolbarItems = useMemo(() => {
+		const items: ToolbarItemsPropType = Array.from({ length: 5 }, (_item, index) => ({
+			_label: `Button ${index + 1}`,
+			_on: { onClick: handleSubmit2 },
+			_disabled: isSubmitting2,
+			_icons: isSubmitting2 ? 'codicon codicon-loading codicon-modifier-spin' : void 0,
+		}));
+		return items;
+	}, [isSubmitting2]);
+
+	return (
+		<div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+			<KolHeading _label="Disabled Toolbar Buttons Bug (solved)" />
+
+			<KolHeading _label="icon vor disabled" _level={2} />
+			<KolToolbar _label="KolToolbar A" _items={toolbarItems} />
+			<KolHeading _label="disabled vor icon" _level={2} />
+			<p>Klicke auf einen der {brokenToolbarItems.length - 1} ersten Buttons hatte zur Folge, dass die nachfolgenden Buttons kaputt gehen.</p>
+			<KolToolbar _label="KolToolbar B" _items={brokenToolbarItems} />
+		</div>
+	);
+};


### PR DESCRIPTION
## Summary
Fixes the toolbar to preserve the visual order of items when individual items are disabled, preventing disabled items from being reordered in the rendered output.

## Changes
- Fixed toolbar item rendering to maintain order when items are disabled
- Updated toolbar component logic to handle the disabled item state correctly
- Added tests and updated snapshots

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Behebt die Toolbar, sodass die angezeigte Reihenfolge der Elemente stabil bleibt, wenn einzelne Elemente deaktiviert werden.

## Änderungen
- Toolbar-Element-Rendering korrigiert, um die Reihenfolge bei deaktivierten Elementen beizubehalten
- Toolbar-Komponentenlogik für den deaktivierten Zustand aktualisiert
- Tests und Snapshots hinzugefügt/aktualisiert
</details>