### PR TITLE
fix(security-scan): scope concurrency per pr

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 concurrency:
-  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  group: ${{ github.event_name == 'pull_request' && format('workflow-{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('workflow-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
Internal CI-only fix scoping the security scan workflow concurrency group per PR to prevent runs from different PRs canceling each other.

## Changes
- Updated security scan workflow concurrency group to scope per PR

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Internes CI-Fix: Security-Scan-Workflow-Nebenläufigkeitsgruppe auf PR-Ebene begrenzt, damit Runs verschiedener PRs sich nicht gegenseitig abbrechen.

## Änderungen
- Nebenläufigkeitsgruppe des Security-Scan-Workflows auf PR-Ebene begrenzt
</details>