### PR TITLE
ci(mcp): configure vercel rewrites

### DIFF
--- a/packages/tools/mcp/DEPLOYMENT.md
+++ b/packages/tools/mcp/DEPLOYMENT.md
@@ -116,6 +116,9 @@ Falls du zusätzliche Umgebungsvariablen brauchst, kannst du diese in Netlify un
 7. Output Directory: leer lassen (Serverless Functions werden direkt aus `api/` erzeugt).
 8. Optional: `NODE_VERSION` auf eine unterstützte Node-18-Version setzen (z.B. `18`).
 
+Alle Angaben zu Install- und Build-Command sowie die notwendigen Rewrites sind zusätzlich in `vercel.json` hinterlegt.
+Die Datei liegt im Ordner `packages/tools/mcp` und stellt sicher, dass lokale `vercel`-CLI-Builds und Deployments aus der Vercel Cloud automatisch denselben Buildschritt ausführen und Anfragen auf `/health`, `/samples`, `/sample` und `/refresh` korrekt auf die Funktion `api/mcp` umleiten.
+
 Der Build-Command ruft das Skript `packages/tools/mcp/vercel/build.mjs` auf. Dieses Skript generiert den Sample-Index einmal für
 Netlify und kopiert ihn zusätzlich nach `packages/tools/mcp/vercel/sample-index.json`, sodass die Vercel-Funktion den gleichen
 Index nutzen kann.

--- a/packages/tools/mcp/vercel.json
+++ b/packages/tools/mcp/vercel.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"version": 2,
+	"installCommand": "pnpm install --frozen-lockfile",
+	"buildCommand": "pnpm --filter @public-ui/mcp build:deps && pnpm --filter @public-ui/mcp vercel:build",
+	"rewrites": [
+		{
+			"source": "/health",
+			"destination": "/api/mcp"
+		},
+		{
+			"source": "/samples",
+			"destination": "/api/mcp"
+		},
+		{
+			"source": "/sample",
+			"destination": "/api/mcp"
+		},
+		{
+			"source": "/refresh",
+			"destination": "/api/mcp"
+		}
+	]
+}


### PR DESCRIPTION
## What changed?

Adds a Vercel configuration for the MCP server that runs the MCP build step and rewrites API routes to the serverless function, and documents this setup in the deployment guide. The rewrites let the required MCP routes work without the `/api/mcp` prefix. Only two files change (+27 lines): the new Vercel config and the deployment documentation. This affects MCP deployment tooling only — no component-library or public-API change.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Fügt eine Vercel-Konfiguration für den MCP-Server hinzu, die den MCP-Build-Schritt ausführt und API-Routen auf die Serverless-Function umschreibt, und dokumentiert dies im Deployment-Guide. Die Rewrites sorgen dafür, dass die benötigten MCP-Routen ohne das `/api/mcp`-Präfix funktionieren. Es ändern sich nur zwei Dateien (+27 Zeilen): die neue Vercel-Konfiguration und die Deployment-Dokumentation. Betroffen ist ausschließlich das MCP-Deployment-Tooling — keine Änderung an der Komponentenbibliothek oder der öffentlichen API.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/mcp/vercel.json` (bzw. Vercel-Konfiguration) — Build-Schritt und Rewrites der API-Routen auf die Serverless-Function.
- MCP-Deployment-Dokumentation — beschreibt die neue Konfiguration und die Routen ohne `/api/mcp`-Präfix.

</details>