### PR TITLE
fix(mcp): fix vercel deployment path handling

### DIFF
--- a/.github/workflows/mcp-vercel.yml
+++ b/.github/workflows/mcp-vercel.yml
@@ -45,38 +45,38 @@ jobs:
       - name: Pull Vercel environment configuration (production)
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         run: |
-          pnpm dlx vercel@latest pull --yes --environment=production --cwd packages/tools/mcp --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@latest pull --yes --environment=production --token "$VERCEL_TOKEN"
 
       - name: Build project with Vercel CLI (production)
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         run: |
-          pnpm dlx vercel@latest build --prod --cwd packages/tools/mcp --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@latest build --prod --token "$VERCEL_TOKEN"
 
       - name: Deploy to Vercel (production)
         id: deploy_prod
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         run: |
           set -eo pipefail
-          DEPLOY_URL=$(pnpm dlx vercel@latest deploy --prebuilt --prod --yes --cwd packages/tools/mcp --token "$VERCEL_TOKEN" | tail -n1)
+          DEPLOY_URL=$(pnpm dlx vercel@latest deploy --prebuilt --prod --yes --token "$VERCEL_TOKEN" | tail -n1)
           echo "url=${DEPLOY_URL}" >> "$GITHUB_OUTPUT"
           echo "Production deployment available at ${DEPLOY_URL}"
 
       - name: Pull Vercel environment configuration (preview)
         if: github.event_name == 'pull_request'
         run: |
-          pnpm dlx vercel@latest pull --yes --environment=preview --cwd packages/tools/mcp --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@latest pull --yes --environment=preview --token "$VERCEL_TOKEN"
 
       - name: Build project with Vercel CLI (preview)
         if: github.event_name == 'pull_request'
         run: |
-          pnpm dlx vercel@latest build --cwd packages/tools/mcp --token "$VERCEL_TOKEN"
+          pnpm dlx vercel@latest build --token "$VERCEL_TOKEN"
 
       - name: Deploy to Vercel (preview)
         id: deploy_preview
         if: github.event_name == 'pull_request'
         run: |
           set -eo pipefail
-          DEPLOY_URL=$(pnpm dlx vercel@latest deploy --prebuilt --yes --cwd packages/tools/mcp --token "$VERCEL_TOKEN" | tail -n1)
+          DEPLOY_URL=$(pnpm dlx vercel@latest deploy --prebuilt --yes --token "$VERCEL_TOKEN" | tail -n1)
           echo "url=${DEPLOY_URL}" >> "$GITHUB_OUTPUT"
           echo "Preview deployment available at ${DEPLOY_URL}"
 

--- a/packages/tools/mcp/DEPLOYMENT.md
+++ b/packages/tools/mcp/DEPLOYMENT.md
@@ -108,12 +108,13 @@ Falls du zusätzliche Umgebungsvariablen brauchst, kannst du diese in Netlify un
 ### Projekt anlegen oder importieren
 
 1. Wähle in Vercel "Add New..." → "Project" und importiere das Repository.
-2. Setze **Root Directory** auf `packages/tools/mcp`.
-3. Framework Preset: `Other`.
-4. Install Command: leer lassen (Vercel führt automatisch `pnpm install --frozen-lockfile` aus).
-5. Build Command: `pnpm --filter @public-ui/mcp vercel:build`.
-6. Output Directory: leer lassen (Serverless Functions werden direkt aus `api/` erzeugt).
-7. Optional: `NODE_VERSION` auf eine unterstützte Node-18-Version setzen (z.B. `18`).
+2. Wähle als Projektnamen `kolibri-mcp`.
+3. Setze **Root Directory** auf `packages/tools/mcp`.
+4. Framework Preset: `Other`.
+5. Install Command: leer lassen (Vercel führt automatisch `pnpm install --frozen-lockfile` aus).
+6. Build Command: `pnpm --filter @public-ui/mcp vercel:build`.
+7. Output Directory: leer lassen (Serverless Functions werden direkt aus `api/` erzeugt).
+8. Optional: `NODE_VERSION` auf eine unterstützte Node-18-Version setzen (z.B. `18`).
 
 Der Build-Command ruft das Skript `packages/tools/mcp/vercel/build.mjs` auf. Dieses Skript generiert den Sample-Index einmal für
 Netlify und kopiert ihn zusätzlich nach `packages/tools/mcp/vercel/sample-index.json`, sodass die Vercel-Funktion den gleichen
@@ -176,14 +177,16 @@ pnpm install
 pnpm --filter @public-ui/mcp vercel:build
 
 # Deploy (Preview)
-vercel --cwd packages/tools/mcp
+cd packages/tools/mcp
+vercel
 
 # Deploy (Production)
-vercel --cwd packages/tools/mcp --prod
+vercel --prod
 ```
 
 > Hinweis: Das Skript `pnpm --filter @public-ui/mcp vercel:build` muss vor jedem Deploy ausgeführt werden, damit die Datei
-> `vercel/sample-index.json` aktualisiert wird und im Serverless Bundle landet.
+> `vercel/sample-index.json` aktualisiert wird und im Serverless Bundle landet. Das anschließende `vercel`-Kommando wird in
+> `packages/tools/mcp` ausgeführt, sodass keine zusätzlichen `--cwd`-Parameter mehr notwendig sind.
 
 ## Lokales Testen
 


### PR DESCRIPTION
## Summary
Internal sub-PR fixing Vercel deployment path handling in the MCP Vercel workflow. Merged into the MCP feature branch as part of incremental development.

## Changes
- Removed redundant `--cwd` flags from the MCP Vercel workflow
- Updated MCP deployment documentation with correct CLI usage

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interner Teil-PR zur Korrektur der Vercel-Deployment-Pfade im MCP-Workflow.

## Änderungen
- Redundante `--cwd`-Flags aus dem MCP-Vercel-Workflow entfernt
- MCP-Deployment-Dokumentation mit korrekter CLI-Verwendung aktualisiert
</details>