### PR TITLE
feat: render accordions via details markup

### DIFF
--- a/packages/components/src/components/accordion/accordion.e2e.ts
+++ b/packages/components/src/components/accordion/accordion.e2e.ts
@@ -9,31 +9,44 @@ test.describe('kol-accordion', () => {
 		});
 
 		test('should render the accordion title', async ({ page }) => {
-			const button = page.getByRole('button');
+			const button = page.getByRole('button', { name: 'Accordion Label' });
 			await expect(button).toHaveText('Accordion Label');
 		});
 
 		test('should show the accordion content after the title has been clicked', async ({ page }) => {
 			await expect(page.locator('.collapsible__content')).toHaveAttribute('aria-hidden', 'true');
-			await page.getByRole('button', { name: 'Accordion label' }).click();
+			await page.getByRole('button', { name: 'Accordion Label' }).click();
 			await expect(page.locator('.collapsible__content')).not.toHaveAttribute('aria-hidden', 'true');
 		});
 
 		test('should hide the accordion content after the title has been clicked again', async ({ page }) => {
-			await page.getByRole('button', { name: 'Accordion label' }).click();
+			await page.getByRole('button', { name: 'Accordion Label' }).click();
 			await expect(page.locator('.collapsible__content')).not.toHaveAttribute('aria-hidden', 'true');
-			await page.getByRole('button', { name: 'Accordion label' }).click();
+			await page.getByRole('button', { name: 'Accordion Label' }).click();
 			await expect(page.locator('.collapsible__content')).toHaveAttribute('aria-hidden', 'true');
 		});
 
 		test('should emit "click" event when the title is clicked', async ({ page }) => {
-			const eventPromise = page.locator('kol-accordion').evaluate(async (element: HTMLKolAccordionElement, KolEvent) => {
-				return new Promise((resolve) => {
-					element.addEventListener(KolEvent.click, resolve);
+			const eventPromise = page.evaluate((eventName: KolEvent) => {
+				return new Promise<boolean>((resolve) => {
+					const accordion = document.querySelector('kol-accordion');
+
+					if (!accordion) {
+						resolve(false);
+
+						return;
+					}
+
+					const handleEvent = () => {
+						accordion.removeEventListener(eventName, handleEvent);
+						resolve(true);
+					};
+
+					accordion.addEventListener(eventName, handleEvent);
 				});
-			}, KolEvent);
+			}, KolEvent.click);
 			await page.waitForChanges();
-			await page.getByRole('button', { name: 'Accordion label' }).click();
+			await page.getByRole('button', { name: 'Accordion Label' }).click();
 			await expect(eventPromise).resolves.toBeTruthy();
 		});
 
@@ -48,7 +61,7 @@ test.describe('kol-accordion', () => {
 				});
 			});
 			await page.waitForChanges();
-			await page.getByRole('button', { name: 'Accordion label' }).click();
+			await page.getByRole('button', { name: 'Accordion Label' }).click();
 			await expect(callbackPromise).resolves.toBe(true);
 		});
 	});
@@ -59,7 +72,7 @@ test.describe('kol-accordion', () => {
 		});
 
 		test('should not show the accordion content after the title has been clicked', async ({ page }) => {
-			await page.getByRole('button', { name: 'Accordion label' }).click({ force: true });
+			await page.getByRole('button', { name: 'Accordion Label' }).click({ force: true });
 			await expect(page.locator('.collapsible__content')).toHaveAttribute('aria-hidden', 'true');
 		});
 	});

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -39,18 +39,20 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolAccordionElement;
 
 	private readonly nonce = nonce();
-	private buttonWcRef?: HTMLKolButtonWcElement;
+	private summaryRef?: HTMLElement;
 
-	private readonly catchRef = (ref?: HTMLKolButtonWcElement) => {
-		this.buttonWcRef = ref;
+	private readonly catchRef = (ref?: HTMLElement) => {
+		this.summaryRef = ref;
 	};
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+	public kolFocus(): Promise<void> {
+		this.summaryRef?.focus();
+
+		return Promise.resolve();
 	}
 
 	private handleOnClick = (event: MouseEvent) => {
@@ -65,7 +67,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 		setTimeout(() => {
 			this.state._on?.onClick?.(event, this._open === true);
 			if (this.host) {
-				dispatchDomEvent(this.host, KolEvent.click, this._open === true);
+				dispatchDomEvent(this.host as HTMLElement, KolEvent.click, this._open === true);
 			}
 		});
 	};
@@ -86,6 +88,8 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 			HeadingButtonProps: {
 				ref: this.catchRef,
 				class: `${rootClass}__heading-button`,
+				iconClass: `${rootClass}__icon`,
+				labelClass: `${rootClass}__label`,
 			},
 			ContentProps: {
 				class: `${rootClass}__content`,

--- a/packages/components/src/components/accordion/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/accordion/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,10 +3,17 @@
 exports[`kol-accordion should render with _label="Überschrift" _level=3 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <h3 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h3 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </h3>
+    <details class="collapsible kol-accordion" id="nonce">
+      <summary aria-controls="nonce-control" aria-expanded="false" class="collapsible__heading-button kol-accordion__heading-button" role="button">
+        <h3 class="collapsible__heading kol-accordion__heading kol-headline kol-headline--h3 kol-headline--single">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-add" _label="" class="collapsible__icon kol-accordion__icon"></kol-icon>
+            <span class="collapsible__label kol-accordion__label">
+              Überschrift
+            </span>
+          </span>
+        </h3>
+      </summary>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -14,7 +21,7 @@ exports[`kol-accordion should render with _label="Überschrift" _level=3 1`] = `
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-accordion>
 `;
@@ -22,10 +29,17 @@ exports[`kol-accordion should render with _label="Überschrift" _level=3 1`] = `
 exports[`kol-accordion should render with _label="Überschrift" _open=false _disabled=false 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible kol-accordion" id="nonce">
+      <summary aria-controls="nonce-control" aria-expanded="false" class="collapsible__heading-button kol-accordion__heading-button" role="button">
+        <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-add" _label="" class="collapsible__icon kol-accordion__icon"></kol-icon>
+            <span class="collapsible__label kol-accordion__label">
+              Überschrift
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -33,7 +47,7 @@ exports[`kol-accordion should render with _label="Überschrift" _open=false _dis
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-accordion>
 `;
@@ -41,10 +55,17 @@ exports[`kol-accordion should render with _label="Überschrift" _open=false _dis
 exports[`kol-accordion should render with _label="Überschrift" _open=false _disabled=true 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
-    <div class="collapsible collapsible--disabled kol-accordion" id="nonce">
-      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible collapsible--disabled kol-accordion" id="nonce">
+      <summary aria-controls="nonce-control" aria-disabled="true" aria-expanded="false" class="collapsible__heading-button kol-accordion__heading-button" role="button" tabindex="-1">
+        <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-add" _label="" class="collapsible__icon kol-accordion__icon"></kol-icon>
+            <span class="collapsible__label kol-accordion__label">
+              Überschrift
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -52,7 +73,7 @@ exports[`kol-accordion should render with _label="Überschrift" _open=false _dis
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-accordion>
 `;
@@ -60,10 +81,17 @@ exports[`kol-accordion should render with _label="Überschrift" _open=false _dis
 exports[`kol-accordion should render with _label="Überschrift" _open=true _disabled=false 1`] = `
 <kol-accordion _open="">
   <template shadowrootmode="open">
-    <div class="collapsible collapsible--open kol-accordion" id="nonce">
-      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-remove" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible collapsible--open kol-accordion" id="nonce" open="">
+      <summary aria-controls="nonce-control" aria-expanded="true" class="collapsible__heading-button kol-accordion__heading-button" role="button">
+        <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-remove" _label="" class="collapsible__icon kol-accordion__icon"></kol-icon>
+            <span class="collapsible__label kol-accordion__label">
+              Überschrift
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -71,7 +99,7 @@ exports[`kol-accordion should render with _label="Überschrift" _open=true _disa
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-accordion>
 `;
@@ -79,10 +107,17 @@ exports[`kol-accordion should render with _label="Überschrift" _open=true _disa
 exports[`kol-accordion should render with _label="Überschrift" _open=true _disabled=true 1`] = `
 <kol-accordion _open="">
   <template shadowrootmode="open">
-    <div class="collapsible collapsible--disabled collapsible--open kol-accordion" id="nonce">
-      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-remove" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible collapsible--disabled collapsible--open kol-accordion" id="nonce" open="">
+      <summary aria-controls="nonce-control" aria-disabled="true" aria-expanded="true" class="collapsible__heading-button kol-accordion__heading-button" role="button" tabindex="-1">
+        <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-remove" _label="" class="collapsible__icon kol-accordion__icon"></kol-icon>
+            <span class="collapsible__label kol-accordion__label">
+              Überschrift
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -90,7 +125,7 @@ exports[`kol-accordion should render with _label="Überschrift" _open=true _disa
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-accordion>
 `;
@@ -98,10 +133,17 @@ exports[`kol-accordion should render with _label="Überschrift" _open=true _disa
 exports[`kol-accordion should render with _label="Überschrift" 1`] = `
 <kol-accordion>
   <template shadowrootmode="open">
-    <div class="collapsible kol-accordion" id="nonce">
-      <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-add" _label="Überschrift" class="collapsible__heading-button kol-accordion__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible kol-accordion" id="nonce">
+      <summary aria-controls="nonce-control" aria-expanded="false" class="collapsible__heading-button kol-accordion__heading-button" role="button">
+        <strong class="collapsible__heading kol-accordion__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-add" _label="" class="collapsible__icon kol-accordion__icon"></kol-icon>
+            <span class="collapsible__label kol-accordion__label">
+              Überschrift
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-accordion__wrapper">
         <div class="collapsible__wrapper-animation kol-accordion__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content kol-accordion__content" id="nonce-control">
@@ -109,7 +151,7 @@ exports[`kol-accordion should render with _label="Überschrift" 1`] = `
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-accordion>
 `;

--- a/packages/components/src/components/details/details.e2e.ts
+++ b/packages/components/src/components/details/details.e2e.ts
@@ -3,6 +3,36 @@ import { test } from '@stencil/playwright';
 import { KolEvent } from '../../utils/events';
 
 test.describe('kol-details', () => {
+	test.describe('when details is enabled', () => {
+		test.beforeEach(async ({ page }) => {
+			await page.setContent('<kol-details _label="Details">Details content</kol-details>');
+		});
+
+		test('should show the details content after the title has been clicked', async ({ page }) => {
+			await expect(page.locator('.collapsible__content')).toHaveAttribute('aria-hidden', 'true');
+			await page.getByRole('button', { name: 'Details' }).click();
+			await expect(page.locator('.collapsible__content')).not.toHaveAttribute('aria-hidden', 'true');
+		});
+
+		test('should hide the details content after the title has been clicked again', async ({ page }) => {
+			await page.getByRole('button', { name: 'Details' }).click();
+			await expect(page.locator('.collapsible__content')).not.toHaveAttribute('aria-hidden', 'true');
+			await page.getByRole('button', { name: 'Details' }).click();
+			await expect(page.locator('.collapsible__content')).toHaveAttribute('aria-hidden', 'true');
+		});
+	});
+
+	test.describe('when details is disabled', () => {
+		test.beforeEach(async ({ page }) => {
+			await page.setContent('<kol-details _label="Details" _disabled>Details content</kol-details>');
+		});
+
+		test('should not show the details content after the title has been clicked', async ({ page }) => {
+			await page.getByRole('button', { name: 'Details' }).click({ force: true });
+			await expect(page.locator('.collapsible__content')).toHaveAttribute('aria-hidden', 'true');
+		});
+	});
+
 	test.describe('Callbacks', () => {
 		test(`should call 'onToggle' callback when title is clicked`, async ({ page }) => {
 			await page.setContent('<kol-details _label="Details" _has-closer />');
@@ -19,7 +49,7 @@ test.describe('kol-details', () => {
 			});
 			await page.waitForChanges();
 
-			await page.locator('button').click();
+			await page.getByRole('button', { name: 'Details' }).click();
 			await expect(callbackPromise).resolves.toBeUndefined();
 		});
 	});
@@ -27,16 +57,27 @@ test.describe('kol-details', () => {
 	test.describe('DOM events', () => {
 		test(`should emit 'toggle' when title is clicked`, async ({ page }) => {
 			await page.setContent('<kol-details _label="Details" _has-closer />');
-			const kolDetails = page.locator('kol-details');
+			const eventPromise = page.evaluate((eventName: KolEvent) => {
+				return new Promise<boolean>((resolve) => {
+					const detailsElement = document.querySelector('kol-details');
 
-			const eventPromise = kolDetails.evaluate(async (element: HTMLKolDetailsElement, KolEvent) => {
-				return new Promise((resolve) => {
-					element.addEventListener(KolEvent.toggle, resolve);
+					if (!detailsElement) {
+						resolve(false);
+
+						return;
+					}
+
+					const handleEvent = () => {
+						detailsElement.removeEventListener(eventName, handleEvent);
+						resolve(true);
+					};
+
+					detailsElement.addEventListener(eventName, handleEvent);
 				});
-			}, KolEvent);
+			}, KolEvent.toggle);
 			await page.waitForChanges();
 
-			await page.locator('button').click();
+			await page.getByRole('button', { name: 'Details' }).click();
 			await expect(eventPromise).resolves.toBeTruthy();
 		});
 	});

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -20,19 +20,20 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolDetailsElement;
 
 	private readonly nonce = nonce();
-	private buttonWcRef?: HTMLKolButtonWcElement;
+	private summaryRef?: HTMLElement;
 
-	private readonly catchRef = (ref?: HTMLKolButtonWcElement) => {
-		this.buttonWcRef = ref;
+	private readonly catchRef = (ref?: HTMLElement) => {
+		this.summaryRef = ref;
 	};
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+	public kolFocus(): Promise<void> {
+		this.summaryRef?.focus();
+
+		return Promise.resolve();
 	}
 
 	private toggleTimeout?: ReturnType<typeof setTimeout>;
@@ -51,7 +52,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 
 		this.toggleTimeout = setTimeout(() => {
 			if (this.host) {
-				dispatchDomEvent(this.host, KolEvent.toggle, Boolean(this._open));
+				dispatchDomEvent(this.host as HTMLElement, KolEvent.toggle, Boolean(this._open));
 			}
 			this.state._on?.onToggle?.(event, Boolean(this._open));
 		}, 25);
@@ -74,7 +75,9 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 			HeadingButtonProps: {
 				ref: this.catchRef,
 				class: `${rootClass}__heading-button`,
-				_icons: 'codicon codicon-chevron-right',
+				icon: 'codicon codicon-chevron-right',
+				iconClass: `${rootClass}__icon`,
+				labelClass: `${rootClass}__label`,
 			},
 			ContentProps: {
 				class: `${rootClass}__content indented-text`,

--- a/packages/components/src/components/details/style.scss
+++ b/packages/components/src/components/details/style.scss
@@ -7,23 +7,17 @@
 	.kol-details {
 		&__heading-button {
 			display: flex;
-
-			.kol-button {
-				min-height: auto;
-
-				.kol-span {
-					&__label {
-						border-bottom-color: grey;
-						border-bottom-style: solid;
-					}
-				}
-			}
+			gap: 0.5rem;
+			align-items: center;
 		}
 
-		.collapsible--open &__heading-button {
-			.kol-icon::part(icon) {
-				transform: rotate(90deg);
-			}
+		&__label {
+			border-bottom-color: grey;
+			border-bottom-style: solid;
+		}
+
+		.collapsible--open &__icon::part(icon) {
+			transform: rotate(90deg);
 		}
 	}
 }

--- a/packages/components/src/components/details/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/details/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,10 +3,17 @@
 exports[`kol-details should render with _label="Zusammenfassung" _disabled=false _open=false 1`] = `
 <kol-details>
   <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible kol-details" id="nonce">
+      <summary aria-controls="nonce-control" aria-expanded="false" class="collapsible__heading-button kol-details__heading-button" role="button">
+        <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-chevron-right" _label="" class="collapsible__icon kol-details__icon"></kol-icon>
+            <span class="collapsible__label kol-details__label">
+              Zusammenfassung
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -14,7 +21,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-details>
 `;
@@ -22,10 +29,17 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
 exports[`kol-details should render with _label="Zusammenfassung" _disabled=false _open=true 1`] = `
 <kol-details _open="">
   <template shadowrootmode="open">
-    <div class="collapsible collapsible--open kol-details" id="nonce">
-      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible collapsible--open kol-details" id="nonce" open="">
+      <summary aria-controls="nonce-control" aria-expanded="true" class="collapsible__heading-button kol-details__heading-button" role="button">
+        <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-chevron-right" _label="" class="collapsible__icon kol-details__icon"></kol-icon>
+            <span class="collapsible__label kol-details__label">
+              Zusammenfassung
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -33,7 +47,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-details>
 `;
@@ -41,10 +55,17 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=false
 exports[`kol-details should render with _label="Zusammenfassung" _disabled=true _open=false 1`] = `
 <kol-details>
   <template shadowrootmode="open">
-    <div class="collapsible collapsible--disabled kol-details" id="nonce">
-      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _disabled="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible collapsible--disabled kol-details" id="nonce">
+      <summary aria-controls="nonce-control" aria-disabled="true" aria-expanded="false" class="collapsible__heading-button kol-details__heading-button" role="button" tabindex="-1">
+        <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-chevron-right" _label="" class="collapsible__icon kol-details__icon"></kol-icon>
+            <span class="collapsible__label kol-details__label">
+              Zusammenfassung
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -52,7 +73,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-details>
 `;
@@ -60,10 +81,17 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
 exports[`kol-details should render with _label="Zusammenfassung" _disabled=true _open=true 1`] = `
 <kol-details _open="">
   <template shadowrootmode="open">
-    <div class="collapsible collapsible--disabled collapsible--open kol-details" id="nonce">
-      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _ariaexpanded="" _disabled="" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible collapsible--disabled collapsible--open kol-details" id="nonce" open="">
+      <summary aria-controls="nonce-control" aria-disabled="true" aria-expanded="true" class="collapsible__heading-button kol-details__heading-button" role="button" tabindex="-1">
+        <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-chevron-right" _label="" class="collapsible__icon kol-details__icon"></kol-icon>
+            <span class="collapsible__label kol-details__label">
+              Zusammenfassung
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -71,7 +99,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-details>
 `;
@@ -79,10 +107,17 @@ exports[`kol-details should render with _label="Zusammenfassung" _disabled=true 
 exports[`kol-details should render with _label="Zusammenfassung" _level=3 1`] = `
 <kol-details>
   <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <h3 class="collapsible__heading kol-details__heading kol-headline kol-headline--h3 kol-headline--single">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </h3>
+    <details class="collapsible kol-details" id="nonce">
+      <summary aria-controls="nonce-control" aria-expanded="false" class="collapsible__heading-button kol-details__heading-button" role="button">
+        <h3 class="collapsible__heading kol-details__heading kol-headline kol-headline--h3 kol-headline--single">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-chevron-right" _label="" class="collapsible__icon kol-details__icon"></kol-icon>
+            <span class="collapsible__label kol-details__label">
+              Zusammenfassung
+            </span>
+          </span>
+        </h3>
+      </summary>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -90,7 +125,7 @@ exports[`kol-details should render with _label="Zusammenfassung" _level=3 1`] = 
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-details>
 `;
@@ -98,10 +133,17 @@ exports[`kol-details should render with _label="Zusammenfassung" _level=3 1`] = 
 exports[`kol-details should render with _label="Zusammenfassung" 1`] = `
 <kol-details>
   <template shadowrootmode="open">
-    <div class="collapsible kol-details" id="nonce">
-      <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
-        <kol-button-wc _ariacontrols="nonce-control" _icons="codicon codicon-chevron-right" _label="Zusammenfassung" class="collapsible__heading-button kol-details__heading-button" slot="expert"></kol-button-wc>
-      </strong>
+    <details class="collapsible kol-details" id="nonce">
+      <summary aria-controls="nonce-control" aria-expanded="false" class="collapsible__heading-button kol-details__heading-button" role="button">
+        <strong class="collapsible__heading kol-details__heading kol-headline kol-headline--single kol-headline--strong">
+          <span class="collapsible__heading-content">
+            <kol-icon _icons="codicon codicon-chevron-right" _label="" class="collapsible__icon kol-details__icon"></kol-icon>
+            <span class="collapsible__label kol-details__label">
+              Zusammenfassung
+            </span>
+          </span>
+        </strong>
+      </summary>
       <div class="collapsible__wrapper kol-details__wrapper">
         <div class="collapsible__wrapper-animation kol-details__wrapper-animation">
           <div aria-hidden="true" class="collapsible__content indented-text kol-details__content" id="nonce-control">
@@ -109,7 +151,7 @@ exports[`kol-details should render with _label="Zusammenfassung" 1`] = `
           </div>
         </div>
       </div>
-    </div>
+    </details>
   </template>
 </kol-details>
 `;

--- a/packages/components/src/functional-components/Collapsible/Collapsible.tsx
+++ b/packages/components/src/functional-components/Collapsible/Collapsible.tsx
@@ -2,9 +2,9 @@ import type { FunctionalComponent as FC } from '@stencil/core';
 import { h } from '@stencil/core';
 import type { JSXBase } from '@stencil/core/internal';
 import clsx from 'clsx';
-import { KolButtonWcTag } from '../../core/component-names';
-import type { EventValueOrEventCallback, HeadingLevel, IconsPropType, StencilUnknown } from '../../schema';
+import type { HeadingLevel } from '../../schema';
 import KolHeadingFc from '../Heading';
+import KolIconFc from '../Icon';
 
 type ClassType =
 	| string
@@ -18,7 +18,7 @@ export type CollapsibleProps = Omit<JSXBase.HTMLAttributes<HTMLElement>, 'id' | 
 	disabled?: boolean;
 	level?: HeadingLevel;
 	label: string;
-	onClick?: EventValueOrEventCallback<MouseEvent, StencilUnknown>;
+	onClick?: (event: MouseEvent) => void;
 
 	HeadingProps?: {
 		ref?: ((elm?: HTMLElement | undefined) => void) | undefined;
@@ -26,9 +26,11 @@ export type CollapsibleProps = Omit<JSXBase.HTMLAttributes<HTMLElement>, 'id' | 
 	};
 
 	HeadingButtonProps?: {
-		ref?: ((elm?: HTMLKolButtonWcElement | undefined) => void) | undefined;
+		ref?: ((elm?: HTMLElement | undefined) => void) | undefined;
 		class?: ClassType;
-		_icons?: IconsPropType;
+		icon?: string;
+		iconClass?: ClassType;
+		labelClass?: ClassType;
 	};
 
 	ContentProps?: {
@@ -40,11 +42,31 @@ export type CollapsibleProps = Omit<JSXBase.HTMLAttributes<HTMLElement>, 'id' | 
 
 const KolCollapsibleFc: FC<CollapsibleProps> = (props, children) => {
 	const { id, class: classNames, label, level = 1, disabled, open, onClick, HeadingProps = {}, HeadingButtonProps = {}, ContentProps = {}, ...other } = props;
-	const icon = open ? 'remove' : 'add';
+	const iconFromProps = HeadingButtonProps?.icon;
+	const iconClass = typeof iconFromProps === 'string' && iconFromProps.length > 0 ? iconFromProps : `codicon codicon-${open ? 'remove' : 'add'}`;
+	const headingButtonClass = clsx('collapsible__heading-button', HeadingButtonProps?.class);
+	const headingClass = clsx('collapsible__heading', HeadingProps?.class);
+	const iconClasses = clsx('collapsible__icon', HeadingButtonProps?.iconClass);
+	const labelClasses = clsx('collapsible__label', HeadingButtonProps?.labelClass);
+
+	const handleSummaryClick = (event: MouseEvent) => {
+		if (disabled) {
+			event.preventDefault();
+			event.stopPropagation();
+			return;
+		}
+
+		onClick?.(event);
+	};
+
+	const summaryRef = (element?: HTMLElement) => {
+		HeadingButtonProps?.ref?.(element);
+	};
 
 	return (
-		<div
+		<details
 			id={id}
+			open={open === true ? true : undefined}
 			class={clsx(
 				'collapsible',
 				{
@@ -55,19 +77,23 @@ const KolCollapsibleFc: FC<CollapsibleProps> = (props, children) => {
 			)}
 			{...other}
 		>
-			<KolHeadingFc ref={HeadingProps?.ref} level={level} class={clsx('collapsible__heading', HeadingProps?.class)}>
-				<KolButtonWcTag
-					class={clsx('collapsible__heading-button', HeadingButtonProps?.class)}
-					ref={HeadingButtonProps?.ref}
-					slot="expert"
-					_ariaControls={`${id}-control`}
-					_ariaExpanded={open}
-					_disabled={disabled}
-					_icons={HeadingButtonProps?._icons || `codicon codicon-${icon}`}
-					_label={label}
-					_on={{ onClick }}
-				></KolButtonWcTag>
-			</KolHeadingFc>
+			<summary
+				class={headingButtonClass}
+				ref={summaryRef}
+				aria-controls={`${id}-control`}
+				aria-expanded={open === true ? 'true' : 'false'}
+				aria-disabled={disabled ? 'true' : undefined}
+				role="button"
+				tabIndex={disabled ? -1 : undefined}
+				onClick={handleSummaryClick}
+			>
+				<KolHeadingFc ref={HeadingProps?.ref} level={level} class={headingClass}>
+					<span class="collapsible__heading-content">
+						<KolIconFc class={iconClasses} icons={iconClass} label="" />
+						<span class={labelClasses}>{label}</span>
+					</span>
+				</KolHeadingFc>
+			</summary>
 			<div class={clsx('collapsible__wrapper', ContentProps?.wrapperClass)}>
 				<div class={clsx('collapsible__wrapper-animation', ContentProps?.animationClass)}>
 					<div aria-hidden={open === false ? 'true' : undefined} class={clsx('collapsible__content', ContentProps?.class)} id={`${id}-control`}>
@@ -75,7 +101,7 @@ const KolCollapsibleFc: FC<CollapsibleProps> = (props, children) => {
 					</div>
 				</div>
 			</div>
-		</div>
+		</details>
 	);
 };
 

--- a/packages/components/src/functional-components/Collapsible/collapsible.scss
+++ b/packages/components/src/functional-components/Collapsible/collapsible.scss
@@ -4,6 +4,7 @@
 
 @layer kol-component {
 	.collapsible {
+		margin: 0;
 		@media (prefers-reduced-motion) {
 			&__wrapper-animation,
 			&__wrapper {
@@ -46,14 +47,49 @@
 			visibility: visible;
 		}
 
-		/*
-        * Inside a button, the caption text is always centered.
-        * So we have to align the text to the left.
-        */
-		&__heading-button button {
-			.kol-span {
-				justify-items: start;
+		&__heading-button {
+			color: inherit;
+			background: none;
+			display: block;
+			width: 100%;
+			margin: 0;
+			padding: 0;
+			border: 0;
+			cursor: pointer;
+			list-style: none;
+			text-align: inherit;
+
+			&::-webkit-details-marker {
+				display: none;
 			}
+		}
+
+		&__heading {
+			margin: 0;
+		}
+
+		&__heading-content {
+			display: inline-flex;
+			width: 100%;
+			gap: 0.5rem;
+			align-items: center;
+		}
+
+		&__icon {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+		}
+
+		&__label {
+			display: inline-flex;
+			align-items: center;
+			text-align: start;
+		}
+
+		&--disabled &__heading-button {
+			cursor: default;
+			pointer-events: none;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- render the shared collapsible helper with <details>/<summary> markup and icon/label slots
- update kol-accordion and kol-details to use the new summary ref, focus handling, and BEM classes
- adjust styles, snapshots, and e2e tests for the new semantic structure

## Testing
- pnpm --filter @public-ui/components test:unit

------
https://chatgpt.com/codex/tasks/task_e_68dd922d4280832ba03b2474afe54f0f