### PR TITLE
docs: revert skeleton watcher example

### DIFF
--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -71,6 +71,7 @@ The blueprint enforces unidirectional data flow and delegates responsibilities t
 - Hosts lifecycle hooks and ties DOM events to controller callbacks.
 - Owns the Stencil-specific decorators (`@Prop`, `@Event`, `@Watch`). Watchers normalise incoming values and forward them to the controller.
 - Holds normalised data in simple fields (`count`, `name`) instead of `@State` to keep Stencil re-rendering efficient.
+- Mirrors validated props into these simple fields from the corresponding `@Watch` handlers so that the renderer and controller can rely on readily available, normalised values on the component instance.
 - Delegates rendering to the controller output via `controller.getProps()`.
 
 ### Controller Layer


### PR DESCRIPTION
## Summary
Internal architecture proposal sub-PR reverting the skeleton ARC42 watcher example to only forward values to the controller. Merged into the component architecture proposal branch.

## Changes
- Restored skeleton ARC42 watcher example to forward values to the controller only

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Architektur-Proposal-PR: Stellt das Skeleton-ARC42-Watcher-Beispiel wieder her, sodass es nur Werte an den Controller weiterleitet.

## Änderungen
- Skeleton-ARC42-Watcher-Beispiel auf reine Controller-Weiterleitungslogik zurückgesetzt
</details>