### PR TITLE
fix(overlay): prevent Escape from closing modal and drawer while a tooltip is open

### DIFF
--- a/packages/components/src/components/drawer/shadow.tsx
+++ b/packages/components/src/components/drawer/shadow.tsx
@@ -4,6 +4,7 @@ import { setState, validateLabel, validateOpen, validateAlign } from '../../sche
 import { Component, Host, Method, Prop, State, Watch, h } from '@stencil/core';
 
 import type { JSX } from '@stencil/core';
+import { handleCancelOverlay } from '../../utils/tooltip-open-tracking';
 
 /**
  * @slot - The Content of drawer.
@@ -71,7 +72,7 @@ export class KolDrawer implements DrawerAPI {
 	public render(): JSX.Element {
 		return (
 			<Host class={`kol-drawer drawer`} ref={(el) => (this.hostElement = el as HTMLElement)}>
-				<dialog class="drawer__dialog" ref={this.getRef}>
+				<dialog class="drawer__dialog" onCancel={handleCancelOverlay} ref={this.getRef}>
 					{this.renderDialogContent()}
 				</dialog>
 			</Host>

--- a/packages/components/src/components/modal/shadow.tsx
+++ b/packages/components/src/components/modal/shadow.tsx
@@ -3,6 +3,7 @@ import { setState, validateLabel, watchString, watchValidator } from '../../sche
 import type { JSX } from '@stencil/core';
 import { Method } from '@stencil/core';
 import { Component, h, Prop, State, Watch } from '@stencil/core';
+import { handleCancelOverlay } from '../../utils/tooltip-open-tracking';
 
 /**
  * https://en.wikipedia.org/wiki/Modal_window
@@ -65,6 +66,7 @@ export class KolModal implements ModalAPI {
 					width: this.state._width,
 				}}
 				aria-label={this.state._label}
+				onCancel={handleCancelOverlay}
 				onClose={this.handleNativeCloseEvent.bind(this)}
 			>
 				{/* It's necessary to have a block element container for cross-browser compatibility. The display property for the slot content is unknown and could be inline. */}

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -7,6 +7,7 @@ import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
 import { alignFloatingElements } from '../../utils/align-floating-elements';
 import { hideOverlay, showOverlay } from '../../utils/overlay';
 import { KolSpanWcTag } from '../../core/component-names';
+import { tooltipClosed, tooltipOpened } from '../../utils/tooltip-open-tracking';
 
 /**
  * @internal
@@ -40,6 +41,7 @@ export class KolTooltipWc implements TooltipAPI {
 	private showTooltip = (): void => {
 		if (this.previousSibling && this.tooltipElement /* SSR instanceof HTMLElement */) {
 			showOverlay(this.tooltipElement);
+			tooltipOpened();
 			this.tooltipElement.style.setProperty('display', 'block');
 			getDocument().addEventListener('keyup', this.hideTooltipByEscape);
 
@@ -54,6 +56,7 @@ export class KolTooltipWc implements TooltipAPI {
 	private hideTooltip = (): void => {
 		if (this.tooltipElement /* SSR instanceof HTMLElement */) {
 			hideOverlay(this.tooltipElement);
+			tooltipClosed();
 			this.tooltipElement.style.setProperty('display', 'none');
 			this.tooltipElement.style.setProperty('visibility', 'hidden');
 			if (this.cleanupAutoPositioning) {

--- a/packages/components/src/utils/tooltip-open-tracking.ts
+++ b/packages/components/src/utils/tooltip-open-tracking.ts
@@ -1,0 +1,15 @@
+let openTooltips = 0;
+
+export const tooltipOpened = () => {
+	openTooltips++;
+};
+
+export const tooltipClosed = () => {
+	openTooltips = Math.max(0, openTooltips - 1);
+};
+
+export const handleCancelOverlay = (event: Event): void => {
+	if (openTooltips > 0) {
+		event.preventDefault();
+	}
+};


### PR DESCRIPTION
## What changed?

Adds a shared open-tooltip tracking utility and uses it to stop the native dialog `cancel` event (fired when the user presses Escape) from closing a modal or drawer while a tooltip is open. A new module `packages/components/src/utils/tooltip-open-tracking.ts` keeps an `openTooltips` counter with `tooltipOpened()`/`tooltipClosed()` and exposes `handleCancelOverlay()`, which calls `event.preventDefault()` when at least one tooltip is open. The tooltip component (`tooltip/component.tsx`) increments/decrements the counter in its `showTooltip`/`hideTooltip` handlers, and both `modal/shadow.tsx` and `drawer/shadow.tsx` wire `onCancel={handleCancelOverlay}` onto their `<dialog>` elements. As a result, pressing Escape to dismiss a tooltip no longer also closes the surrounding modal or drawer.

## Linked issues

- Refs #8443 — Escape closing the modal when closing a tooltip (release/2 fix).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Führt ein gemeinsames Hilfsmodul zum Verfolgen offener Tooltips ein und verhindert damit, dass das native `cancel`-Event des Dialogs (ausgelöst beim Drücken von Escape) ein Modal oder Drawer schließt, während ein Tooltip geöffnet ist. Das neue Modul `packages/components/src/utils/tooltip-open-tracking.ts` führt einen `openTooltips`-Zähler mit `tooltipOpened()`/`tooltipClosed()` und stellt `handleCancelOverlay()` bereit, das `event.preventDefault()` aufruft, sobald mindestens ein Tooltip offen ist. Die Tooltip-Komponente (`tooltip/component.tsx`) erhöht/verringert den Zähler in `showTooltip`/`hideTooltip`, und sowohl `modal/shadow.tsx` als auch `drawer/shadow.tsx` binden `onCancel={handleCancelOverlay}` an ihr `<dialog>`-Element. Dadurch schließt das Drücken von Escape zum Ausblenden eines Tooltips nicht länger auch das umgebende Modal oder Drawer.

### Verknüpfte Tickets

- Referenziert #8443 — Escape schließt das Modal beim Schließen eines Tooltips (Fix für release/2).

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/utils/tooltip-open-tracking.ts` — Neues Modul mit `openTooltips`-Zähler und `handleCancelOverlay()`.
- `packages/components/src/components/tooltip/component.tsx` — Zählt offene Tooltips beim Ein-/Ausblenden.
- `packages/components/src/components/modal/shadow.tsx` — `onCancel`-Handler am Dialog, um Schließen bei offenem Tooltip zu unterdrücken.
- `packages/components/src/components/drawer/shadow.tsx` — Gleicher `onCancel`-Handler am Drawer-Dialog.

</details>