### PR TITLE
ci: split security scan workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
     - cron: '23 1 * * 6'
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  group: ${{ github.event_name == 'pull_request' && format('workflow-{0}-pr-{1}', github.workflow, github.event.number) || format('workflow-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
     - cron: '23 1 * * 6'
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('workflow-{0}-pr-{1}', github.workflow, github.event.number) || format('workflow-{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ github.event_name == 'pull_request' && format('workflow-{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('workflow-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/security-scan-schedule.yml
+++ b/.github/workflows/security-scan-schedule.yml
@@ -3,6 +3,12 @@ name: Scheduled Security Scan
 on:
   schedule:
     - cron: '0 0,6,12,18 * * *'
+  workflow_dispatch:
+    inputs:
+      branches:
+        description: 'JSON encoded array of branch names to scan'
+        required: false
+        default: '["develop", "release/2"]'
 
 concurrency:
   group: ${{ format('workflow-{0}-{1}', github.workflow, github.ref) }}
@@ -14,9 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch:
-          - develop
-          - 'release/2'
+        branch: ${{ fromJson(github.event_name == 'workflow_dispatch' && inputs.branches || '["develop", "release/2"]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/security-scan-schedule.yml
+++ b/.github/workflows/security-scan-schedule.yml
@@ -1,0 +1,43 @@
+name: Scheduled Security Scan
+
+on:
+  schedule:
+    - cron: '0 0,6,12,18 * * *'
+
+concurrency:
+  group: ${{ format('workflow-{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: true
+
+jobs:
+  scheduled-scan:
+    name: Scheduled Security Scan (${{ matrix.branch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - develop
+          - 'release/2'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ matrix.branch }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Run security scans
+        uses: ./.github/actions/security-scan
+        with:
+          install-deps: 'true'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,7 +25,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('workflow-{0}-pr-{1}', github.workflow, github.event.number) || format('workflow-{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ github.event_name == 'pull_request' && format('workflow-{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('workflow-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - 'develop'
       - 'release/*'
-  schedule:
-    - cron: '0 0,6,12,18 * * *'
   workflow_dispatch:
     inputs:
       enable_audit:
@@ -27,44 +25,10 @@ on:
         default: false
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  group: ${{ github.event_name == 'pull_request' && format('workflow-{0}-pr-{1}', github.workflow, github.event.number) || format('workflow-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
-  scheduled-scan:
-    name: Scheduled Security Scan (${{ matrix.branch }})
-    strategy:
-      fail-fast: false
-      matrix:
-        branch:
-          - develop
-          - 'release/2'
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          ref: ${{ matrix.branch }}
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - name: Run security scans
-        uses: ./.github/actions/security-scan
-        with:
-          install-deps: 'true'
-
   targeted-scan:
     name: Security Scan
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Internal CI-only change splitting the security scan into two workflows: one for pull requests and manual triggers, and a dedicated scheduled scan that fans out to develop and release branches.

## Changes
- Limited existing security scan workflow to pull_request and manual triggers
- Added dedicated scheduled security scan workflow for develop and release branches

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Internes CI-Update: Security-Scan in zwei Workflows aufgeteilt – einer für Pull Requests und manuelle Trigger, ein dedizierter geplanter Scan für develop und Release-Branches.

## Änderungen
- Bestehenden Security-Scan-Workflow auf pull_request und manuelle Trigger beschränkt
- Dedizierten geplanten Security-Scan-Workflow für develop und Release-Branches hinzugefügt
</details>