### PR TITLE
fix(table): restore header checkbox for multiple selection

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -566,7 +566,7 @@ export class KolTableStateless implements TableStatelessAPI {
 	private renderHeadingSelectionCell(): JSX.Element {
 		const selection = this.state._selection;
 
-		if (!selection?.multiple) {
+		if (selection?.multiple === false) {
 			return <td key={`thead-0-selection`} class="table__header-cell table__header-cell--horizontal selection-cell"></td>;
 		}
 		const keyPropertyName = selection.keyPropertyName ?? 'id';


### PR DESCRIPTION
## Summary
Internal sub-PR restoring the header checkbox for multiple selection in the stateful table. Merged into the table component feature branch.

## Changes
- Stateful table now renders the selection checkbox in the header when row selection is in multi-select mode

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR: Stellt das Kopfzeilen-Kontrollkästchen für die Mehrfachauswahl in der stateful Tabelle wieder her.

## Änderungen
- Stateful-Tabelle rendert jetzt das Auswahl-Kontrollkästchen in der Kopfzeile bei aktivierter Mehrfachauswahl
</details>