### PR TITLE
feat(samples): show all toast types by default

### DIFF
--- a/packages/samples/react/src/components/toast/configurator.tsx
+++ b/packages/samples/react/src/components/toast/configurator.tsx
@@ -24,24 +24,27 @@ export const ToastConfigurator: FC = () => {
 	const queryType = searchParams.get('type');
 	const defaultType = isAlertType(queryType) ? queryType : undefined;
 	const [selectedType, setSelectedType] = useState<AlertTypePropType>(() => defaultType ?? 'default');
-	const toaster = useMemo(
-		() =>
-			ToasterService.getInstance(document, {
-				defaultVariant: 'card',
-			}),
-		[],
-	);
+	const toaster = useMemo<ToasterService>(() => ToasterService.getInstance(document), []);
+
+	useEffect(() => {
+		toastTypes.forEach((type) => {
+			void toaster.enqueue({
+				description: 'Toasty',
+				label: `Toast with type '${type}'`,
+				type,
+			});
+		});
+
+		return () => {
+			toaster.closeAll();
+		};
+	}, [toaster]);
 
 	useEffect(() => {
 		if (defaultType) {
 			setSelectedType(defaultType);
-			void toaster.enqueue({
-				description: 'Toasty',
-				label: `Toast with type '${defaultType}'`,
-				type: defaultType,
-			});
 		}
-	}, [defaultType, toaster]);
+	}, [defaultType]);
 
 	const handleTypeChange = (_: Event, value: unknown) => {
 		if (isAlertType(value)) {

--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -905,6 +905,17 @@ ROUTES.set('toast/basic?variant=card', {
 		},
 	},
 });
+ROUTES.set('toast/configurator', {
+	snapshot: {
+		viewportSize: {
+			width: 600,
+			height: 300,
+		},
+		zoom: {
+			skip: true,
+		},
+	},
+});
 
 ROUTES.set('toast/basic?type=default&variant=msg', {
 	snapshot: {


### PR DESCRIPTION
## What changed?

The toast configurator sample (`packages/samples/react/src/components/toast/configurator.tsx`) now enqueues every alert type from `toastTypes` on mount, so all toast variants render immediately when the sample loads instead of only the single type passed via the `type` query parameter. The `ToasterService.getInstance` call no longer sets `defaultVariant: 'card'`, so the sample falls back to the service default variant, and the instance is now explicitly typed as `ToasterService`. A cleanup function was added that calls `toaster.closeAll()` on unmount, and the query-parameter type synchronisation was split into its own `useEffect` keyed on `defaultType`. In `packages/tools/visual-tests/tests/sample-app.routes.js`, a new `toast/configurator` route (600×300 viewport, zoom skipped) is registered so the configurator is captured by the visual regression snapshots.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das Toast-Konfigurator-Sample (`packages/samples/react/src/components/toast/configurator.tsx`) reiht jetzt beim Mounten jeden Alert-Typ aus `toastTypes` ein, sodass beim Laden des Samples sofort alle Toast-Varianten angezeigt werden, statt nur des einzelnen über den Query-Parameter `type` übergebenen Typs. Der Aufruf `ToasterService.getInstance` setzt `defaultVariant: 'card'` nicht mehr, wodurch das Sample auf die Standardvariante des Service zurückfällt, und die Instanz wird nun explizit als `ToasterService` typisiert. Eine Aufräumfunktion wurde ergänzt, die beim Unmounten `toaster.closeAll()` aufruft, und die Synchronisation des Typs aus dem Query-Parameter wurde in einen eigenen, auf `defaultType` reagierenden `useEffect` ausgelagert. In `packages/tools/visual-tests/tests/sample-app.routes.js` wird eine neue Route `toast/configurator` (Viewport 600×300, Zoom übersprungen) registriert, damit der Konfigurator von den visuellen Regressionstests erfasst wird.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/toast/configurator.tsx` — Sample zeigt beim Laden alle Toast-Typen an, entfernt `defaultVariant: 'card'`, ergänzt `closeAll()`-Cleanup und trennt die Typ-Synchronisation in einen eigenen Effect.
- `packages/tools/visual-tests/tests/sample-app.routes.js` — Registriert die Route `toast/configurator` für die visuellen Regressions-Snapshots.

</details>