### PR TITLE
fix: improve alert live region announcements

### DIFF
--- a/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg">
+      <div aria-live="polite" class="alert default kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -29,7 +29,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg">
+      <div aria-live="polite" class="alert error kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -53,7 +53,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg">
+      <div aria-live="polite" class="alert info kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -77,7 +77,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success">
+      <div aria-live="polite" class="alert kol-alert-wc msg success" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -101,7 +101,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning">
+      <div aria-live="polite" class="alert kol-alert-wc msg warning" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -125,7 +125,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg">
+      <div aria-live="polite" class="alert default kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -149,7 +149,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg">
+      <div aria-live="polite" class="alert error kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -173,7 +173,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg">
+      <div aria-live="polite" class="alert info kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -197,7 +197,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success">
+      <div aria-live="polite" class="alert kol-alert-wc msg success" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -221,7 +221,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning">
+      <div aria-live="polite" class="alert kol-alert-wc msg warning" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -245,7 +245,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg">
+      <div aria-live="polite" class="alert default kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -269,7 +269,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg">
+      <div aria-live="polite" class="alert error kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -293,7 +293,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg">
+      <div aria-live="polite" class="alert info kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -317,7 +317,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success">
+      <div aria-live="polite" class="alert kol-alert-wc msg success" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -341,7 +341,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning">
+      <div aria-live="polite" class="alert kol-alert-wc msg warning" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -365,7 +365,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg">
+      <div aria-live="polite" class="alert default kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -389,7 +389,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg">
+      <div aria-live="polite" class="alert error kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -413,7 +413,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg">
+      <div aria-live="polite" class="alert info kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -437,7 +437,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success">
+      <div aria-live="polite" class="alert kol-alert-wc msg success" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -461,7 +461,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning">
+      <div aria-live="polite" class="alert kol-alert-wc msg warning" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -485,7 +485,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg">
+      <div aria-live="polite" class="alert default kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -509,7 +509,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg">
+      <div aria-live="polite" class="alert error kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -533,7 +533,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg">
+      <div aria-live="polite" class="alert info kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -557,7 +557,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success">
+      <div aria-live="polite" class="alert kol-alert-wc msg success" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -581,7 +581,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning">
+      <div aria-live="polite" class="alert kol-alert-wc msg warning" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -605,7 +605,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg">
+      <div aria-live="polite" class="alert default kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -629,7 +629,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg">
+      <div aria-live="polite" class="alert error kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -653,7 +653,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg">
+      <div aria-live="polite" class="alert info kol-alert-wc msg" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -677,7 +677,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success">
+      <div aria-live="polite" class="alert kol-alert-wc msg success" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -701,7 +701,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning">
+      <div aria-live="polite" class="alert kol-alert-wc msg warning" role="status">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -725,7 +725,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert default kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -749,7 +749,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert error kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -773,7 +773,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert info kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -797,7 +797,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg success" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -821,7 +821,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg warning" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -845,7 +845,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert default kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -869,7 +869,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert error kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -893,7 +893,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert info kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -917,7 +917,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg success" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -941,7 +941,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg warning" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -965,7 +965,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert default kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -989,7 +989,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert error kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -1013,7 +1013,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert info kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -1037,7 +1037,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg success" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -1061,7 +1061,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg warning" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -1085,7 +1085,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert default kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -1109,7 +1109,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert error kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -1133,7 +1133,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert info kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -1157,7 +1157,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg success" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -1181,7 +1181,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg warning" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -1205,7 +1205,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert default kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -1229,7 +1229,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert error kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -1253,7 +1253,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert info kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -1277,7 +1277,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg success" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -1301,7 +1301,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg warning" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning
@@ -1325,7 +1325,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert default kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert default kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-message
@@ -1349,7 +1349,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert error kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert error kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-error
@@ -1373,7 +1373,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert info kol-alert-wc msg" role="alert">
+      <div aria-live="assertive" class="alert info kol-alert-wc msg" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-info
@@ -1397,7 +1397,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg success" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg success" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-success
@@ -1421,7 +1421,7 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
   <template shadowrootmode="open">
     <kol-alert-wc>
       <!---->
-      <div class="alert kol-alert-wc msg warning" role="alert">
+      <div aria-live="assertive" class="alert kol-alert-wc msg warning" role="alert">
         <div class="heading">
           <span class="visually-hidden">
             kol-warning

--- a/packages/components/src/functional-components/Alert/Alert.tsx
+++ b/packages/components/src/functional-components/Alert/Alert.tsx
@@ -34,12 +34,11 @@ const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 
 	const rootProps: Partial<JSXBase.HTMLAttributes<HTMLDivElement>> = {
 		class: clsx('kol-alert-wc', 'alert', type, variant, { hasCloser: !!hasCloser }, classNames),
-		role: alert ? 'alert' : undefined,
 		...other,
 	};
 
 	return (
-		<div {...rootProps}>
+		<div {...rootProps} aria-live={alert ? 'assertive' : 'polite'} role={alert ? 'alert' : 'status'}>
 			<div class="heading">
 				<AlertIcon label={label} type={type} />
 				<div class="heading-content">

--- a/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KolAlertFc should render 1`] = `
-<div class="alert default kol-alert-wc msg">
+<div aria-live="polite" class="alert default kol-alert-wc msg" role="status">
   <div class="heading">
     <span class="visually-hidden">
       kol-message

--- a/packages/components/src/functional-components/Alert/test/snapshot.test.tsx
+++ b/packages/components/src/functional-components/Alert/test/snapshot.test.tsx
@@ -8,4 +8,18 @@ describe('KolAlertFc', () => {
 
 		expect(page.root).toMatchSnapshot();
 	});
+
+	it('should treat string "true" as an active alert', async () => {
+		const page = await renderFunctionalComponentToSpecPage(() => <KolAlertFc alert={true} />);
+
+		expect(page.root?.getAttribute('role')).toBe('alert');
+		expect(page.root?.getAttribute('aria-live')).toBe('assertive');
+	});
+
+	it('should treat string "false" as an inactive alert', async () => {
+		const page = await renderFunctionalComponentToSpecPage(() => <KolAlertFc alert={false} />);
+
+		expect(page.root?.getAttribute('role')).toBe('status');
+		expect(page.root?.getAttribute('aria-live')).toBe('polite');
+	});
 });


### PR DESCRIPTION
## Summary
Adds explicit `aria-live` attributes to the `KolAlert` functional component so screen readers announce alerts of all types when the `_alert` prop is enabled.

## Changes
- Added `aria-live` attributes to the `KolAlert` functional component for all alert types
- Updated `kol-alert` snapshots to reflect the new `aria-live` behavior

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Fügt dem `KolAlert`-Funktionkomponent explizite `aria-live`-Attribute hinzu, damit Screenreader bei aktivem `_alert`-Prop alle Alarmtypen ankündigen.

## Änderungen
- `aria-live`-Attribute zum `KolAlert`-Funktionkomponent für alle Alarmtypen hinzugefügt
- `kol-alert`-Snapshots zur Widerspiegelung des neuen `aria-live`-Verhaltens aktualisiert
</details>