### PR TITLE
feat(mcp): add model context protocol backend for kolibri samples

### DIFF
--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -1,4 +1,4 @@
-name: Netlify Draft Deploy
+name: Netlify Draft-Deploy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/mcp-vercel.yml
+++ b/.github/workflows/mcp-vercel.yml
@@ -1,0 +1,123 @@
+name: Vercel MCP-Deploy
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: 'mcp-vercel-${{ github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      PNPM_CACHE_FOLDER: .pnpm
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_MCP_TEAM_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_MCP_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_MCP_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm workspace
+        uses: ./.github/actions/pnpm-setup
+
+      - name: Build workspace dependencies
+        run: pnpm --filter @public-ui/mcp build:deps
+
+      - name: Build Vercel assets
+        run: |
+          pnpm --filter @public-ui/mcp vercel:build
+          ls -la packages/tools/mcp/vercel/
+
+      - name: Pull Vercel environment configuration (production)
+        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        working-directory: packages/tools/mcp
+        run: |
+          pnpm dlx vercel@latest pull --yes --environment=production --token "$VERCEL_TOKEN"
+
+      - name: Build project with Vercel CLI (production)
+        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        working-directory: packages/tools/mcp
+        run: |
+          pnpm dlx vercel@latest build --prod --token "$VERCEL_TOKEN"
+
+      - name: Deploy to Vercel (production)
+        id: deploy_prod
+        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        working-directory: packages/tools/mcp
+        run: |
+          set -eo pipefail
+          DEPLOY_URL=$(pnpm dlx vercel@latest deploy --prebuilt --prod --yes --token "$VERCEL_TOKEN" | tail -n1)
+          echo "url=${DEPLOY_URL}" >> "$GITHUB_OUTPUT"
+          echo "Production deployment available at ${DEPLOY_URL}"
+
+      - name: Pull Vercel environment configuration (preview)
+        if: github.event_name == 'pull_request'
+        working-directory: packages/tools/mcp
+        run: |
+          pnpm dlx vercel@latest pull --yes --environment=preview --token "$VERCEL_TOKEN"
+
+      - name: Build project with Vercel CLI (preview)
+        if: github.event_name == 'pull_request'
+        working-directory: packages/tools/mcp
+        run: |
+          pnpm dlx vercel@latest build --token "$VERCEL_TOKEN"
+
+      - name: Deploy to Vercel (preview)
+        id: deploy_preview
+        if: github.event_name == 'pull_request'
+        working-directory: packages/tools/mcp
+        run: |
+          set -eo pipefail
+          DEPLOY_URL=$(pnpm dlx vercel@latest deploy --prebuilt --yes --token "$VERCEL_TOKEN" | tail -n1)
+          echo "url=${DEPLOY_URL}" >> "$GITHUB_OUTPUT"
+          echo "Preview deployment available at ${DEPLOY_URL}"
+
+      - name: Share preview URL in PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
+        with:
+          script: |
+            const marker = '<!-- mcp-vercel-preview -->';
+            const url = process.env.PREVIEW_URL;
+            if (!url) {
+              core.setFailed('Missing Vercel preview URL');
+              return;
+            }
+            const body = `${marker}\n🚀 MCP preview deployed to Vercel: ${url}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+            const existing = comments.find((comment) => comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,4 +1,4 @@
-name: Netlify Test Deploy - Deploy stable branches under fixed aliases
+name: Netlify Stable-Deploy
 
 on:
   push:

--- a/packages/tools/mcp/.lintstagedrc
+++ b/packages/tools/mcp/.lintstagedrc
@@ -1,0 +1,3 @@
+{
+	"**/*.{md,css,scss,ts,tsx,js,jsx,json}": ["prettier --list-different"]
+}

--- a/packages/tools/mcp/DEPLOYMENT.md
+++ b/packages/tools/mcp/DEPLOYMENT.md
@@ -1,0 +1,97 @@
+# MCP Deployment Setup
+
+Dieses Dokument beschreibt, wie das MCP-Tool mit Vercel bereitgestellt werden kann. Der bisherige Netlify-Workflow wurde entfernt, alle Serverless-Deployments laufen über Vercel.
+
+## Deployment auf Vercel
+
+### Voraussetzungen
+
+1. [Vercel](https://vercel.com) Konto und Teamzugriff
+2. Zugriff auf das Git-Repository (GitHub/GitLab/Bitbucket)
+3. Aktiviertes `pnpm` in der Vercel-Organisation (Vercel nutzt automatisch die lockfile)
+
+### Projekt anlegen oder importieren
+
+1. Wähle in Vercel "Add New..." → "Project" und importiere das Repository.
+2. Wähle als Projektnamen `kolibri-mcp`.
+3. Setze **Root Directory** auf `packages/tools/mcp`.
+4. Framework Preset: `Other`.
+5. Install Command: leer lassen (Vercel führt automatisch `pnpm install --frozen-lockfile` aus).
+6. Build Command: `pnpm --filter @public-ui/mcp build:deps && pnpm --filter @public-ui/mcp vercel:build`.
+7. Output Directory: leer lassen (Serverless Functions werden direkt aus `api/` erzeugt).
+8. Optional: `NODE_VERSION` auf eine unterstützte Node-18-Version setzen (z.B. `18`).
+
+Der Build-Command ruft das Skript `packages/tools/mcp/vercel/build.mjs` auf. Dieses Skript generiert den Sample-Index und legt ihn unter `packages/tools/mcp/vercel/sample-index.json` ab, sodass die Vercel-Funktion ohne Dateisystemzugriff arbeiten kann.
+
+### Environment Variables (optional)
+
+| Name                     | Standardverhalten                                    | Beschreibung                                               |
+| ------------------------ | ---------------------------------------------------- | ---------------------------------------------------------- |
+| `KOLIBRI_MCP_INDEX_PATH` | Automatische Suche (`vercel/sample-index.json`, ...) | Erzwingt einen konkreten Pfad zur JSON-Datei mit dem Index |
+| `PORT` (lokale Tests)    | `3030`                                               | Lokaler Port für `pnpm start`                              |
+
+### Endpunkte nach Deployment
+
+Die Funktion wird von Vercel automatisch unter `/api/mcp` bereitgestellt. Zusätzliche Rewrites sind nicht erforderlich. Nach dem Deployment erreichst du die Endpunkte beispielsweise so:
+
+```bash
+https://<projekt>.vercel.app/api/mcp/health
+https://<projekt>.vercel.app/api/mcp/samples?q=button
+https://<projekt>.vercel.app/api/mcp/sample?id=button/basic
+```
+
+Die Route `POST /api/mcp/refresh` lädt den vorkompilierten Index neu. Sofern der Build-Command ausgeführt wurde, lädt die Funktion die Datei erneut; andernfalls fällt sie auf einen dynamischen Neuaufbau zurück.
+
+### Automatisiertes Deployment mit GitHub Actions
+
+Für kontinuierliche Deployments steht der Workflow `.github/workflows/mcp-vercel.yml` bereit. Er nutzt die Vercel CLI, baut den Sample-Index über `pnpm --filter @public-ui/mcp vercel:build` vor und triggert anschließend ein Deployment.
+
+#### Benötigte GitHub Secrets
+
+Lege in GitHub unter **Settings → Secrets and variables → Actions** folgende Secrets an:
+
+- `VERCEL_MCP_TOKEN`: Persönliches Access Token aus dem Vercel Dashboard unter Account Settings → Tokens (https://vercel.com/account/tokens)
+- `VERCEL_MCP_TEAM_ID`: Team-ID aus **Vercel → Settings → General → IDs → Team ID** (wird im Workflow als `VERCEL_ORG_ID` an die CLI weitergereicht)
+- `VERCEL_MCP_PROJECT_ID`: Projekt-ID aus **Vercel → Project → Settings → General → Project ID**
+
+> Tipp: Kopiere die Werte direkt aus der `vercel.json`, die du über `vercel pull --yes` lokal erzeugen kannst.
+
+#### Workflow-Ablauf
+
+- **Production Deploy**: Push auf `develop`
+- **Preview Deploy**: Pull Requests gegen `develop` (inkl. Kommentar mit Vercel-URL in der PR)
+- **Manuelles Deploy**: Über den "Run workflow" Button im Actions-Tab
+
+Der Workflow lädt die passende Vercel-Umgebung (`vercel pull`), erzeugt das Build-Artefakt (`vercel build`) und deployt es (`vercel deploy --prebuilt`). Für Pull Requests wird die erzeugte Preview-URL automatisch als Kommentar geteilt (Kommentar wird bei erneuten Läufen aktualisiert).
+
+### Manuelles Deployment mit der Vercel CLI
+
+```bash
+# Einmalig CLI installieren (global)
+npm install -g vercel
+
+# Repository vorbereiten
+pnpm install
+pnpm --filter @public-ui/mcp build:deps
+pnpm --filter @public-ui/mcp vercel:build
+
+# Deploy (Preview)
+cd packages/tools/mcp
+vercel
+
+# Deploy (Production)
+vercel --prod
+```
+
+> Hinweis: Die Befehle `pnpm --filter @public-ui/mcp build:deps` und `pnpm --filter @public-ui/mcp vercel:build` müssen vor jedem Deploy ausgeführt werden, damit alle abhängigen Pakete gebaut werden und die Datei `vercel/sample-index.json` aktualisiert wird.
+> Das anschließende `vercel`-Kommando wird in `packages/tools/mcp` ausgeführt, sodass keine zusätzlichen `--cwd`-Parameter mehr notwendig sind.
+
+## Lokales Testen
+
+```bash
+# MCP-Tool lokal starten
+cd packages/tools/mcp
+pnpm start
+```
+
+Die lokale Instanz antwortet ebenfalls auf den Pfaden unter `/api/mcp`, zum Beispiel `http://localhost:3030/api/mcp/health`.

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -1,0 +1,43 @@
+# @public-ui/mcp
+
+Dieses Paket stellt einen einfachen Node.js-gestützten Backend-Dienst für das Model Context Protocol (MCP) bereit. Darüber können KI-Agents strukturierte Informationen zu den KoliBri-Beispielen abrufen und sich den Original-Quellcode zurückgeben lassen.
+
+## Starten des Servers
+
+```bash
+pnpm --filter @public-ui/mcp start
+```
+
+Standardmäßig lauscht der Dienst auf Port `3030`. Über die Umgebungsvariable `PORT` kann ein anderer Port gewählt werden. Die lokalen Endpunkte sind anschließend unter `http://localhost:<port>/api/mcp/...` erreichbar.
+
+## Serverless-Einsatz auf Vercel
+
+Für den Serverless-Betrieb steht eine Vercel-Funktion im Verzeichnis `packages/tools/mcp/api/mcp.js` bereit. Sie beantwortet alle MCP-Routen (`/health`, `/samples`, `/sample`, `/refresh`) unter dem Vercel-Standardpräfix `/api/mcp`.
+
+Vor dem Deploy sollte ein vorkompilierter Sample-Index erzeugt werden, damit die Funktion ohne Dateisystemzugriff arbeiten kann:
+
+```bash
+pnpm --filter @public-ui/mcp prebuild
+```
+
+Der Befehl schreibt die Datei `vercel/sample-index.json`, die beim Deployment neben die Funktion gelegt wird. Wird kein Index gefunden, erzeugt die Funktion ihn beim ersten Aufruf dynamisch.
+
+Nach dem Deployment erreichst du die Endpunkte auf Vercel beispielsweise über `https://<projekt>.vercel.app/api/mcp/health`, `https://<projekt>.vercel.app/api/mcp/samples` oder `https://<projekt>.vercel.app/api/mcp/sample?id=button/basic`.
+
+## Endpunkte
+
+- `GET /api/mcp/health` – liefert den Status des Backends sowie Metadaten zum aktuellen Sample-Index.
+- `GET /api/mcp/samples` – listet alle verfügbaren Samples. Optional kann über den Query-Parameter `q` gefiltert werden.
+- `GET /api/mcp/sample?id=<component/sample>` – liefert Pfad und Quellcode eines spezifischen Samples zurück.
+- `POST /api/mcp/refresh` – baut den Sample-Index neu auf, falls sich Dateien verändert haben.
+
+Alle Antworten werden als JSON ausgeliefert und enthalten bereits die relativen Pfade innerhalb des Repositorys.
+
+## Funktionsweise
+
+Beim Start werden sämtliche `routes.ts`-Dateien aus dem React-Sample-Projekt analysiert. Die darin referenzierten Komponentendateien werden aufgelöst, gelesen und in einem Index zwischengespeichert. Auf Basis dieses Indexes beantwortet der Server Anfragen von MCP-kompatiblen Clients.
+
+## Weiterentwicklung
+
+- Zusätzliche Filter oder Volltextsuche können direkt im `SampleIndex` umgesetzt werden.
+- Für produktive Umgebungen empfiehlt sich das Hinterlegen einer Authentifizierung vor dem MCP-Backend.

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -1,0 +1,155 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { handleApiRequest } from '../src/api-handler.js';
+import { buildDynamicSampleIndex, createSampleIndexFromData } from '../src/prebuilt/sample-index-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_INDEX_CANDIDATES = [process.env.KOLIBRI_MCP_INDEX_PATH, path.join(__dirname, '../vercel/sample-index.json')];
+
+let cachedIndex;
+let currentStrategy = 'prebuilt';
+let lastSource;
+
+function getCandidatePaths() {
+	const candidates = new Set();
+	for (const candidate of DEFAULT_INDEX_CANDIDATES) {
+		if (candidate) {
+			candidates.add(candidate);
+		}
+	}
+	return Array.from(candidates);
+}
+
+async function loadIndexFromFile(filePath) {
+	try {
+		const content = await readFile(filePath, 'utf8');
+		const data = JSON.parse(content);
+		const index = createSampleIndexFromData(data);
+		lastSource = filePath;
+		currentStrategy = 'prebuilt';
+		return index;
+	} catch (error) {
+		if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+async function loadPrebuiltIndex() {
+	const candidates = getCandidatePaths();
+	for (const candidate of candidates) {
+		try {
+			const index = await loadIndexFromFile(candidate);
+			if (index) {
+				console.log(`[mcp] loaded sample index from ${candidate}`);
+				return index;
+			}
+		} catch (error) {
+			console.warn(`[mcp] failed to load prebuilt index from ${candidate}:`, error);
+		}
+	}
+	return undefined;
+}
+
+async function ensureIndex() {
+	if (cachedIndex) {
+		return cachedIndex;
+	}
+
+	const prebuilt = await loadPrebuiltIndex();
+	if (prebuilt) {
+		cachedIndex = prebuilt;
+		return cachedIndex;
+	}
+
+	console.warn('[mcp] no prebuilt index found – generating on demand');
+	cachedIndex = await buildDynamicSampleIndex();
+	currentStrategy = 'dynamic';
+	lastSource = 'dynamic-build';
+	return cachedIndex;
+}
+
+async function refreshIndex() {
+	if (currentStrategy === 'dynamic') {
+		cachedIndex = await buildDynamicSampleIndex();
+		return cachedIndex;
+	}
+
+	cachedIndex = undefined;
+	return ensureIndex();
+}
+
+function buildRequestUrl(request) {
+	const rawHost = request.headers?.host ?? 'vercel.local';
+	const forwardedProto = request.headers?.['x-forwarded-proto'];
+	const protocol = typeof forwardedProto === 'string' ? forwardedProto.split(',')[0] : rawHost.includes('localhost') ? 'http' : 'https';
+	const baseUrl = `${protocol}://${rawHost}`;
+	const requestUrl = request.url ?? '/';
+	return new URL(requestUrl, baseUrl).toString();
+}
+
+function setCorsHeaders(response) {
+	response.setHeader('Access-Control-Allow-Origin', '*');
+	response.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+	response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function sendResponse(response, result) {
+	setCorsHeaders(response);
+	const headers = {
+		'Content-Type': 'application/json; charset=utf-8',
+		...result.headers,
+	};
+	for (const [name, value] of Object.entries(headers)) {
+		if (value !== undefined) {
+			response.setHeader(name, value);
+		}
+	}
+	response.statusCode = result.statusCode;
+	response.end(result.body === undefined ? '' : JSON.stringify(result.body));
+}
+
+function sendError(response, error) {
+	console.error('[mcp] vercel handler failed', error);
+	setCorsHeaders(response);
+	response.statusCode = 500;
+	response.setHeader('Content-Type', 'application/json; charset=utf-8');
+	response.end(
+		JSON.stringify({
+			error: 'internal_error',
+			message: error instanceof Error ? error.message : 'unknown_error',
+			timestamp: new Date().toISOString(),
+			strategy: currentStrategy,
+			source: lastSource,
+		}),
+	);
+}
+
+function handleOptions(response) {
+	setCorsHeaders(response);
+	response.statusCode = 204;
+	response.end();
+}
+
+export default async function handler(request, response) {
+	if ((request.method ?? 'GET').toUpperCase() === 'OPTIONS') {
+		handleOptions(response);
+		return;
+	}
+
+	try {
+		const result = await handleApiRequest({
+			method: request.method ?? 'GET',
+			url: buildRequestUrl(request),
+			getIndex: () => ensureIndex(),
+			refresh: () => refreshIndex(),
+		});
+		sendResponse(response, result);
+	} catch (error) {
+		sendError(response, error);
+	}
+}

--- a/packages/tools/mcp/package.json
+++ b/packages/tools/mcp/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@public-ui/mcp",
+	"version": "3.0.7-rc.3",
+	"license": "EUPL-1.2",
+	"homepage": "https://public-ui.github.io",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/public-ui/kolibri"
+	},
+	"bugs": {
+		"url": "https://github.com/public-ui/kolibri/issues",
+		"email": "kolibri@itzbund.de"
+	},
+	"author": {
+		"name": "Informationstechnikzentrum Bund",
+		"email": "kolibri@itzbund.de"
+	},
+	"type": "module",
+	"private": false,
+	"description": "Model Context Protocol backend exposing KoliBri sample code to AI agents.",
+	"scripts": {
+		"build:deps": "pnpm --filter @public-ui/mcp^... build",
+		"format": "prettier --check api src vercel",
+		"prebuild": "node src/prebuild.js",
+		"start": "node src/index.js",
+		"vercel:build": "node vercel/build.mjs"
+	},
+	"devDependencies": {
+		"prettier": "3.6.2"
+	},
+	"files": [
+		"README.md",
+		"api/*.js",
+		"src",
+		"vercel/*.mjs",
+		"vercel/.gitignore"
+	]
+}

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>KoliBri MCP</title>
+	</head>
+	<body>
+		<h1>KoliBri Model Context Protocol</h1>
+		<p>This is a serverless API. Use the following endpoints:</p>
+		<ul>
+			<li><a href="/health">/health</a> - Health check</li>
+			<li><a href="/samples">/samples</a> - List all samples</li>
+			<li><a href="/sample">/sample</a> - Get specific sample</li>
+		</ul>
+	</body>
+</html>

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -1,0 +1,142 @@
+import { URL } from 'node:url';
+
+function buildCorsHeaders() {
+	return {
+		'Access-Control-Allow-Origin': '*',
+		'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+		'Access-Control-Allow-Headers': 'Content-Type',
+	};
+}
+
+function normalizePathname(pathname) {
+	if (pathname === '/') {
+		return pathname;
+	}
+	const prefixes = ['/api/mcp'];
+
+	for (const prefix of prefixes) {
+		if (pathname.startsWith(prefix)) {
+			const suffix = pathname.slice(prefix.length) || '/';
+			return suffix.startsWith('/') ? suffix : `/${suffix}`;
+		}
+	}
+
+	return pathname;
+}
+
+export async function handleApiRequest({ method = 'GET', url = '/', getIndex, refresh }) {
+	const baseHeaders = buildCorsHeaders();
+	const normalizedMethod = method.toUpperCase();
+	const requestUrl = new URL(url, 'http://localhost');
+	const pathname = normalizePathname(requestUrl.pathname);
+
+	if (normalizedMethod === 'OPTIONS') {
+		return { statusCode: 204, headers: baseHeaders };
+	}
+
+	if (normalizedMethod === 'GET' && pathname === '/') {
+		return {
+			statusCode: 200,
+			headers: baseHeaders,
+			body: {
+				message: 'KoliBri MCP backend is running.',
+				endpoints: ['/health', '/samples', '/sample?id=<component/sample>'],
+			},
+		};
+	}
+
+	if (normalizedMethod === 'GET' && pathname === '/health') {
+		const index = await getIndex();
+		return {
+			statusCode: 200,
+			headers: baseHeaders,
+			body: {
+				status: 'ok',
+				totalSamples: index.entries.length,
+				generatedAt: index.generatedAt.toISOString(),
+			},
+		};
+	}
+
+	if (normalizedMethod === 'GET' && pathname === '/samples') {
+		const index = await getIndex();
+		const query = requestUrl.searchParams.get('q') ?? '';
+		const items = index.list(query).map((entry) => ({
+			group: entry.group,
+			id: entry.id,
+			name: entry.name,
+			path: entry.path,
+		}));
+		return {
+			statusCode: 200,
+			headers: baseHeaders,
+			body: {
+				items,
+				query,
+				total: items.length,
+				generatedAt: index.generatedAt.toISOString(),
+			},
+		};
+	}
+
+	if (normalizedMethod === 'GET' && pathname === '/sample') {
+		const index = await getIndex();
+		const id = requestUrl.searchParams.get('id');
+		if (!id) {
+			return {
+				statusCode: 400,
+				headers: baseHeaders,
+				body: { error: 'missing_id' },
+			};
+		}
+
+		const entry = index.get(id);
+		if (!entry) {
+			return {
+				statusCode: 404,
+				headers: baseHeaders,
+				body: { error: 'not_found', id },
+			};
+		}
+
+		return {
+			statusCode: 200,
+			headers: baseHeaders,
+			body: {
+				id: entry.id,
+				group: entry.group,
+				name: entry.name,
+				path: entry.path,
+				code: entry.code,
+			},
+		};
+	}
+
+	if (normalizedMethod === 'POST' && pathname === '/refresh') {
+		try {
+			const index = await refresh();
+			return {
+				statusCode: 200,
+				headers: baseHeaders,
+				body: {
+					status: 'refreshed',
+					totalSamples: index.entries.length,
+					generatedAt: index.generatedAt.toISOString(),
+				},
+			};
+		} catch (error) {
+			console.error('[mcp] refresh failed', error);
+			return {
+				statusCode: 500,
+				headers: baseHeaders,
+				body: { error: 'refresh_failed' },
+			};
+		}
+	}
+
+	return {
+		statusCode: 404,
+		headers: baseHeaders,
+		body: { error: 'not_found' },
+	};
+}

--- a/packages/tools/mcp/src/index.js
+++ b/packages/tools/mcp/src/index.js
@@ -1,0 +1,6 @@
+import { startServer } from './server.js';
+
+startServer().catch((error) => {
+	console.error('[mcp] failed to start server', error);
+	process.exitCode = 1;
+});

--- a/packages/tools/mcp/src/prebuild.js
+++ b/packages/tools/mcp/src/prebuild.js
@@ -1,0 +1,116 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { buildSampleIndex } from './sample-index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_OUTPUTS = [path.join(__dirname, '../vercel/sample-index.json')];
+
+function serializeIndex(index) {
+	return {
+		entries: index.entries.map((entry) => ({
+			id: entry.id,
+			group: entry.group,
+			name: entry.name,
+			path: entry.path,
+			code: entry.code,
+		})),
+		generatedAt: index.generatedAt.toISOString(),
+	};
+}
+
+function normalizeOutputs(outputs = []) {
+	const normalized = outputs.map((output) => path.resolve(output));
+	return Array.from(new Set(normalized));
+}
+
+export async function generateSampleIndex({ outputs = DEFAULT_OUTPUTS, silent = false } = {}) {
+	const resolvedOutputs = normalizeOutputs(outputs);
+	if (resolvedOutputs.length === 0) {
+		throw new Error('No output paths provided for sample index prebuild.');
+	}
+
+	if (!silent) {
+		const targets = resolvedOutputs.map((output) => path.relative(process.cwd(), output));
+		console.log(`[mcp] building sample index for ${targets.length} target(s)...`);
+		for (const target of targets) {
+			console.log(` - ${target}`);
+		}
+	}
+
+	const index = await buildSampleIndex();
+	const serialized = serializeIndex(index);
+
+	for (const outputPath of resolvedOutputs) {
+		mkdirSync(path.dirname(outputPath), { recursive: true });
+		writeFileSync(outputPath, JSON.stringify(serialized));
+		if (!silent) {
+			console.log(`[mcp] sample index written to ${outputPath}`);
+		}
+	}
+
+	if (!silent) {
+		console.log(`[mcp] total entries: ${serialized.entries.length}`);
+	}
+
+	return serialized;
+}
+
+function parseOutputsFromArgs(args) {
+	const outputs = [];
+	for (let index = 0; index < args.length; index += 1) {
+		const argument = args[index];
+		if (argument === '--help' || argument === '-h') {
+			printUsage();
+			return null;
+		}
+
+		if (argument === '--output' || argument === '-o') {
+			const next = args[index + 1];
+			if (!next) {
+				throw new Error('Missing value for --output option.');
+			}
+			outputs.push(next);
+			index += 1;
+			continue;
+		}
+
+		if (argument.startsWith('--output=')) {
+			outputs.push(argument.slice('--output='.length));
+			continue;
+		}
+	}
+
+	return outputs.length > 0 ? outputs : undefined;
+}
+
+function printUsage() {
+	console.log('Usage: node src/prebuild.js [--output <file>]');
+	console.log('');
+	console.log('Options:');
+	console.log('  --output, -o   Path to write the generated sample index to.');
+	console.log('                 You can provide the flag multiple times.');
+	console.log('                 Defaults to vercel/sample-index.json.');
+}
+
+async function runFromCommandLine() {
+	try {
+		const args = process.argv.slice(2);
+		const outputs = parseOutputsFromArgs(args);
+		if (outputs === null) {
+			return;
+		}
+
+		await generateSampleIndex({ outputs: outputs ?? DEFAULT_OUTPUTS });
+	} catch (error) {
+		console.error('[mcp] failed to prebuild sample index', error);
+		process.exitCode = 1;
+	}
+}
+
+const executedAsScript = pathToFileURL(process.argv[1] ?? '').href === import.meta.url;
+if (executedAsScript) {
+	void runFromCommandLine();
+}

--- a/packages/tools/mcp/src/prebuilt/sample-index-utils.js
+++ b/packages/tools/mcp/src/prebuilt/sample-index-utils.js
@@ -1,0 +1,42 @@
+import { buildSampleIndex } from '../sample-index.js';
+
+export function createSampleIndexFromData(data = {}) {
+	const entries = Array.isArray(data?.entries)
+		? data.entries.map((entry) => ({
+				id: entry.id,
+				group: entry.group,
+				name: entry.name,
+				path: entry.path,
+				code: entry.code,
+			}))
+		: [];
+
+	const indexMap = new Map(entries.map((entry) => [entry.id, entry]));
+	const generatedAt = data?.generatedAt ? new Date(data.generatedAt) : new Date();
+
+	return {
+		entries,
+		generatedAt,
+		map: indexMap,
+		list(query) {
+			if (!query) {
+				return entries;
+			}
+
+			const normalized = query.trim().toLowerCase();
+			return entries.filter((entry) => {
+				const id = entry.id?.toLowerCase() ?? '';
+				const group = entry.group?.toLowerCase() ?? '';
+				const name = entry.name?.toLowerCase() ?? '';
+				return id.includes(normalized) || group.includes(normalized) || name.includes(normalized);
+			});
+		},
+		get(id) {
+			return indexMap.get(id);
+		},
+	};
+}
+
+export async function buildDynamicSampleIndex() {
+	return buildSampleIndex();
+}

--- a/packages/tools/mcp/src/sample-index.js
+++ b/packages/tools/mcp/src/sample-index.js
@@ -1,0 +1,169 @@
+import { access, readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SAMPLE_ROOT = path.join(REPO_ROOT, 'packages/samples/react/src');
+const ROUTE_FILENAMES = ['routes.ts', 'routes.tsx'];
+const SAMPLE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
+
+const COMPONENTS_DIR = path.join(SAMPLE_ROOT, 'components');
+const SCENARIOS_DIR = path.join(SAMPLE_ROOT, 'scenarios');
+
+class SampleIndex {
+	constructor(entries) {
+		this.entries = entries;
+		this.map = new Map(entries.map((entry) => [entry.id, entry]));
+		this.generatedAt = new Date();
+	}
+
+	list(query) {
+		if (!query) {
+			return this.entries;
+		}
+
+		const normalized = query.trim().toLowerCase();
+		return this.entries.filter(
+			(entry) => entry.id.toLowerCase().includes(normalized) || entry.group.toLowerCase().includes(normalized) || entry.name.toLowerCase().includes(normalized),
+		);
+	}
+
+	get(id) {
+		return this.map.get(id);
+	}
+}
+
+export async function buildSampleIndex() {
+	const routeFiles = await discoverRouteFiles();
+	const entries = [];
+
+	for (const routeFile of routeFiles) {
+		const routeDir = path.dirname(routeFile);
+		const routeData = await parseRouteFile(routeFile);
+
+		for (const [group, value] of Object.entries(routeData)) {
+			if (!value || typeof value !== 'object' || Array.isArray(value)) {
+				continue;
+			}
+
+			for (const [name, descriptor] of Object.entries(value)) {
+				const importPath = descriptor?.__path;
+				if (!importPath) {
+					continue;
+				}
+
+				const absolutePath = await resolveSamplePath(routeDir, importPath);
+				if (!absolutePath) {
+					continue;
+				}
+
+				const code = await readFile(absolutePath, 'utf8');
+				entries.push({
+					id: `${group}/${name}`,
+					group,
+					name,
+					path: path.relative(REPO_ROOT, absolutePath),
+					absolutePath,
+					code,
+				});
+			}
+		}
+	}
+
+	entries.sort((a, b) => a.id.localeCompare(b.id));
+
+	return new SampleIndex(entries);
+}
+
+async function discoverRouteFiles() {
+	const files = [];
+	for (const baseDir of [COMPONENTS_DIR, SCENARIOS_DIR]) {
+		const rootRoute = await findRouteFile(baseDir);
+		if (rootRoute) {
+			files.push(rootRoute);
+		}
+		const directories = await safeReadDir(baseDir);
+		for (const entry of directories) {
+			const routeFile = await findRouteFile(path.join(baseDir, entry.name));
+			if (routeFile) {
+				files.push(routeFile);
+			}
+		}
+	}
+	return files;
+}
+
+async function safeReadDir(dir) {
+	try {
+		const entries = await readdir(dir, { withFileTypes: true });
+		return entries.filter((entry) => entry.isDirectory());
+	} catch {
+		return [];
+	}
+}
+
+async function findRouteFile(dir) {
+	for (const file of ROUTE_FILENAMES) {
+		const candidate = path.join(dir, file);
+		if (await pathExists(candidate)) {
+			return candidate;
+		}
+	}
+	return undefined;
+}
+
+async function pathExists(filePath) {
+	try {
+		await access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function parseRouteFile(filePath) {
+	const raw = await readFile(filePath, 'utf8');
+	const importDeclarations = [];
+
+	let content = raw.replace(/import\s+type[^;]+;\s*/g, '').replace(/import\s+\{\s*Routes\s*\}\s+from\s+['"][^'"]+['"];\s*/g, '');
+
+	content = content.replace(/import\s+\{\s*([^}]+)\s*\}\s+from\s+['"]([^'"]+)['"];\s*/g, (_, identifiers, source) => {
+		const names = identifiers
+			.split(',')
+			.map((part) => part.trim())
+			.filter(Boolean);
+		const declarations = names.map((name) => `const ${name} = { __path: '${source}' };`).join('\n');
+		importDeclarations.push(declarations);
+		return '';
+	});
+
+	content = content.replace(/export\s+const\s+\w+\s*:\s*\w+\s*=\s*/, '');
+	content = content.replace(/export\s+const\s+\w+\s*=\s*/, '');
+	content = content.trim();
+	if (content.endsWith(';')) {
+		content = content.slice(0, -1);
+	}
+
+	const fnBody = `${importDeclarations.join('\n')}\nreturn ${content};`;
+	const routes = new Function(fnBody)();
+	return routes && typeof routes === 'object' ? routes : {};
+}
+
+async function resolveSamplePath(baseDir, relativeImport) {
+	const normalized = relativeImport.replace(/['"];?$/g, '');
+	const base = normalized.startsWith('.') ? normalized : `./${normalized}`;
+
+	for (const extension of SAMPLE_EXTENSIONS) {
+		const candidate = path.resolve(baseDir, `${base}${extension}`);
+		if (await pathExists(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+export function getRepoRoot() {
+	return REPO_ROOT;
+}

--- a/packages/tools/mcp/src/server.js
+++ b/packages/tools/mcp/src/server.js
@@ -1,0 +1,70 @@
+import { createServer } from 'node:http';
+import { buildSampleIndex } from './sample-index.js';
+import { handleApiRequest } from './api-handler.js';
+
+const DEFAULT_PORT = Number.parseInt(process.env.PORT ?? '3030', 10);
+
+export async function startServer(options = {}) {
+	const port = Number.parseInt(`${options.port ?? DEFAULT_PORT}`, 10);
+	let index = await buildSampleIndex();
+
+	const server = createServer((request, response) => {
+		Promise.resolve(
+			handleApiRequest({
+				method: request.method ?? 'GET',
+				url: request.url ?? '/',
+				getIndex: () => index,
+				refresh: () => rebuild(),
+			}),
+		)
+			.then((result) => respondWithResult(response, result))
+			.catch((error) => {
+				console.error('[mcp] request failed', error);
+				if (!response.headersSent) {
+					respondWithResult(response, {
+						statusCode: 500,
+						headers: {
+							'Access-Control-Allow-Origin': '*',
+							'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+							'Access-Control-Allow-Headers': 'Content-Type',
+						},
+						body: { error: 'internal_error' },
+					});
+				}
+			});
+	});
+
+	server.listen(port, () => {
+		console.log(`[mcp] server listening on http://localhost:${port}`);
+	});
+
+	async function rebuild() {
+		index = await buildSampleIndex();
+		return index;
+	}
+
+	return server;
+}
+
+function respondWithResult(response, result) {
+	if (response.headersSent) {
+		return;
+	}
+
+	response.statusCode = result.statusCode;
+	const headers = {
+		'Content-Type': 'application/json; charset=utf-8',
+		...result.headers,
+	};
+
+	for (const [name, value] of Object.entries(headers)) {
+		response.setHeader(name, value);
+	}
+
+	if (result.body === undefined) {
+		response.end();
+		return;
+	}
+
+	response.end(JSON.stringify(result.body, null, 2));
+}

--- a/packages/tools/mcp/vercel.json
+++ b/packages/tools/mcp/vercel.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"version": 2,
+	"installCommand": "pnpm install --frozen-lockfile",
+	"buildCommand": "pnpm --filter @public-ui/mcp build:deps && pnpm --filter @public-ui/mcp vercel:build",
+	"rewrites": [
+		{
+			"source": "/health",
+			"destination": "/api/mcp"
+		},
+		{
+			"source": "/samples",
+			"destination": "/api/mcp"
+		},
+		{
+			"source": "/sample",
+			"destination": "/api/mcp"
+		}
+	]
+}

--- a/packages/tools/mcp/vercel/.gitignore
+++ b/packages/tools/mcp/vercel/.gitignore
@@ -1,0 +1,1 @@
+sample-index.json

--- a/packages/tools/mcp/vercel/build.mjs
+++ b/packages/tools/mcp/vercel/build.mjs
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { generateSampleIndex } from '../src/prebuild.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+async function main() {
+	const outputs = [path.join(__dirname, 'sample-index.json')];
+
+	await generateSampleIndex({ outputs });
+	console.log('[mcp] vercel build preparation finished');
+}
+
+main().catch((error) => {
+	console.error('[mcp] vercel build failed', error);
+	process.exitCode = 1;
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,10 +344,10 @@ importers:
         version: link:../../components
       react:
         specifier: '>=16.14.0'
-        version: 18.3.1
+        version: 19.1.1
       react-dom:
         specifier: '>=16.14.0'
-        version: 18.3.1(react@18.3.1)
+        version: 19.1.1(react@19.1.1)
     devDependencies:
       '@public-ui/react':
         specifier: workspace:*
@@ -722,7 +722,7 @@ importers:
         version: 5.2.2(react-hook-form@7.63.0(react@19.1.1))
       '@leanup/stack':
         specifier: 1.3.54
-        version: 1.3.54(chromedriver@139.0.3)(esbuild@0.25.9)(geckodriver@5.0.0)(typescript@5.9.2)
+        version: 1.3.54(chromedriver@139.0.3)(esbuild@0.25.10)(geckodriver@5.0.0)(typescript@5.9.2)
       '@playwright/test':
         specifier: 1.55.1
         version: 1.55.1
@@ -1159,6 +1159,12 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+
+  packages/tools/mcp:
+    devDependencies:
+      prettier:
+        specifier: 3.6.2
+        version: 3.6.2
 
   packages/tools/visual-tests:
     dependencies:
@@ -2336,16 +2342,34 @@ packages:
     resolution: {integrity: sha512-YAdE/IJSpwbOTiaURNCKECdAwqrJuFiZhylmesBcIRawtYKnBR2wxPhoIewMg+Yu+QuYvHfJNReWpoxGBKOChA==}
     engines: {node: '>=18'}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.9':
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.9':
@@ -2354,16 +2378,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.9':
     resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.9':
     resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.9':
@@ -2372,10 +2414,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.9':
     resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.9':
@@ -2384,10 +2438,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.9':
     resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.9':
@@ -2396,10 +2462,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.9':
     resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.9':
@@ -2408,10 +2486,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.9':
     resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.9':
@@ -2420,10 +2510,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.9':
     resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.9':
@@ -2432,16 +2534,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.9':
     resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.25.9':
     resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.9':
@@ -2450,10 +2570,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.25.9':
     resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.9':
@@ -2462,11 +2594,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.25.9':
     resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.25.9':
     resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
@@ -2474,16 +2618,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.9':
     resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.9':
     resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.9':
@@ -2494,6 +2656,12 @@ packages:
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -4978,10 +5146,6 @@ packages:
     resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/types@8.43.0':
-    resolution: {integrity: sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.44.1':
     resolution: {integrity: sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -7187,6 +7351,11 @@ packages:
 
   esbuild-wasm@0.25.9:
     resolution: {integrity: sha512-Jpv5tCSwQg18aCqCRD3oHIX/prBhXMDapIoG//A+6+dV0e7KQMGFg85ihJ5T1EeMjbZjON3TqFy0VrGAnIHLDA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -15523,84 +15692,162 @@ snapshots:
   '@es-joy/jsdoccomment@0.50.2':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.43.0
+      '@typescript-eslint/types': 8.44.1
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
 
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
     optional: true
 
   '@esbuild/android-arm64@0.25.9':
     optional: true
 
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
   '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
     optional: true
 
   '@esbuild/android-x64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
     optional: true
 
   '@esbuild/darwin-x64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
     optional: true
 
   '@esbuild/linux-arm@0.25.9':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
     optional: true
 
   '@esbuild/linux-loong64@0.25.9':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
     optional: true
 
   '@esbuild/linux-s390x@0.25.9':
     optional: true
 
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
   '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
     optional: true
 
   '@esbuild/win32-arm64@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
     optional: true
 
   '@esbuild/win32-x64@0.25.9':
@@ -15614,6 +15861,11 @@ snapshots:
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.0)':
+    dependencies:
+      eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -16112,7 +16364,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@leanup/stack@1.3.54(chromedriver@139.0.3)(esbuild@0.25.9)(geckodriver@5.0.0)(typescript@5.9.2)':
+  '@leanup/stack@1.3.54(chromedriver@139.0.3)(esbuild@0.25.10)(geckodriver@5.0.0)(typescript@5.9.2)':
     dependencies:
       '@types/chai': 4.3.16
       '@types/mocha': 9.1.1
@@ -16123,8 +16375,8 @@ snapshots:
       chai: 4.4.1
       chromedriver: 139.0.3
       cross-env: 7.0.3
-      esbuild: 0.25.9
-      esbuild-register: 3.5.0(esbuild@0.25.9)
+      esbuild: 0.25.10
+      esbuild-register: 3.5.0(esbuild@0.25.10)
       eslint: 8.57.0
       eslint-plugin-html: 7.1.0
       eslint-plugin-json: 3.1.0
@@ -17871,7 +18123,7 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
@@ -17883,7 +18135,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
 
   '@types/babel__traverse@7.20.7':
@@ -18303,8 +18555,6 @@ snapshots:
 
   '@typescript-eslint/types@7.18.0': {}
 
-  '@typescript-eslint/types@8.43.0': {}
-
   '@typescript-eslint/types@8.44.1': {}
 
   '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.2)':
@@ -18355,7 +18605,7 @@ snapshots:
 
   '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.0)
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 6.21.0
@@ -20933,14 +21183,43 @@ snapshots:
 
   es6-error@4.1.1: {}
 
-  esbuild-register@3.5.0(esbuild@0.25.9):
+  esbuild-register@3.5.0(esbuild@0.25.10):
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
-      esbuild: 0.25.9
+      esbuild: 0.25.10
     transitivePeerDependencies:
       - supports-color
 
   esbuild-wasm@0.25.9: {}
+
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
 
   esbuild@0.25.9:
     optionalDependencies:
@@ -22829,7 +23108,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.5.2)(typescript@5.9.2))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -22925,7 +23204,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.5.2)(typescript@5.9.2)):
+  jest-jasmine2@26.6.3:
     dependencies:
       '@babel/traverse': 7.28.3
       '@jest/environment': 26.6.2
@@ -22946,11 +23225,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,4 +14,5 @@ packages:
   - packages/themes
   - packages/tools/benchmark-tests
   - packages/tools/kolibri-cli
+  - packages/tools/mcp
   - packages/tools/visual-tests


### PR DESCRIPTION
## Summary
Introduces the new `@public-ui/mcp` package — a Node.js backend service that implements a Model Context Protocol (MCP) API for AI agents to query KoliBri component sample code. The server indexes React sample project routes at build time and exposes endpoints for listing and fetching samples. A GitHub Actions workflow handles automated deployments to Vercel.

## Changes
- New `packages/tools/mcp` workspace with HTTP server exposing `/health`, `/samples`, `/sample`, and `/refresh` endpoints
- Vercel serverless function with pre-built sample index and build script for runtime-free operation
- GitHub Actions workflow for automated production and preview deployments to Vercel, including PR comments with preview URLs
- Dependency updates: esbuild 0.25.9→0.25.10, React 18.3.1→19.1.1 in the samples package
- Package registered in `pnpm-workspace.yaml`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Führt das neue Paket `@public-ui/mcp` ein, einen Node.js-Backend-Dienst, der ein Model Context Protocol (MCP) implementiert und KI-Agenten den strukturierten Zugriff auf KoliBri-Komponentenbeispiele ermöglicht. Der Server indiziert beim Build die Beispieldateien und stellt sie über eine JSON-API bereit. Ein GitHub-Actions-Workflow übernimmt automatisierte Deployments auf Vercel.

## Änderungen
- Neues Workspace-Paket `packages/tools/mcp` mit HTTP-Server für `/health`, `/samples`, `/sample` und `/refresh`
- Vercel-Serverless-Funktion mit vorgebautem Sample-Index und Build-Skript für laufzeitunabhängigen Betrieb
- GitHub-Actions-Workflow für automatisierte Production- und Preview-Deployments auf Vercel, inkl. PR-Kommentare mit Preview-URL
- Dependency-Updates: esbuild 0.25.9→0.25.10, React 18.3.1→19.1.1 im Samples-Paket
- Paket in `pnpm-workspace.yaml` registriert
</details>