### PR TITLE
fix: render tooltips only when labels are hidden

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -172,19 +172,21 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 						<slot name="expert" slot="expert"></slot>
 					</KolSpanFc>
 				</button>
-				<KolTooltipWcTag
-					ref={(ref) => (this.tooltipRef = ref)}
-					/**
-					 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
-					 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.
-					 */
-					aria-hidden="true"
-					hidden={hasExpertSlot || !hideLabel}
-					class="kol-button__tooltip"
-					_badgeText={badgeText}
-					_align={this.state._tooltipAlign}
-					_label={typeof this.state._label === 'string' ? this.state._label : ''}
-				></KolTooltipWcTag>
+				{hideLabel && (
+					<KolTooltipWcTag
+						ref={(ref) => (this.tooltipRef = ref)}
+						/**
+						 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
+						 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.
+						 */
+						aria-hidden="true"
+						hidden={hasExpertSlot}
+						class="kol-button__tooltip"
+						_badgeText={badgeText}
+						_align={this.state._tooltipAlign}
+						_label={typeof this.state._label === 'string' ? this.state._label : ''}
+					></KolTooltipWcTag>
+				)}
 				{hasAriaDescription && (
 					<span class="visually-hidden" id={this.internalDescriptionById}>
 						{this.state._ariaDescription}

--- a/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -17,7 +17,6 @@ exports[`kol-button should render with _label="Label" _ariaDescription="Aria Des
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
       <span class="visually-hidden" id="nonce">
         Aria Description
       </span>
@@ -43,7 +42,6 @@ exports[`kol-button should render with _label="Label" _disabled=false 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -66,7 +64,6 @@ exports[`kol-button should render with _label="Label" _disabled=true 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -89,7 +86,6 @@ exports[`kol-button should render with _label="Label" _value="Hello" 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -112,7 +108,6 @@ exports[`kol-button should render with _label="Label" _variant="danger" 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -135,7 +130,6 @@ exports[`kol-button should render with _label="Label" _variant="ghost" 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -158,7 +152,6 @@ exports[`kol-button should render with _label="Label" _variant="normal" 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -181,7 +174,6 @@ exports[`kol-button should render with _label="Label" _variant="primary" 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -204,7 +196,6 @@ exports[`kol-button should render with _label="Label" _variant="secondary" 1`] =
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>
@@ -227,7 +218,6 @@ exports[`kol-button should render with _label="Label" 1`] = `
           </span>
         </span>
       </button>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
     </kol-button-wc>
   </template>
 </kol-button>

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -198,18 +198,20 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 						/>
 					)}
 				</a>
-				<KolTooltipWcTag
-					/**
-					 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
-					 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.
-					 */
-					aria-hidden="true"
-					class="kol-link__tooltip"
-					hidden={hasExpertSlot || !this.state._hideLabel}
-					_badgeText={this.state._accessKey || this.state._shortKey}
-					_align={this.state._tooltipAlign}
-					_label={this.state._label || this.state._href}
-				></KolTooltipWcTag>
+				{this.state._hideLabel === true && (
+					<KolTooltipWcTag
+						/**
+						 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
+						 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.
+						 */
+						aria-hidden="true"
+						class="kol-link__tooltip"
+						hidden={hasExpertSlot}
+						_badgeText={this.state._accessKey || this.state._shortKey}
+						_align={this.state._tooltipAlign}
+						_label={this.state._label || this.state._href}
+					></KolTooltipWcTag>
+				)}
 				{hasAriaDescription && (
 					<span class="visually-hidden" id={this.internalDescriptionById}>
 						{this.state._ariaDescription}

--- a/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -19,7 +19,6 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
         </span>
         <kol-icon _icons="codicon codicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
       </a>
-      <kol-tooltip-wc _align="bottom" _label="Label" aria-hidden="true" class="kol-link__tooltip" hidden=""></kol-tooltip-wc>
     </kol-link-wc>
   </template>
 </kol-link>
@@ -44,7 +43,6 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
         </span>
         <kol-icon _icons="codicon codicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
       </a>
-      <kol-tooltip-wc _align="left" _label="Label" aria-hidden="true" class="kol-link__tooltip" hidden=""></kol-tooltip-wc>
     </kol-link-wc>
   </template>
 </kol-link>
@@ -69,7 +67,6 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
         </span>
         <kol-icon _icons="codicon codicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
       </a>
-      <kol-tooltip-wc _align="right" _label="Label" aria-hidden="true" class="kol-link__tooltip" hidden=""></kol-tooltip-wc>
     </kol-link-wc>
   </template>
 </kol-link>
@@ -116,7 +113,6 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
         </span>
         <kol-icon _icons="codicon codicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
       </a>
-      <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-link__tooltip" hidden=""></kol-tooltip-wc>
     </kol-link-wc>
   </template>
 </kol-link>
@@ -141,7 +137,6 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
         </span>
         <kol-icon _icons="codicon codicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
       </a>
-      <kol-tooltip-wc _align="right" _label="Label" aria-hidden="true" class="kol-link__tooltip" hidden=""></kol-tooltip-wc>
     </kol-link-wc>
   </template>
 </kol-link>
@@ -165,7 +160,6 @@ exports[`kol-link should render with _label="Label" _href="" _download="download
         </span>
         <kol-icon _icons="codicon codicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
       </a>
-      <kol-tooltip-wc _align="right" _label="Label" aria-hidden="true" class="kol-link__tooltip" hidden=""></kol-tooltip-wc>
     </kol-link-wc>
   </template>
 </kol-link>

--- a/packages/components/src/functional-components/FieldControl/FieldControl.tsx
+++ b/packages/components/src/functional-components/FieldControl/FieldControl.tsx
@@ -88,14 +88,7 @@ const KolFieldControlFc: FC<FieldControlProps> = (props, children) => {
 		<>
 			<InputContainer {...fieldControlInputProps}>{children}</InputContainer>
 			{useTooltipInsteadOfLabel && (
-				<KolFieldControlTooltipFc
-					{...(fieldControlTooltipProps || {})}
-					id={id}
-					label={label}
-					hideLabel={hideLabel}
-					align={tooltipAlign}
-					badgeText={badgeText}
-				/>
+				<KolFieldControlTooltipFc {...(fieldControlTooltipProps || {})} id={id} label={label} align={tooltipAlign} badgeText={badgeText} />
 			)}
 		</>,
 		<KolFieldControlLabelFc

--- a/packages/components/src/functional-components/FormField/FormField.tsx
+++ b/packages/components/src/functional-components/FormField/FormField.tsx
@@ -141,8 +141,8 @@ const KolFormFieldFc: FC<FormFieldProps> = (props, children) => {
 			)}
 			<InputContainer {...formFieldInputProps}>
 				{children}
-				{useTooltipInsteadOfLabel && (
-					<KolFormFieldTooltipFc {...(formFieldTooltipProps || {})} id={id} label={label} hideLabel={hideLabel} align={tooltipAlign} badgeText={badgeText} />
+				{useTooltipInsteadOfLabel && hideLabel === true && (
+					<KolFormFieldTooltipFc {...(formFieldTooltipProps || {})} id={id} label={label} align={tooltipAlign} badgeText={badgeText} />
 				)}
 			</InputContainer>
 			{counter ? <KolFormFieldCounterFc {...counter} /> : null}

--- a/packages/components/src/functional-components/FormFieldTooltip/FormFieldTooltip.tsx
+++ b/packages/components/src/functional-components/FormFieldTooltip/FormFieldTooltip.tsx
@@ -8,11 +8,10 @@ type FormFieldTooltipProps = Pick<JSXBase.HTMLAttributes<HTMLElement>, 'class'> 
 	id: string;
 	align?: AlignPropType;
 	badgeText?: string;
-	hideLabel?: boolean;
 	label: string;
 };
 
-const FormFieldTooltipFc: FC<FormFieldTooltipProps> = ({ id, align, badgeText, hideLabel, label, class: classNames }) => {
+const FormFieldTooltipFc: FC<FormFieldTooltipProps> = ({ id, align, badgeText, label, class: classNames }) => {
 	return (
 		<KolTooltipWcTag
 			/**
@@ -23,7 +22,7 @@ const FormFieldTooltipFc: FC<FormFieldTooltipProps> = ({ id, align, badgeText, h
 			class={clsx('kol-form-field__tooltip', classNames)}
 			_badgeText={badgeText}
 			_align={align}
-			_id={hideLabel ? `${id}-label` : undefined}
+			_id={`${id}-label`}
 			_label={label}
 		></KolTooltipWcTag>
 	);

--- a/packages/components/src/functional-components/FormFieldTooltip/tests/__snapshots__/snapshort.test.tsx.snap
+++ b/packages/components/src/functional-components/FormFieldTooltip/tests/__snapshots__/snapshort.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`FormFieldTooltipFc should render correctly 1`] = `
 <kol-tooltip-wc
+  _id="test-id-label"
   _label="Test Label"
   aria-hidden="true"
   class="kol-form-field__tooltip"
@@ -11,6 +12,7 @@ exports[`FormFieldTooltipFc should render correctly 1`] = `
 exports[`FormFieldTooltipFc should set the correct align property 1`] = `
 <kol-tooltip-wc
   _align="left"
+  _id="test-id-label"
   _label="Test Label"
   aria-hidden="true"
   class="kol-form-field__tooltip"
@@ -20,6 +22,7 @@ exports[`FormFieldTooltipFc should set the correct align property 1`] = `
 exports[`FormFieldTooltipFc should set the correct badgeText 1`] = `
 <kol-tooltip-wc
   _badgetext="Badge Text"
+  _id="test-id-label"
   _label="Test Label"
   aria-hidden="true"
   class="kol-form-field__tooltip"
@@ -28,6 +31,7 @@ exports[`FormFieldTooltipFc should set the correct badgeText 1`] = `
 
 exports[`FormFieldTooltipFc should set the correct class names 1`] = `
 <kol-tooltip-wc
+  _id="test-id-label"
   _label="Test Label"
   aria-hidden="true"
   class="kol-form-field__tooltip custom-class"
@@ -36,17 +40,10 @@ exports[`FormFieldTooltipFc should set the correct class names 1`] = `
 
 exports[`FormFieldTooltipFc should set the correct id and label 1`] = `
 <kol-tooltip-wc
-  _label="Test Label"
-  aria-hidden="true"
-  class="kol-form-field__tooltip"
-/>
-`;
-
-exports[`FormFieldTooltipFc should set the correct id when hideLabel is true 1`] = `
-<kol-tooltip-wc
   _id="test-id-label"
   _label="Test Label"
   aria-hidden="true"
   class="kol-form-field__tooltip"
 />
 `;
+

--- a/packages/components/src/functional-components/FormFieldTooltip/tests/snapshort.test.tsx
+++ b/packages/components/src/functional-components/FormFieldTooltip/tests/snapshort.test.tsx
@@ -7,7 +7,7 @@ describe('FormFieldTooltipFc', () => {
 		const label = 'Test Label';
 		const page = await renderFunctionalComponentToSpecPage(() => <FormFieldTooltipFc id="test-id" label={label} />);
 		expect(page.root).toMatchSnapshot();
-		expect(page.root?.getAttribute('_id')).toBe(null);
+		expect(page.root?.getAttribute('_id')).toBe('test-id-label');
 		expect(page.root?.getAttribute('_label')).toBe(label);
 	});
 
@@ -45,16 +45,6 @@ describe('FormFieldTooltipFc', () => {
 		const id = 'test-id';
 		const label = 'Test Label';
 		const page = await renderFunctionalComponentToSpecPage(() => <FormFieldTooltipFc id={id} label={label} />);
-
-		expect(page.root).toMatchSnapshot();
-		expect(page.root?.getAttribute('_id')).toBe(null);
-		expect(page.root?.getAttribute('_label')).toBe(label);
-	});
-
-	it('should set the correct id when hideLabel is true', async () => {
-		const id = 'test-id';
-		const label = 'Test Label';
-		const page = await renderFunctionalComponentToSpecPage(() => <FormFieldTooltipFc id={id} label={label} hideLabel={true} />);
 
 		expect(page.root).toMatchSnapshot();
 		expect(page.root?.getAttribute('_id')).toBe(`${id}-label`);


### PR DESCRIPTION
## Summary
Optimizes tooltip rendering by only adding a `kol-tooltip` to buttons and links when their label is hidden, avoiding redundant DOM nodes when a visible label is already present.

## Changes
- `kol-tooltip` on buttons and links is now rendered only when `_hideLabel` is set
- Shared form field tooltip functional component guarded behind a `hideLabel` check
- Updated button, link, and form field tooltip snapshots to match the new conditional rendering

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Optimiert das Tooltip-Rendering, indem ein `kol-tooltip` bei Buttons und Links nur noch gerendert wird, wenn deren Beschriftung ausgeblendet ist, um redundante DOM-Knoten zu vermeiden.

## Änderungen
- `kol-tooltip` bei Buttons und Links wird nur noch gerendert, wenn `_hideLabel` gesetzt ist
- Gemeinsame Formularfeld-Tooltip-Funktionalkomponente durch eine `hideLabel`-Prüfung abgesichert
- Button-, Link- und Formularfeld-Tooltip-Snapshots an das neue bedingte Rendering angepasst
</details>