### PR TITLE
feat(components): separate optional and required skeleton props

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/api.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/api.tsx
@@ -2,7 +2,9 @@ import type { LabelProp } from '../../schema/props/label';
 import type { ComponentApi } from '../generic-types';
 
 export interface ClickButtonApi extends ComponentApi {
-	Props: LabelProp;
+	Props: {
+		Required: LabelProp;
+	};
 	Callbacks: {
 		click: () => void;
 	};

--- a/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/click-button/controller.ts
@@ -1,10 +1,13 @@
 import type { LabelPropType } from '../../schema/props/label';
 import { normalizeLabel, validateLabel } from '../../schema/props/label';
 import { BaseController } from '../base-controller';
-import type { ControllerInterface } from '../generic-types';
+import type { ControllerInterface, ResolvedProps } from '../generic-types';
 import type { ClickButtonApi } from './api';
 
-export class ClickButtonController extends BaseController<ClickButtonApi['Props'], ClickButtonApi['States']> implements ControllerInterface<ClickButtonApi> {
+export class ClickButtonController
+	extends BaseController<ResolvedProps<ClickButtonApi>, ClickButtonApi['States']>
+	implements ControllerInterface<ClickButtonApi>
+{
 	private buttonRef?: HTMLButtonElement;
 
 	public constructor(states: ClickButtonApi['States'] = {}) {
@@ -13,7 +16,7 @@ export class ClickButtonController extends BaseController<ClickButtonApi['Props'
 		});
 	}
 
-	public componentWillLoad(props: ClickButtonApi['Props']): void {
+	public componentWillLoad(props: ResolvedProps<ClickButtonApi>): void {
 		const { label } = props;
 		this.watchLabel(label);
 	}

--- a/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/generic-types.ts
@@ -2,8 +2,28 @@ import type { EventEmitter } from '@stencil/core';
 
 type Callback<T> = (value?: T) => void;
 
+type PropsDefinition = {
+	Optional?: Record<string, unknown>;
+	Required?: Record<string, unknown>;
+};
+
+type PropsOrDefault<T extends ComponentApi> = T['Props'] extends PropsDefinition ? T['Props'] : PropsDefinition;
+
+type ExtractDefinitionEntry<Definition extends PropsDefinition, K extends keyof PropsDefinition> =
+	Definition[K] extends Record<string, unknown> ? Definition[K] : Record<never, never>;
+
+type ExtractPropsDefinition<T extends ComponentApi> = PropsOrDefault<T>;
+
+type ExtractRequiredProps<T extends ComponentApi> = ExtractDefinitionEntry<ExtractPropsDefinition<T>, 'Required'>;
+
+type ExtractOptionalProps<T extends ComponentApi> = ExtractDefinitionEntry<ExtractPropsDefinition<T>, 'Optional'>;
+
+type ExtractAllProps<T extends ComponentApi> = ExtractRequiredProps<T> & ExtractOptionalProps<T>;
+
+export type ResolvedProps<T extends ComponentApi> = ExtractRequiredProps<T> & Partial<ExtractOptionalProps<T>>;
+
 export interface ComponentApi {
-	Props?: Record<string, unknown>;
+	Props?: PropsDefinition;
 	States?: Record<string, unknown>;
 	Emitters?: Record<string, unknown>;
 	Methods?: Record<string, () => unknown>;
@@ -14,13 +34,16 @@ export interface ComponentApi {
 
 type Extract<T extends ComponentApi, K extends keyof ComponentApi> = T[K] extends Record<string, unknown> ? T[K] : Record<never, never>;
 
-type ExtractProps<T extends ComponentApi> = Extract<T, 'Props'>;
 type ExtractStates<T extends ComponentApi> = Extract<T, 'States'>;
 type ExtractEmitters<T extends ComponentApi> = Extract<T, 'Emitters'>;
 type ExtractMethods<T extends ComponentApi> = Extract<T, 'Methods'>;
 type ExtractListeners<T extends ComponentApi> = Extract<T, 'Listeners'>;
 type ExtractCallbacks<T extends ComponentApi> = Extract<T, 'Callbacks'>;
 type ExtractRefs<T extends ComponentApi> = Extract<T, 'Refs'>;
+
+type ExtractProps<T extends ComponentApi> = ExtractAllProps<T>;
+type ExtractRequired<T extends ComponentApi> = ExtractRequiredProps<T>;
+type ExtractOptional<T extends ComponentApi> = ExtractOptionalProps<T>;
 
 type ComponentCallbacks<Callbacks> = {
 	[K in keyof Callbacks as `handle${Capitalize<string & K>}`]: Callbacks[K];
@@ -34,9 +57,15 @@ type FunctionalComponentEmitters<Emitters> = {
 	[K in keyof Emitters as `on${Capitalize<string & K>}`]: EventEmitter<Emitters[K]>;
 };
 
-type ComponentProps<Props> = {
+type ComponentPropsRequired<Props> = {
 	[K in keyof Props as `_${Lowercase<string & K>}`]: Props[K];
 };
+
+type ComponentPropsOptional<Props> = {
+	[K in keyof Props as `_${Lowercase<string & K>}`]?: Props[K];
+};
+
+type ComponentProps<T extends ComponentApi> = ComponentPropsRequired<ExtractRequired<T>> & ComponentPropsOptional<ExtractOptional<T>>;
 
 type ComponentRefs<Refs> = {
 	[K in keyof Refs as `ref${Capitalize<string & K>}`]: (element?: Refs[K]) => void;
@@ -60,7 +89,7 @@ export type NotNullableFields<Props> = {
 
 export type WebComponentInterface<T extends ComponentApi> = {
 	componentWillLoad(): void;
-} & ComponentProps<ExtractProps<T>> &
+} & ComponentProps<T> &
 	NotNullableFields<ExtractStates<T>> &
 	ComponentWatchers<ExtractProps<T>> &
 	WebComponentEmitters<ExtractEmitters<T>> &
@@ -90,7 +119,7 @@ type ControllerRefSetters<Refs> = {
 };
 
 export type ControllerInterface<T extends ComponentApi = ComponentApi> = {
-	componentWillLoad(props: NotNullableFields<ExtractProps<T>>): void;
+	componentWillLoad(props: ResolvedProps<T>): void;
 	getProps(): NotNullableFields<ExtractProps<T>>;
 } & ComponentWatchers<ExtractProps<T>> &
 	ControllerCallbackHandlers<ExtractCallbacks<T>> &

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/api.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/api.tsx
@@ -5,7 +5,10 @@ import type { ShowProp } from '../../schema/props/show';
 import type { ComponentApi } from '../generic-types';
 
 export interface SkeletonApi extends ComponentApi {
-	Props: CountProp & NameProp;
+	Props: {
+		Optional: CountProp;
+		Required: NameProp;
+	};
 	States: CountProp & LabelProp & ShowProp;
 	Emitters: {
 		loaded: number;

--- a/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/skeleton/controller.ts
@@ -7,10 +7,10 @@ import type { NamePropType } from '../../schema/props/name';
 import { normalizeName, validateName } from '../../schema/props/name';
 import { BaseController } from '../base-controller';
 import { ClickButtonController } from '../click-button/controller';
-import type { ControllerInterface } from '../generic-types';
+import type { ControllerInterface, ResolvedProps } from '../generic-types';
 import type { SkeletonApi } from './api';
 
-export class SkeletonController extends BaseController<SkeletonApi['Props'], SkeletonApi['States']> implements ControllerInterface<SkeletonApi> {
+export class SkeletonController extends BaseController<ResolvedProps<SkeletonApi>, SkeletonApi['States']> implements ControllerInterface<SkeletonApi> {
 	private readonly clickButtonCtrl: ClickButtonController;
 	private intervalId?: NodeJS.Timeout;
 
@@ -27,7 +27,7 @@ export class SkeletonController extends BaseController<SkeletonApi['Props'], Ske
 		this.startLoadedEventInterval();
 	}
 
-	public componentWillLoad(props: SkeletonApi['Props']): void {
+	public componentWillLoad(props: ResolvedProps<SkeletonApi>): void {
 		const { count, name } = props;
 		this.watchCount(count);
 		this.watchName(name);

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -30,7 +30,7 @@ export class KolSkeleton implements WebComponentInterface<SkeletonApi> {
 	}
 
 	@Prop()
-	public _count!: CountPropType;
+	public _count?: CountPropType;
 
 	@Watch('_count')
 	public watchCount(value?: CountPropType): void {


### PR DESCRIPTION
## Summary
Internal architecture proposal PR adding generic helpers to derive optional and required prop buckets for component APIs, and refining the skeleton component blueprint. Merged into the component architecture proposal branch.

## Changes
- Added generic helpers for optional/required prop type derivation
- Marked `count` as optional and `name` as required in the skeleton blueprint
- Adjusted click-button blueprint and skeleton web component for refined API typing

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Architektur-Proposal-PR mit generischen Hilfsmitteln für optionale/erforderliche Prop-Typen und einer Verfeinerung des Skeleton-Komponenten-Blueprints.

## Änderungen
- Generische Helfer für optionale/erforderliche Prop-Typ-Ableitung hinzugefügt
- `count` als optional, `name` als erforderlich im Skeleton-Blueprint markiert
- Click-Button-Blueprint und Skeleton-Web-Component angepasst
</details>