### PR TITLE
feat: add multi select component

### DIFF
--- a/packages/components/src/components/component-list.ts
+++ b/packages/components/src/components/component-list.ts
@@ -32,6 +32,7 @@ import { KolLink } from './link/shadow';
 import { KolLinkButton } from './link-button/shadow';
 import { KolLinkWc } from './link/component';
 import { KolModal } from './modal/shadow';
+import { KolMultiSelect } from './multi-select/shadow';
 import { KolNav } from './nav/shadow';
 import { KolPagination } from './pagination/shadow';
 import { KolPopover } from './popover/component';
@@ -89,6 +90,7 @@ export const COMPONENTS = [
 	KolLinkButton,
 	KolLinkWc,
 	KolModal,
+	KolMultiSelect,
 	KolNav,
 	KolPagination,
 	KolPopover,

--- a/packages/components/src/components/input-adapter-leanup/associated.controller.ts
+++ b/packages/components/src/components/input-adapter-leanup/associated.controller.ts
@@ -29,6 +29,7 @@ const isAssociatedTagName = (name?: string): boolean =>
 	name === 'KOL-INPUT-RANGE' ||
 	name === 'KOL-INPUT-TEXT' ||
 	name === 'KOL-SELECT' ||
+	name === 'KOL-MULTI-SELECT' ||
 	name === 'KOL-SINGLE-SELECT' ||
 	name === 'KOL-TEXTAREA';
 
@@ -66,6 +67,7 @@ export class AssociatedInputController implements Watches {
 					this.formAssociated.setAttribute('type', this.type);
 					break;
 				case 'select':
+				case 'multi-select':
 					this.formAssociated = document.createElement('select');
 					this.formAssociated.setAttribute('multiple', '');
 					break;

--- a/packages/components/src/components/multi-select/controller.ts
+++ b/packages/components/src/components/multi-select/controller.ts
@@ -1,0 +1,93 @@
+import type {
+	MultiSelectProps,
+	MultiSelectWatches,
+	Option,
+	OptionsPropType,
+	PlaceholderPropType,
+	RequiredPropType,
+	SelectOption,
+	StencilUnknown,
+	Stringified,
+	W3CInputValue,
+} from '../../schema';
+import { validateOptions, validatePlaceholder, validateRequired, watchBoolean, watchJsonArrayString, watchNumber } from '../../schema';
+
+import { InputIconController } from '../@deprecated/input/controller-icon';
+import { fillKeyOptionMap } from '../input-radio/controller';
+
+import type { Generic } from 'adopted-style-sheets';
+
+export class MultiSelectController extends InputIconController implements MultiSelectWatches {
+	protected readonly component: Generic.Element.Component & MultiSelectProps;
+	private readonly keyOptionMap = new Map<string, Option<string>>();
+
+	public constructor(component: Generic.Element.Component & MultiSelectProps, name: string, host?: HTMLElement) {
+		super(component, name, host);
+		this.component = component;
+	}
+
+	protected readonly afterPatchOptions = (value: unknown, _state: Record<string, unknown>, _component: Generic.Element.Component, key: string): void => {
+		if (key === '_value') {
+			this.setFormAssociatedValue(value as StencilUnknown[]);
+		}
+	};
+
+	protected readonly beforePatchOptions = (_value: unknown, nextState: Map<string, unknown>): void => {
+		const options = nextState.has('_options') ? nextState.get('_options') : this.component.state._options;
+		const rawValue = nextState.has('_value') ? nextState.get('_value') : this.component.state._value;
+		if (!Array.isArray(rawValue)) {
+			nextState.set('_value', typeof rawValue === 'undefined' ? [] : [rawValue]);
+		}
+		if (Array.isArray(options) && options.length > 0) {
+			this.keyOptionMap.clear();
+			fillKeyOptionMap(this.keyOptionMap, options as SelectOption<W3CInputValue>[]);
+			const value = (nextState.has('_value') ? nextState.get('_value') : this.component.state._value) as StencilUnknown[];
+			const filteredValues = value.filter((item) => (options as Option<StencilUnknown>[]).some((option) => option.value === item));
+			nextState.set('_value', filteredValues);
+		}
+	};
+
+	public validateOptions(value?: OptionsPropType): void {
+		validateOptions(this.component, value, {
+			hooks: {
+				afterPatch: this.afterPatchOptions,
+				beforePatch: this.beforePatchOptions,
+			},
+		});
+	}
+
+	public validateRequired(value?: RequiredPropType): void {
+		validateRequired(this.component, value);
+	}
+
+	public validateValue(value?: Stringified<StencilUnknown[]>): void {
+		watchJsonArrayString(this.component, '_value', () => true, value, undefined, {
+			hooks: {
+				afterPatch: this.afterPatchOptions,
+				beforePatch: this.beforePatchOptions,
+			},
+		});
+	}
+
+	public validatePlaceholder(value?: PlaceholderPropType): void {
+		validatePlaceholder(this.component, value);
+	}
+
+	public validateHideClearButton(value?: boolean): void {
+		watchBoolean(this.component, '_hideClearButton', value);
+	}
+
+	public validateRows(value?: number): void {
+		watchNumber(this.component, '_rows', value);
+	}
+
+	public componentWillLoad(): void {
+		super.componentWillLoad();
+		this.validateOptions(this.component._options);
+		this.validateRequired(this.component._required);
+		this.validateValue(this.component._value);
+		this.validatePlaceholder(this.component._placeholder);
+		this.validateHideClearButton(this.component._hideClearButton);
+		this.validateRows(this.component._rows);
+	}
+}

--- a/packages/components/src/components/multi-select/multi-select.e2e.ts
+++ b/packages/components/src/components/multi-select/multi-select.e2e.ts
@@ -1,0 +1,143 @@
+import { expect } from '@playwright/test';
+import { test } from '@stencil/playwright';
+import { testInputCallbacksAndEvents, testInputValueReflection } from '../../e2e';
+import { testInputMessage } from '../../e2e/input-msg';
+import type { FillAction } from '../../e2e/utils/FillAction';
+
+const COMPONENT_NAME = 'kol-multi-select';
+const TEST_VALUES = ['E', 'W'];
+const TEST_LABELS = ['East', 'West'];
+const OPTIONS = [
+	{ label: 'North', value: 'N' },
+	{ label: 'South', value: 'S' },
+	{ label: 'West', value: 'W' },
+	{ label: 'East', value: 'E' },
+];
+const OPTIONS_ATTRIBUTE = `_options='${JSON.stringify(OPTIONS)}'`;
+const fillAction: FillAction = async (page) => {
+	await page.getByRole('button').click();
+	await page.getByRole('listbox').getByText(TEST_LABELS[0]).click({ force: true });
+	await page.getByRole('listbox').getByText(TEST_LABELS[1]).click({ force: true });
+};
+
+test.describe(COMPONENT_NAME, () => {
+	testInputValueReflection<HTMLKolMultiSelectElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		equalityCheck: 'toEqual',
+		fillAction,
+		testValue: TEST_VALUES,
+	});
+	testInputCallbacksAndEvents<HTMLKolMultiSelectElement>({
+		additionalProperties: OPTIONS_ATTRIBUTE,
+		componentName: COMPONENT_NAME,
+		equalityCheck: 'toEqual',
+		expectedValue: TEST_VALUES,
+		fillAction,
+		omittedEvents: ['input', 'change'],
+	});
+	testInputMessage<HTMLKolMultiSelectElement>(COMPONENT_NAME);
+
+	test.describe('kol-multi-select additional interactions', () => {
+		test('allows selecting and deselecting multiple options', async ({ page }) => {
+			await page.setContent(`<kol-multi-select _label="Input" ${OPTIONS_ATTRIBUTE}></kol-multi-select>`);
+
+			await page.getByRole('button').click();
+			await page.getByRole('listbox').getByText(TEST_LABELS[0]).click({ force: true });
+			await page.getByRole('listbox').getByText(TEST_LABELS[1]).click({ force: true });
+
+			let value = await page.locator('kol-multi-select').evaluate((el: HTMLKolMultiSelectElement) => el._value);
+			expect(value).toEqual(TEST_VALUES);
+
+			await page.getByRole('listbox').getByText(TEST_LABELS[0]).click({ force: true });
+			value = await page.locator('kol-multi-select').evaluate((el: HTMLKolMultiSelectElement) => el._value);
+			expect(value).toEqual([TEST_VALUES[1]]);
+		});
+
+		test('filters options when typing and keeps selections', async ({ page }) => {
+			await page.setContent(`<kol-multi-select _label="Input" ${OPTIONS_ATTRIBUTE}></kol-multi-select>`);
+
+			await page.locator('input.kol-multi-select__input').focus();
+			await page.locator('input.kol-multi-select__input').fill('We');
+
+			await expect(page.getByText('West')).toBeVisible();
+			await expect(page.getByText('North')).toHaveCount(0);
+
+			await page.keyboard.press('ArrowDown');
+			await page.keyboard.press('Enter');
+
+			const value = await page.locator('kol-multi-select').evaluate((el: HTMLKolMultiSelectElement) => el._value);
+			expect(value).toEqual(['W']);
+		});
+
+		test('clears all selections when clear button is clicked', async ({ page }) => {
+			await page.setContent(`<kol-multi-select _label="Input" ${OPTIONS_ATTRIBUTE}></kol-multi-select>`);
+			await fillAction(page);
+
+			const clearButton = page.getByTestId('multi-select-delete');
+			await expect(clearButton).toHaveCount(1);
+			await clearButton.click({ force: true });
+
+			const value = await page.locator('kol-multi-select').evaluate((el: HTMLKolMultiSelectElement) => el._value);
+			expect(value).toEqual([]);
+		});
+
+		test('does not render clear button when _hideClearButton is true', async ({ page }) => {
+			await page.setContent(`<kol-multi-select _label="Input" _hideClearButton="true" ${OPTIONS_ATTRIBUTE}></kol-multi-select>`);
+			await fillAction(page);
+
+			const clearButton = page.getByTestId('multi-select-delete');
+			await expect(clearButton).toHaveCount(0);
+		});
+
+		test('removes last selected option with backspace when input is empty', async ({ page }) => {
+			await page.setContent(`<kol-multi-select _label="Input" ${OPTIONS_ATTRIBUTE}></kol-multi-select>`);
+			await fillAction(page);
+
+			const input = page.locator('input.kol-multi-select__input');
+			await input.focus();
+			await input.press('Backspace');
+
+			const value = await page.locator('kol-multi-select').evaluate((el: HTMLKolMultiSelectElement) => el._value);
+			expect(value).toEqual([TEST_VALUES[0]]);
+		});
+
+		test('shows summary of selected labels when input is not focused', async ({ page }) => {
+			await page.setContent(`<kol-multi-select _label="Input" ${OPTIONS_ATTRIBUTE}></kol-multi-select>`);
+			await fillAction(page);
+
+			const input = page.locator('input.kol-multi-select__input');
+			await page.click('body');
+			await expect(input).toHaveValue(`${TEST_LABELS[0]}, ${TEST_LABELS[1]}`);
+		});
+
+		test('emits input and change events with array values on selection', async ({ page }) => {
+			await page.setContent(`<kol-multi-select _label="Input" ${OPTIONS_ATTRIBUTE}></kol-multi-select>`);
+
+			const component = page.locator('kol-multi-select');
+			await component.evaluate((element) => {
+				const el = element as HTMLKolMultiSelectElement & { _inputValues: unknown[]; _changeValues: unknown[] };
+				el._inputValues = [];
+				el._changeValues = [];
+				element.addEventListener('kol-input', (event) => {
+					el._inputValues.push((event as CustomEvent).detail);
+				});
+				element.addEventListener('kol-change', (event) => {
+					el._changeValues.push((event as CustomEvent).detail);
+				});
+			});
+
+			await page.getByRole('button').click();
+			await page.getByRole('listbox').getByText(TEST_LABELS[0]).click({ force: true });
+			await page.getByRole('listbox').getByText(TEST_LABELS[1]).click({ force: true });
+
+			const details = await component.evaluate((element) => {
+				const el = element as HTMLKolMultiSelectElement & { _inputValues: unknown[]; _changeValues: unknown[] };
+				return { input: el._inputValues, change: el._changeValues };
+			});
+
+			expect(details.input).toEqual([[TEST_VALUES[0]], TEST_VALUES]);
+			expect(details.change).toEqual([[TEST_VALUES[0]], TEST_VALUES]);
+		});
+	});
+});

--- a/packages/components/src/components/multi-select/shadow.tsx
+++ b/packages/components/src/components/multi-select/shadow.tsx
@@ -1,0 +1,728 @@
+import type { JSX } from '@stencil/core';
+import { Component, Element, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
+
+import type {
+	DisabledPropType,
+	HideLabelPropType,
+	HideMsgPropType,
+	HintPropType,
+	IconsHorizontalPropType,
+	IdPropType,
+	InputTypeOnDefault,
+	LabelWithExpertSlotPropType,
+	MsgPropType,
+	MultiSelectAPI,
+	MultiSelectStates,
+	NamePropType,
+	Option,
+	OptionsPropType,
+	PlaceholderPropType,
+	RequiredPropType,
+	RowsPropType,
+	ShortKeyPropType,
+	StencilUnknown,
+	Stringified,
+	SyncValueBySelectorPropType,
+	TooltipAlignPropType,
+} from '../../schema';
+
+import clsx from 'clsx';
+import { KolIconTag } from '../../core/component-names';
+import { getRenderStates } from '../../functional-component-wrappers/_helpers/getRenderStates';
+import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper';
+import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
+import type { InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
+import KolInputStateWrapperFc from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
+import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggestionsOption/CustomSuggestionsOption';
+import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
+import CustomSuggestionsToggleFc from '../../functional-components/CustomSuggestionsToggle';
+import { translate } from '../../i18n';
+import type { EventDetail } from '../../schema/interfaces/EventDetail';
+import { nonce } from '../../utils/dev.utils';
+import { MultiSelectController } from './controller';
+
+/**
+ * @slot - The input field label.
+ */
+@Component({
+	tag: 'kol-multi-select',
+	styleUrls: {
+		default: './style.scss',
+	},
+	shadow: {
+		delegatesFocus: true,
+	},
+})
+export class KolMultiSelect implements MultiSelectAPI {
+	@Element() private readonly host?: HTMLKolMultiSelectElement;
+	private refInput?: HTMLInputElement;
+	private refOptions: HTMLLIElement[] = [];
+	private readonly translateDeleteSelection = translate('kol-delete-selection');
+	private readonly translateNoResultsMessage = translate('kol-no-results-message');
+	private _filteredOptions?: Option<StencilUnknown>[];
+	private _inputValue = '';
+	private _isOpen = false;
+	private _focusedOptionIndex = -1;
+	private blockSuggestionMouseOver = false;
+	private inputHasFocus = false;
+
+	/**
+	 * Returns the current value.
+	 */
+	@Method()
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async getValue(): Promise<StencilUnknown[]> {
+		return this.getSelectedValues();
+	}
+
+	/**
+	 * Sets focus on the internal element.
+	 */
+	@Method()
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async kolFocus() {
+		this.refInput?.focus();
+	}
+
+	private readonly catchRef = (ref?: HTMLInputElement) => {
+		this.refInput = ref;
+	};
+
+	private toggleListbox = (event: Event) => {
+		event?.preventDefault();
+		if (this.state._disabled === true) {
+			return;
+		}
+
+		if (!this._isOpen) {
+			this._isOpen = true;
+			this.refInput?.focus();
+			this._focusedOptionIndex = -1;
+		} else if (!this.inputHasFocus) {
+			this.closeSuggestions();
+		}
+	};
+
+	private closeSuggestions() {
+		this._isOpen = false;
+		this._focusedOptionIndex = -1;
+		this._inputValue = '';
+		this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+	}
+
+	private createEventWithTarget(type: string, detail: EventDetail): CustomEvent<EventDetail> {
+		const event = new CustomEvent<EventDetail>(type, {
+			bubbles: true,
+			detail,
+		});
+
+		if (this.refInput) {
+			Object.defineProperty(event, 'target', {
+				value: this.refInput,
+			});
+
+			Object.defineProperty(event, 'currentTarget', {
+				value: this.refInput,
+			});
+		}
+		return event;
+	}
+
+	private emitSelectionChange(value: StencilUnknown[]): void {
+		const detailValue = [...value];
+		const inputEvent = this.createEventWithTarget('input', {
+			name: this.state._name ?? '',
+			value: detailValue,
+		});
+		const changeEvent = this.createEventWithTarget('change', {
+			name: this.state._name ?? '',
+			value: detailValue,
+		});
+
+		this.controller.onFacade.onInput(inputEvent, false, detailValue);
+		this.controller.onFacade.onChange(changeEvent, detailValue);
+		this.controller.setFormAssociatedValue(detailValue);
+	}
+
+	private clearSelection() {
+		if (this.state._disabled === true) {
+			return;
+		}
+		const empty: StencilUnknown[] = [];
+		this._value = empty;
+		this._inputValue = '';
+		this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+		this.emitSelectionChange(empty);
+	}
+
+	private selectOption(option: Option<StencilUnknown>) {
+		const current = this.getSelectedValues();
+		const index = current.findIndex((value) => value === option.value);
+		const next = index >= 0 ? [...current.slice(0, index), ...current.slice(index + 1)] : [...current, option.value];
+		this._value = next;
+		this._inputValue = '';
+		this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+		this.emitSelectionChange(next);
+	}
+
+	private onInput(event: Event) {
+		const target = event.target as HTMLInputElement;
+		this._inputValue = target.value;
+		this._isOpen = true;
+		this.setFilteredOptionsByQuery(target.value);
+		this._focusedOptionIndex = -1;
+	}
+
+	private handleKeyDownDropdown(event: KeyboardEvent) {
+		if (event.key.length === 1 && /[a-z0-9]/i.test(event.key)) {
+			event.preventDefault();
+			this._isOpen = true;
+			this.focusSuggestionStartingWith(event.key);
+		}
+	}
+
+	private setFilteredOptionsByQuery(query: string) {
+		if (!query?.trim()) {
+			this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+		} else if (Array.isArray(this.state._options) && this.state._options.length > 0) {
+			this._filteredOptions = this.state._options.filter((option) => {
+				return String(option.label).toLowerCase().includes(query.toLowerCase());
+			});
+		}
+	}
+
+	private moveFocus(delta: number) {
+		if (!Array.isArray(this._filteredOptions) || this._filteredOptions.length === 0) {
+			return;
+		}
+		let newIndex = this._focusedOptionIndex + delta;
+
+		if (newIndex >= this._filteredOptions.length) {
+			newIndex = 0;
+		}
+
+		if (newIndex < 0) {
+			newIndex = this._filteredOptions.length - 1;
+		}
+
+		this._focusedOptionIndex = newIndex;
+		this.focusOption(this._focusedOptionIndex);
+	}
+
+	private focusOption(index: number) {
+		const optionElement = this.refOptions[index];
+		optionElement?.focus();
+	}
+
+	private focusSuggestionStartingWith(char: string) {
+		const charLowerCase = char.toLowerCase();
+
+		const index = Array.isArray(this._filteredOptions)
+			? this._filteredOptions.findIndex((option) => String(option.label).toLowerCase().startsWith(charLowerCase))
+			: -1;
+
+		if (index >= 0) {
+			this._focusedOptionIndex = index;
+			this.focusOption(index);
+		}
+	}
+
+	private getSelectedValues(): StencilUnknown[] {
+		return Array.isArray(this._value) ? [...this._value] : [];
+	}
+
+	private getSelectedSummary(): string {
+		if (!Array.isArray(this.state._options) || this.state._options.length === 0) {
+			return '';
+		}
+		const selectedValues = this.getSelectedValues();
+		if (selectedValues.length === 0) {
+			return '';
+		}
+		return this.state._options
+			.filter((option) => selectedValues.includes(option.value))
+			.map((option) => String(option.label))
+			.join(', ');
+	}
+
+	private removeLastSelectedValue() {
+		const current = this.getSelectedValues();
+		if (current.length === 0) {
+			return;
+		}
+		current.pop();
+		this._value = current;
+		this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+		this.emitSelectionChange(current);
+	}
+
+	private getFormFieldProps(): FormFieldStateWrapperProps {
+		return {
+			state: this.state,
+			class: clsx('kol-multi-select', {
+				'kol-form-field--has-value': this.getSelectedValues().length > 0,
+			}),
+			tooltipAlign: this._tooltipAlign,
+			onClick: () => this.refInput?.focus(),
+			alert: this.showAsAlert(),
+		};
+	}
+
+	private getInputProps(): InputStateWrapperProps {
+		const { ariaDescribedBy } = getRenderStates(this.state);
+		const isDisabled = this.state._disabled === true;
+		const selectedSummary = this.getSelectedSummary();
+
+		return {
+			'aria-activedescendant': this._isOpen && this._focusedOptionIndex >= 0 ? `option-${this._focusedOptionIndex}` : undefined,
+			'aria-autocomplete': 'list',
+			'aria-controls': 'listbox',
+			'aria-describedby': ariaDescribedBy.length > 0 ? ariaDescribedBy.join(' ') : undefined,
+			'aria-label': this.state._hideLabel && typeof this.state._label === 'string' ? this.state._label : undefined,
+			'aria-keyshortcuts': this.state._shortKey,
+			accessKey: this.state._accessKey,
+			autocapitalize: 'off',
+			autocorrect: 'off',
+			class: 'kol-multi-select__input',
+			disabled: isDisabled,
+			name: this.state._name,
+			placeholder: this.state._placeholder,
+			ref: this.catchRef,
+			required: this.state._required,
+			state: this.state,
+			type: 'text',
+			value: this.inputHasFocus ? this._inputValue : selectedSummary,
+			...this.controller.onFacade,
+			onChange: this.onChange.bind(this),
+			onClick: this.onClick.bind(this),
+			onInput: this.onInput.bind(this),
+			onFocus: (event) => {
+				this.controller.onFacade.onFocus(event);
+				this.inputHasFocus = true;
+				this._inputValue = '';
+			},
+			onBlur: (event) => {
+				this.controller.onFacade.onBlur(event);
+				this.inputHasFocus = false;
+				this.closeSuggestions();
+			},
+		};
+	}
+
+	public render(): JSX.Element {
+		const isDisabled = this.state._disabled === true;
+		const selectedValues = this.getSelectedValues();
+		const hasSelections = selectedValues.length > 0;
+
+		return (
+			<KolFormFieldStateWrapperFc {...this.getFormFieldProps()}>
+				<KolInputContainerFc state={this.state}>
+					<div class="kol-multi-select__group">
+						<KolInputStateWrapperFc {...this.getInputProps()} />
+
+						{!this.state._hideClearButton && (hasSelections || this._inputValue) && (
+							<KolIconTag
+								_icons="codicon codicon-close"
+								data-testid="multi-select-delete"
+								_label={this.translateDeleteSelection}
+								onClick={() => {
+									this.clearSelection();
+									this.refInput?.focus();
+								}}
+								class={clsx('kol-multi-select__delete', {
+									'kol-multi-select__delete--disabled': isDisabled,
+								})}
+							/>
+						)}
+
+						<CustomSuggestionsToggleFc onClick={this.toggleListbox.bind(this)} disabled={isDisabled} />
+					</div>
+					{this._isOpen && !isDisabled && (
+						<CustomSuggestionsOptionsGroupFc
+							blockSuggestionMouseOver={this.blockSuggestionMouseOver}
+							onKeyDown={this.handleKeyDownDropdown.bind(this)}
+							aria-multiselectable="true"
+							style={{ '--visible-options': `${this._rows ?? 5}` }}
+						>
+							{Array.isArray(this._filteredOptions) && this._filteredOptions.length > 0 ? (
+								this._filteredOptions.map((option, index) => {
+									const isSelected = selectedValues.includes(option.value);
+									return (
+										<CustomSuggestionsOptionFc
+											index={index}
+											option={option.label}
+											searchTerm={this._inputValue}
+											ref={(el) => {
+												if (el) this.refOptions[index] = el;
+											}}
+											selected={isSelected}
+											onClick={(event: Event) => {
+												this.selectOption(option);
+												this.refInput?.focus();
+												event.preventDefault();
+											}}
+											onMouseOver={() => {
+												if (!this.blockSuggestionMouseOver) {
+													this._focusedOptionIndex = index;
+													this.focusOption(index);
+												}
+											}}
+											onFocus={() => {
+												this._focusedOptionIndex = index;
+												this.focusOption(index);
+											}}
+											onKeyDown={(e) => {
+												if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar' || e.key === 'NumpadEnter') {
+													this.selectOption(option);
+													this.refInput?.focus();
+													e.preventDefault();
+												}
+											}}
+										/>
+									);
+								})
+							) : (
+								<li class="kol-multi-select__no-results-message">{this.translateNoResultsMessage}</li>
+							)}
+						</CustomSuggestionsOptionsGroupFc>
+					)}
+				</KolInputContainerFc>
+			</KolFormFieldStateWrapperFc>
+		);
+	}
+
+	private readonly controller: MultiSelectController;
+
+	/**
+	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 */
+	@Prop() public _accessKey?: string;
+
+	/**
+	 * Makes the element not focusable and ignore all events.
+	 * @TODO: Change type back to `DisabledPropType` after Stencil#4663 has been resolved.
+	 */
+	@Prop() public _disabled?: boolean = false;
+
+	/**
+	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
+	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
+	 */
+	@Prop() public _hideMsg?: boolean = false;
+
+	/**
+	 * Hides the caption by default and displays the caption text with a tooltip when the
+	 * interactive element is focused or the mouse is over it.
+	 * @TODO: Change type back to `HideLabelPropType` after Stencil#4663 has been resolved.
+	 */
+	@Prop() public _hideLabel?: boolean = false;
+
+	/**
+	 * Defines the hint text.
+	 */
+	@Prop() public _hint?: string = '';
+
+	/**
+	 * Defines the icon classnames (e.g. `_icons="fa-solid fa-user"`).
+	 */
+	@Prop() public _icons?: IconsHorizontalPropType;
+
+	/**
+	 * Defines the internal ID of the primary component element.
+	 * @deprecated Will be removed in the next major version.
+	 */
+	@Prop() public _id?: IdPropType;
+
+	/**
+	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.). Set to `false` to enable the expert slot.
+	 */
+	@Prop() public _label!: LabelWithExpertSlotPropType;
+
+	/**
+	 * Defines the properties for a message rendered as Alert component.
+	 */
+	@Prop() public _msg?: Stringified<MsgPropType>;
+
+	/**
+	 * Defines the placeholder text.
+	 */
+	@Prop() public _placeholder?: PlaceholderPropType;
+
+	/**
+	 * Defines the technical name of an input field.
+	 */
+	@Prop() public _name?: NamePropType;
+
+	/**
+	 * Gibt die EventCallback-Funktionen für das Input-Event an.
+	 */
+	@Prop() public _on?: InputTypeOnDefault;
+
+	/**
+	 * Options the user can choose from.
+	 */
+	@Prop() public _options!: OptionsPropType;
+
+	/**
+	 * Makes the input element required.
+	 * @TODO: Change type back to `RequiredPropType` after Stencil#4663 has been resolved.
+	 */
+	@Prop() public _required?: boolean = false;
+
+	/**
+	 * Adds a visual shortcut hint after the label and instructs the screen reader to read the shortcut aloud.
+	 */
+	@Prop() public _shortKey?: ShortKeyPropType;
+
+	/**
+	 * Selector for synchronizing the value with another input element.
+	 * @internal
+	 */
+	@Prop() public _syncValueBySelector?: SyncValueBySelectorPropType;
+
+	/**
+	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
+	 */
+	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
+
+	/**
+	 * Shows if the input was touched by a user.
+	 * @TODO: Change type back to `TouchedPropType` after Stencil#4663 has been resolved.
+	 */
+	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
+
+	/**
+	 * Defines the value of the input.
+	 */
+	@Prop({ mutable: true, reflect: true }) public _value: StencilUnknown[] = [];
+
+	/**
+	 * Defines the whether the clear button should be hidden.
+	 */
+	@Prop() public _hideClearButton?: boolean = false;
+
+	/**
+	 * Maximum number of visible rows in the options dropdown before scrolling.
+	 */
+	@Prop() public _rows?: RowsPropType;
+
+	@State() public state: MultiSelectStates = {
+		_hideMsg: false,
+		_id: `id-${nonce()}`,
+		_label: '',
+		_options: [],
+		_hideClearButton: false,
+	};
+
+	public constructor() {
+		this.controller = new MultiSelectController(this, 'multi-select', this.host);
+	}
+
+	private showAsAlert(): boolean {
+		return Boolean(this.state._touched) && !this.inputHasFocus;
+	}
+
+	@Watch('_placeholder')
+	public validatePlaceholder(value?: PlaceholderPropType): void {
+		this.controller.validatePlaceholder(value);
+	}
+
+	@Watch('_accessKey')
+	public validateAccessKey(value?: string): void {
+		this.controller.validateAccessKey(value);
+	}
+
+	@Watch('_disabled')
+	public validateDisabled(value?: DisabledPropType): void {
+		this.controller.validateDisabled(value);
+	}
+
+	@Watch('_hideMsg')
+	public validateHideMsg(value?: HideMsgPropType): void {
+		this.controller.validateHideMsg(value);
+	}
+
+	@Watch('_hideLabel')
+	public validateHideLabel(value?: HideLabelPropType): void {
+		this.controller.validateHideLabel(value);
+	}
+
+	@Watch('_hint')
+	public validateHint(value?: HintPropType): void {
+		this.controller.validateHint(value);
+	}
+
+	@Watch('_icons')
+	public validateIcons(value?: IconsHorizontalPropType): void {
+		this.controller.validateIcons(value);
+	}
+
+	@Watch('_id')
+	public validateId(value?: string): void {
+		this.controller.validateId(value);
+	}
+
+	@Watch('_label')
+	public validateLabel(value?: LabelWithExpertSlotPropType): void {
+		this.controller.validateLabel(value);
+	}
+
+	@Watch('_msg')
+	public validateMsg(value?: Stringified<MsgPropType>): void {
+		this.controller.validateMsg(value);
+	}
+
+	@Watch('_name')
+	public validateName(value?: string): void {
+		this.controller.validateName(value);
+	}
+
+	@Watch('_on')
+	public validateOn(value?: InputTypeOnDefault): void {
+		this.controller.validateOn(value);
+	}
+
+	@Watch('_options')
+	public validateOptions(value?: OptionsPropType): void {
+		this.controller.validateOptions(value);
+		this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+	}
+
+	@Watch('_required')
+	public validateRequired(value?: RequiredPropType): void {
+		this.controller.validateRequired(value);
+	}
+
+	@Watch('_shortKey')
+	public validateShortKey(value?: ShortKeyPropType): void {
+		this.controller.validateShortKey(value);
+	}
+
+	@Watch('_syncValueBySelector')
+	public validateSyncValueBySelector(value?: SyncValueBySelectorPropType): void {
+		this.controller.validateSyncValueBySelector(value);
+	}
+
+	@Watch('_touched')
+	public validateTouched(value?: boolean): void {
+		this.controller.validateTouched(value);
+	}
+
+	@Watch('_value')
+	public validateValue(value?: Stringified<StencilUnknown[]>): void {
+		this.controller.validateValue(value);
+		this._inputValue = '';
+		this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+	}
+
+	@Watch('_hideClearButton')
+	public validateHideClearButton(value?: boolean): void {
+		this.controller.validateHideClearButton(value);
+	}
+
+	@Watch('_rows')
+	public validateRows(value?: number): void {
+		this.controller.validateRows(value);
+	}
+
+	@Listen('mousemove')
+	public handleMouseEvent() {
+		this.blockSuggestionMouseOver = false;
+	}
+
+	@Listen('focusout', { target: 'window' })
+	public handleFocusOut() {
+		setTimeout(() => {
+			if (!this.host?.contains(document.activeElement)) {
+				this.closeSuggestions();
+			}
+		}, 0);
+	}
+
+	@Listen('blur', { target: 'window' })
+	public handleWindowBlur() {
+		this.closeSuggestions();
+	}
+
+	@Listen('keydown')
+	public handleKeyDown(event: KeyboardEvent) {
+		const handleEvent = (isOpen?: boolean, callback?: () => void): void => {
+			event.preventDefault();
+
+			if (isOpen !== undefined) {
+				this._isOpen = isOpen;
+				if (!isOpen) {
+					this.refInput?.focus();
+				}
+			}
+			callback?.();
+		};
+
+		switch (event.key) {
+			case 'Down':
+			case 'ArrowDown': {
+				this.blockSuggestionMouseOver = true;
+				handleEvent(true, () => this.moveFocus(1));
+				break;
+			}
+			case 'Up':
+			case 'ArrowUp': {
+				this.blockSuggestionMouseOver = true;
+				handleEvent(true, () => this.moveFocus(-1));
+				break;
+			}
+			case 'Tab':
+				if (this._isOpen) {
+					this.closeSuggestions();
+				}
+				break;
+			case 'Esc':
+			case 'Escape': {
+				this.closeSuggestions();
+				handleEvent(false);
+				break;
+			}
+			case ' ': // Space
+			case 'Spacebar':
+			case 'Enter':
+			case 'NumpadEnter': {
+				if (this._isOpen && this._focusedOptionIndex >= 0 && Array.isArray(this._filteredOptions)) {
+					const option = this._filteredOptions[this._focusedOptionIndex];
+					if (option) {
+						this.selectOption(option);
+					}
+				}
+				event.preventDefault();
+				break;
+			}
+			case 'Backspace': {
+				if (!this._inputValue) {
+					this.removeLastSelectedValue();
+					event.preventDefault();
+				}
+				break;
+			}
+		}
+	}
+
+	private updateInitialState() {
+		this.refOptions = [];
+		this._filteredOptions = Array.isArray(this.state._options) ? [...this.state._options] : [];
+		this._value = this.getSelectedValues();
+	}
+
+	public componentWillLoad(): void {
+		this._touched = this._touched === true;
+		this.controller.componentWillLoad();
+		this.updateInitialState();
+	}
+
+	private onChange(event: Event): void {
+		this.controller.onFacade.onChange(event, this.getSelectedValues());
+	}
+
+	private onClick(event: MouseEvent): void {
+		this.toggleListbox(event);
+		this.controller.onFacade.onClick(event);
+	}
+}

--- a/packages/components/src/components/multi-select/style.scss
+++ b/packages/components/src/components/multi-select/style.scss
@@ -1,0 +1,44 @@
+@use '../../styles/global' as *;
+@use '../../styles/kol-alert-mixin' as *;
+@use '../../styles/kol-custom-suggestions-option' as *;
+@use '../../styles/kol-custom-suggestions-options-group' as *;
+@use '../../styles/kol-custom-suggestions-toggle' as *;
+@use '../../styles/kol-form-field-mixin' as *;
+@use '../../styles/kol-input-container-mixin' as *;
+@use '../../styles/kol-input-mixin' as *;
+@use '../@shared/mixins' as *;
+
+@layer kol-component {
+	@include kol-alert;
+	@include kol-custom-suggestions-option;
+	@include kol-custom-suggestions-options-group;
+	@include kol-custom-suggestions-toggle;
+	@include kol-form-field;
+	@include kol-input-container;
+	@include kol-input;
+
+	$option-height: to-rem(40);
+	$visible-options: var(--visible-options, 5);
+
+	.kol-multi-select {
+		&__delete {
+			cursor: pointer;
+
+			&--disabled {
+				cursor: not-allowed;
+			}
+		}
+
+		&__no-results-message {
+			display: flex;
+			min-height: to-rem(50);
+			align-items: center;
+			justify-content: center;
+			cursor: default;
+		}
+
+		.kol-custom-suggestions-options-group {
+			max-height: calc($option-height * $visible-options + to-rem(2)) !important;
+		}
+	}
+}

--- a/packages/components/src/components/multi-select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/multi-select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,0 +1,384 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _accessKey="V" 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          Label
+          <kbd aria-hidden="true" class="badge-text-hint">
+            V
+          </kbd>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input accesskey="V" aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _alert=true 1`] = `
+<kol-multi-select _alert="">
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _disabled=true 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-form-field--disabled kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container kol-input-container--disabled">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-multi-select__input" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" disabled="" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hint="Hint" 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span class="kol-form-field__hint" id="id-nonce-hint">
+        Hint
+      </span>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__adornment kol-input-container__adornment--start">
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+          </div>
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+          <div class="kol-input-container__adornment kol-input-container__adornment--end">
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__adornment kol-input-container__adornment--start">
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+          </div>
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+          <div class="kol-input-container__adornment kol-input-container__adornment--end"></div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__adornment kol-input-container__adornment--start"></div>
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+          <div class="kol-input-container__adornment kol-input-container__adornment--end">
+            <kol-icon _icons="codicon codicon-codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
+<kol-multi-select _touched="">
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container kol-input-container--error">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _readOnly=true 1`] = `
+<kol-multi-select _readonly="">
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _shortKey="S" 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          Label
+          <kbd aria-hidden="true" class="badge-text-hint">
+            S
+          </kbd>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _touched=true 1`] = `
+<kol-multi-select _touched="">
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-form-field--touched kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--touched kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;
+
+exports[`kol-multi-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] 1`] = `
+<kol-multi-select>
+  <template shadowrootmode="open" shadowrootdelegatesfocus>
+    <div class="kol-form-field kol-multi-select">
+      <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
+        <span class="kol-form-field__label-text">
+          <span>
+            Label
+          </span>
+        </span>
+      </label>
+      <div class="kol-form-field__input">
+        <div class="kol-input-container">
+          <div class="kol-input-container__container">
+            <div class="kol-multi-select__group">
+              <input aria-autocomplete="list" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-multi-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
+              <button class="kol-custom-suggestions-toggle" tabindex="-1">
+                <kol-icon _icons="codicon codicon-triangle-down" _label="kol-dropdown"></kol-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+</kol-multi-select>
+`;

--- a/packages/components/src/components/multi-select/test/snapshot.spec.tsx
+++ b/packages/components/src/components/multi-select/test/snapshot.spec.tsx
@@ -1,0 +1,25 @@
+import { KolMultiSelectTag } from '../../../core/component-names';
+import type { MultiSelectProps } from '../../../schema';
+import { executeInputSnapshotTests } from '../../../utils/testing';
+
+import { KolMultiSelect } from '../shadow';
+
+const options = [
+	{
+		label: 'Frau',
+		value: 'Frau',
+		disabled: true,
+	},
+	{
+		label: 'Herr',
+		value: 'Herr',
+	},
+	{
+		label: 'Divers',
+		value: 'Divers',
+	},
+];
+
+executeInputSnapshotTests<MultiSelectProps>(KolMultiSelectTag, [KolMultiSelect], {
+	_options: options,
+});

--- a/packages/components/src/core/component-names.ts
+++ b/packages/components/src/core/component-names.ts
@@ -34,6 +34,7 @@ export let KolLinkButtonTag = 'kol-link-button' as const;
 export let KolLinkTag = 'kol-link' as const;
 export let KolLinkWcTag = 'kol-link-wc' as const;
 export let KolModalTag = 'kol-modal' as const;
+export let KolMultiSelectTag = 'kol-multi-select' as const;
 export let KolNavTag = 'kol-nav' as const;
 export let KolPaginationTag = 'kol-pagination' as const;
 export let KolPaginationWcTag = 'kol-pagination-wc' as const;
@@ -99,6 +100,7 @@ export const setCustomTagNames = (transformTagName: (tagName: string) => string)
 	KolLinkTag = transformTagName(KolLinkTag as string) as 'kol-link';
 	KolLinkWcTag = transformTagName(KolLinkWcTag as string) as 'kol-link-wc';
 	KolModalTag = transformTagName(KolModalTag as string) as 'kol-modal';
+	KolMultiSelectTag = transformTagName(KolMultiSelectTag as string) as 'kol-multi-select';
 	KolNavTag = transformTagName(KolNavTag as string) as 'kol-nav';
 	KolPaginationTag = transformTagName(KolPaginationTag as string) as 'kol-pagination';
 	KolPaginationWcTag = transformTagName(KolPaginationWcTag as string) as 'kol-pagination-wc';

--- a/packages/components/src/functional-components/CustomSuggestionsOptionsGroup/CustomSuggestionsOptionsGroup.tsx
+++ b/packages/components/src/functional-components/CustomSuggestionsOptionsGroup/CustomSuggestionsOptionsGroup.tsx
@@ -6,15 +6,19 @@ export type CustomSuggestionsOptionsGroupProps = JSXBase.HTMLAttributes<HTMLULis
 	blockSuggestionMouseOver: boolean;
 };
 
-const CustomSuggestionsOptionsGroupFc: FC<CustomSuggestionsOptionsGroupProps> = ({ blockSuggestionMouseOver, onKeyDown, style }, children) => {
+const CustomSuggestionsOptionsGroupFc: FC<CustomSuggestionsOptionsGroupProps> = (
+	{ blockSuggestionMouseOver, class: className, onKeyDown, style, ...rest },
+	children,
+) => {
 	return (
 		<ul
 			role="listbox"
 			style={style}
-			class={clsx('kol-custom-suggestions-options-group', {
+			class={clsx('kol-custom-suggestions-options-group', className, {
 				'kol-custom-suggestions-options-group--cursor-hidden': blockSuggestionMouseOver,
 			})}
 			onKeyDown={onKeyDown}
+			{...rest}
 		>
 			{children}
 		</ul>

--- a/packages/components/src/schema/components/index.ts
+++ b/packages/components/src/schema/components/index.ts
@@ -33,6 +33,7 @@ export * from './popover';
 export * from './popover-button';
 export * from './progress';
 export * from './quote';
+export * from './multi-select';
 export * from './select';
 export * from './skip-nav';
 export * from './span';

--- a/packages/components/src/schema/components/multi-select.ts
+++ b/packages/components/src/schema/components/multi-select.ts
@@ -1,0 +1,69 @@
+import type { Generic } from 'adopted-style-sheets';
+
+import type {
+	MsgPropType,
+	PropAccessKey,
+	PropDisabled,
+	PropHideLabel,
+	PropHideMsg,
+	PropHint,
+	PropHorizontalIcons,
+	PropId,
+	PropLabelWithExpertSlot,
+	PropMsg,
+	PropName,
+	PropOptions,
+	PropRequired,
+	PropRows,
+	PropShortKey,
+	PropSyncValueBySelector,
+	PropTouched,
+} from '../props';
+import type { InputTypeOnDefault, KoliBriHIcons, Option, StencilUnknown, Stringified } from '../types';
+
+type RequiredProps = PropLabelWithExpertSlot & PropOptions;
+type OptionalProps = {
+	hideClearButton: boolean;
+	msg: Stringified<MsgPropType>;
+	on: InputTypeOnDefault;
+	placeholder: string;
+	value: Stringified<StencilUnknown[]>;
+} & PropAccessKey &
+	PropDisabled &
+	PropHideMsg &
+	PropHideLabel &
+	PropHint &
+	PropHorizontalIcons &
+	PropName &
+	PropRequired &
+	PropRows &
+	PropShortKey &
+	PropSyncValueBySelector &
+	PropTouched;
+
+type RequiredStates = {
+	options: Option<StencilUnknown>[];
+} & PropId &
+	PropHideMsg &
+	PropLabelWithExpertSlot;
+type OptionalStates = {
+	hideClearButton: boolean;
+	on: InputTypeOnDefault;
+	placeholder: string;
+} & PropAccessKey &
+	PropDisabled &
+	PropHideLabel &
+	KoliBriHIcons &
+	PropHint &
+	PropId &
+	PropName &
+	PropRequired &
+	PropRows &
+	PropMsg &
+	PropShortKey &
+	PropTouched;
+
+export type MultiSelectProps = Generic.Element.Members<RequiredProps, OptionalProps>;
+export type MultiSelectStates = Generic.Element.Members<RequiredStates, OptionalStates>;
+export type MultiSelectWatches = Generic.Element.Watchers<RequiredProps, OptionalProps>;
+export type MultiSelectAPI = Generic.Element.ComponentApi<RequiredProps, OptionalProps, RequiredStates, OptionalStates>;

--- a/packages/components/src/schema/tag-names.ts
+++ b/packages/components/src/schema/tag-names.ts
@@ -30,6 +30,7 @@ export enum TagEnum {
 	'link-button',
 	'logo',
 	'modal',
+	'multi-select',
 	'nav',
 	'pagination',
 	'popover-button',

--- a/packages/samples/react/src/components/multi-select/basic.tsx
+++ b/packages/samples/react/src/components/multi-select/basic.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { FC } from 'react';
+
+import { FormWrap } from '../FormWrap';
+import { SampleDescription } from '../SampleDescription';
+import { MultiSelectVariants } from './partials/variants';
+
+export const MultiSelectBasic: FC = () => {
+	return (
+		<>
+			<SampleDescription>
+				<p>MultiSelect allows searching and choosing zero or more options from a list.</p>
+			</SampleDescription>
+
+			<FormWrap RefComponent={MultiSelectVariants} showButtons={false} />
+		</>
+	);
+};

--- a/packages/samples/react/src/components/multi-select/partials/cases.tsx
+++ b/packages/samples/react/src/components/multi-select/partials/cases.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { KolMultiSelect } from '@public-ui/react-v19';
+import type { Components, Option, StencilUnknown } from '@public-ui/components';
+
+import { ERROR_MSG, HINT_MSG } from '../../../shares/constants';
+import { COUNTRY_OPTIONS } from '../../../shares/country';
+import { LONG_OPTIONS } from '../../../shares/longOptions';
+
+export const MultiSelectCases = (props: Components.KolMultiSelect) => {
+	const defaultOptions = COUNTRY_OPTIONS as Option<StencilUnknown>[];
+	const longLabelOptions = LONG_OPTIONS as Option<StencilUnknown>[];
+
+	return (
+		<div className="grid gap-4">
+			<KolMultiSelect
+				{...props}
+				_hint={HINT_MSG}
+				_label="Label"
+				_options={defaultOptions}
+				_value={['de', 'fr']}
+				_on={{
+					onBlur: console.log,
+					onInput: console.log,
+					onChange: console.log,
+					onClick: console.log,
+					onFocus: console.log,
+				}}
+			/>
+			<KolMultiSelect {...props} _label="Disabled" _options={defaultOptions} _value={['de', 'fr']} _disabled />
+			<KolMultiSelect
+				{...props}
+				_options={defaultOptions}
+				_msg={{ _type: 'error', _description: ERROR_MSG }}
+				_rows={4}
+				_touched
+				_label="Label"
+				_placeholder="Placeholder"
+				_required
+			/>
+			<KolMultiSelect {...props} _label="With access key" _options={defaultOptions} _value={['de']} _accessKey="m" />
+			<KolMultiSelect {...props} _label="With short key" _options={defaultOptions} _value={['de']} _shortKey="m" />
+			<KolMultiSelect {...props} _label="With long labels" _options={longLabelOptions} _placeholder="Select options" />
+			<KolMultiSelect {...props} _label="With hidden clear button" _options={defaultOptions} _value={['de', 'fr']} _hideClearButton />
+		</div>
+	);
+};

--- a/packages/samples/react/src/components/multi-select/partials/variants.tsx
+++ b/packages/samples/react/src/components/multi-select/partials/variants.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import type { Components } from '@public-ui/components';
+
+import { SampleColumns } from '../../SampleColumns';
+import { MultiSelectCases } from './cases';
+
+export const MultiSelectVariants = (props: Components.KolMultiSelect) => {
+	return (
+		<SampleColumns>
+			<fieldset>
+				<legend>Text</legend>
+				<MultiSelectCases {...props} />
+			</fieldset>
+			<fieldset>
+				<legend>Text (hideLabel)</legend>
+				<MultiSelectCases {...props} _hideLabel />
+			</fieldset>
+		</SampleColumns>
+	);
+};

--- a/packages/samples/react/src/components/multi-select/routes.ts
+++ b/packages/samples/react/src/components/multi-select/routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '../../shares/types';
+import { MultiSelectBasic } from './basic';
+
+export const MULTI_SELECT_ROUTES: Routes = {
+	'multi-select': {
+		basic: MultiSelectBasic,
+	},
+};

--- a/packages/samples/react/src/shares/routes.ts
+++ b/packages/samples/react/src/shares/routes.ts
@@ -28,6 +28,7 @@ import { KOLIBRI_ROUTES } from '../components/kolibri/routes';
 import { LINK_BUTTON_ROUTES } from '../components/link-button/routes';
 import { LINK_ROUTES } from '../components/link/routes';
 import { MODAL_ROUTES } from '../components/modal/routes';
+import { MULTI_SELECT_ROUTES } from '../components/multi-select/routes';
 import { NAV_ROUTES } from '../components/nav/routes';
 import { PAGINATION_ROUTES } from '../components/pagination/routes';
 import { POPOVER_BUTTON_ROUTES } from '../components/popover-button/routes';
@@ -81,12 +82,12 @@ export const ROUTES: Routes = {
 	...LINK_BUTTON_ROUTES,
 	...LINK_ROUTES,
 	...MODAL_ROUTES,
+	...MULTI_SELECT_ROUTES,
 	...NAV_ROUTES,
 	...PAGINATION_ROUTES,
 	...POPOVER_BUTTON_ROUTES,
 	...PROGRESS_ROUTES,
 	...QUOTE_ROUTES,
-	...SELECT_ROUTES,
 	...SELECT_ROUTES,
 	...SKIP_NAV_ROUTES,
 	...SPIN_ROUTES,

--- a/packages/themes/default/src/components/multi-select.scss
+++ b/packages/themes/default/src/components/multi-select.scss
@@ -1,0 +1,46 @@
+@use '../mixins/to-rem' as *;
+@use '../mixins/alert-wc' as *;
+@use '../mixins/input-error' as *;
+@use '../mixins/typography' as *;
+@use '../mixins/custom-suggestions-option' as *;
+@use '../mixins/custom-suggestions-options-group' as *;
+@use '../mixins/custom-suggestions-toggle' as *;
+@use '../@shared/input-core' as *;
+
+$option-height: to-rem(40);
+$visible-options: 5;
+$icon-size: to-rem(40);
+
+@layer kol-theme-component {
+	@include kol-alert-theme;
+	@include kol-custom-suggestions-option-theme($option-height);
+	@include kol-custom-suggestions-options-group-theme($option-height, $visible-options);
+	@include kol-custom-suggestions-toggle-theme;
+
+	.kol-multi-select {
+		&__group {
+			display: inline-flex;
+			width: 100%;
+			align-items: center;
+		}
+
+		&__input {
+			position: relative;
+			min-width: 0;
+			flex: 1 1 auto;
+			border: none;
+
+			&::placeholder {
+				color: var(--color-subtle);
+			}
+		}
+
+		&__delete {
+			display: inline-flex;
+			width: $icon-size;
+			height: $icon-size;
+			align-items: center;
+			justify-content: center;
+		}
+	}
+}

--- a/packages/themes/default/src/index.ts
+++ b/packages/themes/default/src/index.ts
@@ -25,6 +25,7 @@ import inputRangeCss from './components/input-range.scss';
 import inputTextCss from './components/input-text.scss';
 import linkButtonCss from './components/link-button.scss';
 import modalCss from './components/modal.scss';
+import multiSelectCss from './components/multi-select.scss';
 import linkCss from './components/link.scss';
 import navCss from './components/nav.scss';
 import paginationCss from './components/pagination.scss';
@@ -71,6 +72,7 @@ export const DEFAULT = KoliBri.createTheme('default', {
 	'KOL-LINK': linkCss,
 	'KOL-LINK-BUTTON': linkButtonCss,
 	'KOL-MODAL': modalCss,
+	'KOL-MULTI-SELECT': multiSelectCss,
 	'KOL-NAV': navCss,
 	'KOL-PAGINATION': paginationCss,
 	'KOL-POPOVER-BUTTON': popoverButtonCss,

--- a/packages/themes/ecl/src/ecl-ec/components/multi-select.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/multi-select.scss
@@ -1,0 +1,61 @@
+@use '../../mixins/to-rem' as *;
+@use '../mixins/alert-wc' as *;
+@use '../mixins/custom-suggestions-option' as *;
+@use '../mixins/custom-suggestions-options-group' as *;
+@use '../mixins/custom-suggestions-toggle' as *;
+@use '../@shared/input-text' as *;
+
+$option-height: to-rem(40);
+$visible-options: 5;
+$icon-size: to-rem(24);
+
+@layer kol-theme-component {
+	@include kol-alert-theme;
+	@include kol-custom-suggestions-option-theme($option-height);
+	@include kol-custom-suggestions-options-group-theme($option-height, $visible-options);
+	@include kol-custom-suggestions-toggle-theme;
+
+	.kol-multi-select {
+		&__group {
+			color: var(--color-grey);
+			display: inline-flex;
+			width: 100%;
+			min-height: var(--a11y-min-size);
+			padding: to-rem(1) 0.5em;
+			order: 4;
+			align-items: center;
+			text-align: left;
+		}
+
+		&__input {
+			position: relative;
+			flex: 1 1 auto;
+			min-width: 0;
+			border: none;
+
+			&::placeholder {
+				color: var(--color-grey-50);
+			}
+
+			&:first-child {
+				padding-left: var(--spacing);
+			}
+
+			&:last-child {
+				padding-right: var(--spacing);
+			}
+
+			&:focus {
+				border: none;
+			}
+		}
+
+		&__delete {
+			display: inline-flex;
+			width: $icon-size;
+			height: $icon-size;
+			align-items: center;
+			justify-content: center;
+		}
+	}
+}

--- a/packages/themes/ecl/src/ecl-ec/index.ts
+++ b/packages/themes/ecl/src/ecl-ec/index.ts
@@ -8,6 +8,7 @@ import buttonCss from './components/button.scss';
 import buttonLinkCss from './components/button-link.scss';
 import cardCss from './components/card.scss';
 import ComboboxCss from './components/combobox.scss';
+import multiSelectCss from './components/multi-select.scss';
 import detailsCss from './components/details.scss';
 import drawerCss from './components/drawer.scss';
 import formCss from './components/form.scss';
@@ -71,6 +72,7 @@ export const ECL_EC = KoliBri.createTheme('ecl-ec', {
 	'KOL-LINK': linkCss,
 	'KOL-LINK-BUTTON': linkButtonCss,
 	'KOL-MODAL': modalCss,
+	'KOL-MULTI-SELECT': multiSelectCss,
 	'KOL-NAV': navCss,
 	'KOL-PAGINATION': paginationCss,
 	'KOL-POPOVER-BUTTON': popoverButtonCss,

--- a/packages/themes/ecl/src/ecl-eu/components/multi-select.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/multi-select.scss
@@ -1,0 +1,60 @@
+@use '../../mixins/to-rem' as *;
+@use '../mixins/alert-wc' as *;
+@use '../mixins/custom-suggestions-option' as *;
+@use '../mixins/custom-suggestions-options-group' as *;
+@use '../mixins/custom-suggestions-toggle' as *;
+@use '../@shared/input-text' as *;
+
+$option-height: to-rem(40);
+$visible-options: 5;
+$icon-size: to-rem(24);
+
+@layer kol-theme-component {
+	@include kol-alert-theme;
+	@include kol-custom-suggestions-option-theme($option-height);
+	@include kol-custom-suggestions-options-group-theme($option-height, $visible-options);
+	@include kol-custom-suggestions-toggle-theme;
+
+	.kol-multi-select {
+		&__group {
+			color: var(--color-grey);
+			display: inline-flex;
+			width: 100%;
+			min-height: var(--a11y-min-size);
+			padding: to-rem(1) 0.5em;
+			order: 4;
+			align-items: center;
+		}
+
+		&__input {
+			position: relative;
+			flex: 1 1 auto;
+			min-width: 0;
+			border: none;
+
+			&::placeholder {
+				color: var(--color-grey-50);
+			}
+
+			&:first-child {
+				padding-left: var(--spacing);
+			}
+
+			&:last-child {
+				padding-right: var(--spacing);
+			}
+
+			&:focus {
+				border: none;
+			}
+		}
+
+		&__delete {
+			display: inline-flex;
+			width: $icon-size;
+			height: $icon-size;
+			align-items: center;
+			justify-content: center;
+		}
+	}
+}

--- a/packages/themes/ecl/src/ecl-eu/index.ts
+++ b/packages/themes/ecl/src/ecl-eu/index.ts
@@ -8,6 +8,7 @@ import buttonCss from './components/button.scss';
 import buttonLinkCss from './components/button-link.scss';
 import cardCss from './components/card.scss';
 import ComboboxCss from './components/combobox.scss';
+import multiSelectCss from './components/multi-select.scss';
 import detailsCss from './components/details.scss';
 import drawerCss from './components/drawer.scss';
 import formCss from './components/form.scss';
@@ -70,6 +71,7 @@ export const ECL_EU = KoliBri.createTheme('ecl-eu', {
 	'KOL-LINK': linkCss,
 	'KOL-LINK-BUTTON': linkButtonCss,
 	'KOL-MODAL': modalCss,
+	'KOL-MULTI-SELECT': multiSelectCss,
 	'KOL-NAV': navCss,
 	'KOL-PAGINATION': paginationCss,
 	'KOL-POPOVER-BUTTON': popoverButtonCss,


### PR DESCRIPTION
## Summary
- add the kol-multi-select component with multi-value selection behaviour, controller logic, and styling
- register the component in the library and schema, and enable form-association for its values
- cover the component with snapshot and Playwright e2e tests while allowing listbox ARIA attributes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00a1ca9cc832b9adf61b6c1d0e2ed