### PR TITLE
fix(modal): prevent esc from closing when a tooltip is open

### DIFF
--- a/packages/components/src/components/drawer/shadow.tsx
+++ b/packages/components/src/components/drawer/shadow.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-import type { AlignPropType, DrawerAPI, DrawerStates, HasCloserPropType, KoliBriModalEventCallbacks, LabelPropType, OpenPropType } from '../../schema';
-import { setState, validateAlign, validateHasCloser, validateLabel, validateOpen } from '../../schema';
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
-import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import clsx from 'clsx';
 import { KolCardWcTag } from '../../core/component-names';
+import type { AlignPropType, DrawerAPI, DrawerStates, HasCloserPropType, KoliBriModalEventCallbacks, LabelPropType, OpenPropType } from '../../schema';
+import { setState, validateAlign, validateHasCloser, validateLabel, validateOpen } from '../../schema';
+import { dispatchDomEvent, KolEvent } from '../../utils/events';
+import { handleCancelOverlay } from '../../utils/tooltip-open-tracking';
 
 /**
  * @slot - The Content of drawer.
@@ -87,7 +88,7 @@ export class KolDrawer implements DrawerAPI {
 	public render(): JSX.Element {
 		return (
 			<Host class="kol-drawer">
-				<dialog aria-label={this.state._label} class="kol-drawer__dialog" ref={this.getRef}>
+				<dialog aria-label={this.state._label} class="kol-drawer__dialog" onCancel={handleCancelOverlay} ref={this.getRef}>
 					{this.renderDialogContent()}
 				</dialog>
 			</Host>

--- a/packages/components/src/components/modal/shadow.tsx
+++ b/packages/components/src/components/modal/shadow.tsx
@@ -7,7 +7,7 @@ import { setState, validateLabel, validateWidth } from '../../schema';
 import type { ModalVariantPropType } from '../../schema/props/variant/modal';
 import { validateModalVariant } from '../../schema/props/variant/modal';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
-import { isAnyTooltipOpen } from '../../utils/tooltip-open-tracking';
+import { handleCancelOverlay } from '../../utils/tooltip-open-tracking';
 
 /**
  * https://en.wikipedia.org/wiki/Modal_window
@@ -35,12 +35,6 @@ export class KolModal implements ModalAPI {
 			dispatchDomEvent(this.host, KolEvent.close);
 		}
 	}
-
-	private handleCancelEvent = (event: Event): void => {
-		if (this.refDialog && isAnyTooltipOpen(this.refDialog.ownerDocument)) {
-			event.preventDefault();
-		}
-	};
 
 	/**
 	 * Opens the modal dialog.
@@ -75,7 +69,7 @@ export class KolModal implements ModalAPI {
 					'kol-modal__blank': this.state._variant === 'blank',
 					'kol-modal__card': this.state._variant === 'card',
 				})}
-				onCancel={this.handleCancelEvent}
+				onCancel={handleCancelOverlay}
 				onClose={this.handleNativeCloseEvent.bind(this)}
 				ref={(el) => {
 					this.refDialog = el;

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -8,7 +8,7 @@ import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
 import { alignFloatingElements } from '../../utils/align-floating-elements';
 import { hideOverlay, showOverlay } from '../../utils/overlay';
 import { KolSpanFc } from '../../functional-components';
-import { decOpenTooltips, incOpenTooltips } from '../../utils/tooltip-open-tracking';
+import { tooltipClosed, tooltipOpened } from '../../utils/tooltip-open-tracking';
 
 // Timing Guidelines for Exposing Hidden Content: https://www.nngroup.com/articles/timing-exposing-content/
 const TOOLTIP_DELAY = 300;
@@ -43,9 +43,10 @@ export class KolTooltipWc implements TooltipAPI {
 	private showTooltip = (): void => {
 		if (this.previousSibling && this.tooltipElement /* SSR instanceof HTMLElement */) {
 			showOverlay(this.tooltipElement);
+			tooltipOpened();
 			this.tooltipElement.style.setProperty('display', 'block');
-			incOpenTooltips(getDocument());
 			getDocument().addEventListener('keyup', this.hideTooltipByEscape);
+
 			const target = this.previousSibling;
 			const tooltipEl = this.tooltipElement;
 			this.cleanupAutoPositioning = autoUpdate(target, tooltipEl, () => {
@@ -80,6 +81,7 @@ export class KolTooltipWc implements TooltipAPI {
 		clearTimeout(this.showTooltipTimeout); // Cancel scheduled tooltips
 		if (this.tooltipElement /* SSR instanceof HTMLElement */) {
 			hideOverlay(this.tooltipElement);
+			tooltipClosed();
 			this.tooltipElement.style.setProperty('display', 'none');
 			this.tooltipElement.style.setProperty('visibility', 'hidden');
 			if (this.cleanupAutoPositioning) {
@@ -88,7 +90,6 @@ export class KolTooltipWc implements TooltipAPI {
 			}
 		}
 		getDocument().removeEventListener('keyup', this.hideTooltipByEscape);
-		decOpenTooltips(getDocument());
 	}
 
 	private hideTooltipByEscape = (event: KeyboardEvent): void => {

--- a/packages/components/src/utils/tooltip-open-tracking.ts
+++ b/packages/components/src/utils/tooltip-open-tracking.ts
@@ -1,33 +1,15 @@
-/**
- * Track globally whether any tooltip is currently visible.
- * This uses attributes on <html> so disparate components can coordinate
- * without tight coupling or cross-imports.
- */
+let openTooltips = 0;
 
-export const TOOLTIP_COUNTER_ATTR = 'data-kol-tooltips-open';
-export const TOOLTIP_OPEN_ATTR = 'data-kol-tooltip-open';
+export const tooltipOpened = () => {
+	openTooltips++;
+};
 
-/** Increment the global "open tooltips" counter and set the boolean flag. */
-export function incOpenTooltips(doc: Document): void {
-	const el = doc.documentElement;
-	const n = Number(el.getAttribute(TOOLTIP_COUNTER_ATTR) || '0') + 1;
-	el.setAttribute(TOOLTIP_COUNTER_ATTR, String(n));
-	el.setAttribute(TOOLTIP_OPEN_ATTR, ''); // boolean presence attribute
-}
+export const tooltipClosed = () => {
+	openTooltips = Math.max(0, openTooltips - 1);
+};
 
-/** Decrement the global "open tooltips" counter and clear the flag at zero. */
-export function decOpenTooltips(doc: Document): void {
-	const el = doc.documentElement;
-	const current = Math.max(0, Number(el.getAttribute(TOOLTIP_COUNTER_ATTR) || '0') - 1);
-	if (current === 0) {
-		el.removeAttribute(TOOLTIP_COUNTER_ATTR);
-		el.removeAttribute(TOOLTIP_OPEN_ATTR);
-	} else {
-		el.setAttribute(TOOLTIP_COUNTER_ATTR, String(current));
+export const handleCancelOverlay = (event: Event): void => {
+	if (openTooltips > 0) {
+		event.preventDefault();
 	}
-}
-
-/** Returns true if at least one tooltip is open. */
-export function isAnyTooltipOpen(doc: Document): boolean {
-	return doc.documentElement.hasAttribute(TOOLTIP_OPEN_ATTR);
-}
+};


### PR DESCRIPTION
## Summary
Internal sub-PR providing an alternative simpler implementation for preventing ESC from closing a modal when a tooltip is open. Merged into the feature branch as part of incremental development.

## Changes
- Simplified implementation preventing modal ESC close when tooltip is open

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR mit einer vereinfachten alternativen Implementierung zur Verhinderung des Modal-Schließens per ESC bei geöffnetem Tooltip.

## Änderungen
- Vereinfachte Implementierung zur Verhinderung des Modal-ESC-Schließens bei geöffnetem Tooltip
</details>