### PR TITLE
test(pagination): fix e2e selectors after aria description change

### DIFF
--- a/packages/components/src/components/pagination/pagination.e2e.ts
+++ b/packages/components/src/components/pagination/pagination.e2e.ts
@@ -29,7 +29,7 @@ test.describe('kol-pagination', () => {
 						};
 					});
 				}, callbackName);
-				await page.getByRole('button', { name: 'Seite 2' }).click();
+				await page.getByRole('button', { name: '2' }).click();
 
 				await expect(callbackPromise).resolves.toBe(2);
 			});
@@ -62,7 +62,7 @@ test.describe('kol-pagination', () => {
 						});
 					});
 				}, eventName);
-				await page.getByRole('button', { name: 'Seite 2' }).click();
+				await page.getByRole('button', { name: '2' }).click();
 
 				await expect(eventPromise).resolves.toBe(2);
 			});


### PR DESCRIPTION
## Summary
Internal sub-PR updating pagination e2e test selectors to match the new button accessible names after removing the aria description. Merged into the pagination aria feature branch.

## Changes
- Updated pagination e2e test to target the new button accessible name after aria description removal

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR zur Aktualisierung der Paginierungs-E2E-Testselektoren nach der Entfernung der ARIA-Beschreibung.

## Änderungen
- E2E-Tests der Paginierung auf den neuen zugänglichen Button-Namen nach der ARIA-Beschreibungs-Entfernung aktualisiert
</details>