### PR TITLE
feat: add BEM helpers to skeleton blueprint

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/bem.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/bem.ts
@@ -1,0 +1,29 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-click-button': {
+		elements: {
+			label: {
+				modifiers: null;
+			};
+		};
+		modifiers: null;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-click-button': {
+		elements: {
+			label: { modifiers: null },
+		},
+		modifiers: null,
+	},
+};
+
+const BEM_CLASS_CLICK_BUTTON = bem('kol-click-button');
+const BEM_CLASS_CLICK_BUTTON__LABEL = bem('kol-click-button', 'label');
+
+export { bem as genBemClickButton, BEM as BEM_CLICK_BUTTON };
+export { BEM_CLASS_CLICK_BUTTON, BEM_CLASS_CLICK_BUTTON__LABEL };

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
@@ -1,10 +1,12 @@
 import type { FunctionalComponent as FC } from '@stencil/core';
 import { h } from '@stencil/core';
+
 import type { FunctionalComponentProps } from '../generic-types';
+import { BEM_CLASS_CLICK_BUTTON, BEM_CLASS_CLICK_BUTTON__LABEL } from './bem';
 import type { ClickButtonApi } from './api';
 
 export const ClickButtonFC: FC<FunctionalComponentProps<ClickButtonApi>> = ({ label, handleClick, refButton }) => (
-	<button ref={refButton} onClick={handleClick}>
-		{label}
+	<button class={BEM_CLASS_CLICK_BUTTON} ref={refButton} onClick={handleClick}>
+		<span class={BEM_CLASS_CLICK_BUTTON__LABEL}>{label}</span>
 	</button>
 );

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/bem.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/bem.ts
@@ -1,0 +1,44 @@
+import { generateBemClassNames } from 'typed-bem';
+
+type SCHEMA = {
+	'kol-skeleton': {
+		elements: {
+			container: {
+				modifiers: null;
+			};
+			name: {
+				modifiers: null;
+			};
+			counter: {
+				modifiers: null;
+			};
+			actions: {
+				modifiers: null;
+			};
+		};
+		modifiers: Set<'has-name' | 'is-hidden'>;
+	};
+};
+
+const bem = generateBemClassNames<SCHEMA>();
+
+const BEM: SCHEMA = {
+	'kol-skeleton': {
+		elements: {
+			actions: { modifiers: null },
+			container: { modifiers: null },
+			counter: { modifiers: null },
+			name: { modifiers: null },
+		},
+		modifiers: new Set(['has-name', 'is-hidden']),
+	},
+};
+
+const BEM_CLASS_SKELETON = bem('kol-skeleton');
+const BEM_CLASS_SKELETON__ACTIONS = bem('kol-skeleton', 'actions');
+const BEM_CLASS_SKELETON__CONTAINER = bem('kol-skeleton', 'container');
+const BEM_CLASS_SKELETON__COUNTER = bem('kol-skeleton', 'counter');
+const BEM_CLASS_SKELETON__NAME = bem('kol-skeleton', 'name');
+
+export { bem as genBemSkeleton, BEM as BEM_SKELETON };
+export { BEM_CLASS_SKELETON, BEM_CLASS_SKELETON__ACTIONS, BEM_CLASS_SKELETON__CONTAINER, BEM_CLASS_SKELETON__COUNTER, BEM_CLASS_SKELETON__NAME };

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
@@ -1,18 +1,36 @@
 import type { FunctionalComponent as FC } from '@stencil/core';
 import { h } from '@stencil/core';
+
 import { ClickButtonFC } from '../click-button/component';
 import type { FunctionalComponentProps } from '../generic-types';
+import {
+	BEM_CLASS_SKELETON__ACTIONS,
+	BEM_CLASS_SKELETON__CONTAINER,
+	BEM_CLASS_SKELETON__COUNTER,
+	BEM_CLASS_SKELETON__NAME,
+	genBemSkeleton as bem,
+} from './bem';
 import type { SkeletonApi } from './api';
 
 export const SkeletonFC: FC<FunctionalComponentProps<SkeletonApi>> = ({ count, label, name, show, onLoaded, handleClick, refButton }) => {
 	setTimeout(() => {
 		onLoaded.emit(100);
 	}, 1000);
+
+	const hasName = !!(show && name?.trim());
+	const BEM_CLASS_ROOT = bem('kol-skeleton', {
+		'has-name': hasName,
+		'is-hidden': !show,
+	});
 	return (
-		<div>
-			{show && <span>{name}</span>}
-			<div>Count: {count}</div>
-			<ClickButtonFC label={label} handleClick={handleClick} refButton={refButton} />
+		<div class={BEM_CLASS_ROOT}>
+			<div class={BEM_CLASS_SKELETON__CONTAINER}>
+				{hasName && <span class={BEM_CLASS_SKELETON__NAME}>{name}</span>}
+				<div class={BEM_CLASS_SKELETON__COUNTER}>Count: {count}</div>
+			</div>
+			<div class={BEM_CLASS_SKELETON__ACTIONS}>
+				<ClickButtonFC label={label} handleClick={handleClick} refButton={refButton} />
+			</div>
 		</div>
 	);
 };

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.spec.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.spec.ts
@@ -7,8 +7,10 @@ import { SkeletonController } from './controller';
 describe('SkeletonController', () => {
 	it('delegates focusButton to injected ClickButtonController', () => {
 		const component = { show: true } as WebComponentInterface<SkeletonApi>;
+		const watchLabel = jest.fn();
 		const clickButtonController = {
 			focusButton: jest.fn(),
+			watchLabel,
 			setButtonRef: jest.fn(),
 			componentWillLoad: jest.fn(),
 		} as unknown as ClickButtonController;
@@ -17,5 +19,22 @@ describe('SkeletonController', () => {
 		controller.focusButton();
 
 		expect(clickButtonController.focusButton).toHaveBeenCalled();
+	});
+
+	it('normalizes labels and forwards them to the click button controller', () => {
+		const component = { label: 'Label', show: true } as WebComponentInterface<SkeletonApi>;
+		const watchLabel = jest.fn();
+		const clickButtonController = {
+			watchLabel,
+			focusButton: jest.fn(),
+			setButtonRef: jest.fn(),
+			componentWillLoad: jest.fn(),
+		} as unknown as ClickButtonController;
+		const controller = new SkeletonController(component, clickButtonController);
+
+		controller.watchLabel('Submit form');
+
+		expect(component.label).toBe('Submit form');
+		expect(watchLabel).toHaveBeenCalledWith('Submit form');
 	});
 });

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -1,5 +1,7 @@
 import type { CountPropType } from '../../schema/props/count';
 import { normalizeCount, validateCount } from '../../schema/props/count';
+import type { LabelPropType } from '../../schema/props/label';
+import { normalizeLabel, validateLabel } from '../../schema/props/label';
 import type { NamePropType } from '../../schema/props/name';
 import { normalizeName, validateName } from '../../schema/props/name';
 import { BaseController } from '../base-controller';
@@ -22,6 +24,7 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Web
 		const { count, name } = props;
 		this.watchCount(count);
 		this.watchName(name);
+		this.watchLabel(this.component.label);
 		this.clickButtonController.componentWillLoad({
 			label: this.component.label,
 		});
@@ -38,6 +41,14 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Web
 		const normalized = normalizeName(value);
 		if (validateName(normalized)) {
 			this.setProp('name', normalized);
+		}
+	}
+
+	public watchLabel(value?: LabelPropType): void {
+		const normalized = normalizeLabel(value);
+		if (validateLabel(normalized)) {
+			this.setState('label', normalized);
+			this.clickButtonController.watchLabel(normalized);
 		}
 	}
 

--- a/packages/components/src/components/_skeleton/web-components/click-button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/_skeleton/web-components/click-button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`kol-click-button should render with _label="Click me" 1`] = `
+<kol-click-button>
+  <template shadowrootmode="open">
+    <button class="kol-click-button">
+      <span class="kol-click-button__label">
+        Click me
+      </span>
+    </button>
+  </template>
+</kol-click-button>
+`;
+
+exports[`kol-click-button should render with _label="Submit form" 1`] = `
+<kol-click-button>
+  <template shadowrootmode="open">
+    <button class="kol-click-button">
+      <span class="kol-click-button__label">
+        Submit form
+      </span>
+    </button>
+  </template>
+</kol-click-button>
+`;

--- a/packages/components/src/components/_skeleton/web-components/click-button/test/snapshot.spec.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/test/snapshot.spec.tsx
@@ -1,0 +1,11 @@
+import { executeSnapshotTests } from '../../../../../utils/testing';
+
+import { KolClickButton } from '../component';
+
+const KOL_CLICK_BUTTON_TAG = 'kol-click-button';
+
+type ClickButtonSnapshotProps = {
+	_label: string;
+};
+
+executeSnapshotTests<ClickButtonSnapshotProps>(KOL_CLICK_BUTTON_TAG, [KolClickButton], [{ _label: 'Click me' }, { _label: 'Submit form' }]);

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,5 +1,6 @@
 import type { EventEmitter, JSX } from '@stencil/core';
 import { Component, Event, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
+import type { ClickButtonApi } from '../../internal/functional-components/click-button/api';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type { SkeletonApi } from '../../internal/functional-components/skeleton/api';
@@ -14,7 +15,7 @@ import type { ShowPropType } from '../../internal/schema/props/show';
 	tag: 'kol-skeleton',
 	shadow: true,
 })
-export class KolSkeleton implements WebComponentInterface<SkeletonApi> {
+export class KolSkeleton implements WebComponentInterface<SkeletonApi>, WebComponentInterface<ClickButtonApi> {
 	private readonly controller = new SkeletonController(this, new ClickButtonController(this));
 
 	@Prop()
@@ -31,6 +32,14 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi> {
 	@Watch('_name')
 	public watchName(value?: NamePropType): void {
 		this.controller.watchName(value);
+	}
+
+	@Prop()
+	public _label: LabelPropType = 'Label';
+
+	@Watch('_label')
+	public watchLabel(value?: LabelPropType): void {
+		this.controller.watchLabel(value);
 	}
 
 	@State()
@@ -65,6 +74,7 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi> {
 	}
 
 	public componentWillLoad(): void {
+		this.watchLabel(this._label);
 		this.controller.componentWillLoad({
 			count: this._count,
 			name: this._name,

--- a/packages/components/src/components/_skeleton/web-components/skeleton/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`kol-skeleton should render with _count=0 _name="Ada Lovelace" 1`] = `
+<kol-skeleton>
+  <template shadowrootmode="open">
+    <div class="kol-skeleton kol-skeleton--has-name">
+      <div class="kol-skeleton__container">
+        <span class="kol-skeleton__name">
+          Ada Lovelace
+        </span>
+        <div class="kol-skeleton__counter">
+          Count: 0
+        </div>
+      </div>
+      <div class="kol-skeleton__actions">
+        <button class="kol-click-button">
+          <span class="kol-click-button__label">
+            Label
+          </span>
+        </button>
+      </div>
+    </div>
+  </template>
+</kol-skeleton>
+`;
+
+exports[`kol-skeleton should render with _count=5 _name="  " 1`] = `
+<kol-skeleton>
+  <template shadowrootmode="open">
+    <div class="kol-skeleton">
+      <div class="kol-skeleton__container">
+        <div class="kol-skeleton__counter">
+          Count: 5
+        </div>
+      </div>
+      <div class="kol-skeleton__actions">
+        <button class="kol-click-button">
+          <span class="kol-click-button__label">
+            Label
+          </span>
+        </button>
+      </div>
+    </div>
+  </template>
+</kol-skeleton>
+`;

--- a/packages/components/src/components/_skeleton/web-components/skeleton/test/snapshot.spec.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/test/snapshot.spec.tsx
@@ -1,0 +1,19 @@
+import { executeSnapshotTests } from '../../../../../utils/testing';
+
+import { KolSkeleton } from '../component';
+
+const KOL_SKELETON_TAG = 'kol-skeleton';
+
+type SkeletonSnapshotProps = {
+	_count: number;
+	_name: string;
+};
+
+executeSnapshotTests<SkeletonSnapshotProps>(
+	KOL_SKELETON_TAG,
+	[KolSkeleton],
+	[
+		{ _count: 0, _name: 'Ada Lovelace' },
+		{ _count: 5, _name: '  ' },
+	],
+);


### PR DESCRIPTION
## Summary
Internal architecture proposal sub-PR adding typed-BEM schema helpers for the skeleton and click-button functional components. Merged into the component architecture proposal branch.

## Changes
- Added typed-BEM schema helpers for skeleton and click-button functional components
- Applied example BEM classes in skeleton blueprint markup

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Architektur-Proposal-PR: Fügt typisierte BEM-Schema-Helfer für die Skeleton- und Click-Button-Funktionalkomponenten hinzu.

## Änderungen
- Typisierte BEM-Schema-Helfer für Skeleton und Click-Button hinzugefügt
- Beispiel-BEM-Klassen im Skeleton-Blueprint-Markup angewendet
</details>