### PR TITLE
fix: remove MCP API base path normalization

### DIFF
--- a/packages/tools/mcp/DEPLOYMENT.md
+++ b/packages/tools/mcp/DEPLOYMENT.md
@@ -129,16 +129,18 @@ Index nutzen kann.
 
 ### Endpunkte nach Deployment
 
-Die Vercel-Funktion liegt unter `/api/mcp`. Beispiele:
+Das Backend erwartet keine `/api/mcp`-Präfixe mehr. Richte daher in Vercel (z. B. über "Rewrites") Weiterleitungen ein, die
+die gewünschten Routen wie `/health`, `/samples` oder `/sample` auf die Funktion `api/mcp` zeigen. Nach einer entsprechenden
+Rewrite-Regel lassen sich die Endpunkte beispielsweise so aufrufen:
 
 ```bash
-https://<projekt>.vercel.app/api/mcp/health
-https://<projekt>.vercel.app/api/mcp/samples?q=button
-https://<projekt>.vercel.app/api/mcp/sample?id=button/basic
+https://<projekt>.vercel.app/health
+https://<projekt>.vercel.app/samples?q=button
+https://<projekt>.vercel.app/sample?id=button/basic
 ```
 
-Die `POST /api/mcp/refresh`-Route lädt den vorkompilierten Index neu. Sofern der Build-Command ausgeführt wurde, lädt die
-Funktion die Datei erneut; andernfalls fällt sie auf einen dynamischen Neuaufbau zurück.
+Die `POST /refresh`-Route lädt den vorkompilierten Index neu. Sofern der Build-Command ausgeführt wurde, lädt die Funktion die
+Datei erneut; andernfalls fällt sie auf einen dynamischen Neuaufbau zurück.
 
 ### Automatisiertes Deployment mit GitHub Actions
 

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -12,8 +12,7 @@ function normalizePathname(pathname) {
 	if (pathname === '/') {
 		return pathname;
 	}
-
-	const prefixes = ['/api/mcp', '/.netlify/functions/mcp'];
+	const prefixes = ['/.netlify/functions/mcp'];
 
 	for (const prefix of prefixes) {
 		if (pathname.startsWith(prefix)) {


### PR DESCRIPTION
## What changed?

Stops normalizing the `/api/mcp` prefix so the MCP endpoints are handled without that base path, and documents the new expectation for Vercel deployments — including how to expose the routes via rewrites. Two files change (+9 / −8): the MCP request-path handling and the deployment documentation. This affects the MCP server/deployment tooling only; there is no change to the KoliBri component library or its public API.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Beendet die Normalisierung des `/api/mcp`-Präfixes, sodass die MCP-Endpunkte ohne diesen Basispfad verarbeitet werden, und dokumentiert die neue Erwartung für Vercel-Deployments — einschließlich der Freigabe der Routen über Rewrites. Es ändern sich zwei Dateien (+9 / −8): die MCP-Pfadverarbeitung und die Deployment-Dokumentation. Betroffen ist ausschließlich das MCP-Server-/Deployment-Tooling; die KoliBri-Komponentenbibliothek und ihre öffentliche API bleiben unverändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- MCP-Pfadverarbeitung — entfernt die `/api/mcp`-Präfix-Normalisierung.
- MCP-Deployment-Dokumentation — beschreibt die Erwartung für Vercel und die Rewrite-Konfiguration.

</details>