### PR TITLE
fix(link): align aria-description handling in link component

### DIFF
--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -131,7 +131,8 @@ export class KolLinkWc implements LinkWcAPI, FocusableElement {
 	public render(): JSX.Element {
 		const { isExternal, tagAttrs } = this.getRenderValues();
 		const hasExpertSlot = showExpertSlot(this.state._label);
-		const hasAriaDescription = Boolean(this.state._ariaDescription?.trim()?.length);
+		const ariaDescription = this.state._ariaDescription?.trim();
+		const hasAriaDescription = Boolean(ariaDescription?.length);
 
 		return (
 			<Host class="kol-link-wc">
@@ -139,6 +140,7 @@ export class KolLinkWc implements LinkWcAPI, FocusableElement {
 					ref={this.catchRef}
 					{...tagAttrs}
 					accessKey={this.state._accessKey}
+					aria-description={ariaDescription || undefined}
 					aria-keyshortcuts={this.state._shortKey}
 					aria-current={this.state._ariaCurrent}
 					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
@@ -195,7 +197,7 @@ export class KolLinkWc implements LinkWcAPI, FocusableElement {
 				></KolTooltipWcTag>
 				{hasAriaDescription && (
 					<span class="visually-hidden" id={this.internalDescriptionById}>
-						{this.state._ariaDescription}
+						{ariaDescription}
 					</span>
 				)}
 			</Host>


### PR DESCRIPTION
## Summary
Internal sub-PR aligning `aria-description` handling in `KolLink`. Merged into the aria refactor feature branch as part of incremental development.

## Changes
- Trimmed the configured description before use in `KolLink`
- Set `aria-description` attribute on the rendered anchor while keeping the `aria-describedby` fallback

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR zur Angleichung der `aria-description`-Behandlung in `KolLink`.

## Änderungen
- Konfigurierte Beschreibung in `KolLink` vor der Verwendung getrimmt
- `aria-description`-Attribut am gerenderten Anchor gesetzt, `aria-describedby`-Fallback beibehalten
</details>