### PR TITLE
fix(table): fix settings menu display on repeated open

### DIFF
--- a/packages/components/src/components/@shared/_kol-table-settings-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-table-settings-mixin.scss
@@ -25,11 +25,10 @@
 
 		&__columns {
 			display: grid;
-			overflow: hidden;
 			gap: to-rem(8);
 			align-items: center;
 			grid-auto-rows: min-content;
-			grid-template-columns: min-content 1fr to-rem(100) auto auto;
+			grid-template-columns: min-content minmax(max-content, 1fr) to-rem(100) auto auto;
 		}
 
 		&__column {


### PR DESCRIPTION
## Summary
Fixes the table settings menu (column visibility controls) to maintain a stable display state when opened multiple times in succession.

## Changes
- Fixed table settings menu display to remain stable on repeated open/close cycles

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Behebt die Anzeige des Tabellen-Einstellungsmenüs (Spaltensichtbarkeit), sodass es bei wiederholtem Öffnen stabil bleibt.

## Änderungen
- Anzeige des Tabellen-Einstellungsmenüs bei wiederholtem Öffnen/Schließen stabilisiert
</details>