### PR TITLE
chore: override axios and semver to remediate CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
 	"engines": {
 		"pnpm": "^10"
 	},
+	"pnpm": {
+		"overrides": {
+			"axios": "1.12.0",
+			"semver": "7.5.2"
+		}
+	},
 	"private": true,
 	"scripts": {
 		"build": "pnpm -r build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: 1.12.0
+  semver: 7.5.2
+
 importers:
 
   .:
@@ -1088,8 +1092,8 @@ importers:
         specifier: 3.6.2
         version: 3.6.2
       semver:
-        specifier: 7.7.2
-        version: 7.7.2
+        specifier: 7.5.2
+        version: 7.5.2
       typed-bem:
         specifier: 1.0.0-rc.7
         version: 1.0.0-rc.7
@@ -5613,8 +5617,8 @@ packages:
     peerDependencies:
       playwright: '>1.0.0'
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
+  axios@1.12.0:
+    resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -12113,21 +12117,8 @@ packages:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
     engines: {node: '>=10'}
 
-  semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.3.5:
-    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+  semver@7.5.2:
+    resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -14106,7 +14097,7 @@ snapshots:
       rxjs: 7.8.2
       sass: 1.90.0
       sass-loader: 16.0.5(sass-embedded@1.92.1)(sass@1.90.0)(webpack@5.101.2(@swc/core@1.13.2)(esbuild@0.25.9))
-      semver: 7.7.2
+      semver: 7.5.2
       source-map-loader: 5.0.0(webpack@5.101.2(@swc/core@1.13.2)(esbuild@0.25.9))
       source-map-support: 0.5.21
       terser: 5.43.1
@@ -14207,7 +14198,7 @@ snapshots:
       piscina: 5.1.3
       rolldown: 1.0.0-beta.32
       sass: 1.90.0
-      semver: 7.7.2
+      semver: 7.5.2
       source-map-support: 0.5.21
       tinyglobby: 0.2.14
       tslib: 2.8.1
@@ -14252,7 +14243,7 @@ snapshots:
       npm-package-arg: 13.0.0
       pacote: 21.0.0
       resolve: 1.22.10
-      semver: 7.7.2
+      semver: 7.5.2
       yargs: 18.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14292,7 +14283,7 @@ snapshots:
       chokidar: 3.6.0
       convert-source-map: 1.9.0
       reflect-metadata: 0.2.2
-      semver: 7.7.2
+      semver: 7.5.2
       tslib: 2.8.1
       typescript: 5.4.5
       yargs: 17.7.2
@@ -14307,7 +14298,7 @@ snapshots:
       chokidar: 4.0.3
       convert-source-map: 1.9.0
       reflect-metadata: 0.2.2
-      semver: 7.7.2
+      semver: 7.5.2
       tslib: 2.8.1
       typescript: 5.5.4
       yargs: 17.7.2
@@ -14322,7 +14313,7 @@ snapshots:
       chokidar: 4.0.3
       convert-source-map: 1.9.0
       reflect-metadata: 0.2.2
-      semver: 7.7.2
+      semver: 7.5.2
       tslib: 2.8.1
       typescript: 5.8.3
       yargs: 17.7.2
@@ -14337,7 +14328,7 @@ snapshots:
       chokidar: 4.0.3
       convert-source-map: 1.9.0
       reflect-metadata: 0.2.2
-      semver: 7.7.2
+      semver: 7.5.2
       tslib: 2.8.1
       yargs: 18.0.0
     optionalDependencies:
@@ -14439,7 +14430,7 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14459,7 +14450,7 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14479,7 +14470,7 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14499,7 +14490,7 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14519,7 +14510,7 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14529,7 +14520,7 @@ snapshots:
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
+      semver: 7.5.2
 
   '@babel/generator@7.28.0':
     dependencies:
@@ -14557,7 +14548,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.25.1
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.5.2
 
   '@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.28.3)':
     dependencies:
@@ -14568,7 +14559,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.28.0
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14581,7 +14572,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.28.3
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -14590,7 +14581,7 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.2.0
-      semver: 6.3.1
+      semver: 7.5.2
 
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.3)':
     dependencies:
@@ -15155,7 +15146,7 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.3)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.3)
       babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.3)
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15282,7 +15273,7 @@ snapshots:
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.3)
       babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.3)
       core-js-compat: 3.44.0
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15385,7 +15376,7 @@ snapshots:
   '@commitlint/is-ignored@19.8.1':
     dependencies:
       '@commitlint/types': 19.8.1
-      semver: 7.7.2
+      semver: 7.5.2
 
   '@commitlint/lint@19.8.1':
     dependencies:
@@ -16188,7 +16179,7 @@ snapshots:
       read-cmd-shim: 4.0.0
       resolve-from: 5.0.0
       rimraf: 4.4.1
-      semver: 7.7.2
+      semver: 7.5.2
       set-blocking: 2.0.0
       signal-exit: 3.0.7
       slash: 3.0.0
@@ -16448,7 +16439,7 @@ snapshots:
       promise-all-reject-late: 1.0.1
       promise-call-limit: 3.0.2
       read-package-json-fast: 3.0.2
-      semver: 7.7.2
+      semver: 7.5.2
       ssri: 10.0.6
       treeverse: 3.0.0
       walk-up-path: 3.0.1
@@ -16458,11 +16449,11 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.7.2
+      semver: 7.5.2
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.2
+      semver: 7.5.2
 
   '@npmcli/git@5.0.8':
     dependencies:
@@ -16473,7 +16464,7 @@ snapshots:
       proc-log: 4.2.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.7.2
+      semver: 7.5.2
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -16486,7 +16477,7 @@ snapshots:
       npm-pick-manifest: 10.0.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      semver: 7.7.2
+      semver: 7.5.2
       which: 5.0.0
 
   '@npmcli/installed-package-contents@2.1.0':
@@ -16512,7 +16503,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       pacote: 18.0.6
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -16531,7 +16522,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 6.0.2
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - bluebird
 
@@ -16542,7 +16533,7 @@ snapshots:
       hosted-git-info: 8.1.0
       json-parse-even-better-errors: 4.0.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-license: 3.0.4
 
   '@npmcli/promise-spawn@7.0.2':
@@ -16591,7 +16582,7 @@ snapshots:
       ignore: 5.3.2
       minimatch: 9.0.3
       nx: 20.8.2(@swc/core@1.13.2)
-      semver: 7.7.2
+      semver: 7.5.2
       tmp: 0.2.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
@@ -16779,7 +16770,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
       forwarded-parse: 2.1.2
-      semver: 7.7.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -16904,7 +16895,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.14.2
       require-in-the-middle: 7.5.2
-      semver: 7.7.2
+      semver: 7.5.2
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -17104,7 +17095,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.2
+      semver: 7.5.2
       tar-fs: 3.1.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -17117,7 +17108,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.2
+      semver: 7.5.2
       tar-fs: 3.1.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -18147,7 +18138,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.7.2
+      semver: 7.5.2
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -18307,7 +18298,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.7.2
+      semver: 7.5.2
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -18322,7 +18313,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.5.2
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -18339,7 +18330,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.5.2
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -18354,7 +18345,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.2)
       eslint: 8.57.0
-      semver: 7.7.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -19162,7 +19153,7 @@ snapshots:
       picocolors: 1.1.1
       playwright: 1.55.0
 
-  axios@1.11.0:
+  axios@1.12.0:
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.1)
       form-data: 4.0.4
@@ -19216,7 +19207,7 @@ snapshots:
       '@babel/compat-data': 7.28.0
       '@babel/core': 7.28.3
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.3)
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -19714,7 +19705,7 @@ snapshots:
   chromedriver@139.0.3:
     dependencies:
       '@testim/chrome-version': 1.1.4
-      axios: 1.11.0
+      axios: 1.12.0
       compare-versions: 6.1.1
       extract-zip: 2.0.1
       proxy-agent: 6.5.0
@@ -20017,7 +20008,7 @@ snapshots:
       handlebars: 4.7.8
       json-stringify-safe: 5.0.1
       meow: 8.1.2
-      semver: 7.7.2
+      semver: 7.5.2
       split: 1.0.1
 
   conventional-commits-filter@3.0.0:
@@ -20147,7 +20138,7 @@ snapshots:
       normalize-package-data: 7.0.1
       read-pkg-up: 10.1.0
       recursive-readdir: 2.2.3
-      semver: 7.7.2
+      semver: 7.5.2
       type-fest: 4.41.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -20166,7 +20157,7 @@ snapshots:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.2
+      semver: 7.5.2
       shebang-command: 1.2.0
       which: 1.3.1
 
@@ -20197,7 +20188,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.5.6)
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
-      semver: 7.7.2
+      semver: 7.5.2
     optionalDependencies:
       webpack: 5.101.2(@swc/core@1.13.2)(esbuild@0.25.9)
 
@@ -21015,7 +21006,7 @@ snapshots:
       espree: 10.4.0
       esquery: 1.6.0
       parse-imports-exports: 0.2.4
-      semver: 7.7.2
+      semver: 7.5.2
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -21062,7 +21053,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
-      semver: 6.3.1
+      semver: 7.5.2
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -21877,7 +21868,7 @@ snapshots:
   git-semver-tags@5.0.1:
     dependencies:
       meow: 8.1.2
-      semver: 7.7.2
+      semver: 7.5.2
 
   git-up@7.0.0:
     dependencies:
@@ -22373,7 +22364,7 @@ snapshots:
       npm-package-arg: 11.0.2
       promzard: 1.0.2
       read: 3.0.1
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -22724,7 +22715,7 @@ snapshots:
       '@babel/core': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -22734,7 +22725,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -22744,7 +22735,7 @@ snapshots:
       '@babel/parser': 7.28.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -23138,7 +23129,7 @@ snapshots:
       jest-resolve: 26.6.2
       natural-compare: 1.4.0
       pretty-format: 26.6.2
-      semver: 7.7.2
+      semver: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -23617,7 +23608,7 @@ snapshots:
       read-cmd-shim: 4.0.0
       resolve-from: 5.0.0
       rimraf: 4.4.1
-      semver: 7.7.2
+      semver: 7.5.2
       set-blocking: 2.0.0
       signal-exit: 3.0.7
       slash: 3.0.0
@@ -23701,7 +23692,7 @@ snapshots:
       npm-package-arg: 11.0.2
       npm-registry-fetch: 17.1.0
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.5.2
       sigstore: 2.3.1
       ssri: 10.0.6
     transitivePeerDependencies:
@@ -23716,7 +23707,7 @@ snapshots:
       got: 14.4.7
       ini: 5.0.0
       rc: 1.2.8
-      semver: 7.7.2
+      semver: 7.5.2
       tablemark: 3.1.0
       text-table: 0.2.0
       visit-values: 2.0.0
@@ -24106,15 +24097,15 @@ snapshots:
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
-      semver: 5.7.2
+      semver: 7.5.2
 
   make-dir@3.1.0:
     dependencies:
-      semver: 6.3.1
+      semver: 7.5.2
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.5.2
 
   make-error@1.3.6: {}
 
@@ -24425,7 +24416,7 @@ snapshots:
       pkg-types: 2.2.0
       postcss: 8.5.6
       postcss-nested: 7.0.2(postcss@8.5.6)
-      semver: 7.7.2
+      semver: 7.5.2
       tinyglobby: 0.2.14
     optionalDependencies:
       sass: 1.92.1
@@ -24650,7 +24641,7 @@ snapshots:
       open: 8.4.0
       ora: 5.4.1
       selenium-webdriver: 4.6.1
-      semver: 7.3.5
+      semver: 7.5.2
       stacktrace-parser: 0.1.10
       strip-ansi: 6.0.1
       untildify: 4.0.0
@@ -24713,7 +24704,7 @@ snapshots:
       make-fetch-happen: 13.0.1
       nopt: 7.2.1
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.5.2
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -24727,7 +24718,7 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.5.2
       tar: 7.4.3
       tinyglobby: 0.2.15
       which: 5.0.0
@@ -24742,7 +24733,7 @@ snapshots:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.7.2
+      semver: 7.5.2
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -24761,7 +24752,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
-      semver: 7.7.2
+      semver: 7.5.2
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -24779,26 +24770,26 @@ snapshots:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.10
-      semver: 5.7.2
+      semver: 7.5.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@3.0.3:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.16.1
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@7.0.1:
     dependencies:
       hosted-git-info: 8.1.0
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -24825,11 +24816,11 @@ snapshots:
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.5.2
 
   npm-install-checks@7.1.1:
     dependencies:
-      semver: 7.7.2
+      semver: 7.5.2
 
   npm-normalize-package-bin@3.0.1: {}
 
@@ -24839,21 +24830,21 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-name: 5.0.1
 
   npm-package-arg@12.0.2:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-name: 6.0.2
 
   npm-package-arg@13.0.0:
     dependencies:
       hosted-git-info: 9.0.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.5.2
       validate-npm-package-name: 6.0.2
 
   npm-packlist@10.0.1:
@@ -24869,14 +24860,14 @@ snapshots:
       npm-install-checks: 7.1.1
       npm-normalize-package-bin: 4.0.0
       npm-package-arg: 12.0.2
-      semver: 7.7.2
+      semver: 7.5.2
 
   npm-pick-manifest@9.1.0:
     dependencies:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.2
-      semver: 7.7.2
+      semver: 7.5.2
 
   npm-registry-fetch@17.1.0:
     dependencies:
@@ -24940,7 +24931,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.11.0
+      axios: 1.12.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -24961,7 +24952,7 @@ snapshots:
       open: 8.4.2
       ora: 5.3.0
       resolve.exports: 2.0.3
-      semver: 7.7.2
+      semver: 7.5.2
       string-width: 4.2.3
       tar-stream: 2.2.0
       tmp: 0.2.3
@@ -25664,7 +25655,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.9.2)
       jiti: 1.21.7
       postcss: 8.5.6
-      semver: 7.7.2
+      semver: 7.5.2
     optionalDependencies:
       webpack: 5.101.2(@swc/core@1.13.2)(esbuild@0.25.9)
     transitivePeerDependencies:
@@ -27045,15 +27036,9 @@ snapshots:
       '@types/node-forge': 1.3.13
       node-forge: 1.3.1
 
-  semver@5.7.2: {}
-
-  semver@6.3.1: {}
-
-  semver@7.3.5:
+  semver@7.5.2:
     dependencies:
       lru-cache: 6.0.0
-
-  semver@7.7.2: {}
 
   send@0.19.0:
     dependencies:
@@ -27287,7 +27272,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.5.2
 
   sinon@13.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
Internal sub-PR adding pnpm overrides for `axios` (1.12.0) and `semver` (7.5.2) to remediate known CVEs. Merged into the security workflow feature branch.

## Changes
- Added pnpm overrides for `axios` 1.12.0 and `semver` 7.5.2
- Refreshed lockfile to consume the patched releases

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR mit pnpm-Overrides für `axios` (1.12.0) und `semver` (7.5.2) zur CVE-Behebung.

## Änderungen
- pnpm-Overrides für `axios` 1.12.0 und `semver` 7.5.2 hinzugefügt
- Lockfile mit gepatchten Versionen aktualisiert
</details>