### PR TITLE
chore: reorder security scan steps

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -95,11 +95,12 @@ jobs:
         run: pnpm install --frozen-lockfile
         shell: bash
 
-      - name: Scan repository with ClamAV
-        id: clamav
-        if: steps.check_branch.outputs.should_run == 'true' && env.RUN_CLAMAV == 'true'
+      - name: Run pnpm audit
+        id: pnpm_audit
+        if: steps.check_branch.outputs.should_run == 'true' && env.RUN_PNPM_AUDIT == 'true'
         continue-on-error: true
-        uses: djdefi/gitavscan@main
+        run: pnpm audit
+        shell: bash
       - name: Scan repository with Trivy
         id: trivy
         if: steps.check_branch.outputs.should_run == 'true' && env.RUN_TRIVY == 'true'
@@ -114,12 +115,11 @@ jobs:
           format: 'table'
           exit-code: '1'
 
-      - name: Run pnpm audit
-        id: pnpm_audit
-        if: steps.check_branch.outputs.should_run == 'true' && env.RUN_PNPM_AUDIT == 'true'
+      - name: Scan repository with ClamAV
+        id: clamav
+        if: steps.check_branch.outputs.should_run == 'true' && env.RUN_CLAMAV == 'true'
         continue-on-error: true
-        run: pnpm audit
-        shell: bash
+        uses: djdefi/gitavscan@main
 
       - name: Summarize scan results
         if: always() && steps.check_branch.outputs.should_run == 'true'
@@ -134,11 +134,11 @@ jobs:
           printf '| Step | Outcome |\n' >> "$GITHUB_STEP_SUMMARY"
           printf '| --- | --- |\n' >> "$GITHUB_STEP_SUMMARY"
 
-          clamav_outcome="$CLAMAV_OUTCOME"
-          if [[ "$RUN_CLAMAV" != 'true' ]]; then
-            clamav_outcome='skipped'
+          pnpm_audit_outcome="$PNPM_AUDIT_OUTCOME"
+          if [[ "$RUN_PNPM_AUDIT" != 'true' ]]; then
+            pnpm_audit_outcome='skipped'
           fi
-          printf '| ClamAV | %s |\n' "$clamav_outcome" >> "$GITHUB_STEP_SUMMARY"
+          printf '| pnpm audit | %s |\n' "$pnpm_audit_outcome" >> "$GITHUB_STEP_SUMMARY"
 
           trivy_outcome="$TRIVY_OUTCOME"
           if [[ "$RUN_TRIVY" != 'true' ]]; then
@@ -146,11 +146,11 @@ jobs:
           fi
           printf '| Trivy | %s |\n' "$trivy_outcome" >> "$GITHUB_STEP_SUMMARY"
 
-          pnpm_audit_outcome="$PNPM_AUDIT_OUTCOME"
-          if [[ "$RUN_PNPM_AUDIT" != 'true' ]]; then
-            pnpm_audit_outcome='skipped'
+          clamav_outcome="$CLAMAV_OUTCOME"
+          if [[ "$RUN_CLAMAV" != 'true' ]]; then
+            clamav_outcome='skipped'
           fi
-          printf '| pnpm audit | %s |\n' "$pnpm_audit_outcome" >> "$GITHUB_STEP_SUMMARY"
+          printf '| ClamAV | %s |\n' "$clamav_outcome" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$clamav_outcome" != 'success' && "$clamav_outcome" != 'skipped' || \
                 "$trivy_outcome" != 'success' && "$trivy_outcome" != 'skipped' || \


### PR DESCRIPTION
## Summary
Internal sub-PR reordering steps in the security scan CI pipeline. Merged into the security workflow feature branch.

## Changes
- Moved pnpm audit before other security tools in the pipeline
- Moved ClamAV scan to the end of the security pipeline
- Aligned GitHub summary table with the new execution order

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR zur Neuordnung der Security-Pipeline-Schritte.

## Änderungen
- pnpm-Audit vor andere Security-Tools in der Pipeline verschoben
- ClamAV-Scan ans Ende der Security-Pipeline verschoben
- GitHub-Summary-Tabelle an neue Ausführungsreihenfolge angepasst
</details>