### PR TITLE
fix: expose MCP API without base path

### DIFF
--- a/packages/tools/mcp/DEPLOYMENT.md
+++ b/packages/tools/mcp/DEPLOYMENT.md
@@ -69,7 +69,7 @@ Die `netlify.toml` im Repository-Root konfiguriert:
 
 - **Build Command**: `pnpm --filter @public-ui/mcp prebuild` erzeugt den Sample-Index vor dem Deployment
 - **Functions Directory**: `packages/tools/mcp/netlify/functions`
-- **URL Redirects**: Alle API-Calls werden zur MCP-Funktion weitergeleitet
+- **URL Redirects**: Alle API-Calls ohne Präfix werden automatisch zur MCP-Funktion weitergeleitet
 - **CORS Headers**: Automatische CORS-Header für API-Endpunkte
 
 #### Environment Variables (Optional)
@@ -95,7 +95,7 @@ Falls du zusätzliche Umgebungsvariablen brauchst, kannst du diese in Netlify un
 
 1. Prüfe die Redirects in `netlify.toml`
 2. Stelle sicher, dass `netlify/functions/mcp.js` existiert
-3. Teste direkt: `https://site.netlify.app/.netlify/functions/mcp/health`
+3. Teste direkt: `https://site.netlify.app/health`
 
 ## Deployment auf Vercel
 
@@ -129,16 +129,18 @@ Index nutzen kann.
 
 ### Endpunkte nach Deployment
 
-Die Vercel-Funktion liegt unter `/api/mcp`. Beispiele:
+Das Backend erwartet keine `/api/mcp`-Präfixe mehr. Richte daher in Vercel (z. B. über "Rewrites") Weiterleitungen ein, die
+die gewünschten Routen wie `/health`, `/samples` oder `/sample` auf die Funktion `api/mcp` zeigen. Nach einer entsprechenden
+Rewrite-Regel lassen sich die Endpunkte beispielsweise so aufrufen:
 
 ```bash
-https://<projekt>.vercel.app/api/mcp/health
-https://<projekt>.vercel.app/api/mcp/samples?q=button
-https://<projekt>.vercel.app/api/mcp/sample?id=button/basic
+https://<projekt>.vercel.app/health
+https://<projekt>.vercel.app/samples?q=button
+https://<projekt>.vercel.app/sample?id=button/basic
 ```
 
-Die `POST /api/mcp/refresh`-Route lädt den vorkompilierten Index neu. Sofern der Build-Command ausgeführt wurde, lädt die
-Funktion die Datei erneut; andernfalls fällt sie auf einen dynamischen Neuaufbau zurück.
+Die `POST /refresh`-Route lädt den vorkompilierten Index neu. Sofern der Build-Command ausgeführt wurde, lädt die Funktion die
+Datei erneut; andernfalls fällt sie auf einen dynamischen Neuaufbau zurück.
 
 ### Automatisiertes Deployment mit GitHub Actions
 

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -12,7 +12,7 @@ Standardmäßig lauscht der Dienst auf Port `3030`. Über die Umgebungsvariable 
 
 ## Serverless-Einsatz auf Netlify
 
-Neben dem lokalen Node.js-Server stellt das Paket eine Netlify-Funktion bereit. Beim Deployen reicht es aus, das Verzeichnis `packages/tools/mcp/netlify/functions` als Funktionsordner zu konfigurieren. Die Funktion `mcp` übernimmt alle Routen (`/health`, `/samples`, `/sample`, `/refresh`) und kümmert sich intern um CORS-Header sowie die Index-Aktualisierung.
+Neben dem lokalen Node.js-Server stellt das Paket eine Netlify-Funktion bereit. Beim Deployen reicht es aus, das Verzeichnis `packages/tools/mcp/netlify/functions` als Funktionsordner zu konfigurieren. Die Funktion `mcp` übernimmt alle Routen (`/health`, `/samples`, `/sample`, `/refresh`) und kümmert sich intern um CORS-Header sowie die Index-Aktualisierung. Über die `netlify.toml` werden die Anfragen ohne Präfix auf diese Funktion umgeleitet, sodass die REST-Endpunkte direkt unter `/` verfügbar sind.
 
 Damit die Funktion ohne direkten Zugriff auf das Repository-Dateisystem antworten kann, muss vor dem Deploy ein vorkompilierter Sample-Index erzeugt werden:
 
@@ -22,7 +22,7 @@ pnpm --filter @public-ui/mcp prebuild
 
 Der Befehl schreibt die Datei `netlify/functions/sample-index.json`, die beim Deployment gemeinsam mit der Funktion gebündelt wird. Der in Netlify verwendete Build-Schritt sollte diesen Befehl daher immer ausführen (siehe `netlify.toml`).
 
-Im lokalen Netlify-Dev-Modus können die Endpunkte beispielsweise unter `http://localhost:8888/.netlify/functions/mcp/health` angesprochen werden. In einer produktiven Netlify-Umgebung lautet der Pfad entsprechend `/.netlify/functions/mcp/...`.
+Im lokalen Netlify-Dev-Modus sowie nach dem Deployment erreichst du die Endpunkte daher unmittelbar über `http://localhost:8888/health`, `https://<deine-site>.netlify.app/samples` usw. Der direkte Funktionspfad `/.netlify/functions/mcp/...` bleibt weiterhin erreichbar, ist aber nicht mehr erforderlich.
 
 ## Endpunkte
 

--- a/packages/tools/mcp/netlify.toml
+++ b/packages/tools/mcp/netlify.toml
@@ -10,8 +10,31 @@
   directory = "netlify/functions"
   included_files = ["netlify/functions/sample-index.json"]
 
-# Mit TypeScript Function Routing über config.path
-# Keine manuellen Redirects mehr nötig
+# Rewrite API-Routen ohne Präfix auf die Function
+[[redirects]]
+  from = "/"
+  to = "/.netlify/functions/mcp"
+  status = 200
+
+[[redirects]]
+  from = "/health"
+  to = "/.netlify/functions/mcp/health"
+  status = 200
+
+[[redirects]]
+  from = "/samples"
+  to = "/.netlify/functions/mcp/samples"
+  status = 200
+
+[[redirects]]
+  from = "/sample"
+  to = "/.netlify/functions/mcp/sample"
+  status = 200
+
+[[redirects]]
+  from = "/refresh"
+  to = "/.netlify/functions/mcp/refresh"
+  status = 200
 
 # CORS Headers für Function responses
 [[headers]]

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -12,8 +12,7 @@ function normalizePathname(pathname) {
 	if (pathname === '/') {
 		return pathname;
 	}
-
-	const prefixes = ['/api/mcp', '/.netlify/functions/mcp'];
+	const prefixes = ['/.netlify/functions/mcp'];
 
 	for (const prefix of prefixes) {
 		if (pathname.startsWith(prefix)) {


### PR DESCRIPTION
## Summary
- stop normalizing the `/api/mcp` prefix so MCP endpoints are handled without that base path
- document the new expectation for Vercel deployments and how to expose the routes via rewrites
- configure Netlify redirects so the MCP REST API is reachable on root-level paths and document the behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e32310fcd4832bad59a0f724f01832