### PR TITLE
fix: improve skeleton sample interactions

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/api.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/api.tsx
@@ -6,6 +6,9 @@ export interface ClickButtonApi extends ComponentApi {
 	Callbacks: {
 		click: () => void;
 	};
+	Methods: {
+		focus: () => void;
+	};
 	Refs: {
 		button: HTMLButtonElement;
 	};

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/component.tsx
@@ -10,7 +10,7 @@ const BEM_CLASS_CLICK_BUTTON = clickButtonBem();
 const BEM_CLASS_CLICK_BUTTON__LABEL = clickButtonBem('label');
 
 export const ClickButtonFC: FC<FunctionalComponentProps<ClickButtonApi>> = ({ label, handleClick, refButton }) => (
-	<button class={BEM_CLASS_CLICK_BUTTON} ref={refButton} onClick={handleClick}>
+	<button class={BEM_CLASS_CLICK_BUTTON} ref={refButton} onClick={handleClick} onKeyDown={(event) => event.preventDefault()}>
 		<span class={BEM_CLASS_CLICK_BUTTON__LABEL}>{label}</span>
 	</button>
 );

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -1,16 +1,13 @@
 import type { LabelPropType } from '../../schema/props/label';
 import { normalizeLabel, validateLabel } from '../../schema/props/label';
 import { BaseController } from '../base-controller';
-import type { ControllerInterface, WebComponentInterface } from '../generic-types';
+import type { ControllerInterface } from '../generic-types';
 import type { ClickButtonApi } from './api';
 
-export class ClickButtonController
-	extends BaseController<ClickButtonApi['Props'], WebComponentInterface<ClickButtonApi>>
-	implements ControllerInterface<ClickButtonApi>
-{
+export class ClickButtonController extends BaseController<ClickButtonApi['Props'], ClickButtonApi['States']> implements ControllerInterface<ClickButtonApi> {
 	private buttonRef?: HTMLButtonElement;
 
-	public constructor(states: WebComponentInterface<ClickButtonApi>) {
+	public constructor(states: ClickButtonApi['States'] = {}) {
 		super(states, {
 			label: '',
 		});
@@ -33,9 +30,9 @@ export class ClickButtonController
 		console.log(this, this.buttonRef, 'button clicked');
 	};
 
-	public focusButton = (): void => {
+	public focus(): void {
 		this.buttonRef?.focus();
-	};
+	}
 
 	public setButtonRef = (element?: HTMLButtonElement): void => {
 		this.buttonRef = element;

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -6,7 +6,7 @@ export interface ComponentApi {
 	Props?: Record<string, unknown>;
 	States?: Record<string, unknown>;
 	Emitters?: Record<string, unknown>;
-	Methods?: Record<string, () => Promise<unknown>>;
+	Methods?: Record<string, () => unknown>;
 	Listeners?: Record<string, unknown>;
 	Callbacks?: Record<string, () => unknown>;
 	Refs?: Record<string, HTMLElement>;
@@ -47,7 +47,7 @@ type ComponentListeners<Listeners> = {
 };
 
 type ComponentMethods<Methods> = {
-	[K in keyof Methods]: Methods[K];
+	[K in keyof Methods as `kol${Capitalize<string & K>}`]: Methods[K];
 };
 
 type ComponentWatchers<Props> = {
@@ -58,7 +58,7 @@ export type NotNullableFields<Props> = {
 	[K in keyof Props]-?: NonNullable<Props[K]>;
 };
 
-export type WebComponentInterface<T extends ComponentApi = ComponentApi> = {
+export type WebComponentInterface<T extends ComponentApi> = {
 	componentWillLoad(): void;
 } & ComponentProps<ExtractProps<T>> &
 	NotNullableFields<ExtractStates<T>> &
@@ -67,7 +67,7 @@ export type WebComponentInterface<T extends ComponentApi = ComponentApi> = {
 	ComponentMethods<ExtractMethods<T>> &
 	ComponentListeners<ExtractListeners<T>>;
 
-export type FunctionalComponentProps<T extends ComponentApi = ComponentApi> = NotNullableFields<ExtractProps<T>> &
+export type FunctionalComponentProps<T extends ComponentApi> = NotNullableFields<ExtractProps<T>> &
 	NotNullableFields<ExtractStates<T>> &
 	ComponentCallbacks<ExtractCallbacks<T>> &
 	ComponentRefs<ExtractRefs<T>> &

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/api.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/api.tsx
@@ -6,7 +6,7 @@ import type { ComponentApi } from '../generic-types';
 
 export interface SkeletonApi extends ComponentApi {
 	Props: CountProp & NameProp;
-	States: LabelProp & ShowProp;
+	States: CountProp & LabelProp & ShowProp;
 	Emitters: {
 		loaded: number;
 	};

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/api.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/api.tsx
@@ -11,7 +11,8 @@ export interface SkeletonApi extends ComponentApi {
 		loaded: number;
 	};
 	Methods: {
-		toggle: () => Promise<void>;
+		focus: () => void;
+		toggle: () => void;
 	};
 	Listeners: {
 		keydown: KeyboardEvent;

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
@@ -12,7 +12,8 @@ const BEM_CLASS_SKELETON__CONTAINER = bem(BEM_BLOCK_SKELETON, 'container');
 const BEM_CLASS_SKELETON__COUNTER = bem(BEM_BLOCK_SKELETON, 'counter');
 const BEM_CLASS_SKELETON__NAME = bem(BEM_BLOCK_SKELETON, 'name');
 
-export const SkeletonFC: FC<FunctionalComponentProps<SkeletonApi>> = ({ count, label, name, show, handleClick, refButton }) => {
+export const SkeletonFC: FC<FunctionalComponentProps<SkeletonApi>> = (props) => {
+	const { count, label, name, show, handleClick, refButton } = props;
 	const hasName = !!(show && name?.trim());
 	const BEM_CLASS_ROOT = bem(BEM_BLOCK_SKELETON, {
 		'has-name': hasName,

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/component.tsx
@@ -6,19 +6,15 @@ import type { FunctionalComponentProps } from '../generic-types';
 import { bem } from '../../../../../schema/bem-registry';
 import type { SkeletonApi } from './api';
 
-const skeletonBem = bem.forBlock('kol-skeleton');
-const BEM_CLASS_SKELETON__ACTIONS = skeletonBem('actions');
-const BEM_CLASS_SKELETON__CONTAINER = skeletonBem('container');
-const BEM_CLASS_SKELETON__COUNTER = skeletonBem('counter');
-const BEM_CLASS_SKELETON__NAME = skeletonBem('name');
+const BEM_BLOCK_SKELETON = 'kol-skeleton';
+const BEM_CLASS_SKELETON__ACTIONS = bem(BEM_BLOCK_SKELETON, 'actions');
+const BEM_CLASS_SKELETON__CONTAINER = bem(BEM_BLOCK_SKELETON, 'container');
+const BEM_CLASS_SKELETON__COUNTER = bem(BEM_BLOCK_SKELETON, 'counter');
+const BEM_CLASS_SKELETON__NAME = bem(BEM_BLOCK_SKELETON, 'name');
 
-export const SkeletonFC: FC<FunctionalComponentProps<SkeletonApi>> = ({ count, label, name, show, onLoaded, handleClick, refButton }) => {
-	setTimeout(() => {
-		onLoaded.emit(100);
-	}, 1000);
-
+export const SkeletonFC: FC<FunctionalComponentProps<SkeletonApi>> = ({ count, label, name, show, handleClick, refButton }) => {
 	const hasName = !!(show && name?.trim());
-	const BEM_CLASS_ROOT = skeletonBem({
+	const BEM_CLASS_ROOT = bem(BEM_BLOCK_SKELETON, {
 		'has-name': hasName,
 		'is-hidden': !show,
 	});

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -5,19 +5,23 @@ import { normalizeLabel, validateLabel } from '../../schema/props/label';
 import type { NamePropType } from '../../schema/props/name';
 import { normalizeName, validateName } from '../../schema/props/name';
 import { BaseController } from '../base-controller';
-import type { ClickButtonController } from '../click-button/controller';
-import type { ControllerInterface, WebComponentInterface } from '../generic-types';
+import { ClickButtonController } from '../click-button/controller';
+import type { ControllerInterface } from '../generic-types';
 import type { SkeletonApi } from './api';
 
-export class SkeletonController extends BaseController<SkeletonApi['Props'], WebComponentInterface<SkeletonApi>> implements ControllerInterface<SkeletonApi> {
-	public constructor(
-		states: WebComponentInterface<SkeletonApi>,
-		private readonly clickButtonController: ClickButtonController,
-	) {
+export class SkeletonController extends BaseController<SkeletonApi['Props'], SkeletonApi['States']> implements ControllerInterface<SkeletonApi> {
+	private readonly clickButtonCtrl: ClickButtonController;
+
+	public constructor(states: SkeletonApi['States']) {
 		super(states, {
 			count: 0,
 			name: '',
 		});
+
+		/**
+		 * hier muss irgendein handling rein
+		 */
+		this.clickButtonCtrl = new ClickButtonController({});
 	}
 
 	public componentWillLoad(props: SkeletonApi['Props']): void {
@@ -25,7 +29,7 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Web
 		this.watchCount(count);
 		this.watchName(name);
 		this.watchLabel(this.component.label);
-		this.clickButtonController.componentWillLoad({
+		this.clickButtonCtrl.componentWillLoad({
 			label: this.component.label,
 		});
 	}
@@ -49,13 +53,12 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Web
 		const normalized = normalizeLabel(value);
 		if (validateLabel(normalized)) {
 			this.setState('label', normalized);
-			this.clickButtonController.watchLabel(normalized);
+			this.clickButtonCtrl.watchLabel(normalized);
 		}
 	}
 
-	public toggle(): Promise<void> {
+	public toggle(): void {
 		this.setState('show', !this.component.show);
-		return Promise.resolve();
 	}
 
 	public onKeydown = (event: KeyboardEvent): void => {
@@ -67,18 +70,19 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Web
 	};
 
 	public handleClick = (): void => {
+		// eslint-disable-next-line no-console
+		console.log('Button clicked, count should be increased');
 		const { count } = this.getProps();
 		const nextCount = count + 1;
 		this.setProp('count', nextCount);
 		this.setState('count', nextCount);
-		this.component.loaded.emit(nextCount);
 	};
 
-	public focusButton = (): void => {
-		this.clickButtonController.focusButton();
-	};
+	public focus(): void {
+		return this.clickButtonCtrl.focus();
+	}
 
 	public setButtonRef = (element?: HTMLButtonElement): void => {
-		this.clickButtonController.setButtonRef(element);
+		this.clickButtonCtrl.setButtonRef(element);
 	};
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -1,3 +1,4 @@
+import { Log } from '../../../../../schema';
 import type { CountPropType } from '../../schema/props/count';
 import { normalizeCount, validateCount } from '../../schema/props/count';
 import type { LabelPropType } from '../../schema/props/label';
@@ -70,8 +71,7 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Ske
 	};
 
 	public handleClick = (): void => {
-		// eslint-disable-next-line no-console
-		console.log('Button clicked, count should be increased');
+		Log.debug('Button clicked, count should be increased');
 		const { count } = this.getProps();
 		const nextCount = count + 1;
 		this.setProp('count', nextCount);

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -12,6 +12,7 @@ import type { SkeletonApi } from './api';
 
 export class SkeletonController extends BaseController<SkeletonApi['Props'], SkeletonApi['States']> implements ControllerInterface<SkeletonApi> {
 	private readonly clickButtonCtrl: ClickButtonController;
+	private intervalId?: NodeJS.Timeout;
 
 	public constructor(states: SkeletonApi['States']) {
 		super(states, {
@@ -23,6 +24,7 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Ske
 		 * hier muss irgendein handling rein
 		 */
 		this.clickButtonCtrl = new ClickButtonController({});
+		this.startLoadedEventInterval();
 	}
 
 	public componentWillLoad(props: SkeletonApi['Props']): void {
@@ -85,4 +87,34 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Ske
 	public setButtonRef = (element?: HTMLButtonElement): void => {
 		this.clickButtonCtrl.setButtonRef(element);
 	};
+
+	private startLoadedEventInterval(): void {
+		// Emit loaded event every 2 seconds with current count value
+		this.intervalId = setInterval(() => {
+			const { count } = this.getProps();
+			this.emitLoaded(count);
+		}, 2000);
+	}
+
+	private emitLoaded(count: number): void {
+		// This method will be used by the web component to emit the loaded event
+		// The web component needs to call this method to actually emit the event
+		// We use a callback approach to let the web component handle the emission
+		if (this.onLoadedCallback) {
+			this.onLoadedCallback(count);
+		}
+	}
+
+	private onLoadedCallback?: (count: number) => void;
+
+	public setOnLoadedCallback(callback: (count: number) => void): void {
+		this.onLoadedCallback = callback;
+	}
+
+	public destroy(): void {
+		if (this.intervalId) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+	}
 }

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -34,6 +34,7 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Web
 		const normalized = normalizeCount(value);
 		if (validateCount(normalized)) {
 			this.setProp('count', normalized);
+			this.setState('count', normalized);
 		}
 	}
 
@@ -66,8 +67,11 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Web
 	};
 
 	public handleClick = (): void => {
-		// eslint-disable-next-line no-console
-		console.log(this, 'button clicked');
+		const { count } = this.getProps();
+		const nextCount = count + 1;
+		this.setProp('count', nextCount);
+		this.setState('count', nextCount);
+		this.component.loaded.emit(nextCount);
 	};
 
 	public focusButton = (): void => {

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from '@stencil/core';
-import { Component, h, Host, Prop, Watch } from '@stencil/core';
+import { Component, h, Host, Method, Prop, Watch } from '@stencil/core';
 import type { ClickButtonApi } from '../../internal/functional-components/click-button/api';
 import { ClickButtonFC } from '../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
@@ -11,27 +11,33 @@ import type { LabelPropType } from '../../internal/schema/props/label';
 	shadow: true,
 })
 export class KolClickButton implements WebComponentInterface<ClickButtonApi> {
-	private readonly controller = new ClickButtonController(this);
+	private readonly ctrl = new ClickButtonController();
 
 	@Prop()
 	public _label!: LabelPropType;
 
 	@Watch('_label')
 	public watchLabel(value?: LabelPropType): void {
-		this.controller.watchLabel(value);
+		this.ctrl.watchLabel(value);
+	}
+
+	@Method()
+	public async kolFocus(): Promise<void> {
+		this.ctrl.focus();
+		return Promise.resolve();
 	}
 
 	public componentWillLoad(): void {
-		this.controller.componentWillLoad({
+		this.ctrl.componentWillLoad({
 			label: this._label,
 		});
 	}
 
 	public render(): JSX.Element {
-		const { label } = this.controller.getProps();
+		const { label } = this.ctrl.getProps();
 		return (
 			<Host>
-				<ClickButtonFC label={label} refButton={this.controller.setButtonRef} handleClick={this.controller.handleClick} />
+				<ClickButtonFC label={label} refButton={this.ctrl.setButtonRef} handleClick={this.ctrl.handleClick} />
 			</Host>
 		);
 	}

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -1,7 +1,5 @@
 import type { EventEmitter, JSX } from '@stencil/core';
 import { Component, Event, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
-import type { ClickButtonApi } from '../../internal/functional-components/click-button/api';
-import { ClickButtonController } from '../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type { SkeletonApi } from '../../internal/functional-components/skeleton/api';
 import { SkeletonFC } from '../../internal/functional-components/skeleton/component';
@@ -15,15 +13,27 @@ import type { ShowPropType } from '../../internal/schema/props/show';
 	tag: 'kol-skeleton',
 	shadow: true,
 })
-export class KolSkeleton implements WebComponentInterface<SkeletonApi>, WebComponentInterface<ClickButtonApi> {
-	private readonly controller = new SkeletonController(this, new ClickButtonController(this));
+export class KolSkeleton implements WebComponentInterface<SkeletonApi> {
+	private readonly ctrl = new SkeletonController(this);
+
+	@Method()
+	public async kolFocus(): Promise<void> {
+		this.ctrl.focus();
+		return Promise.resolve();
+	}
+
+	@Method()
+	public async kolToggle(): Promise<void> {
+		this.ctrl.toggle();
+		return Promise.resolve();
+	}
 
 	@Prop()
 	public _count!: CountPropType;
 
 	@Watch('_count')
 	public watchCount(value?: CountPropType): void {
-		this.controller.watchCount(value);
+		this.ctrl.watchCount(value);
 	}
 
 	@Prop()
@@ -31,7 +41,7 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi>, WebCompo
 
 	@Watch('_name')
 	public watchName(value?: NamePropType): void {
-		this.controller.watchName(value);
+		this.ctrl.watchName(value);
 	}
 
 	@Prop()
@@ -39,7 +49,7 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi>, WebCompo
 
 	@Watch('_label')
 	public watchLabel(value?: LabelPropType): void {
-		this.controller.watchLabel(value);
+		this.ctrl.watchLabel(value);
 	}
 
 	@State()
@@ -51,41 +61,30 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi>, WebCompo
 	@State()
 	public count: CountPropType = 0;
 
-	@Method()
-	public focusButton(): Promise<void> {
-		this.controller.focusButton();
-		return Promise.resolve();
-	}
-
 	@Listen('keydown')
 	public handleKeyDown(event: KeyboardEvent): void {
 		if (event.key === 'Enter' || event.key === ' ') {
-			this.controller.handleClick();
+			this.ctrl.handleClick();
 		}
 	}
 
 	@Event() public loaded!: EventEmitter<number>;
 
-	@Method()
-	public toggle(): Promise<void> {
-		return this.controller.toggle();
-	}
-
 	@Listen('keydown', { target: 'window' })
 	public onKeydown(event: KeyboardEvent): void {
-		this.controller.onKeydown(event);
+		this.ctrl.onKeydown(event);
 	}
 
 	public componentWillLoad(): void {
 		this.watchLabel(this._label);
-		this.controller.componentWillLoad({
+		this.ctrl.componentWillLoad({
 			count: this._count,
 			name: this._name,
 		});
 	}
 
 	public render(): JSX.Element {
-		const { count, name } = this.controller.getProps();
+		const { count, name } = this.ctrl.getProps();
 		const { label, show } = this;
 		return (
 			<Host>
@@ -93,10 +92,10 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi>, WebCompo
 					count={count}
 					label={label}
 					name={name}
-					handleClick={this.controller.handleClick}
+					handleClick={this.ctrl.handleClick}
 					onLoaded={this.loaded}
 					show={show}
-					refButton={this.controller.setButtonRef}
+					refButton={this.ctrl.setButtonRef}
 				/>
 			</Host>
 		);

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -83,6 +83,15 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi> {
 			count: this._count,
 			name: this._name,
 		});
+
+		// Set up the callback for emitting loaded events
+		this.ctrl.setOnLoadedCallback((count: number) => {
+			this.loaded.emit(count);
+		});
+	}
+
+	public disconnectedCallback(): void {
+		this.ctrl.destroy();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -48,6 +48,9 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi>, WebCompo
 	@State()
 	public show: ShowPropType = true;
 
+	@State()
+	public count: CountPropType = 0;
+
 	@Method()
 	public focusButton(): Promise<void> {
 		this.controller.focusButton();

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -8,6 +8,7 @@ import type { CountPropType } from '../../internal/schema/props/count';
 import type { LabelPropType } from '../../internal/schema/props/label';
 import type { NamePropType } from '../../internal/schema/props/name';
 import type { ShowPropType } from '../../internal/schema/props/show';
+import { Log } from '../../../../schema';
 
 @Component({
 	tag: 'kol-skeleton',
@@ -64,6 +65,7 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi> {
 	@Listen('keydown')
 	public handleKeyDown(event: KeyboardEvent): void {
 		if (event.key === 'Enter' || event.key === ' ') {
+			Log.debug('button pressed');
 			this.ctrl.handleClick();
 		}
 	}

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -96,7 +96,6 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 			event.preventDefault();
 		} else {
 			if (typeof this.state._on?.onClick === 'function') {
-				event.preventDefault();
 				setEventTarget(event, this.anchorRef);
 				this.state._on?.onClick(event, this.state._href);
 			}

--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -5,7 +5,7 @@ import { querySelector } from 'query-selector-shadow-root';
 import rgba from 'rgba-convert';
 import { hex, score } from 'wcag-contrast';
 
-import { getDocument, Log } from './dev.utils';
+import { getDocument, getExperimentalMode, Log } from './dev.utils';
 
 import type { Stringified } from '../types/common';
 import { devHint } from './a11y.tipps';
@@ -44,11 +44,11 @@ export const emptyStringByArrayHandler = (value: unknown, cb: () => void): void 
  * wir das Target explizit und stoppen die Propagation.
  */
 export const setEventTarget = (event: Event, target?: HTMLElement): void => {
-	// if (getExperimentalMode()) {
-	// 	event.preventDefault();
-	// 	Log.debug([event, target]);
-	// 	Log.debug(`↑ We propagate the (submit) event to this target.`);
-	// }
+	if (getExperimentalMode()) {
+		event.preventDefault();
+		Log.debug([event, target]);
+		Log.debug(`↑ We propagate the (submit) event to this target.`);
+	}
 	Object.defineProperty(event, 'target', {
 		value: target,
 		writable: false,

--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -5,7 +5,7 @@ import { querySelector } from 'query-selector-shadow-root';
 import rgba from 'rgba-convert';
 import { hex, score } from 'wcag-contrast';
 
-import { getDocument, getExperimentalMode, Log } from './dev.utils';
+import { getDocument, Log } from './dev.utils';
 
 import type { Stringified } from '../types/common';
 import { devHint } from './a11y.tipps';
@@ -44,10 +44,11 @@ export const emptyStringByArrayHandler = (value: unknown, cb: () => void): void 
  * wir das Target explizit und stoppen die Propagation.
  */
 export const setEventTarget = (event: Event, target?: HTMLElement): void => {
-	if (getExperimentalMode()) {
-		Log.debug([event, target]);
-		Log.debug(`↑ We propagate the (submit) event to this target.`);
-	}
+	// if (getExperimentalMode()) {
+	// 	event.preventDefault();
+	// 	Log.debug([event, target]);
+	// 	Log.debug(`↑ We propagate the (submit) event to this target.`);
+	// }
 	Object.defineProperty(event, 'target', {
 		value: target,
 		writable: false,

--- a/packages/samples/react/src/scenarios/skeleton.tsx
+++ b/packages/samples/react/src/scenarios/skeleton.tsx
@@ -21,9 +21,20 @@ export const Skeleton: FC = () => {
 				</p>
 			</SampleDescription>
 
-			<KolButton _label="Toggle" onClick={() => skeletonRef.current?.toggle()} />
-			<KolButton _label="Focus Button" onClick={() => skeletonRef.current?.focusButton()} />
-			<KolSkeleton _count={initialCount} _label="Click Button" _name="Example" onKolLoaded={handleLoaded} ref={skeletonRef} />
+			<KolButton
+				_label="Toggle"
+				_on={{
+					onClick: () => skeletonRef.current?.kolToggle(),
+				}}
+				_variant="primary"
+			/>
+			<KolButton
+				_label="Focus Button"
+				_on={{
+					onClick: () => skeletonRef.current?.kolFocus(),
+				}}
+			/>
+			<KolSkeleton _count={initialCount} _label="Click Button" _name="Example" onLoaded={handleLoaded} ref={skeletonRef} />
 			<p aria-live="polite">Loaded value: {count}</p>
 		</>
 	);

--- a/packages/samples/react/src/scenarios/skeleton.tsx
+++ b/packages/samples/react/src/scenarios/skeleton.tsx
@@ -4,38 +4,111 @@ import type { FC } from 'react';
 import { KolButton, KolSkeleton } from '@public-ui/react-v19';
 import { SampleDescription } from '../components/SampleDescription';
 
+interface EventLogEntry {
+	timestamp: string;
+	count: number;
+	id: number;
+}
+
 export const Skeleton: FC = () => {
 	const skeletonRef = useRef<HTMLKolSkeletonElement>(null);
 	const initialCount = 3;
 	const [count, setCount] = useState<number>(initialCount);
+	const [eventLog, setEventLog] = useState<EventLogEntry[]>([]);
+	const [lastEventTime, setLastEventTime] = useState<string>('');
+	const [eventCount, setEventCount] = useState<number>(0);
+
 	const handleLoaded = (event: CustomEvent<number>) => {
+		const now = new Date();
+		const timestamp = now.toLocaleTimeString('de-DE');
+		const newEventCount = eventCount + 1;
+
 		setCount(event.detail);
+		setLastEventTime(timestamp);
+		setEventCount(newEventCount);
+
+		// Add to event log (keep only last 5 entries)
+		setEventLog((prev) => {
+			const newEntry: EventLogEntry = {
+				timestamp,
+				count: event.detail,
+				id: newEventCount,
+			};
+			return [newEntry, ...prev.slice(0, 4)];
+		});
 	};
 
 	return (
 		<>
 			<SampleDescription>
 				<p>
-					KolSkeleton can be toggled to display loading placeholders. Clicking the internal ClickButton increments the counter and focusing moves the focus to
-					that button.
+					KolSkeleton demonstriert Event-Emitter mit automatischem Intervall. Die Komponente emittiert alle 2 Sekunden ein &quot;loaded&quot; Event mit dem
+					aktuellen Count-Wert. Über die Buttons kann die Komponente getoggled und fokussiert werden. Der interne ClickButton erhöht bei Klick den Counter.
 				</p>
 			</SampleDescription>
 
-			<KolButton
-				_label="Toggle"
-				_on={{
-					onClick: () => skeletonRef.current?.kolToggle(),
-				}}
-				_variant="primary"
-			/>
-			<KolButton
-				_label="Focus Button"
-				_on={{
-					onClick: () => skeletonRef.current?.kolFocus(),
-				}}
-			/>
+			<div className="flex gap-4 mb-4">
+				<KolButton
+					_label="Toggle Sichtbarkeit"
+					_on={{
+						onClick: () => skeletonRef.current?.kolToggle(),
+					}}
+					_variant="primary"
+				/>
+				<KolButton
+					_label="Fokus auf Button"
+					_on={{
+						onClick: () => skeletonRef.current?.kolFocus(),
+					}}
+					_variant="secondary"
+				/>
+			</div>
+
 			<KolSkeleton _count={initialCount} _label="Click Button" _name="Example" onLoaded={handleLoaded} ref={skeletonRef} />
-			<p aria-live="polite">Loaded value: {count}</p>
+
+			<div className="mt-6 p-4 border border-gray-300 rounded-lg bg-gray-50">
+				<h3 className="text-lg font-semibold mb-3">Event Monitor</h3>
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div>
+						<p className="font-medium">Aktueller Count-Wert:</p>
+						<p className="text-2xl font-bold text-blue-600" aria-live="polite">
+							{count}
+						</p>
+					</div>
+					<div>
+						<p className="font-medium">Letztes Event:</p>
+						<p className="text-lg" aria-live="polite">
+							{lastEventTime || 'Noch kein Event empfangen'}
+						</p>
+					</div>
+				</div>
+				<div className="mt-4">
+					<p className="font-medium mb-2">
+						Events empfangen: <span className="font-bold">{eventCount}</span>
+					</p>
+					{eventLog.length > 0 && (
+						<div>
+							<p className="font-medium mb-2">Event-Historie (letzte 5):</p>
+							<ul className="text-sm space-y-1 max-h-32 overflow-y-auto">
+								{eventLog.map((entry) => (
+									<li key={entry.id} className="flex justify-between items-center p-2 bg-white rounded border">
+										<span>
+											#{entry.id}: Count = {entry.count}
+										</span>
+										<span className="text-gray-500">{entry.timestamp}</span>
+									</li>
+								))}
+							</ul>
+						</div>
+					)}
+				</div>
+				<div className="mt-4 p-3 bg-blue-50 rounded">
+					<p className="text-sm text-blue-800">
+						💡 <strong>Tipp:</strong> Die Komponente emittiert automatisch alle 2 Sekunden ein Event. Klicke auf den &quot;Click Button&quot; in der Komponente,
+						um den Count-Wert zu erhöhen.
+					</p>
+				</div>
+			</div>
 		</>
 	);
 };

--- a/packages/samples/react/src/scenarios/skeleton.tsx
+++ b/packages/samples/react/src/scenarios/skeleton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import type { FC } from 'react';
 
 import { KolButton, KolSkeleton } from '@public-ui/react-v19';
@@ -6,16 +6,25 @@ import { SampleDescription } from '../components/SampleDescription';
 
 export const Skeleton: FC = () => {
 	const skeletonRef = useRef<HTMLKolSkeletonElement>(null);
+	const initialCount = 3;
+	const [count, setCount] = useState<number>(initialCount);
+	const handleLoaded = (event: CustomEvent<number>) => {
+		setCount(event.detail);
+	};
 
 	return (
 		<>
 			<SampleDescription>
-				<p>KolSkeleton can be toggled to display loading placeholders.</p>
+				<p>
+					KolSkeleton can be toggled to display loading placeholders. Clicking the internal ClickButton increments the counter and focusing moves the focus to
+					that button.
+				</p>
 			</SampleDescription>
 
 			<KolButton _label="Toggle" onClick={() => skeletonRef.current?.toggle()} />
 			<KolButton _label="Focus Button" onClick={() => skeletonRef.current?.focusButton()} />
-			<KolSkeleton _count={3} _name="Example" ref={skeletonRef} />
+			<KolSkeleton _count={initialCount} _label="Click Button" _name="Example" onKolLoaded={handleLoaded} ref={skeletonRef} />
+			<p aria-live="polite">Loaded value: {count}</p>
 		</>
 	);
 };


### PR DESCRIPTION
## Summary
Internal architecture proposal sub-PR improving the skeleton sample interactions by keeping the counter in component state and removing the artificial timeout. Merged into the component architecture proposal branch.

## Changes
- Skeleton counter moved to component state, emitting the loaded value on button click
- Removed artificial timeout from the skeleton functional component
- Refreshed React skeleton scenario to demonstrate counting and focus reactions

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Architektur-Proposal-PR: Verbessert die Skeleton-Sample-Interaktionen durch Zustandsverwaltung des Zählers und Entfernung des künstlichen Timeouts.

## Änderungen
- Skeleton-Zähler in den Komponentenzustand verschoben, geladenen Wert beim Klick ausgegeben
- Künstliches Timeout aus der Skeleton-Funktionalkomponente entfernt
- React-Skeleton-Szenario für Zählung und Fokus-Reaktionen aktualisiert
</details>