### PR TITLE
feat(tooltip): export isTooltipOpen to detect open tooltips (#8443)

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -20,3 +20,4 @@ export type {
 } from './schema';
 export { BEM_ALERT } from './functional-components/Alert/bem';
 export { BEM_ICON } from './components/icon/bem';
+export { isTooltipOpen } from './utils/tooltip-open-tracking';

--- a/packages/components/src/utils/tooltip-open-tracking.ts
+++ b/packages/components/src/utils/tooltip-open-tracking.ts
@@ -13,3 +13,5 @@ export const handleCancelOverlay = (event: Event): void => {
 		event.preventDefault();
 	}
 };
+
+export const isTooltipOpen = (): boolean => openTooltips > 0;


### PR DESCRIPTION
## What changed?

Adds a new public helper `isTooltipOpen()` to `packages/components/src/utils/tooltip-open-tracking.ts` that returns `true` when at least one tooltip is currently open (the internal `openTooltips` counter is greater than zero) and re-exports it from the package entry point `packages/components/src/index.ts`. This promotes the previously internal open-tooltip tracking state to the public component-library API so consumers can programmatically detect whether any tooltip is open. The change is purely additive — no existing behavior or signatures are modified.

## Linked issues

- Closes #8443 — Export `isTooltipOpen` to detect/check for open tooltips.

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ergänzt eine neue öffentliche Hilfsfunktion `isTooltipOpen()` in `packages/components/src/utils/tooltip-open-tracking.ts`, die `true` zurückgibt, wenn mindestens ein Tooltip geöffnet ist (der interne Zähler `openTooltips` ist größer als null), und exportiert sie über den Paket-Einstiegspunkt `packages/components/src/index.ts`. Damit wird der bisher interne Zustand des Tooltip-Trackings Teil der öffentlichen Komponentenbibliotheks-API, sodass Konsumenten programmatisch erkennen können, ob ein Tooltip geöffnet ist. Die Änderung ist rein additiv — bestehendes Verhalten und Signaturen bleiben unverändert.

### Verknüpfte Tickets

- Schließt #8443 — Export von `isTooltipOpen` zur Erkennung offener Tooltips.

### Art der Änderung

✨ Neues Feature

### Geänderte Dateien

- `packages/components/src/utils/tooltip-open-tracking.ts` — Neue Funktion `isTooltipOpen()`, die anhand des `openTooltips`-Zählers meldet, ob ein Tooltip offen ist.
- `packages/components/src/index.ts` — Re-Export von `isTooltipOpen` als Teil der öffentlichen API.

</details>