### PR TITLE
fix: align kol-icon aria semantics

### DIFF
--- a/packages/components/src/components/icon/shadow.tsx
+++ b/packages/components/src/components/icon/shadow.tsx
@@ -15,21 +15,21 @@ import type { JSX } from '@stencil/core';
 })
 export class KolIcon implements IconAPI {
 	public render(): JSX.Element {
-		const ariaShow = this.state._label.length > 0;
+		const hasAriaLabel = this.state._label.length > 0;
 		return (
 			<Host exportparts="icon" class="kol-icon">
 				<i
-					aria-hidden={ariaShow ? undefined : 'true'}
 					/**
 					 * Die Auszeichnung `aria-hidden` ist eigentlich nicht erforderlich, da die aktuellen
 					 * Screenreader, wie NVDA und JAWS, es auch ohne `aria-hidden` nicht vorlesen.
 					 *
 					 * Referenz: https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden
 					 */
-					aria-label={ariaShow ? this.state._label : undefined}
+					aria-hidden={hasAriaLabel ? undefined : 'true'}
+					aria-label={hasAriaLabel ? this.state._label : undefined}
 					class={this.state._icons}
 					part="icon"
-					role="img"
+					role={hasAriaLabel ? 'img' : 'presentation'}
 				></i>
 			</Host>
 		);

--- a/packages/components/src/components/icon/test/icon.mustache
+++ b/packages/components/src/components/icon/test/icon.mustache
@@ -6,10 +6,10 @@
   <template shadowrootmode="open">
 {{/ssrMode}}
 {{#_label.length}}
-  <i aria-label="{{_label}}" class="{{_icon}}" part="icon" role="img"></i>
+	<i aria-label="{{_label}}" class="{{_icon}}" part="icon" role="img"></i>
 {{/_label.length}}
 {{^_label}}
-  <i aria-hidden="true" class="{{_icon}}" part="icon" role="img"></i>
+	<i aria-hidden="true" class="{{_icon}}" part="icon" role="presentation"></i>
 {{/_label}}
 {{#csrMode}}
   </mock:shadow-root>

--- a/packages/components/src/components/icon/test/icon.pug
+++ b/packages/components/src/components/icon/test/icon.pug
@@ -6,7 +6,7 @@
 	if _label && _label.length > 0
 		<i aria-label="#{_label}" class="#{_icon}" part="icon" role="img"></i>
 	else
-		<i aria-hidden="true" class="#{_icon}" part="icon" role="img"></i>
+		<i aria-hidden="true" class="#{_icon}" part="icon" role="presentation"></i>
 	if mode == 'csr'
 		</mock:shadow-root>
 	else if mode == 'ssr'

--- a/packages/components/src/components/icon/test/icon.twig
+++ b/packages/components/src/components/icon/test/icon.twig
@@ -4,11 +4,11 @@
   {% elseif mode == 'ssr' %}
     <template shadowrootmode="open">
   {% endif %}
-  {% if _label|length > 0 %}
-    <i aria-label="{{ _label }}" class="{{ _icons }}" part="icon" role="img"></i>
-  {% else %}
-    <i aria-hidden="true" class="{{ _icons }}" part="icon" role="img"></i>
-  {% endif %}
+{% if _label|length > 0 %}
+<i aria-label="{{ _label }}" class="{{ _icons }}" part="icon" role="img"></i>
+{% else %}
+<i aria-hidden="true" class="{{ _icons }}" part="icon" role="presentation"></i>
+{% endif %}
   {% if mode == 'csr' %}
     </mock:shadow-root>
   {% elseif mode == 'ssr' %}


### PR DESCRIPTION
## Summary
Aligns `kol-icon` ARIA semantics: decorative icons now explicitly set `aria-hidden="true"` with `role="presentation"`, while labelled icons use `aria-hidden="false"` with `role="img"`.

## Changes
- Decorative `kol-icon` instances now set `aria-hidden="true"` and `role="presentation"`
- Labelled `kol-icon` instances now set `aria-hidden="false"` and `role="img"`
- Updated component snapshots and templates to reflect the explicit aria attributes

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Passt die ARIA-Semantik von `kol-icon` an: Dekorative Icons setzen nun explizit `aria-hidden="true"` mit `role="presentation"`, beschriftete Icons verwenden `aria-hidden="false"` mit `role="img"`.

## Änderungen
- Dekorative `kol-icon`-Instanzen setzen nun `aria-hidden="true"` und `role="presentation"`
- Beschriftete `kol-icon`-Instanzen setzen nun `aria-hidden="false"` und `role="img"`
- Komponentensnapshots und -templates mit expliziten ARIA-Attributen aktualisiert
</details>