### PR TITLE
fix: prevent invalid button and link roles

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -130,6 +130,9 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 		const isDisabled = this.state._disabled === true;
 		const hideLabel = this.state._hideLabel === true;
 
+		const requestedRole = this.state._role as string | undefined;
+		const role = requestedRole === 'link' ? undefined : requestedRole;
+
 		return (
 			<Host>
 				<button
@@ -155,7 +158,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 					name={this.state._name}
 					onClick={this.onClick}
 					onMouseDown={this.onMouseDown}
-					role={this.state._role}
+					role={role}
 					tabIndex={this.state._tabIndex}
 					type={this.state._type}
 				>

--- a/packages/components/src/components/button/test/role.spec.tsx
+++ b/packages/components/src/components/button/test/role.spec.tsx
@@ -1,0 +1,29 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolButtonWc } from '../component';
+
+describe('KolButtonWc role handling', () => {
+	it('does not render role="link" on the button element', async () => {
+		const page = await newSpecPage({
+			components: [KolButtonWc],
+			html: '<kol-button-wc _label="Do" _role="link"></kol-button-wc>',
+		});
+
+		await page.waitForChanges();
+
+		const button = page.root?.querySelector('button');
+		expect(button?.getAttribute('role')).toBeNull();
+	});
+
+	it('keeps supported roles like "tab"', async () => {
+		const page = await newSpecPage({
+			components: [KolButtonWc],
+			html: '<kol-button-wc _label="Do" _role="tab"></kol-button-wc>',
+		});
+
+		await page.waitForChanges();
+
+		const button = page.root?.querySelector('button');
+		expect(button?.getAttribute('role')).toBe('tab');
+	});
+});

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -144,6 +144,9 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 		const hasExpertSlot = showExpertSlot(this.state._label);
 		const ariaDescription = this.state._ariaDescription?.trim();
 
+		const requestedRole = this.state._role as string | undefined;
+		const role = requestedRole === 'button' ? undefined : requestedRole;
+
 		return (
 			<Host>
 				<a
@@ -175,7 +178,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 					// https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/click-events-have-key-events.md
 					onClick={this.onClick}
 					onKeyPress={this.onClick}
-					role={this.state._role}
+					role={role}
 					tabIndex={this.state._disabled ? -1 : this.state._tabIndex}
 				>
 					<KolSpanFc

--- a/packages/components/src/components/link/test/role.spec.tsx
+++ b/packages/components/src/components/link/test/role.spec.tsx
@@ -1,0 +1,29 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolLinkWc } from '../component';
+
+describe('KolLinkWc role handling', () => {
+	it('does not render role="button" on the anchor element', async () => {
+		const page = await newSpecPage({
+			components: [KolLinkWc],
+			html: '<kol-link-wc _href="#" _role="button"></kol-link-wc>',
+		});
+
+		await page.waitForChanges();
+
+		const anchor = page.root?.querySelector('a');
+		expect(anchor?.getAttribute('role')).toBeNull();
+	});
+
+	it('keeps supported roles like "tab"', async () => {
+		const page = await newSpecPage({
+			components: [KolLinkWc],
+			html: '<kol-link-wc _href="#" _role="tab"></kol-link-wc>',
+		});
+
+		await page.waitForChanges();
+
+		const anchor = page.root?.querySelector('a');
+		expect(anchor?.getAttribute('role')).toBe('tab');
+	});
+});


### PR DESCRIPTION
## Summary
- ensure `kol-link-wc` ignores the deprecated `_role="button"` value when rendering the underlying anchor
- update `kol-button-wc` to drop `_role="link"` on the internal `<button>` while leaving other roles untouched
- add focused unit tests that cover the new role handling for both components

## Testing
- `pnpm --filter @public-ui/components test:unit -- --runTestsByPath packages/components/src/components/link/test/role.spec.tsx packages/components/src/components/button/test/role.spec.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68db627247c4832bba6b45aac3edc786