### PR TITLE
feat: add disabled option handling to single select

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -96,8 +96,8 @@ export class KolSingleSelect implements SingleSelectAPI {
 	private onBlur() {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 
-		if (matchingOption) {
-			this.selectOption(matchingOption as Option<string>);
+		if (matchingOption && this.selectOption(matchingOption as Option<string>)) {
+			return;
 		} else {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];
@@ -149,11 +149,15 @@ export class KolSingleSelect implements SingleSelectAPI {
 		}
 	}
 
-	private selectOption(option: Option<string>) {
+	private selectOption(option: Option<string>): boolean {
+		if (option.disabled) {
+			return false;
+		}
+
 		if (option.value === this._value) {
 			this._inputValue = option.label as string;
 			this._filteredOptions = [...this.state._options];
-			return;
+			return true;
 		}
 
 		this._value = option.value;
@@ -174,6 +178,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 		this._filteredOptions = [...this.state._options];
 
 		this.controller.setFormAssociatedValue(this._value);
+		return true;
 	}
 
 	private onInput(event: Event) {
@@ -205,21 +210,27 @@ export class KolSingleSelect implements SingleSelectAPI {
 	private _focusedOptionIndex: number = -1;
 
 	private moveFocus(delta: number) {
-		if (!this._filteredOptions) {
+		if (!Array.isArray(this._filteredOptions) || this._filteredOptions.length === 0) {
 			return;
 		}
-		let newIndex = this._focusedOptionIndex + delta;
+		let newIndex = this._focusedOptionIndex;
+		for (let i = 0; i < this._filteredOptions.length; i++) {
+			newIndex += delta;
 
-		if (newIndex >= this._filteredOptions.length) {
-			newIndex = 0;
+			if (newIndex >= this._filteredOptions.length) {
+				newIndex = 0;
+			}
+
+			if (newIndex < 0) {
+				newIndex = this._filteredOptions.length - 1;
+			}
+
+			if (!(this._filteredOptions[newIndex] as Option<string>).disabled) {
+				this._focusedOptionIndex = newIndex;
+				this.focusOption(this._focusedOptionIndex);
+				break;
+			}
 		}
-
-		if (newIndex < 0) {
-			newIndex = this._filteredOptions.length - 1;
-		}
-
-		this._focusedOptionIndex = newIndex;
-		this.focusOption(this._focusedOptionIndex);
 	}
 
 	private focusOption(index: number) {
@@ -233,9 +244,10 @@ export class KolSingleSelect implements SingleSelectAPI {
 		const charLowerCase = char.toLowerCase();
 
 		const index =
-			Array.isArray(this._filteredOptions) && this._filteredOptions.findIndex((option) => (option.label as string).toLowerCase().startsWith(charLowerCase));
+			Array.isArray(this._filteredOptions) &&
+			this._filteredOptions.findIndex((option) => !option.disabled && (option.label as string).toLowerCase().startsWith(charLowerCase));
 
-		if (typeof index === 'number') {
+		if (typeof index === 'number' && index >= 0) {
 			this._focusedOptionIndex = index;
 			this.focusOption(index);
 		}
@@ -348,30 +360,40 @@ export class KolSingleSelect implements SingleSelectAPI {
 												tabIndex={-1}
 												role="option"
 												aria-selected={this._value === (option as Option<string>).value ? 'true' : undefined}
+												aria-disabled={(option as Option<string>).disabled ? 'true' : undefined}
+												class={clsx('single-select__item', (option as Option<string>).disabled && 'single-select__item--disabled')}
 												onClick={(event: Event) => {
-													this.selectOption(option as Option<string>);
-													this.refInput?.focus();
-													this.toggleListbox(event);
-													this._isOpen = false;
-													this._hasOpened = false;
+													if (this.selectOption(option as Option<string>)) {
+														this.refInput?.focus();
+														this.toggleListbox(event);
+														this._isOpen = false;
+														this._hasOpened = false;
+													} else {
+														event.preventDefault();
+														event.stopImmediatePropagation();
+													}
 												}}
 												onMouseOver={() => {
-													if (!this.blockSuggestionMouseOver) {
+													if (!this.blockSuggestionMouseOver && !(option as Option<string>).disabled) {
 														this._focusedOptionIndex = index;
 														this.focusOption(index);
 													}
 												}}
 												onFocus={() => {
-													this._focusedOptionIndex = index;
-													this.focusOption(index);
+													if (!(option as Option<string>).disabled) {
+														this._focusedOptionIndex = index;
+														this.focusOption(index);
+													}
 												}}
-												class="single-select__item"
 												onKeyDown={(e) => {
 													if (e.key === 'Enter' || e.key === 'NumpadEnter') {
-														this.selectOption(option as Option<string>);
-														this.refInput?.focus();
-														this.toggleListbox(e);
-														e.preventDefault();
+														if (this.selectOption(option as Option<string>)) {
+															this.refInput?.focus();
+															this.toggleListbox(e);
+															e.preventDefault();
+														} else {
+															e.preventDefault();
+														}
 													}
 												}}
 											>
@@ -382,6 +404,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 													id={`option-radio-${index}`}
 													value={(option as Option<string>).value}
 													checked={this._value === (option as Option<string>).value || index === this._focusedOptionIndex}
+													disabled={(option as Option<string>).disabled}
 												/>
 
 												<label htmlFor={`option-radio-${index}`} class="radio-label">
@@ -458,9 +481,11 @@ export class KolSingleSelect implements SingleSelectAPI {
 			case ' ': {
 				if (this._isOpen) {
 					if (Array.isArray(this._filteredOptions) && this._filteredOptions.length > 0) {
-						this.selectOption(this._filteredOptions[this._focusedOptionIndex] as Option<string>);
-						this.refInput?.focus();
-						handleEvent(false);
+						const option = this._filteredOptions[this._focusedOptionIndex] as Option<string> | undefined;
+						if (option && this.selectOption(option)) {
+							this.refInput?.focus();
+							handleEvent(false);
+						}
 					}
 				} else {
 					this.toggleListbox(event);

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -12,6 +12,11 @@ const OPTIONS = [
 	{ label: 'West', value: 'W' },
 	{ label: 'East', value: 'E' },
 ];
+const OPTIONS_WITH_DISABLED = [
+	{ label: 'North', value: 'N', disabled: true },
+	{ label: 'South', value: 'S' },
+	{ label: 'East', value: 'E' },
+];
 const OPTIONS_ATTRIBUTE = `_options='${JSON.stringify(OPTIONS)}'`;
 const fillAction: FillAction = async (page) => {
 	await page.getByRole('button').click();
@@ -109,6 +114,28 @@ test.describe(COMPONENT_NAME, () => {
 			await input.press('Space');
 
 			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', 'N');
+		});
+
+		test('should skip disabled options when navigating with keyboard', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS_WITH_DISABLED)}'></kol-single-select>`);
+
+			const input = page.getByTestId('single-select-input');
+
+			await input.click();
+			await input.press('ArrowDown');
+			await input.press('Space');
+
+			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', 'S');
+		});
+
+		test('should not select disabled option on click', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS_WITH_DISABLED)}'></kol-single-select>`);
+
+			await page.getByRole('button').click();
+			await page.getByRole('listbox').getByText('North').click({ force: true });
+
+			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', undefined);
+			await expect(page.getByRole('listbox')).toBeVisible();
 		});
 
 		test('should disable interaction when _disabled is true', async ({ page }) => {

--- a/packages/components/src/components/single-select/style.scss
+++ b/packages/components/src/components/single-select/style.scss
@@ -49,6 +49,11 @@ $visible-options: var(--visible-options, 5);
 			.single-select__listbox--cursor-hidden & {
 				cursor: none !important;
 			}
+
+			&--disabled {
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
 		}
 
 		&__no-results-message {

--- a/packages/themes/default/src/components/single-select.scss
+++ b/packages/themes/default/src/components/single-select.scss
@@ -77,6 +77,19 @@ $visible-options: 5;
 				background-color: var(--color-primary-variant);
 				outline: 0;
 			}
+
+			&.single-select__item--disabled {
+				color: var(--color-subtle);
+				background-color: transparent;
+				cursor: not-allowed;
+
+				&[aria-selected],
+				&:focus,
+				&.highlighted {
+					color: var(--color-subtle);
+					background-color: transparent;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- prevent `kol-single-select` from focusing or selecting disabled options and update keyboard handling accordingly
- add a disabled item treatment for the single select list across the base styles and default theme
- cover disabled option behaviour with new end-to-end tests

## Testing
- pnpm --filter @public-ui/components test:e2e -- packages/components/src/components/single-select/single-select.e2e.ts --project chromium *(fails: build step in Playwright setup stops with "Rollup: Missing Export" which leads to timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc80ec772c832bb3850705534b646c