### PR TITLE
fix: sync hidden elements with aria helpers

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -179,9 +179,11 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 						 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
 						 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.
 						 */
-						aria-hidden="true"
+						aria-hidden={hasExpertSlot ? 'true' : undefined}
 						hidden={hasExpertSlot}
-						class="kol-button__tooltip"
+						class={clsx('kol-button__tooltip', {
+							'visually-hidden': hasExpertSlot,
+						})}
 						_badgeText={badgeText}
 						_align={this.state._tooltipAlign}
 						_label={typeof this.state._label === 'string' ? this.state._label : ''}

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -191,10 +191,10 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 					</KolSpanFc>
 					{isExternal && (
 						<KolIconTag
+							aria-hidden={this.state._hideLabel ? 'true' : undefined}
 							class="kol-link__icon"
 							_label={this.state._hideLabel ? '' : this.translateOpenLinkInTab}
 							_icons={'codicon codicon-link-external'}
-							aria-hidden={this.state._hideLabel}
 						/>
 					)}
 				</a>
@@ -204,8 +204,10 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 						 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
 						 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.
 						 */
-						aria-hidden="true"
-						class="kol-link__tooltip"
+						aria-hidden={hasExpertSlot ? 'true' : undefined}
+						class={clsx('kol-link__tooltip', {
+							'visually-hidden': hasExpertSlot,
+						})}
 						hidden={hasExpertSlot}
 						_badgeText={this.state._accessKey || this.state._shortKey}
 						_align={this.state._tooltipAlign}

--- a/packages/components/src/components/popover/component.tsx
+++ b/packages/components/src/components/popover/component.tsx
@@ -99,7 +99,11 @@ export class KolPopover implements PopoverAPI {
 		return (
 			<Host ref={this.catchHostAndTriggerElement} class="kol-popover">
 				<div
-					class={clsx('kol-popover__content', { 'kol-popover__content--visible': this.state._visible })}
+					aria-hidden={this.state._show ? undefined : 'true'}
+					class={clsx('kol-popover__content', {
+						'kol-popover__content--visible': this.state._visible,
+						'visually-hidden': !this.state._show,
+					})}
 					ref={this.catchPopoverElement}
 					hidden={!this.state._show}
 				>

--- a/packages/components/src/components/quote/shadow.tsx
+++ b/packages/components/src/components/quote/shadow.tsx
@@ -70,19 +70,20 @@ export class KolQuote implements QuoteAPI {
 
 	public render(): JSX.Element {
 		const hasExpertSlot = showExpertSlot(this.state._quote); // _quote instead of _caption as _label
+		const hideExpertSlot = !hasExpertSlot;
 		return (
 			<figure class={clsx('kol-quote', `kol-quote--${this.state._variant}`)}>
 				{this.state._variant === 'block' ? (
 					<blockquote class="kol-quote__blockquote" cite={this.state._href}>
 						{this.state._quote}
-						<span aria-hidden={!hasExpertSlot ? 'true' : undefined} hidden={!hasExpertSlot}>
+						<span aria-hidden={hideExpertSlot ? 'true' : undefined} class={clsx({ 'visually-hidden': hideExpertSlot })} hidden={hideExpertSlot}>
 							<slot name="expert" />
 						</span>
 					</blockquote>
 				) : (
 					<q class="kol-quote__quote" cite={this.state._href}>
 						{this.state._quote}
-						<span aria-hidden={!hasExpertSlot ? 'true' : undefined} hidden={!hasExpertSlot}>
+						<span aria-hidden={hideExpertSlot ? 'true' : undefined} class={clsx({ 'visually-hidden': hideExpertSlot })} hidden={hideExpertSlot}>
 							<slot name="expert" />
 						</span>
 					</q>

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -117,7 +117,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 							});
 						}}
 					>
-						<input type="submit" hidden />
+						<input aria-hidden="true" class="visually-hidden" hidden type="submit" />
 						<KolSelectStateWrapperFc {...this.getSelectProps()} />
 					</form>
 				</KolInputContainerFc>

--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -19,6 +19,7 @@ export class KolTreeItemWc implements TreeItemAPI {
 
 	public render(): JSX.Element {
 		const { _href, _active, _hasChildren, _open, _label } = this.state;
+		const hideChildren = !_hasChildren || !_open;
 		return (
 			<Host onSlotchange={this.handleSlotchange.bind(this)}>
 				<li
@@ -59,7 +60,15 @@ export class KolTreeItemWc implements TreeItemAPI {
 							<span class="kol-tree-item__text">{_label}</span>
 						</span>
 					</KolLinkWcTag>
-					<ul class="kol-tree-item__children" hidden={!_hasChildren || !_open} role="group" id={this.groupId}>
+					<ul
+						aria-hidden={hideChildren ? 'true' : undefined}
+						class={clsx('kol-tree-item__children', {
+							'visually-hidden': hideChildren,
+						})}
+						hidden={hideChildren}
+						role="group"
+						id={this.groupId}
+					>
 						<slot />
 					</ul>
 				</li>

--- a/packages/components/src/functional-components/Collapsible/Collapsible.tsx
+++ b/packages/components/src/functional-components/Collapsible/Collapsible.tsx
@@ -70,7 +70,14 @@ const KolCollapsibleFc: FC<CollapsibleProps> = (props, children) => {
 			</KolHeadingFc>
 			<div class={clsx('collapsible__wrapper', ContentProps?.wrapperClass)}>
 				<div class={clsx('collapsible__wrapper-animation', ContentProps?.animationClass)}>
-					<div aria-hidden={open === false ? 'true' : undefined} class={clsx('collapsible__content', ContentProps?.class)} id={`${id}-control`}>
+					<div
+						aria-hidden={open === false ? 'true' : undefined}
+						class={clsx('collapsible__content', ContentProps?.class, {
+							'visually-hidden': open === false,
+						})}
+						hidden={open === false}
+						id={`${id}-control`}
+					>
 						{children}
 					</div>
 				</div>

--- a/packages/components/src/functional-components/FormFieldLabel/FormFieldLabel.tsx
+++ b/packages/components/src/functional-components/FormFieldLabel/FormFieldLabel.tsx
@@ -67,7 +67,10 @@ const KolFormFieldLabelFc: FC<FormFieldLabelProps> = ({
 	return (
 		<Component
 			{...other}
-			class={clsx(`${baseClassName}__label`, classNames)}
+			aria-hidden={useTooltipInsteadOfLabel ? 'true' : undefined}
+			class={clsx(`${baseClassName}__label`, classNames, {
+				'visually-hidden': useTooltipInsteadOfLabel,
+			})}
 			id={!useTooltipInsteadOfLabel ? `${id}-label` : undefined}
 			hidden={useTooltipInsteadOfLabel}
 			htmlFor={id}

--- a/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
+++ b/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
@@ -1,4 +1,5 @@
 import { Fragment, h, type FunctionalComponent as FC } from '@stencil/core';
+import clsx from 'clsx';
 import { isString } from 'lodash-es';
 
 import { showExpertSlot } from '../../schema';
@@ -13,7 +14,7 @@ const KolSpanCoreHelperFc: FC<{ label: string; hideLabel?: boolean; badgeText?: 
 	return (
 		<>
 			{hideExpertSlot && <LabelHelper label={label} hideLabel={hideLabel} badgeText={badgeText} allowMarkdown={allowMarkdown} />}
-			<span aria-hidden={hideExpertSlot ? 'true' : undefined} class="kol-span__label" hidden={hideExpertSlot}>
+			<span aria-hidden={hideExpertSlot ? 'true' : undefined} class={clsx('kol-span__label', { 'visually-hidden': hideExpertSlot })} hidden={hideExpertSlot}>
 				{children}
 			</span>
 			{isString(badgeText) && badgeText.length > 0 && (


### PR DESCRIPTION
## Summary
- update shared span and label helpers to add `visually-hidden` styling and aria attributes when content is suppressed
- adjust button, link, popover, quote, select and tree components to pair `hidden` with matching accessibility attributes
- ensure collapsible containers hide their slot content consistently with the new visibility rules

## Testing
- pnpm prettier --write packages/components/src/components/button/component.tsx packages/components/src/components/link/component.tsx packages/components/src/components/popover/component.tsx packages/components/src/components/quote/shadow.tsx packages/components/src/components/select/shadow.tsx packages/components/src/components/tree-item/component.tsx packages/components/src/functional-components/Collapsible/Collapsible.tsx packages/components/src/functional-components/FormFieldLabel/FormFieldLabel.tsx packages/components/src/functional-components/Span/SpanCoreHelper.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db2475b8bc832bbd37e1c15d657ad3