### PR TITLE
chore: enforce patched form-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"overrides": {
 			"axios": "1.12.0",
 			"braces": "3.0.3",
+			"form-data@^4.0.0": "4.0.4",
 			"lodash.pick": "npm:lodash@4.17.21",
 			"loupe": "2.3.7",
 			"semver": "7.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   axios: 1.12.0
   braces: 3.0.3
+  form-data@^4.0.0: 4.0.4
   lodash.pick: npm:lodash@4.17.21
   loupe: 2.3.7
   semver: 7.5.2


### PR DESCRIPTION
## Summary
Adds a pnpm override to pin all form-data 4.x dependents to the patched 4.0.4 release, addressing CVE-2025-7783. No functional changes to library components.

## Changes
- Added pnpm override to force form-data to version 4.0.4
- Updated lockfile to record the fixed version

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Fügt einen pnpm-Override hinzu, um alle form-data-4.x-Abhängigkeiten auf die gepatchte Version 4.0.4 zu fixieren (CVE-2025-7783). Keine funktionalen Änderungen.

## Änderungen
- pnpm-Override zur Fixierung von form-data auf 4.0.4 hinzugefügt
- Lockfile mit der gepatchten Version aktualisiert
</details>