### PR TITLE
fix: expose aria descriptions directly

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -51,7 +51,6 @@ import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
 
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
-import { nonce } from '../../utils/dev.utils';
 import { propagateResetEventToForm, propagateSubmitEventToForm } from '../form/controller';
 import { AssociatedInputController } from '../input-adapter-leanup/associated.controller';
 import { KolTooltipWcTag } from '../../core/component-names';
@@ -71,8 +70,6 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolButtonWcElement;
 	private buttonRef?: HTMLButtonElement;
 	private tooltipRef?: HTMLKolTooltipWcElement;
-
-	private readonly internalDescriptionById = nonce();
 
 	/**
 	 * Sets focus on the internal element.
@@ -128,7 +125,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 
 	public render(): JSX.Element {
 		const hasExpertSlot = showExpertSlot(this.state._label);
-		const hasAriaDescription = Boolean(this.state._ariaDescription?.trim()?.length);
+		const ariaDescription = this.state._ariaDescription?.trim();
 		const badgeText = this.state._accessKey || this.state._shortKey;
 		const isDisabled = this.state._disabled === true;
 		const hideLabel = this.state._hideLabel === true;
@@ -139,7 +136,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 					ref={(ref) => (this.buttonRef = ref)}
 					accessKey={this.state._accessKey}
 					aria-controls={this.state._ariaControls}
-					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
+					aria-description={ariaDescription || undefined}
 					aria-expanded={mapBoolean2String(this.state._ariaExpanded)}
 					aria-haspopup={this._ariaHasPopup}
 					aria-keyshortcuts={this.state._shortKey}
@@ -186,11 +183,6 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 						_align={this.state._tooltipAlign}
 						_label={typeof this.state._label === 'string' ? this.state._label : ''}
 					></KolTooltipWcTag>
-				)}
-				{hasAriaDescription && (
-					<span class="visually-hidden" id={this.internalDescriptionById}>
-						{this.state._ariaDescription}
-					</span>
 				)}
 			</Host>
 		);

--- a/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/button/test/__snapshots__/snapshot.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`kol-button should render with _label="Label" _ariaDescription="Aria Des
   <template shadowrootmode="open" shadowrootdelegatesfocus>
     <kol-button-wc>
       <!---->
-      <button aria-describedby="nonce" class="kol-button kol-button--normal" type="button">
+      <button aria-description="Aria Description" class="kol-button kol-button--normal" type="button">
         <span class="kol-button__text kol-span">
           <span class="kol-span__container">
             <span class="kol-span__label">
@@ -17,9 +17,6 @@ exports[`kol-button should render with _label="Label" _ariaDescription="Aria Des
           </span>
         </span>
       </button>
-      <span class="visually-hidden" id="nonce">
-        Aria Description
-      </span>
     </kol-button-wc>
   </template>
 </kol-button>

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -54,7 +54,6 @@ import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stenci
 import type { UnsubscribeFunction } from './ariaCurrentService';
 import { onLocationChange } from './ariaCurrentService';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
-import { nonce } from '../../utils/dev.utils';
 import { KolIconTag, KolTooltipWcTag } from '../../core/component-names';
 
 import { translate } from '../../i18n';
@@ -75,7 +74,6 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	private anchorRef?: HTMLAnchorElement;
 	private unsubscribeOnLocationChange?: UnsubscribeFunction;
 
-	private readonly internalDescriptionById = nonce();
 	private readonly translateOpenLinkInTab = translate('kol-open-link-in-tab');
 
 	private readonly catchRef = (ref?: HTMLAnchorElement) => {
@@ -144,7 +142,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	public render(): JSX.Element {
 		const { isExternal, tagAttrs } = this.getRenderValues();
 		const hasExpertSlot = showExpertSlot(this.state._label);
-		const hasAriaDescription = Boolean(this.state._ariaDescription?.trim()?.length);
+		const ariaDescription = this.state._ariaDescription?.trim();
 
 		return (
 			<Host>
@@ -154,7 +152,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 					accessKey={this.state._accessKey}
 					aria-current={this.state._ariaCurrent}
 					aria-controls={this.state._ariaControls}
-					aria-describedby={hasAriaDescription ? this.internalDescriptionById : undefined}
+					aria-description={ariaDescription || undefined}
 					aria-disabled={this.state._disabled ? 'true' : undefined}
 					aria-expanded={typeof this.state._ariaExpanded === 'boolean' ? String(this.state._ariaExpanded) : undefined}
 					aria-owns={this.state._ariaOwns}
@@ -211,11 +209,6 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 						_align={this.state._tooltipAlign}
 						_label={this.state._label || this.state._href}
 					></KolTooltipWcTag>
-				)}
-				{hasAriaDescription && (
-					<span class="visually-hidden" id={this.internalDescriptionById}>
-						{this.state._ariaDescription}
-					</span>
 				)}
 			</Host>
 		);


### PR DESCRIPTION
## Summary
Passes the `_ariaDescription` prop directly to the native `aria-description` attribute on `kol-button` and `kol-link`, removing the previously generated hidden description elements that are no longer needed.

## Changes
- `_ariaDescription` now sets the `aria-description` attribute directly on `kol-button` and `kol-link`
- Removed generated hidden description elements that were used as the previous `aria-describedby` target
- Updated component snapshot to reflect the simplified markup

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Übergibt das `_ariaDescription`-Prop direkt als natives `aria-description`-Attribut an `kol-button` und `kol-link` und entfernt die zuvor generierten versteckten Beschreibungselemente.

## Änderungen
- `_ariaDescription` setzt nun das `aria-description`-Attribut direkt auf `kol-button` und `kol-link`
- Generierte versteckte Beschreibungselemente für `aria-describedby` entfernt
- Komponentensnapshot an das vereinfachte Markup angepasst
</details>