### PR TITLE
feat: extend table header cell options for table settings

### DIFF
--- a/packages/components/src/components/table-stateful/readme.md
+++ b/packages/components/src/components/table-stateful/readme.md
@@ -53,6 +53,11 @@ Die Table-Komponente unterstützt folgende Funktionalitäten **nicht**:
         useTdInsteadOfTh?: boolean,
         render?: (data) => string,
         sort?: (data) => data,
+        options?: {
+          hidable?: boolean,
+          sizable?: boolean,
+          sortable?: boolean,
+        },
       },
       …
     ],
@@ -68,6 +73,11 @@ Die Table-Komponente unterstützt folgende Funktionalitäten **nicht**:
         useTdInsteadOfTh?: boolean,
         render?: (data) => string,
         sort?: (data) => data,
+        options?: {
+          hidable?: boolean,
+          sizable?: boolean,
+          sortable?: boolean,
+        },
       },
       …
     ],

--- a/packages/components/src/components/table-stateless/readme.md
+++ b/packages/components/src/components/table-stateless/readme.md
@@ -39,7 +39,12 @@ const selection: KoliBriTableSelection = {
   _headerCells={{
     horizontal: [
       [
-        { key: 'value', label: 'Value', sortDirection: 'ASC' },
+        {
+          key: 'value',
+          label: 'Value',
+          sortDirection: 'ASC',
+          options: { hidable: false, sizable: true, sortable: true },
+        },
       ],
     ],
   }}
@@ -73,6 +78,18 @@ const selection: KoliBriTableSelection = {
 
 Der Sortierschalter verwendet das Attribut `_aria-description` und zeigt immer den
 Sprachtext `kol-sort` an, unabhängig vom aktuellen Sortierzustand.
+
+### Header-Optionen
+
+Horizontale Header-Zellen unterstützen das optionale Property `options`. Darüber lassen
+sich Einstellungen für das Table-Settings-Menü definieren:
+
+- `hidable`: Steuert, ob die Spalte ausgeblendet werden darf.
+- `sizable`: Aktiviert oder deaktiviert Größenänderungen der Spalte.
+- `sortable`: Legt fest, ob die Spalte über das Menü sortierbar ist.
+
+Alle Eigenschaften sind optional und standardmäßig deaktiviert, sofern sie nicht
+explizit gesetzt werden.
 
 <!-- Auto Generated Below -->
 

--- a/packages/components/src/schema/types/table.ts
+++ b/packages/components/src/schema/types/table.ts
@@ -19,9 +19,25 @@ export type KoliBriTableCell = {
 	data?: KoliBriTableDataType;
 };
 
+export type KoliBriTableHeaderCellOptions = {
+	/**
+	 * Controls whether the column can be hidden through the table settings menu.
+	 */
+	hidable?: boolean;
+	/**
+	 * Controls whether the column can be resized through the table settings menu.
+	 */
+	sizable?: boolean;
+	/**
+	 * Controls whether the column can be sorted through the table settings menu.
+	 */
+	sortable?: boolean;
+};
+
 export type KoliBriTableHeaderCell = KoliBriTableCell & {
 	key?: string;
 	sortDirection?: KoliBriSortDirection;
+	options?: KoliBriTableHeaderCellOptions;
 };
 
 export type KoliBriTableSelection = {


### PR DESCRIPTION
## Summary
- add an `options` object to table header cell typings for configuring hidable, sizable, and sortable state
- document the new table header options for both stateless and stateful table usage guides

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcac059f28832b9daa4afd29a109c6