### PR TITLE
fix(components): align skeleton controllers with web component types

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/api.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/api.tsx
@@ -3,10 +3,6 @@ import type { ComponentApi } from '../generic-types';
 
 export interface ClickButtonApi extends ComponentApi {
 	Props: LabelProp;
-	States: Record<never, never>;
-	Emitters: Record<never, never>;
-	Methods: Record<never, never>;
-	Listeners: Record<never, never>;
 	Callbacks: {
 		click: () => void;
 	};

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -1,13 +1,16 @@
 import type { LabelPropType } from '../../schema/props/label';
 import { normalizeLabel, validateLabel } from '../../schema/props/label';
 import { BaseController } from '../base-controller';
-import type { ControllerInterface } from '../generic-types';
+import type { ControllerInterface, WebComponentInterface } from '../generic-types';
 import type { ClickButtonApi } from './api';
 
-export class ClickButtonController extends BaseController<ClickButtonApi['Props'], ClickButtonApi['States']> implements ControllerInterface<ClickButtonApi> {
+export class ClickButtonController
+	extends BaseController<ClickButtonApi['Props'], WebComponentInterface<ClickButtonApi>>
+	implements ControllerInterface<ClickButtonApi>
+{
 	private buttonRef?: HTMLButtonElement;
 
-	public constructor(states: ClickButtonApi['States']) {
+	public constructor(states: WebComponentInterface<ClickButtonApi>) {
 		super(states, {
 			label: '',
 		});

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -4,12 +4,12 @@ import type { NamePropType } from '../../schema/props/name';
 import { normalizeName, validateName } from '../../schema/props/name';
 import { BaseController } from '../base-controller';
 import type { ClickButtonController } from '../click-button/controller';
-import type { ControllerInterface } from '../generic-types';
+import type { ControllerInterface, WebComponentInterface } from '../generic-types';
 import type { SkeletonApi } from './api';
 
-export class SkeletonController extends BaseController<SkeletonApi['Props'], SkeletonApi['States']> implements ControllerInterface<SkeletonApi> {
+export class SkeletonController extends BaseController<SkeletonApi['Props'], WebComponentInterface<SkeletonApi>> implements ControllerInterface<SkeletonApi> {
 	public constructor(
-		states: SkeletonApi['States'],
+		states: WebComponentInterface<SkeletonApi>,
 		private readonly clickButtonController: ClickButtonController,
 	) {
 		super(states, {


### PR DESCRIPTION
## Summary
Internal architecture proposal sub-PR aligning skeleton and click-button controllers with the concrete `WebComponentInterface` type. Merged into the component architecture proposal branch.

## Changes
- Aligned skeleton and click-button controllers with `WebComponentInterface` when extending `BaseController`
- Removed unnecessary placeholder state definitions from click-button API definition

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Architektur-Proposal-PR: Skeleton- und Click-Button-Controller auf den konkreten `WebComponentInterface`-Typ ausgerichtet.

## Änderungen
- Skeleton- und Click-Button-Controller beim Erweitern von `BaseController` auf `WebComponentInterface` ausgerichtet
- Unnötige Platzhalter-Zustandsdefinitionen aus Click-Button-API-Definition entfernt
</details>