### PR TITLE
chore: override loupe to patched release

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 	"pnpm": {
 		"overrides": {
 			"axios": "1.12.0",
-			"semver": "7.5.2"
+			"semver": "7.5.2",
+			"loupe": "2.3.7"
 		}
 	},
 	"private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   axios: 1.12.0
   semver: 7.5.2
+  loupe: 2.3.7
 
 importers:
 
@@ -9473,10 +9474,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.4:
-    resolution: {integrity: sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==}
-    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
-
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
@@ -16368,7 +16365,7 @@ snapshots:
       assertion-error: 1.1.0
       check-error: 1.0.2
       deep-eql: 4.0.1
-      loupe: 2.3.4
+      loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
 
@@ -22838,7 +22835,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@24.5.0)(typescript@5.9.2))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -22934,7 +22931,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.13.2)(@types/node@24.5.0)(typescript@5.9.2)):
+  jest-jasmine2@26.6.3:
     dependencies:
       '@babel/traverse': 7.28.3
       '@jest/environment': 26.6.2
@@ -22955,11 +22952,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:
@@ -24057,10 +24050,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  loupe@2.3.4:
-    dependencies:
-      get-func-name: 2.0.2
 
   loupe@2.3.7:
     dependencies:


### PR DESCRIPTION
## Summary
Internal sub-PR adding a pnpm override to pin `loupe` to version 2.3.7 to apply a security patch. Merged into the security workflow feature branch.

## Changes
- Added pnpm override to force `loupe` to version 2.3.7
- Refreshed lockfile to resolve to the patched version

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR mit pnpm-Override für `loupe` auf Version 2.3.7 (Sicherheits-Patch).

## Änderungen
- pnpm-Override für `loupe` auf Version 2.3.7 hinzugefügt
- Lockfile auf gepatchte Version aktualisiert
</details>