### PR TITLE
docs(mcp): update live API demo link in README

### DIFF
--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -146,7 +146,7 @@ Returns:
 
 ## 🌐 Online Demo
 
-Try the live API at: [https://kolibri-mcp.vercel.app](https://kolibri-mcp.vercel.app)
+Try the live API at: [https://public-ui-kolibri-mcp.vercel.app/mcp/](https://public-ui-kolibri-mcp.vercel.app/mcp/)
 
 - Landing page with API documentation
 - Interactive sample browser


### PR DESCRIPTION
## What changed?

Updated the "Online Demo" section of `packages/tools/mcp/README.md`. The live API demo link was changed from the old `https://kolibri-mcp.vercel.app` URL to the current `https://public-ui-kolibri-mcp.vercel.app/mcp/` deployment URL. This is a documentation-only change (one line, no code or API surface affected) that ensures readers of the MCP package README reach the correct, working demo endpoint.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Abschnitt "Online Demo" in `packages/tools/mcp/README.md` wurde aktualisiert. Der Link zur Live-API-Demo wurde von der alten URL `https://kolibri-mcp.vercel.app` auf die aktuelle Deployment-URL `https://public-ui-kolibri-mcp.vercel.app/mcp/` geändert. Es handelt sich um eine reine Dokumentationsänderung (eine Zeile, kein Code und keine API-Oberfläche betroffen), damit Leser des MCP-Paket-READMEs den korrekten, funktionierenden Demo-Endpunkt erreichen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/mcp/README.md` — Link zur Live-API-Demo im Abschnitt "Online Demo" auf die neue Vercel-URL aktualisiert.

</details>