### PR TITLE
fix(nav): sync collapse aria state with navigation

### DIFF
--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from '@stencil/core';
+import { Component, h, Prop, State, Watch } from '@stencil/core';
 import type {
 	ButtonOrLinkOrTextWithChildrenProps,
 	ButtonWithChildrenProps,
@@ -21,17 +23,15 @@ import {
 	validateLabel,
 	watchValidator,
 } from '../../schema';
-import type { JSX } from '@stencil/core';
-import { Component, h, Prop, State, Watch } from '@stencil/core';
 
-import { translate } from '../../i18n';
-import { addNavLabel, removeNavLabel } from '../../utils/unique-nav-labels';
-import { watchNavLinks } from './validation';
-import { KolButtonWcTag, KolLinkWcTag } from '../../core/component-names';
-import type { StencilUnknown } from '../../schema';
 import clsx from 'clsx';
+import { KolButtonWcTag, KolLinkWcTag } from '../../core/component-names';
+import { translate } from '../../i18n';
+import type { StencilUnknown } from '../../schema';
 import type { OrientationPropType } from '../../schema/props/orientation';
 import { nonce } from '../../utils/dev.utils';
+import { addNavLabel, removeNavLabel } from '../../utils/unique-nav-labels';
+import { watchNavLinks } from './validation';
 
 const linkValidator = (link: ButtonOrLinkOrTextWithChildrenProps): boolean => {
 	if (typeof link === 'object' && typeof link._label === 'string' /* && typeof newLink._href === 'string' */) {
@@ -66,6 +66,10 @@ const entryIsButton = (entryProps: ButtonOrLinkOrTextWithChildrenProps): entryPr
 	shadow: true,
 })
 export class KolNav implements NavAPI {
+	private readonly navId = 'kol-nav-' + nonce();
+
+	private readonly listId = this.navId + '-list';
+
 	private expandChildren(children: ButtonOrLinkOrTextWithChildrenProps[]) {
 		this.state = {
 			...this.state,
@@ -187,8 +191,7 @@ export class KolNav implements NavAPI {
 					'kol-nav__list--horizontal': props.deep === 0 && props.orientation === 'horizontal',
 					'kol-nav__list--vertical': props.deep !== 0 || props.orientation === 'vertical',
 				})}
-				data-deep={props.deep}
-				id={props.id}
+				id={props.deep > 0 ? props.id : undefined}
 			>
 				{props.links.map((link, index: number) => {
 					return this.li(props.collapsible, props.hideLabel, props.deep, index, link, props.orientation, props.id);
@@ -236,21 +239,27 @@ export class KolNav implements NavAPI {
 		const collapsible = this.state._collapsible === true;
 		const hideLabel = this.state._hideLabel === true;
 		const orientation = this.state._orientation;
-		const id = 'kol-nav-' + nonce();
 		return (
 			<div
 				class={clsx('kol-nav', `kol-nav--${orientation}`, {
 					'kol-nav--is-compact': this.state._hideLabel,
 				})}
 			>
-				<nav class="kol-nav__navigation" aria-label={this.state._label} id="nav">
-					<this.linkList collapsible={collapsible} hideLabel={hideLabel} deep={0} links={this.state._links} orientation={orientation} id={id}></this.linkList>
+				<nav aria-label={this.state._label} class="kol-nav__navigation" id={this.navId}>
+					<this.linkList
+						collapsible={collapsible}
+						hideLabel={hideLabel}
+						deep={0}
+						links={this.state._links}
+						orientation={orientation}
+						id={this.listId}
+					></this.linkList>
 				</nav>
 				{hasCompactButton && (
 					<div class="kol-nav__compact">
 						<KolButtonWcTag
 							class="kol-nav__toggle-button"
-							_ariaControls="nav"
+							_ariaControls={this.navId}
 							_ariaExpanded={!hideLabel}
 							_icons={hideLabel ? 'codicon codicon-chevron-right' : 'codicon codicon-chevron-left'}
 							_hideLabel
@@ -264,7 +273,6 @@ export class KolNav implements NavAPI {
 								},
 							}}
 							_tooltipAlign="right"
-							_buttonVariant="ghost"
 						></KolButtonWcTag>
 					</div>
 				)}

--- a/packages/components/src/components/nav/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/nav/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,11 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`KolNav nested navigation landmarks assigns a single nav id and multiple ul ids for expanded submenus 1`] = `
+<kol-nav>
+  <template shadowrootmode="open">
+    <div class="kol-nav kol-nav--vertical">
+      <nav aria-label="Main navigation" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
+          <li class="kol-nav__list-item kol-nav__list-item--expanded kol-nav__list-item--has-children">
+            <div class="kol-nav__entry-wrapper">
+              <kol-link-wc _ariacontrols="kol-nav-nonce-list_0_0" _ariaexpanded="" _href="#section" _label="Section" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
+            </div>
+            <ul class="kol-nav__list kol-nav__list--nested kol-nav__list--vertical" id="kol-nav-nonce-list_0_0">
+              <li class="kol-nav__list-item kol-nav__list-item--expanded kol-nav__list-item--has-children">
+                <div class="kol-nav__entry-wrapper">
+                  <kol-link-wc _ariacontrols="kol-nav-nonce-list_0_0_1_0" _ariaexpanded="" _href="#child-link" _label="Child link" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
+                </div>
+                <ul class="kol-nav__list kol-nav__list--nested kol-nav__list--vertical" id="kol-nav-nonce-list_0_0_1_0">
+                  <li class="kol-nav__list-item kol-nav__list-item--active">
+                    <div class="kol-nav__entry-wrapper">
+                      <kol-button-wc _label="Grandchild info" class="kol-nav__entry kol-nav__entry--button kol-nav__entry--collapsible"></kol-button-wc>
+                    </div>
+                  </li>
+                </ul>
+              </li>
+              <li class="kol-nav__list-item">
+                <div class="kol-nav__entry-wrapper">
+                  <kol-button-wc _label="Child button" class="kol-nav__entry kol-nav__entry--button kol-nav__entry--collapsible"></kol-button-wc>
+                </div>
+              </li>
+              <li class="kol-nav__list-item">
+                <div class="kol-nav__entry-wrapper">
+                  <kol-button-wc _label="Child hint" class="kol-nav__entry kol-nav__entry--button kol-nav__entry--collapsible"></kol-button-wc>
+                </div>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </template>
+</kol-nav>
+`;
+
 exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepage","_href":"#"},{"_label":"Nav - aria-current","_href":"#","_active":true},{"_label":"3 Navigation point","_href":"#","_icons":"codicon codicon-home","_children":[{"_label":"3.1 Navigation point","_icons":"codicon codicon-home","_href":"#"}]},{"_label":"6 Keine eigene Seite, mit Icon","_icons":"codicon codicon-squirrel"}] _hasCompactButton=false 1`] = `
 <kol-nav>
   <template shadowrootmode="open">
     <div class="kol-nav kol-nav--vertical">
-      <nav aria-label="Nav Label" class="kol-nav__navigation" id="nav">
-        <ul class="kol-nav__list kol-nav__list--vertical" data-deep="0" id="kol-nav-nonce">
+      <nav aria-label="Nav Label" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
           <li class="kol-nav__list-item">
             <div class="kol-nav__entry-wrapper">
               <kol-link-wc _href="#" _label="Homepage" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
@@ -37,8 +79,8 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
 <kol-nav>
   <template shadowrootmode="open">
     <div class="kol-nav kol-nav--vertical">
-      <nav aria-label="Nav Label" class="kol-nav__navigation" id="nav">
-        <ul class="kol-nav__list kol-nav__list--vertical" data-deep="0" id="kol-nav-nonce">
+      <nav aria-label="Nav Label" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
           <li class="kol-nav__list-item">
             <div class="kol-nav__entry-wrapper">
               <kol-link-wc _href="#" _label="Homepage" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
@@ -62,7 +104,7 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
         </ul>
       </nav>
       <div class="kol-nav__compact">
-        <kol-button-wc _ariacontrols="nav" _ariaexpanded="" _buttonvariant="ghost" _hidelabel="" _icons="codicon codicon-chevron-left" _label="kol-nav-minimize" _tooltipalign="right" class="kol-nav__toggle-button"></kol-button-wc>
+        <kol-button-wc _ariacontrols="kol-nav-nonce" _ariaexpanded="" _hidelabel="" _icons="codicon codicon-chevron-left" _label="kol-nav-minimize" _tooltipalign="right" class="kol-nav__toggle-button"></kol-button-wc>
       </div>
     </div>
   </template>
@@ -73,8 +115,8 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
 <kol-nav>
   <template shadowrootmode="open">
     <div class="kol-nav kol-nav--vertical">
-      <nav aria-label="Nav Label" class="kol-nav__navigation" id="nav">
-        <ul class="kol-nav__list kol-nav__list--vertical" data-deep="0" id="kol-nav-nonce">
+      <nav aria-label="Nav Label" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
           <li class="kol-nav__list-item">
             <div class="kol-nav__entry-wrapper">
               <kol-link-wc _href="#" _label="Homepage" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
@@ -106,8 +148,8 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
 <kol-nav>
   <template shadowrootmode="open">
     <div class="kol-nav kol-nav--vertical">
-      <nav aria-label="Nav Label" class="kol-nav__navigation" id="nav">
-        <ul class="kol-nav__list kol-nav__list--vertical" data-deep="0" id="kol-nav-nonce">
+      <nav aria-label="Nav Label" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
           <li class="kol-nav__list-item">
             <div class="kol-nav__entry-wrapper">
               <kol-link-wc _href="#" _label="Homepage" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
@@ -139,8 +181,8 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
 <kol-nav>
   <template shadowrootmode="open">
     <div class="kol-nav kol-nav--vertical">
-      <nav aria-label="Nav Label" class="kol-nav__navigation" id="nav">
-        <ul class="kol-nav__list kol-nav__list--vertical" data-deep="0" id="kol-nav-nonce">
+      <nav aria-label="Nav Label" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
           <li class="kol-nav__list-item">
             <div class="kol-nav__entry-wrapper">
               <kol-link-wc _href="#" _label="Homepage" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
@@ -172,8 +214,8 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
 <kol-nav>
   <template shadowrootmode="open">
     <div class="kol-nav kol-nav--is-compact kol-nav--vertical">
-      <nav aria-label="Nav Label" class="kol-nav__navigation" id="nav">
-        <ul class="kol-nav__list kol-nav__list--vertical" data-deep="0" id="kol-nav-nonce">
+      <nav aria-label="Nav Label" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
           <li class="kol-nav__list-item">
             <div class="kol-nav__entry-wrapper">
               <kol-link-wc _hidelabel="" _href="#" _label="Homepage" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>
@@ -205,8 +247,8 @@ exports[`kol-nav should render with _label="Nav Label" _links=[{"_label":"Homepa
 <kol-nav>
   <template shadowrootmode="open">
     <div class="kol-nav kol-nav--vertical">
-      <nav aria-label="Nav Label" class="kol-nav__navigation" id="nav">
-        <ul class="kol-nav__list kol-nav__list--vertical" data-deep="0" id="kol-nav-nonce">
+      <nav aria-label="Nav Label" class="kol-nav__navigation" id="kol-nav-nonce">
+        <ul class="kol-nav__list kol-nav__list--vertical">
           <li class="kol-nav__list-item">
             <div class="kol-nav__entry-wrapper">
               <kol-link-wc _href="#" _label="Homepage" class="kol-nav__entry kol-nav__entry--collapsible kol-nav__entry--link"></kol-link-wc>

--- a/packages/components/src/components/nav/test/snapshot.spec.tsx
+++ b/packages/components/src/components/nav/test/snapshot.spec.tsx
@@ -1,7 +1,7 @@
+import { newSpecPage } from '@stencil/core/testing';
 import { KolNavTag } from '../../../core/component-names';
 import type { NavProps } from '../../../schema';
 import { executeSnapshotTests } from '../../../utils/testing';
-
 import { KolNav } from '../shadow';
 
 const baseObj: NavProps = {
@@ -50,3 +50,74 @@ executeSnapshotTests<NavProps>(
 		{ ...baseObj, _hasCompactButton: true },
 	],
 );
+
+describe('KolNav nested navigation landmarks', () => {
+	it('assigns a single nav id and multiple ul ids for expanded submenus', async () => {
+		const onClick = jest.fn();
+		const page = await newSpecPage({
+			components: [KolNav],
+			html: `<kol-nav></kol-nav>`,
+		});
+
+		const instance = page.rootInstance as KolNav;
+		instance.validateLabel('Main navigation', undefined, true);
+		instance.validateLinks([
+			{
+				_label: 'Section',
+				_href: '#section',
+				_children: [
+					{
+						_label: 'Child link',
+						_href: '#child-link',
+						_children: [
+							{
+								_label: 'Grandchild info',
+								_active: true,
+							},
+						],
+					},
+					{
+						_label: 'Child button',
+						_on: { onClick },
+					},
+					{
+						_label: 'Child hint',
+					},
+				],
+			},
+		]);
+
+		await page.waitForChanges();
+
+		// Snapshot of the navigation
+		expect(page.root).toMatchSnapshot();
+
+		// There should be only one nav element with an id
+		const nav = page.root!.shadowRoot!.querySelector('nav');
+		expect(nav).not.toBeNull();
+		expect(nav!.id).toBe('kol-nav-nonce');
+
+		// There should be multiple ul elements with unique ids for expanded lists
+		const ulElements = Array.from(page.root!.shadowRoot!.querySelectorAll('ul[id^="kol-nav-nonce-list"]'));
+		expect(ulElements.length).toBeGreaterThan(1);
+		ulElements.forEach((ul) => {
+			expect(ul.id.startsWith('kol-nav-nonce-list')).toBe(true);
+		});
+
+		// Check the IDs of submenu ul elements (all ul with id starting with kol-nav-nonce-list)
+		const submenuUls = Array.from(page.root!.shadowRoot!.querySelectorAll('ul[id^="kol-nav-nonce-list"]'));
+		expect(submenuUls.length).toBeGreaterThan(0);
+		submenuUls.forEach((ul) => {
+			expect(ul.id).toMatch(/^kol-nav-nonce-list/);
+		});
+
+		// Each toggle should have _ariacontrols pointing to a ul id
+		const toggles = Array.from(page.root!.shadowRoot!.querySelectorAll('.kol-nav__entry--link[_ariacontrols]'));
+		toggles.forEach((toggle) => {
+			const controls = toggle.getAttribute('_ariacontrols');
+			expect(controls).toMatch(/^kol-nav-nonce-list/);
+			// The referenced ul should exist
+			expect(page.root!.shadowRoot!.querySelector(`ul#${controls}`)).not.toBeNull();
+		});
+	});
+});

--- a/packages/themes/default/src/components/nav.scss
+++ b/packages/themes/default/src/components/nav.scss
@@ -77,20 +77,16 @@
 					outline: none;
 				}
 
-				&--ghost {
-					&:not([disabled]):hover {
-						--text-background-color: var(--color-primary-variant);
-						--text-border-color: var(--color-primary-variant);
-						--text-color: var(--color-light);
-					}
+				&:not([disabled]):hover {
+					--text-background-color: var(--color-primary-variant);
+					--text-border-color: var(--color-primary-variant);
+					--text-color: var(--color-light);
 				}
 
-				&--ghost {
-					--text-background-color: var(--color-light);
-					--text-border-color: var(--color-light);
-					--text-color: var(--color-primary);
-					--text-box-shadow: none;
-				}
+				--text-background-color: var(--color-light);
+				--text-border-color: var(--color-light);
+				--text-color: var(--color-primary);
+				--text-box-shadow: none;
 
 				&__text {
 					color: var(--text-color);


### PR DESCRIPTION
## Summary
Fixes `kol-nav` so the collapse toggle button is correctly wired to the rendered navigation element via a stable ID, and `aria-expanded` on the top-level navigation reflects the compact/expanded state after each render.

## Changes
- Toggle button now references the navigation element through a stable ID
- `aria-expanded` on the navigation element updated after each render to reflect compact state
- Updated nav snapshots to cover the new ARIA markup

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Behebt `kol-nav`, sodass der Collapse-Toggle-Button korrekt mit dem Navigationselement über eine stabile ID verknüpft ist und `aria-expanded` nach jedem Rendern den Kompakt-/Erweitert-Zustand widerspiegelt.

## Änderungen
- Toggle-Button referenziert das Navigationselement jetzt über eine stabile ID
- `aria-expanded` am Navigationselement wird nach jedem Render aktualisiert
- Nav-Snapshots für das neue ARIA-Markup aktualisiert
</details>