### PR TITLE
refactor: remove mutable and reflect properties from _hideMsg in form components

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -396,7 +396,7 @@ export class KolCombobox implements ComboboxAPI {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -215,7 +215,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
 `;
 
 exports[`kol-combobox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Herr" _suggestions=["Frau","Herr","Divers"] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-combobox _hide-msg="" _touched="" _value="Herr">
+<kol-combobox _touched="" _value="Herr">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="has-value kol-combobox kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -167,7 +167,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Makes the element not focusable and ignore all events.

--- a/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -187,7 +187,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _labelAlign="left" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--label-align-left kol-input-checkbox--variant-default">
       <div class="kol-form-field__input">
@@ -530,7 +530,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
       <div class="kol-form-field__input">
@@ -873,7 +873,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="switch" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-switch">
       <div class="kol-form-field__input">
@@ -1216,7 +1216,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _labelAlign="left" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _checked="" _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-left kol-input-checkbox--variant-default">
       <div class="kol-form-field__input">
@@ -1559,7 +1559,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _labelAlign="right" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _checked="" _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-default">
       <div class="kol-form-field__input">
@@ -1902,7 +1902,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _checked="" _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
       <div class="kol-form-field__input">
@@ -2245,7 +2245,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="switch" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _checked="" _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-switch">
       <div class="kol-form-field__input">
@@ -2588,7 +2588,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _indeterminate=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-checkbox _hide-msg="" _indeterminate="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-checkbox _indeterminate="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--indeterminate kol-input-checkbox--label-align-right kol-input-checkbox--variant-default">
       <div class="kol-form-field__input">

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -186,7 +186,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -266,7 +266,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	/**
 	 * Defines the value of the input.
 	 */
-	@Prop({ reflect: true }) public _value?: string;
+	@Prop() public _value?: string;
 
 	@State() public state: InputColorStates = {
 		_hideMsg: false,

--- a/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _accessKey="V" 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -28,7 +28,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _alert=true 1`] = `
-<kol-input-color _alert="" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _alert="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -54,7 +54,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _disabled=true 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--disabled kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -80,7 +80,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _hint="Hint" 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -109,7 +109,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -141,7 +141,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -171,7 +171,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -201,7 +201,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-color _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -227,7 +227,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -253,7 +253,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _readOnly=true 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _readonly="" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _readonly="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -279,7 +279,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _shortKey="S" 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -306,7 +306,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _smartButton={"_icons":["codicon codicon-eye"],"_hideLabel":true,"_label":"einblenden"} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -336,7 +336,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _accessKey="V" 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -363,7 +363,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _alert=true 1`] = `
-<kol-input-color _alert="" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _alert="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -389,7 +389,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _disabled=true 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--disabled kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -415,7 +415,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _hint="Hint" 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -444,7 +444,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -476,7 +476,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -506,7 +506,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -536,7 +536,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-color _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -562,7 +562,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -588,7 +588,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _readOnly=true 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _readonly="" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _readonly="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -614,7 +614,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _shortKey="S" 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -641,7 +641,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _smartButton={"_icons":["codicon codicon-eye"],"_hideLabel":true,"_label":"einblenden"} 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -671,7 +671,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] _touched=true 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--touched kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -697,7 +697,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _suggestions=["#F00","#0F0","#00F"] 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -723,7 +723,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" _touched=true 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--touched kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -749,7 +749,7 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-color should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="#FFF" 1`] = `
-<kol-input-color _placeholder="Hier steht ein Platzhaltertext" _value="#FFF">
+<kol-input-color _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-input-color">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -202,7 +202,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
@@ -180,7 +180,7 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
 `;
 
 exports[`kol-input-date should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="2025-01-01" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-date _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="2025-01-01">
+<kol-input-date _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="2025-01-01">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="date has-value kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-date">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -167,7 +167,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
@@ -180,7 +180,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-email should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="email@example.com" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-email _hide-msg="" _touched="" _value="email@example.com">
+<kol-input-email _touched="" _value="email@example.com">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="email has-value kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-email">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -514,7 +514,7 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-email should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="email@example.com" _suggestions=["email1@example.com","email2@example.com","email3@example.com"] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-email _hide-msg="" _touched="" _value="email@example.com">
+<kol-input-email _touched="" _value="email@example.com">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="email has-value kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-email">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -155,7 +155,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
@@ -208,7 +208,7 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
 `;
 
 exports[`kol-input-file should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-file _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-input-file _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="file kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-file">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -183,7 +183,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
@@ -180,7 +180,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
 `;
 
 exports[`kol-input-number should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-number _hide-msg="" _touched="">
+<kol-input-number _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-number number">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -514,7 +514,7 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
 `;
 
 exports[`kol-input-number should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _suggestions=[1,2,3] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-number _hide-msg="" _touched="">
+<kol-input-number _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-number number">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -194,7 +194,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
@@ -180,7 +180,7 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
 `;
 
 exports[`kol-input-password should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-password _hide-msg="" _touched="" _value="Value">
+<kol-input-password _touched="" _value="Value">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="has-value kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-password password">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -171,7 +171,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
@@ -424,7 +424,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-radio _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Value">
+<kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Value">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <fieldset class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--radio kol-form-field--touched">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">
@@ -967,7 +967,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _orientation="horizontal" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-radio _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Value">
+<kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Value">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <fieldset class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--radio kol-form-field--touched">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -244,7 +244,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
@@ -201,7 +201,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-range should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value=5 _min=1 _max=10 _step=1 _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-range _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="5">
+<kol-input-range _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="5">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-range range">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -590,7 +590,7 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
 `;
 
 exports[`kol-input-range should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value=5 _min=1 _max=10 _step=1 _suggestions=[1,2,3,4,5,6,7,8,9,10] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-range _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="5">
+<kol-input-range _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="5">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-range range">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -184,7 +184,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
@@ -180,7 +180,7 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
 `;
 
 exports[`kol-input-text should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _spellCheck=true _value="Value" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-input-text _hide-msg="" _touched="" _value="Value">
+<kol-input-text _touched="" _value="Value">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="has-value kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-text text">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -142,7 +142,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -271,7 +271,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 `;
 
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-select _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-form-field--error kol-form-field--has-value kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-form-field-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -613,7 +613,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 `;
 
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-select _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-form-field--error kol-form-field--has-value kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-form-field-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -1064,7 +1064,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 `;
 
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _value=["Divers","Frau"] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-select _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-form-field--error kol-form-field--has-value kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-form-field-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -1696,7 +1696,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 `;
 
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _value="Herr" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-select _hide-msg="" _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Herr">
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Herr">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-form-field--error kol-form-field--has-value kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-form-field-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -510,7 +510,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -215,7 +215,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-single-select _hide-msg="" _touched="">
+<kol-single-select _touched="">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -157,7 +157,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop({ mutable: true, reflect: true }) public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean = false;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the

--- a/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
@@ -173,7 +173,7 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
 `;
 
 exports[`kol-textarea should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _rows=5 _spellCheck=true _value="Value" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-textarea _hide-msg="" _touched="" _value="Value">
+<kol-textarea _touched="" _value="Value">
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <div class="kol-form-field kol-form-field--error kol-form-field--has-value kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-form-field-textarea">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">


### PR DESCRIPTION
## Summary
Internal refactoring that removes the `mutable` and `reflect` Stencil decorators from the `_hideMsg` property across form components. No changes to public API behavior.

## Changes
- Removed `mutable` and `reflect` from `_hideMsg` Stencil property declarations in 28 form component files

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Internes Refactoring: Entfernt die `mutable`- und `reflect`-Stencil-Decorator von der `_hideMsg`-Eigenschaft in Form-Komponenten. Keine Änderungen an der öffentlichen API.

## Änderungen
- `mutable` und `reflect` aus `_hideMsg`-Stencil-Property-Deklarationen in 28 Formular-Komponentendateien entfernt
</details>