### PR TITLE
fix: use aria-description on KolButton

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,6 +2,12 @@
 
 # Known Issues
 
+## General
+
+### Limited support for `aria-description` (WAI-ARIA 1.2)
+
+- `aria-description` was introduced with [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/#aria-description), but many assistive technologies have not yet adopted it and continue to rely solely on `aria-describedby` when presenting supplementary text. Components that accept `_ariaDescription` therefore keep rendering hidden fallback markup and set both attributes so older screen readers still expose the description.
+
 ## select
 
 - Disabled options in KolSelect affect the total count in screen readers When an option in `KolSelect` is set to `disabled: true`, it is still counted by screen readers. This leads to incorrect numbering, for example, NVDA announces "2 of 4" instead of "2 of 3". To ensure the correct order, the `aria-hidden="true"` attribute should be set for `disabled` options. This will hide the disabled option from screen readers and keep the total number of items consistent.

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from '@stencil/core';
+import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
 import type {
 	AccessKeyPropType,
 	AlternativeButtonLinkRolePropType,
@@ -43,16 +45,13 @@ import {
 	validateTooltipAlign,
 	watchString,
 } from '../../schema';
-import type { JSX } from '@stencil/core';
-import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
 
+import { KolSpanWcTag, KolTooltipWcTag } from '../../core/component-names';
+import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
+import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 import { stopPropagation, tryToDispatchKoliBriEvent } from '../../utils/events';
-import { nonce } from '../../utils/dev.utils';
 import { propagateResetEventToForm, propagateSubmitEventToForm } from '../form/controller';
 import { AssociatedInputController } from '../input-adapter-leanup/associated.controller';
-import { KolSpanWcTag, KolTooltipWcTag } from '../../core/component-names';
-import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
-import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 
 /**
  * @internal
@@ -64,8 +63,6 @@ import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 export class KolButtonWc implements ButtonAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolButtonWcElement;
 	private buttonRef?: HTMLButtonElement;
-
-	private readonly internalDescriptionById = nonce();
 
 	private readonly catchRef = (ref?: HTMLButtonElement) => {
 		this.buttonRef = ref;
@@ -110,7 +107,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 
 	public render(): JSX.Element {
 		const hasExpertSlot = showExpertSlot(this.state._label);
-		const hasAriaDescription = Boolean(this.state._ariaDescription?.trim()?.length);
+		const ariaDescription = this.state._ariaDescription?.trim();
 
 		return (
 			<Host class="kol-button-wc">
@@ -118,7 +115,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 					ref={this.catchRef}
 					accessKey={this.state._accessKey || undefined}
 					aria-controls={this.state._ariaControls}
-					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
+					aria-description={ariaDescription || undefined}
 					aria-expanded={mapBoolean2String(this.state._ariaExpanded)}
 					aria-haspopup={this._ariaHasPopup}
 					aria-label={this.state._hideLabel && typeof this.state._label === 'string' ? this.state._label : undefined}
@@ -162,11 +159,6 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 					_align={this.state._tooltipAlign}
 					_label={typeof this.state._label === 'string' ? this.state._label : ''}
 				></KolTooltipWcTag>
-				{hasAriaDescription && (
-					<span class="visually-hidden" id={this.internalDescriptionById}>
-						{this.state._ariaDescription}
-					</span>
-				)}
 			</Host>
 		);
 	}

--- a/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -5,15 +5,12 @@ exports[`kol-button should render with _label="Label" _ariaDescription="Aria Des
   <template shadowrootmode="open">
     <kol-button-wc class="button kol-button-wc">
       <!---->
-      <button aria-describedby="nonce" class="button normal" type="button">
+      <button aria-description="Aria Description" class="button normal" type="button">
         <kol-span-wc _label="Label" class="button-inner">
           <slot name="expert" slot="expert"></slot>
         </kol-span-wc>
       </button>
       <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" hidden=""></kol-tooltip-wc>
-      <span class="visually-hidden" id="nonce">
-        Aria Description
-      </span>
     </kol-button-wc>
   </template>
 </kol-button>

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -1,3 +1,6 @@
+import type { JSX } from '@stencil/core';
+import { Component, h, Host, Method, Prop, State, Watch } from '@stencil/core';
+import { KolIconTag, KolSpanWcTag, KolTooltipWcTag } from '../../core/component-names';
 import type {
 	AccessKeyPropType,
 	AlternativeButtonLinkRolePropType,
@@ -45,13 +48,9 @@ import {
 	validateTabIndex,
 	validateTooltipAlign,
 } from '../../schema';
-import type { JSX } from '@stencil/core';
-import { Component, h, Host, Method, Prop, State, Watch } from '@stencil/core';
+import { preventDefaultAndStopPropagation } from '../../utils/events';
 import type { UnsubscribeFunction } from './ariaCurrentService';
 import { onLocationChange } from './ariaCurrentService';
-import { preventDefaultAndStopPropagation } from '../../utils/events';
-import { nonce } from '../../utils/dev.utils';
-import { KolIconTag, KolSpanWcTag, KolTooltipWcTag } from '../../core/component-names';
 
 import { translate } from '../../i18n';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
@@ -66,8 +65,6 @@ import { validateAccessAndShortKey } from '../../schema/validators/access-and-sh
 export class KolLinkWc implements LinkWcAPI, FocusableElement {
 	private anchorRef?: HTMLAnchorElement;
 	private unsubscribeOnLocationChange?: UnsubscribeFunction;
-
-	private readonly internalDescriptionById = nonce();
 
 	private readonly catchRef = (ref?: HTMLAnchorElement) => {
 		this.anchorRef = ref;
@@ -131,7 +128,7 @@ export class KolLinkWc implements LinkWcAPI, FocusableElement {
 	public render(): JSX.Element {
 		const { isExternal, tagAttrs } = this.getRenderValues();
 		const hasExpertSlot = showExpertSlot(this.state._label);
-		const hasAriaDescription = Boolean(this.state._ariaDescription?.trim()?.length);
+		const ariaDescription = this.state._ariaDescription?.trim();
 
 		return (
 			<Host class="kol-link-wc">
@@ -139,11 +136,11 @@ export class KolLinkWc implements LinkWcAPI, FocusableElement {
 					ref={this.catchRef}
 					{...tagAttrs}
 					accessKey={this.state._accessKey}
-					aria-keyshortcuts={this.state._shortKey}
 					aria-current={this.state._ariaCurrent}
-					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
+					aria-description={ariaDescription || undefined}
 					aria-disabled={this.state._disabled ? 'true' : undefined}
 					aria-expanded={typeof this.state._ariaExpanded === 'boolean' ? String(this.state._ariaExpanded) : undefined}
+					aria-keyshortcuts={this.state._shortKey}
 					aria-owns={this.state._ariaOwns}
 					aria-label={
 						this.state._hideLabel && typeof this.state._label === 'string'
@@ -193,11 +190,6 @@ export class KolLinkWc implements LinkWcAPI, FocusableElement {
 					_align={this.state._tooltipAlign}
 					_label={this.state._label || this.state._href}
 				></KolTooltipWcTag>
-				{hasAriaDescription && (
-					<span class="visually-hidden" id={this.internalDescriptionById}>
-						{this.state._ariaDescription}
-					</span>
-				)}
 			</Host>
 		);
 	}


### PR DESCRIPTION
## Summary
`KolButton` now maps `_ariaDescription` directly to the native `aria-description` attribute, removing the hidden description span and `aria-describedby` indirection that was previously used.

## Changes
- `_ariaDescription` now sets `aria-description` directly on the button element
- Removed hidden description span and unused nonce helper
- Refreshed button snapshot to expect `aria-description`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
`KolButton` leitet `_ariaDescription` jetzt direkt an das native `aria-description`-Attribut weiter und entfernt die bisherige versteckte Beschreibungs-Span mit `aria-describedby`.

## Änderungen
- `_ariaDescription` direkt auf `aria-description` am Button-Element abgebildet
- Versteckte Beschreibungs-Span und ungenutzten Nonce-Helfer entfernt
- Button-Snapshot auf `aria-description` aktualisiert
</details>