### PR TITLE
feat(tooltip): export isTooltipOpen to detect open tooltips (#8443)

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -16,3 +16,4 @@ export type {
 	Toast,
 	ToasterOptions,
 } from './schema';
+export { isTooltipOpen } from './utils/tooltip-open-tracking';

--- a/packages/components/src/utils/tooltip-open-tracking.ts
+++ b/packages/components/src/utils/tooltip-open-tracking.ts
@@ -13,3 +13,5 @@ export const handleCancelOverlay = (event: Event): void => {
 		event.preventDefault();
 	}
 };
+
+export const isTooltipOpen = (): boolean => openTooltips > 0;


### PR DESCRIPTION
## What changed?

This PR exposes the internal tooltip open-state tracking as a new public API. A new helper `isTooltipOpen()` was added to `packages/components/src/utils/tooltip-open-tracking.ts`, returning `true` when at least one tooltip is currently open (i.e. the internal `openTooltips` counter is greater than 0). The function is re-exported from the package entry point `packages/components/src/index.ts`, making it part of the library's public surface. This lets consumers programmatically detect whether any KoliBri tooltip is currently open. No existing behavior is changed and the function is purely additive.

## Linked issues

- Closes #8443 — export `isTooltipOpen` so consumers can check for open tooltips

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR macht die intern verwaltete Tooltip-Offen-Zustandsverfolgung als neue öffentliche API verfügbar. In `packages/components/src/utils/tooltip-open-tracking.ts` wurde die neue Hilfsfunktion `isTooltipOpen()` ergänzt, die `true` zurückgibt, wenn mindestens ein Tooltip geöffnet ist (also der interne Zähler `openTooltips` größer als 0 ist). Die Funktion wird über den Paket-Einstiegspunkt `packages/components/src/index.ts` re-exportiert und damit Teil der öffentlichen Bibliotheks-API. Dadurch können Anwender programmatisch prüfen, ob aktuell ein KoliBri-Tooltip geöffnet ist. Bestehendes Verhalten wird nicht verändert; die Änderung ist rein additiv.

### Verknüpfte Tickets

- Schließt #8443 — `isTooltipOpen` exportieren, damit Anwender offene Tooltips prüfen können

### Art der Änderung

✨ Neues Feature

### Geänderte Dateien

- `packages/components/src/utils/tooltip-open-tracking.ts` — neue Funktion `isTooltipOpen()` ergänzt, die `openTooltips > 0` zurückgibt
- `packages/components/src/index.ts` — `isTooltipOpen` aus dem Tooltip-Tracking-Modul re-exportiert

</details>