### PR TITLE
fix: remove aria-hidden from span helper

### DIFF
--- a/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`kol-badge should render with _label="**Te**xt" 1`] = `
             </strong>
             xt
           </span>
-          <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+          <span class="kol-span__label" hidden=""></span>
         </span>
       </span>
     </span>
@@ -29,7 +29,7 @@ exports[`kol-badge should render with _label="Text" _color="#000000" 1`] = `
           <span class="kol-span__label md">
             Text
           </span>
-          <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+          <span class="kol-span__label" hidden=""></span>
         </span>
       </span>
     </span>
@@ -47,7 +47,7 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
           <span class="kol-span__label md">
             Text
           </span>
-          <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+          <span class="kol-span__label" hidden=""></span>
         </span>
       </span>
     </span>
@@ -65,7 +65,7 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
           <span class="kol-span__label md">
             Text
           </span>
-          <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+          <span class="kol-span__label" hidden=""></span>
         </span>
       </span>
     </span>
@@ -82,7 +82,7 @@ exports[`kol-badge should render with _label="Text" 1`] = `
           <span class="kol-span__label md">
             Text
           </span>
-          <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+          <span class="kol-span__label" hidden=""></span>
         </span>
       </span>
     </span>

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -186,7 +186,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 					_label={typeof this.state._label === 'string' ? this.state._label : ''}
 				></KolTooltipWcTag>
 				{hasAriaDescription && (
-					<span class="visually-hidden" id={this.internalDescriptionById}>
+					<span hidden id={this.internalDescriptionById}>
 						{this.state._ariaDescription}
 					</span>
 				)}

--- a/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -11,14 +11,14 @@ exports[`kol-button should render with _label="Label" _ariaDescription="Aria Des
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
         </span>
       </button>
       <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-button__tooltip" hidden=""></kol-tooltip-wc>
-      <span class="visually-hidden" id="nonce">
+      <span hidden="" id="nonce">
         Aria Description
       </span>
     </kol-button-wc>
@@ -37,7 +37,7 @@ exports[`kol-button should render with _label="Label" _disabled=false 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -60,7 +60,7 @@ exports[`kol-button should render with _label="Label" _disabled=true 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -83,7 +83,7 @@ exports[`kol-button should render with _label="Label" _value="Hello" 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -106,7 +106,7 @@ exports[`kol-button should render with _label="Label" _variant="danger" 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -129,7 +129,7 @@ exports[`kol-button should render with _label="Label" _variant="ghost" 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -152,7 +152,7 @@ exports[`kol-button should render with _label="Label" _variant="normal" 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -175,7 +175,7 @@ exports[`kol-button should render with _label="Label" _variant="primary" 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -198,7 +198,7 @@ exports[`kol-button should render with _label="Label" _variant="secondary" 1`] =
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -221,7 +221,7 @@ exports[`kol-button should render with _label="Label" 1`] = `
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -211,7 +211,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 					_label={this.state._label || this.state._href}
 				></KolTooltipWcTag>
 				{hasAriaDescription && (
-					<span class="visually-hidden" id={this.internalDescriptionById}>
+					<span hidden id={this.internalDescriptionById}>
 						{this.state._ariaDescription}
 					</span>
 				)}

--- a/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -37,7 +37,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -62,7 +62,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -84,7 +84,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
         <span class="kol-link__text kol-span kol-span--hide-label">
           <span class="kol-span__container">
             <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -109,7 +109,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -134,7 +134,7 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
@@ -158,7 +158,7 @@ exports[`kol-link should render with _label="Label" _href="" _download="download
             <span class="kol-span__label">
               Label
             </span>
-            <span aria-hidden="true" class="kol-span__label" hidden="">
+            <span class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>

--- a/packages/components/src/components/tooltip/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/tooltip/test/__snapshots__/snapshot.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`kol-tooltip-wc should render with _id="id" _label="Label" _align="botto
         <span class="kol-span__label">
           Label
         </span>
-        <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+        <span class="kol-span__label" hidden=""></span>
       </span>
     </span>
   </div>
@@ -25,7 +25,7 @@ exports[`kol-tooltip-wc should render with _id="id" _label="Label" _align="left"
         <span class="kol-span__label">
           Label
         </span>
-        <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+        <span class="kol-span__label" hidden=""></span>
       </span>
     </span>
   </div>
@@ -41,7 +41,7 @@ exports[`kol-tooltip-wc should render with _id="id" _label="Label" _align="right
         <span class="kol-span__label">
           Label
         </span>
-        <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+        <span class="kol-span__label" hidden=""></span>
       </span>
     </span>
   </div>
@@ -57,7 +57,7 @@ exports[`kol-tooltip-wc should render with _id="id" _label="Label" _align="top" 
         <span class="kol-span__label">
           Label
         </span>
-        <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+        <span class="kol-span__label" hidden=""></span>
       </span>
     </span>
   </div>
@@ -73,7 +73,7 @@ exports[`kol-tooltip-wc should render with _id="id" _label="Label" 1`] = `
         <span class="kol-span__label">
           Label
         </span>
-        <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+        <span class="kol-span__label" hidden=""></span>
       </span>
     </span>
   </div>

--- a/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
+++ b/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
@@ -13,7 +13,7 @@ const KolSpanCoreHelperFc: FC<{ label: string; hideLabel?: boolean; badgeText?: 
 	return (
 		<>
 			{hideExpertSlot && <LabelHelper label={label} hideLabel={hideLabel} badgeText={badgeText} allowMarkdown={allowMarkdown} />}
-			<span aria-hidden={hideExpertSlot ? 'true' : undefined} class="kol-span__label" hidden={hideExpertSlot}>
+			<span class="kol-span__label" hidden={hideExpertSlot}>
 				{children}
 			</span>
 			{isString(badgeText) && badgeText.length > 0 && (

--- a/packages/components/src/functional-components/Span/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Span/test/__snapshots__/snapshot.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`KolSpanFc should allow markdown in label 1`] = `
         Bold Label
       </strong>
     </span>
-    <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+    <span class="kol-span__label" hidden=""></span>
   </span>
 </span>
 `;
@@ -16,7 +16,7 @@ exports[`KolSpanFc should allow markdown in label 1`] = `
 exports[`KolSpanFc should hide label when hideLabel is true 1`] = `
 <span class="kol-span kol-span--hide-label">
   <span class="kol-span__container">
-    <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+    <span class="kol-span__label" hidden=""></span>
   </span>
 </span>
 `;
@@ -30,7 +30,7 @@ exports[`KolSpanFc should render with badge text 1`] = `
         Badge
       </u>
     </span>
-    <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+    <span class="kol-span__label" hidden=""></span>
     <kbd aria-hidden="true" class="badge-text-hint">
       Badge
     </kbd>
@@ -44,7 +44,7 @@ exports[`KolSpanFc should render with default props 1`] = `
     <span class="kol-span__label">
       Default Label
     </span>
-    <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+    <span class="kol-span__label" hidden=""></span>
   </span>
 </span>
 `;
@@ -57,7 +57,7 @@ exports[`KolSpanFc should render with icons 1`] = `
     <span class="kol-span__label">
       Label with Icons
     </span>
-    <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+    <span class="kol-span__label" hidden=""></span>
     <kol-icon _icons="right-icon" _label="" class="icon right"></kol-icon>
   </span>
   <kol-icon _icons="bottom-icon" _label="" class="bottom icon"></kol-icon>


### PR DESCRIPTION
## Summary
- drop the aria-hidden attribute from the KolSpan expert slot container so screen readers only pick up the hidden flag
- refresh the affected snapshots for span, badge, button, link and tooltip to reflect the updated markup

## Testing
- pnpm --filter @public-ui/components test:unit -- --updateSnapshot

------
https://chatgpt.com/codex/tasks/task_e_68db17bc1f94832bb36e62d69202f741