### PR TITLE
feat(mcp)!: expose markdown docs and namespace sample ids

### DIFF
--- a/packages/tools/mcp/AGENTS.md
+++ b/packages/tools/mcp/AGENTS.md
@@ -30,15 +30,19 @@ After deployment to Vercel, the API is available under the following URLs:
 
 - `https://<project>.vercel.app/mcp/health`
 - `https://<project>.vercel.app/mcp/samples`
-- `https://<project>.vercel.app/mcp/sample?id=button/basic`
-- `https://<project>.vercel.app/mcp/refresh` (POST)
+- `https://<project>.vercel.app/mcp/sample?id=sample/button/basic`
+- `https://<project>.vercel.app/mcp/concepts`
+- `https://<project>.vercel.app/mcp/concept?id=concept/README`
 
 ## Endpoints
 
 - `GET /api/mcp/health` – returns the backend status and metadata about the current sample index.
 - `GET /api/mcp/samples` – lists all available samples. Can optionally be filtered using the query parameter `q`.
-- `GET /api/mcp/sample?id=<component/sample>` – returns path and source code of a specific sample.
-- `POST /api/mcp/refresh` – rebuilds the sample index if files have changed.
+- `GET /api/mcp/sample?id=sample/<component>/<sample>` – returns path and source code of a specific sample.
+- `GET /api/mcp/concepts` – lists all available concept and documentation entries.
+- `GET /api/mcp/concept?id=concept/<identifier>` – returns metadata and Markdown source of a specific concept.
+
+Refresh requests are not available on deployed environments because the indexes are embedded during the build.
 
 All responses are delivered as JSON and already contain the relative paths within the repository.
 

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -32,7 +32,8 @@ The server will start on `http://localhost:3030` and provide the following endpo
 - `GET /mcp/sample?id=sample/button/basic` - Get specific sample source code
 - `GET /mcp/concepts` - List Markdown concept documentation
 - `GET /mcp/concept?id=concept/README` - Get a specific concept document
-- `POST /mcp/refresh` - Refresh sample index
+
+The sample and concept indexes are prebuilt for deployments, therefore no manual refresh endpoint is exposed in production.
 
 ### Integration with AI Tools
 

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -65,7 +65,7 @@ const samples = await response.json();
 
 ## 📚 What's Included
 
-This MCP server provides access to **136+ KoliBri component examples** including:
+This MCP server provides access to **136+ KoliBri component examples** and the core **Markdown documentation** of the project, including:
 
 - **Basic Components**: Button, Input, Link, Icon, Badge, etc.
 - **Form Components**: Form, Select, Textarea, Checkbox, Radio, etc.
@@ -73,6 +73,7 @@ This MCP server provides access to **136+ KoliBri component examples** including
 - **Navigation**: Breadcrumb, Pagination, Navigation, etc.
 - **Data Display**: Table, Alert, Toast, Progress, etc.
 - **Advanced Components**: Tree, Tooltip, Popover, etc.
+- **Markdown Docs**: `README.md`, `docs/*.md`, migration guides, security guidelines, and more.
 
 Each sample includes:
 
@@ -89,10 +90,13 @@ Returns server status and metadata:
 
 ```json
 {
+	"status": "ok",
 	"healthy": true,
+	"totalEntries": 154,
 	"totalSamples": 136,
-	"sampleGroups": ["button", "input", "table", "..."],
-	"version": "3.0.7"
+	"totalDocs": 18,
+	"message": "System healthy with 154 entries available",
+	"generatedAt": "2024-05-28T08:15:30.000Z"
 }
 ```
 
@@ -124,9 +128,22 @@ Returns:
 	"group": "button",
 	"name": "basic",
 	"path": "packages/samples/react/src/components/button/basic.tsx",
-	"code": "import React from 'react';\nimport { KolButton } from '@public-ui/react';\n..."
+	"code": "import React from 'react';\nimport { KolButton } from '@public-ui/react';\n...",
+	"kind": "sample"
 }
 ```
+
+### GET /mcp/sample?id=docs/<path>
+
+Fetch Markdown documentation by referencing its `docs/...` identifier:
+
+```bash
+curl "http://localhost:3030/mcp/sample?id=docs/README"
+```
+
+Returns the Markdown content of `README.md` together with metadata.
+
+Every sample or document response also exposes a `kind` field so that clients can distinguish between component examples and documentation entries.
 
 ## 🛠️ Use Cases
 

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -29,9 +29,9 @@ The server will start on `http://localhost:3030` and provide the following endpo
 
 - `GET /mcp/health` - Server status and content counts
 - `GET /mcp/samples` - List all available component examples
-- `GET /mcp/sample?id=button/basic` - Get specific sample source code
+- `GET /mcp/sample?id=sample/button/basic` - Get specific sample source code
 - `GET /mcp/concepts` - List Markdown concept documentation
-- `GET /mcp/concept?id=concepts/getting-started` - Get a specific concept document
+- `GET /mcp/concept?id=concept/README` - Get a specific concept document
 - `POST /mcp/refresh` - Refresh sample index
 
 ### Integration with AI Tools
@@ -99,7 +99,8 @@ Returns server status and metadata:
 	"totalConcepts": 18,
 	"totalDocs": 18,
 	"message": "System healthy with 154 entries available",
-	"generatedAt": "2024-05-28T08:15:30.000Z"
+	"generatedAt": "2024-05-28T08:15:30.000Z",
+	"ai-hints": "KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit."
 }
 ```
 
@@ -120,19 +121,20 @@ curl "http://localhost:3030/mcp/samples?q=button"
 Get complete source code for a specific sample:
 
 ```bash
-curl "http://localhost:3030/mcp/sample?id=button/basic"
+curl "http://localhost:3030/mcp/sample?id=sample/button/basic"
 ```
 
 Returns:
 
 ```json
 {
-	"id": "button/basic",
+	"id": "sample/button/basic",
 	"group": "button",
 	"name": "basic",
 	"path": "packages/samples/react/src/components/button/basic.tsx",
 	"code": "import React from 'react';\nimport { KolButton } from '@public-ui/react';\n...",
-	"kind": "sample"
+	"kind": "sample",
+	"ai-hints": "KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit."
 }
 ```
 
@@ -152,10 +154,12 @@ curl "http://localhost:3030/mcp/concepts?q=theme"
 Fetch Markdown documentation by referencing its `concepts/...` identifier:
 
 ```bash
-curl "http://localhost:3030/mcp/concept?id=concepts/README"
+curl "http://localhost:3030/mcp/concept?id=concept/README"
 ```
 
 Returns the Markdown content together with metadata. Every sample or concept response exposes a `kind` field so that clients can distinguish between component examples and documentation entries.
+
+All JSON responses contain an `ai-hints` field reminding clients that KoliBri Web Components have to be registered in the browser and that integration details depend on the chosen project setup.
 
 ## 🛠️ Use Cases
 

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -27,9 +27,11 @@ npx @public-ui/mcp
 
 The server will start on `http://localhost:3030` and provide the following endpoints:
 
-- `GET /mcp/health` - Server status and sample count
+- `GET /mcp/health` - Server status and content counts
 - `GET /mcp/samples` - List all available component examples
 - `GET /mcp/sample?id=button/basic` - Get specific sample source code
+- `GET /mcp/concepts` - List Markdown concept documentation
+- `GET /mcp/concept?id=concepts/getting-started` - Get a specific concept document
 - `POST /mcp/refresh` - Refresh sample index
 
 ### Integration with AI Tools
@@ -65,7 +67,7 @@ const samples = await response.json();
 
 ## 📚 What's Included
 
-This MCP server provides access to **136+ KoliBri component examples** and the core **Markdown documentation** of the project, including:
+This MCP server provides access to **136+ KoliBri component examples** and the core **Markdown concept documentation** of the project, including:
 
 - **Basic Components**: Button, Input, Link, Icon, Badge, etc.
 - **Form Components**: Form, Select, Textarea, Checkbox, Radio, etc.
@@ -73,7 +75,7 @@ This MCP server provides access to **136+ KoliBri component examples** and the c
 - **Navigation**: Breadcrumb, Pagination, Navigation, etc.
 - **Data Display**: Table, Alert, Toast, Progress, etc.
 - **Advanced Components**: Tree, Tooltip, Popover, etc.
-- **Markdown Docs**: `README.md`, `docs/*.md`, migration guides, security guidelines, and more.
+- **Concept Docs**: `README.md`, `docs/*.md`, migration guides, security guidelines, and more.
 
 Each sample includes:
 
@@ -94,6 +96,7 @@ Returns server status and metadata:
 	"healthy": true,
 	"totalEntries": 154,
 	"totalSamples": 136,
+	"totalConcepts": 18,
 	"totalDocs": 18,
 	"message": "System healthy with 154 entries available",
 	"generatedAt": "2024-05-28T08:15:30.000Z"
@@ -133,17 +136,26 @@ Returns:
 }
 ```
 
-### GET /mcp/sample?id=docs/<path>
+### GET /mcp/concepts
 
-Fetch Markdown documentation by referencing its `docs/...` identifier:
+List Markdown-based concept documentation entries:
 
 ```bash
-curl "http://localhost:3030/mcp/sample?id=docs/README"
+curl http://localhost:3030/mcp/concepts
+
+# Filter by term
+curl "http://localhost:3030/mcp/concepts?q=theme"
 ```
 
-Returns the Markdown content of `README.md` together with metadata.
+### GET /mcp/concept?id={conceptId}
 
-Every sample or document response also exposes a `kind` field so that clients can distinguish between component examples and documentation entries.
+Fetch Markdown documentation by referencing its `concepts/...` identifier:
+
+```bash
+curl "http://localhost:3030/mcp/concept?id=concepts/README"
+```
+
+Returns the Markdown content together with metadata. Every sample or concept response exposes a `kind` field so that clients can distinguish between component examples and documentation entries.
 
 ## 🛠️ Use Cases
 

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -101,7 +101,10 @@ Returns server status and metadata:
 	"totalDocs": 18,
 	"message": "System healthy with 154 entries available",
 	"generatedAt": "2024-05-28T08:15:30.000Z",
-	"ai-hints": "KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit."
+	"ai-hints": [
+		"Always register KoliBri Web Components in the browser runtime before rendering them.",
+		"Choose the integration guide that matches your project setup to load and bundle the components correctly."
+	]
 }
 ```
 
@@ -135,7 +138,10 @@ Returns:
 	"path": "packages/samples/react/src/components/button/basic.tsx",
 	"code": "import React from 'react';\nimport { KolButton } from '@public-ui/react';\n...",
 	"kind": "sample",
-	"ai-hints": "KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit."
+	"ai-hints": [
+		"Always register KoliBri Web Components in the browser runtime before rendering them.",
+		"Choose the integration guide that matches your project setup to load and bundle the components correctly."
+	]
 }
 ```
 
@@ -160,7 +166,7 @@ curl "http://localhost:3030/mcp/concept?id=concept/README"
 
 Returns the Markdown content together with metadata. Every sample or concept response exposes a `kind` field so that clients can distinguish between component examples and documentation entries.
 
-All JSON responses contain an `ai-hints` field reminding clients that KoliBri Web Components have to be registered in the browser and that integration details depend on the chosen project setup.
+All JSON responses contain an `ai-hints` string array that reiterates in English that KoliBri Web Components must be registered in the browser and that integration steps vary with the chosen project setup.
 
 ## 🛠️ Use Cases
 

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -1,3 +1,8 @@
+const AI_HINTS_KEY = 'ai-hints';
+const AI_HINTS_MESSAGE =
+	'KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit.';
+const withAiHints = (body = {}) => ({ ...body, [AI_HINTS_KEY]: AI_HINTS_MESSAGE });
+
 // Vercel Serverless Function für /api/mcp/*
 export default async function handler(request, response) {
 	// CORS Headers setzen
@@ -40,10 +45,15 @@ export default async function handler(request, response) {
 				map: new Map(samplesData.entries.map((entry) => [entry.id, entry])),
 				generatedAt: new Date(samplesData.generatedAt),
 				buildMode: samplesData.buildMode,
-				list: function (query) {
-					if (!query) return this.entries;
+				list: function (query, options = {}) {
+					const kinds = options.kinds ? new Set(options.kinds) : undefined;
+					const normalizeKind = (entry) => entry.kind ?? 'sample';
+					let results = kinds ? this.entries.filter((entry) => kinds.has(normalizeKind(entry))) : this.entries;
+					if (!query) {
+						return results;
+					}
 					const normalized = query.trim().toLowerCase();
-					return this.entries.filter(
+					return results.filter(
 						(entry) =>
 							entry.id.toLowerCase().includes(normalized) || entry.group.toLowerCase().includes(normalized) || entry.name.toLowerCase().includes(normalized),
 					);
@@ -70,11 +80,11 @@ export default async function handler(request, response) {
 			Object.entries(result.headers).forEach(([key, value]) => {
 				response.setHeader(key, value);
 			});
-			response.json(result.body || {});
+			const responseBody = result.body ?? {};
+			response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
 		} else {
 			// Fallback: Verwende Build-Artefakte (kann auf Vercel problematisch sein)
-			const { handleApiRequest } = await import('../dist/index.mjs');
-			const { buildSampleIndex } = await import('../dist/index.mjs');
+			const { handleApiRequest, buildSampleIndex } = await import('../dist/index.mjs');
 
 			// Index-Funktionen definieren (mit Runtime Discovery)
 			let cachedIndex = null;
@@ -103,7 +113,8 @@ export default async function handler(request, response) {
 			Object.entries(result.headers).forEach(([key, value]) => {
 				response.setHeader(key, value);
 			});
-			response.json(result.body || {});
+			const responseBody = result.body ?? {};
+			response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
 		}
 	} catch (error) {
 		console.error('[api/mcp] Handler error:', error);
@@ -111,10 +122,12 @@ export default async function handler(request, response) {
 		// Fallback Error Response
 		response.status(500);
 		response.setHeader('Content-Type', 'application/json');
-		response.json({
-			error: 'Internal server error',
-			message: error.message,
-			timestamp: new Date().toISOString(),
-		});
+		response.json(
+			withAiHints({
+				error: 'Internal server error',
+				message: error.message,
+				timestamp: new Date().toISOString(),
+			}),
+		);
 	}
 }

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -1,7 +1,55 @@
 const AI_HINTS_KEY = 'ai-hints';
-const AI_HINTS_MESSAGE =
-	'KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit.';
-const withAiHints = (body = {}) => ({ ...body, [AI_HINTS_KEY]: AI_HINTS_MESSAGE });
+const AI_HINTS_MESSAGES = Object.freeze([
+	'Always register KoliBri Web Components in the browser runtime before rendering them.',
+	'Choose the integration guide that matches your project setup to load and bundle the components correctly.',
+]);
+
+const normalizeHints = (value) => {
+	if (Array.isArray(value)) {
+		return value.length > 0 ? value : AI_HINTS_MESSAGES;
+	}
+
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		return trimmed ? [trimmed] : AI_HINTS_MESSAGES;
+	}
+
+	return AI_HINTS_MESSAGES;
+};
+
+const withAiHints = (body = {}) => ({ ...body, [AI_HINTS_KEY]: normalizeHints(body[AI_HINTS_KEY]) });
+
+const computeCountsFromEntries = (entries = []) =>
+	entries.reduce(
+		(acc, entry) => {
+			const kind = entry?.kind ?? 'sample';
+			acc.total += 1;
+			if (kind === 'sample') {
+				acc.totalSamples += 1;
+			} else if (kind === 'concept' || kind === 'doc') {
+				acc.totalConcepts += 1;
+				acc.totalDocs += 1;
+			}
+			return acc;
+		},
+		{ total: 0, totalSamples: 0, totalConcepts: 0, totalDocs: 0 },
+	);
+
+const resolveCounts = (index) => {
+	if (!index) {
+		return computeCountsFromEntries();
+	}
+
+	const fallbackCounts = computeCountsFromEntries(index.entries ?? []);
+	const source = index.counts ?? {};
+
+	return {
+		total: typeof source.total === 'number' ? source.total : fallbackCounts.total,
+		totalSamples: typeof source.totalSamples === 'number' ? source.totalSamples : fallbackCounts.totalSamples,
+		totalConcepts: typeof source.totalConcepts === 'number' ? source.totalConcepts : fallbackCounts.totalConcepts,
+		totalDocs: typeof source.totalDocs === 'number' ? source.totalDocs : fallbackCounts.totalDocs,
+	};
+};
 
 // Vercel Serverless Function für /api/mcp/*
 export default async function handler(request, response) {
@@ -40,11 +88,13 @@ export default async function handler(request, response) {
 			const { handleApiRequest } = await import('../dist/index.mjs');
 
 			// Erstelle Mock-Index mit eingebetteten Daten
+			const counts = resolveCounts({ entries: samplesData.entries, counts: samplesData.counts });
 			const mockIndex = {
 				entries: samplesData.entries,
 				map: new Map(samplesData.entries.map((entry) => [entry.id, entry])),
 				generatedAt: new Date(samplesData.generatedAt),
 				buildMode: samplesData.buildMode,
+				counts,
 				list: function (query, options = {}) {
 					const kinds = options.kinds ? new Set(options.kinds) : undefined;
 					const normalizeKind = (entry) => entry.kind ?? 'sample';
@@ -63,17 +113,14 @@ export default async function handler(request, response) {
 				},
 			};
 
-			// Index-Funktionen mit eingebetteten Daten
 			const getIndex = async () => mockIndex;
 
-			// API Handler aufrufen
 			const result = await handleApiRequest({
 				method: request.method || 'GET',
 				url: fullUrl.toString(),
 				getIndex,
 			});
 
-			// Response senden
 			response.status(result.statusCode);
 			Object.entries(result.headers).forEach(([key, value]) => {
 				response.setHeader(key, value);

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -65,14 +65,12 @@ export default async function handler(request, response) {
 
 			// Index-Funktionen mit eingebetteten Daten
 			const getIndex = async () => mockIndex;
-			const refresh = async () => mockIndex;
 
 			// API Handler aufrufen
 			const result = await handleApiRequest({
 				method: request.method || 'GET',
 				url: fullUrl.toString(),
 				getIndex,
-				refresh,
 			});
 
 			// Response senden
@@ -95,17 +93,11 @@ export default async function handler(request, response) {
 				return cachedIndex;
 			};
 
-			const refresh = async () => {
-				cachedIndex = await buildSampleIndex();
-				return cachedIndex;
-			};
-
 			// API Handler aufrufen
 			const result = await handleApiRequest({
 				method: request.method || 'GET',
 				url: fullUrl.toString(),
 				getIndex,
-				refresh,
 			});
 
 			// Response senden

--- a/packages/tools/mcp/package.json
+++ b/packages/tools/mcp/package.json
@@ -43,7 +43,7 @@
 	"scripts": {
 		"build": "node prebuild.js && unbuild",
 		"format": "prettier --check src",
-		"prestart": "unbuild --stub",
+		"prestart": "pnpm build",
 		"start": "node dist/index.mjs"
 	},
 	"devDependencies": {

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -180,7 +180,7 @@
 
 			<div class="api-info">
 				<h2>📡 REST API Endpoints</h2>
-				<p class="description">This API provides structured information about KoliBri examples that can be used by AI agents.</p>
+				<p class="description">This API provides structured information about KoliBri samples that can be used by AI agents.</p>
 
 				<div style="margin-top: 1rem">
 					<div>
@@ -247,13 +247,13 @@
 					</div>
 					<p class="description">In GitHub Copilot Chat you can now write:</p>
 					<div class="endpoint" style="background: #2d3748; color: #90cdf4">
-						@kolibri show me a button example @kolibri how do I implement a KoliBri table? @kolibri create an accessible form
+						@kolibri show me a button sample @kolibri how do I implement a KoliBri table? @kolibri create an accessible form
 					</div>
 
 					<div style="background: #e6fffa; padding: 1rem; border-radius: 6px; margin-top: 1rem; border-left: 4px solid #38a169">
 						<strong style="color: #2d3748">💡 Tip:</strong>
-						<span style="color: #2d3748">
-							The MCP Server gives you access to all 136+ KoliBri component examples and 18 documentation files directly in VS Code!</span
+						<span style="color: #2d3748" id="tip-text">
+							The MCP Server gives you access to all KoliBri component samples and documentation files directly in VS Code!</span
 						>
 					</div>
 				</div>
@@ -300,10 +300,18 @@
 
 					const sampleCountElement = document.getElementById('sample-count');
 					const docCountElement = document.getElementById('doc-count');
+					const tipTextElement = document.getElementById('tip-text');
 
 					if (sampleCountElement && docCountElement) {
 						sampleCountElement.textContent = sampleCount.toLocaleString();
 						docCountElement.textContent = docCount.toLocaleString();
+					}
+
+					// Update tip text with dynamic numbers
+					if (tipTextElement && sampleCount > 0) {
+						const samplesText = sampleCount > 0 ? `${sampleCount.toLocaleString()}+ ` : '';
+						const docsText = docCount > 0 ? ` and ${docCount.toLocaleString()} documentation files` : '';
+						tipTextElement.textContent = `The MCP Server gives you access to all ${samplesText}KoliBri component samples${docsText} directly in VS Code!`;
 					}
 
 					if (data.healthy && sampleCount > 0) {

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -172,8 +172,8 @@
 						<span class="stat-value" id="sample-count">–</span>
 					</div>
 					<div class="stat">
-						<span class="stat-label">Concepts</span>
-						<span class="stat-value" id="concept-count">–</span>
+						<span class="stat-label">Docs</span>
+						<span class="stat-value" id="doc-count">–</span>
 					</div>
 				</div>
 			</div>
@@ -195,28 +195,28 @@
 					</div>
 					<p class="description">List of all available samples (optional filter with ?q=filter)</p>
 
-                                        <div>
-                                                <span class="method get">GET</span>
-                                                <code class="endpoint"><a href="/mcp/sample?id=sample/button/basic" style="color: #90cdf4">/mcp/sample?id=sample/button/basic</a></code>
-                                        </div>
-                                        <p class="description">Path and source code of a specific sample</p>
+					<div>
+						<span class="method get">GET</span>
+						<code class="endpoint"><a href="/mcp/sample?id=sample/button/basic" style="color: #90cdf4">/mcp/sample?id=sample/button/basic</a></code>
+					</div>
+					<p class="description">Path and source code of a specific sample</p>
 
-                                        <div>
-                                                <span class="method get">GET</span>
-                                                <code class="endpoint"><a href="/mcp/concepts" style="color: #90cdf4">/mcp/concepts</a></code>
-                                        </div>
-                                        <p class="description">List of Markdown-based concept documents</p>
+					<div>
+						<span class="method get">GET</span>
+						<code class="endpoint"><a href="/mcp/docs" style="color: #90cdf4">/mcp/docs</a></code>
+					</div>
+					<p class="description">List of Markdown-based documentation documents</p>
 
-                                        <div>
-                                                <span class="method get">GET</span>
-                                                <code class="endpoint"><a href="/mcp/concept?id=concept/README" style="color: #90cdf4">/mcp/concept?id=concept/README</a></code>
-                                        </div>
-                                        <p class="description">Retrieve a specific concept document including its Markdown source</p>
-                                </div>
-                                <p class="description" style="margin-top: 1rem">
-                                        Hinweis: Die Indizes werden im Buildprozess erzeugt. Ein manuelles <code>refresh</code> ist in Deployments nicht verfügbar.
-                                </p>
-                        </div>
+					<div>
+						<span class="method get">GET</span>
+						<code class="endpoint"><a href="/mcp/doc?id=doc/README" style="color: #90cdf4">/mcp/doc?id=doc/README</a></code>
+					</div>
+					<p class="description">Retrieve a specific documentation document including its Markdown source</p>
+				</div>
+				<p class="description" style="margin-top: 1rem">
+					Hinweis: Die Indizes werden im Buildprozess erzeugt. Ein manuelles <code>refresh</code> ist in Deployments nicht verfügbar.
+				</p>
+			</div>
 
 			<div class="footer">
 				<p>
@@ -235,37 +235,57 @@
 					console.log('API Status:', data);
 					const statusElement = document.querySelector('.status');
 
-                                        const sampleCount = typeof data.totalSamples === 'number' ? data.totalSamples : typeof data.total === 'number' ? data.total : 0;
-                                        const conceptCount = typeof data.totalConcepts === 'number' ? data.totalConcepts : typeof data.totalDocs === 'number' ? data.totalDocs : 0;
-                                        const sampleCountElement = document.getElementById('sample-count');
-                                        const conceptCountElement = document.getElementById('concept-count');
+					// Extract sample count with fallback logic
+					let sampleCount = 0;
+					if (typeof data.totalSamples === 'number') {
+						sampleCount = data.totalSamples;
+					} else if (typeof data.samples === 'number') {
+						sampleCount = data.samples;
+					} else if (typeof data.total === 'number') {
+						sampleCount = data.total;
+					}
 
-                                        if (sampleCountElement && conceptCountElement) {
-                                                sampleCountElement.textContent = sampleCount.toLocaleString();
-                                                conceptCountElement.textContent = conceptCount.toLocaleString();
-                                        }
+					// Extract doc count with fallback logic
+					let docCount = 0;
+					if (typeof data.totalDocs === 'number') {
+						docCount = data.totalDocs;
+					} else if (typeof data.docs === 'number') {
+						docCount = data.docs;
+					} else if (typeof data.totalConcepts === 'number') {
+						docCount = data.totalConcepts;
+					} else if (typeof data.concepts === 'number') {
+						docCount = data.concepts;
+					}
 
-                                        if (data.healthy && sampleCount > 0) {
-                                                const conceptText = conceptCount > 0 ? `, ${conceptCount.toLocaleString()} Concepts` : '';
-                                                statusElement.textContent = `🟢 Online (${sampleCount.toLocaleString()} Samples${conceptText})`;
-                                                statusElement.style.background = '#38a169';
-                                        } else {
-                                                statusElement.textContent = '🟡 No samples found';
-                                                statusElement.style.background = '#d69e2e';
-                                        }
+					const sampleCountElement = document.getElementById('sample-count');
+					const docCountElement = document.getElementById('doc-count');
+
+					if (sampleCountElement && docCountElement) {
+						sampleCountElement.textContent = sampleCount.toLocaleString();
+						docCountElement.textContent = docCount.toLocaleString();
+					}
+
+					if (data.healthy && sampleCount > 0) {
+						const docText = docCount > 0 ? `, ${docCount.toLocaleString()} Docs` : '';
+						statusElement.textContent = `🟢 Online (${sampleCount.toLocaleString()} Samples${docText})`;
+						statusElement.style.background = '#38a169';
+					} else {
+						statusElement.textContent = '🟡 No samples found';
+						statusElement.style.background = '#d69e2e';
+					}
 				})
 				.catch((error) => {
-                                        console.warn('API not reachable:', error);
-                                        const statusElement = document.querySelector('.status');
-                                        statusElement.textContent = '🔴 Offline';
-                                        statusElement.style.background = '#e53e3e';
-                                        const sampleCountElement = document.getElementById('sample-count');
-                                        const conceptCountElement = document.getElementById('concept-count');
-                                        if (sampleCountElement && conceptCountElement) {
-                                                sampleCountElement.textContent = '–';
-                                                conceptCountElement.textContent = '–';
-                                        }
-                                });
-                </script>
+					console.warn('API not reachable:', error);
+					const statusElement = document.querySelector('.status');
+					statusElement.textContent = '🔴 Offline';
+					statusElement.style.background = '#e53e3e';
+					const sampleCountElement = document.getElementById('sample-count');
+					const docCountElement = document.getElementById('doc-count');
+					if (sampleCountElement && docCountElement) {
+						sampleCountElement.textContent = '–';
+						docCountElement.textContent = '–';
+					}
+				});
+		</script>
 	</body>
 </html>

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -163,7 +163,7 @@
 		<div class="container">
 			<div class="header">
 				<div class="logo">K</div>
-				<h1>KoliBri MCP-API</h1>
+				<h1>KoliBri MCP API</h1>
 				<p class="subtitle">Model Context Protocol Backend for KoliBri Examples</p>
 				<span class="status">🟢 Online</span>
 				<div class="stats" aria-live="polite">
@@ -214,8 +214,49 @@
 					<p class="description">Retrieve a specific documentation document including its Markdown source</p>
 				</div>
 				<p class="description" style="margin-top: 1rem">
-					Hinweis: Die Indizes werden im Buildprozess erzeugt. Ein manuelles <code>refresh</code> ist in Deployments nicht verfügbar.
+					Note: The indices are generated during the build process. Manual <code>refresh</code> is not available in deployments.
 				</p>
+			</div>
+
+			<div class="api-info">
+				<h2>🔧 VS Code Integration</h2>
+				<p class="description">Use the KoliBri MCP Server with GitHub Copilot Chat in VS Code:</p>
+
+				<div style="margin-top: 1rem">
+					<h3 style="color: #2d3748; margin-bottom: 0.5rem; font-size: 1.1rem">Option 1: Local Installation</h3>
+					<div class="endpoint">npm install -g @public-ui/mcp</div>
+					<p class="description">Install the MCP package globally and create an <code>mcp.json</code>:</p>
+					<div class="endpoint" style="white-space: pre-wrap; font-size: 0.9rem">
+						{ "servers": { "kolibri-mcp": { "command": "npx", "args": ["@public-ui/mcp"] } }, "inputs": [] }
+					</div>
+
+					<h3 style="color: #2d3748; margin-bottom: 0.5rem; margin-top: 1.5rem; font-size: 1.1rem">Option 2: Remote Server (Recommended)</h3>
+					<p class="description">Use the hosted server without local installation in your <code>mcp.json</code>:</p>
+					<div class="endpoint" style="white-space: pre-wrap; font-size: 0.9rem">
+						{ "servers": { "kolibri-mcp": { "url": "https://public-ui-kolibri-mcp.vercel.app/mcp/", "type": "http" } }, "inputs": [] }
+					</div>
+					<div style="background: #fff3cd; padding: 1rem; border-radius: 6px; margin-top: 1rem; border-left: 4px solid #ffc107">
+						<strong style="color: #856404">⚡ Remote Advantage:</strong>
+						<span style="color: #856404"> No installation required, always up-to-date, faster setup!</span>
+					</div>
+
+					<h3 style="color: #2d3748; margin-bottom: 0.5rem; margin-top: 1.5rem; font-size: 1.1rem">Setup</h3>
+					<p class="description">Create an <code>mcp.json</code> file in your project directory or use the global configuration:</p>
+					<div class="endpoint" style="background: #1a202c; color: #90cdf4">
+						# Local file in project echo '{ "servers": { ... } }' > mcp.json # Or globally for all projects ~/.config/mcp/mcp.json
+					</div>
+					<p class="description">In GitHub Copilot Chat you can now write:</p>
+					<div class="endpoint" style="background: #2d3748; color: #90cdf4">
+						@kolibri show me a button example @kolibri how do I implement a KoliBri table? @kolibri create an accessible form
+					</div>
+
+					<div style="background: #e6fffa; padding: 1rem; border-radius: 6px; margin-top: 1rem; border-left: 4px solid #38a169">
+						<strong style="color: #2d3748">💡 Tip:</strong>
+						<span style="color: #2d3748">
+							The MCP Server gives you access to all 136+ KoliBri component examples and 18 documentation files directly in VS Code!</span
+						>
+					</div>
+				</div>
 			</div>
 
 			<div class="footer">

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -195,19 +195,28 @@
 					</div>
 					<p class="description">List of all available samples (optional filter with ?q=filter)</p>
 
-					<div>
-						<span class="method get">GET</span>
-						<code class="endpoint"><a href="/mcp/sample?id=button/basic" style="color: #90cdf4">/mcp/sample?id=button/basic</a></code>
-					</div>
-					<p class="description">Path and source code of a specific sample</p>
+                                        <div>
+                                                <span class="method get">GET</span>
+                                                <code class="endpoint"><a href="/mcp/sample?id=sample/button/basic" style="color: #90cdf4">/mcp/sample?id=sample/button/basic</a></code>
+                                        </div>
+                                        <p class="description">Path and source code of a specific sample</p>
 
-					<div>
-						<span class="method post">POST</span>
-						<code class="endpoint">/mcp/refresh</code>
-					</div>
-					<p class="description">Rebuild sample index (when files change)</p>
-				</div>
-			</div>
+                                        <div>
+                                                <span class="method get">GET</span>
+                                                <code class="endpoint"><a href="/mcp/concepts" style="color: #90cdf4">/mcp/concepts</a></code>
+                                        </div>
+                                        <p class="description">List of Markdown-based concept documents</p>
+
+                                        <div>
+                                                <span class="method get">GET</span>
+                                                <code class="endpoint"><a href="/mcp/concept?id=concept/README" style="color: #90cdf4">/mcp/concept?id=concept/README</a></code>
+                                        </div>
+                                        <p class="description">Retrieve a specific concept document including its Markdown source</p>
+                                </div>
+                                <p class="description" style="margin-top: 1rem">
+                                        Hinweis: Die Indizes werden im Buildprozess erzeugt. Ein manuelles <code>refresh</code> ist in Deployments nicht verfügbar.
+                                </p>
+                        </div>
 
 			<div class="footer">
 				<p>

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -62,6 +62,36 @@
 				margin-bottom: 2rem;
 			}
 
+			.stats {
+				display: grid;
+				grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+				gap: 1rem;
+				margin-top: 1.5rem;
+			}
+
+			.stat {
+				background: #edf2f7;
+				border-radius: 8px;
+				padding: 1rem;
+				text-align: center;
+				border: 1px solid #e2e8f0;
+			}
+
+			.stat-label {
+				display: block;
+				color: #4a5568;
+				font-size: 0.9rem;
+				margin-bottom: 0.5rem;
+				text-transform: uppercase;
+				letter-spacing: 0.08em;
+			}
+
+			.stat-value {
+				font-size: 1.75rem;
+				font-weight: 700;
+				color: #2d3748;
+			}
+
 			.api-info {
 				background: #f7fafc;
 				padding: 1.5rem;
@@ -136,6 +166,16 @@
 				<h1>KoliBri MCP-API</h1>
 				<p class="subtitle">Model Context Protocol Backend for KoliBri Examples</p>
 				<span class="status">🟢 Online</span>
+				<div class="stats" aria-live="polite">
+					<div class="stat">
+						<span class="stat-label">Samples</span>
+						<span class="stat-value" id="sample-count">–</span>
+					</div>
+					<div class="stat">
+						<span class="stat-label">Concepts</span>
+						<span class="stat-value" id="concept-count">–</span>
+					</div>
+				</div>
 			</div>
 
 			<div class="api-info">
@@ -186,20 +226,37 @@
 					console.log('API Status:', data);
 					const statusElement = document.querySelector('.status');
 
-					if (data.healthy && data.totalSamples > 0) {
-						statusElement.textContent = `🟢 Online (${data.totalSamples} Samples)`;
-						statusElement.style.background = '#38a169';
-					} else {
-						statusElement.textContent = '🟡 No samples found';
-						statusElement.style.background = '#d69e2e';
-					}
+                                        const sampleCount = typeof data.totalSamples === 'number' ? data.totalSamples : typeof data.total === 'number' ? data.total : 0;
+                                        const conceptCount = typeof data.totalConcepts === 'number' ? data.totalConcepts : typeof data.totalDocs === 'number' ? data.totalDocs : 0;
+                                        const sampleCountElement = document.getElementById('sample-count');
+                                        const conceptCountElement = document.getElementById('concept-count');
+
+                                        if (sampleCountElement && conceptCountElement) {
+                                                sampleCountElement.textContent = sampleCount.toLocaleString();
+                                                conceptCountElement.textContent = conceptCount.toLocaleString();
+                                        }
+
+                                        if (data.healthy && sampleCount > 0) {
+                                                const conceptText = conceptCount > 0 ? `, ${conceptCount.toLocaleString()} Concepts` : '';
+                                                statusElement.textContent = `🟢 Online (${sampleCount.toLocaleString()} Samples${conceptText})`;
+                                                statusElement.style.background = '#38a169';
+                                        } else {
+                                                statusElement.textContent = '🟡 No samples found';
+                                                statusElement.style.background = '#d69e2e';
+                                        }
 				})
 				.catch((error) => {
-					console.warn('API not reachable:', error);
-					const statusElement = document.querySelector('.status');
-					statusElement.textContent = '🔴 Offline';
-					statusElement.style.background = '#e53e3e';
-				});
-		</script>
+                                        console.warn('API not reachable:', error);
+                                        const statusElement = document.querySelector('.status');
+                                        statusElement.textContent = '🔴 Offline';
+                                        statusElement.style.background = '#e53e3e';
+                                        const sampleCountElement = document.getElementById('sample-count');
+                                        const conceptCountElement = document.getElementById('concept-count');
+                                        if (sampleCountElement && conceptCountElement) {
+                                                sampleCountElement.textContent = '–';
+                                                conceptCountElement.textContent = '–';
+                                        }
+                                });
+                </script>
 	</body>
 </html>

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -32,7 +32,7 @@ function normalizePathname(pathname) {
 	return pathname;
 }
 
-export async function handleApiRequest({ method = 'GET', url = '/', getIndex, refresh }) {
+export async function handleApiRequest({ method = 'GET', url = '/', getIndex } = {}) {
 	const baseHeaders = buildCorsHeaders();
 	const normalizedMethod = method.toUpperCase();
 	const requestUrl = new URL(url, 'http://localhost');
@@ -218,34 +218,14 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 	}
 
 	if (normalizedMethod === 'POST' && pathname === '/refresh') {
-		try {
-			const index = await refresh();
-			const counts = index.counts ?? {
-				total: index.entries.length,
-				totalSamples: index.entries.length,
-				totalConcepts: 0,
-				totalDocs: 0,
-			};
-			return {
-				statusCode: 200,
-				headers: baseHeaders,
-				body: withAiHints({
-					status: 'refreshed',
-					totalEntries: counts.total,
-					totalSamples: counts.totalSamples,
-					totalConcepts: counts.totalConcepts ?? counts.totalDocs ?? 0,
-					totalDocs: counts.totalDocs ?? counts.totalConcepts ?? 0,
-					generatedAt: index.generatedAt.toISOString(),
-				}),
-			};
-		} catch (error) {
-			console.error('[mcp] refresh failed', error);
-			return {
-				statusCode: 500,
-				headers: baseHeaders,
-				body: withAiHints({ error: 'refresh_failed' }),
-			};
-		}
+		return {
+			statusCode: 410,
+			headers: baseHeaders,
+			body: withAiHints({
+				error: 'refresh_unavailable',
+				message: 'Die Re-Indexierung ist in bereitgestellten Umgebungen deaktiviert, da die Inhalte bereits vorab eingebettet werden.',
+			}),
+		};
 	}
 
 	return {

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -111,7 +111,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 			headers: baseHeaders,
 			body: withAiHints({
 				message: 'KoliBri MCP backend is running.',
-				endpoints: ['/health', '/samples', '/sample?id=sample/<component>/<sample>', '/concepts', '/concept?id=concept/<identifier>'],
+				endpoints: ['/health', '/samples', '/sample?id=sample/<component>/<sample>', '/docs', '/doc?id=doc/<identifier>'],
 				totalEntries: counts.total,
 				totalSamples: counts.totalSamples,
 				totalConcepts: counts.totalConcepts,
@@ -224,7 +224,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		};
 	}
 
-	if (normalizedMethod === 'GET' && pathname === '/concepts') {
+	if (normalizedMethod === 'GET' && pathname === '/docs') {
 		const index = await getIndex();
 		const query = requestUrl.searchParams.get('q') ?? '';
 		const items = index.list(query, { kinds: ['concept', 'doc'] }).map((entry) => ({
@@ -232,7 +232,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 			id: entry.id,
 			name: entry.name,
 			path: entry.path,
-			kind: entry.kind ?? 'concept',
+			kind: entry.kind ?? 'doc',
 		}));
 		const counts = resolveCounts(index);
 		return {
@@ -242,7 +242,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				items,
 				query,
 				total: items.length,
-				totalEntries: counts.totalConcepts,
+				totalEntries: counts.totalDocs,
 				totalConcepts: counts.totalConcepts,
 				totalDocs: counts.totalDocs,
 				generatedAt: index.generatedAt.toISOString(),
@@ -250,7 +250,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		};
 	}
 
-	if (normalizedMethod === 'GET' && pathname === '/concept') {
+	if (normalizedMethod === 'GET' && pathname === '/doc') {
 		const index = await getIndex();
 		const id = requestUrl.searchParams.get('id');
 		if (!id) {
@@ -279,7 +279,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				name: entry.name,
 				path: entry.path,
 				code: entry.code,
-				kind: entry.kind ?? 'concept',
+				kind: entry.kind ?? 'doc',
 			}),
 		};
 	}

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -47,11 +47,17 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 
 	if (normalizedMethod === 'GET' && pathname === '/health') {
 		const index = await getIndex();
-		const sampleCount = index.entries.length;
-		const isHealthy = sampleCount > 0;
+		const counts = index.counts ?? {
+			total: index.entries.length,
+			totalSamples: index.entries.length,
+			totalDocs: 0,
+		};
+		const isHealthy = counts.total > 0;
 
 		// Debug information for Vercel
-		console.log('[health] Sample count:', sampleCount);
+		console.log('[health] Total entries:', counts.total);
+		console.log('[health] Sample entries:', counts.totalSamples);
+		console.log('[health] Markdown entries:', counts.totalDocs);
 		console.log('[health] Index generated at:', index.generatedAt);
 		console.log('[health] Is healthy:', isHealthy);
 
@@ -61,8 +67,10 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			body: {
 				status: isHealthy ? 'ok' : 'error',
 				healthy: isHealthy,
-				totalSamples: sampleCount,
-				message: isHealthy ? `System healthy with ${sampleCount} samples available` : 'No samples found - system may not be properly initialized',
+				totalEntries: counts.total,
+				totalSamples: counts.totalSamples,
+				totalDocs: counts.totalDocs,
+				message: isHealthy ? `System healthy with ${counts.total} entries available` : 'No entries found - system may not be properly initialized',
 				generatedAt: index.generatedAt.toISOString(),
 				debug: {
 					indexGeneratedAt: index.generatedAt.toISOString(),
@@ -80,6 +88,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			id: entry.id,
 			name: entry.name,
 			path: entry.path,
+			kind: entry.kind ?? 'sample',
 		}));
 		return {
 			statusCode: 200,
@@ -88,6 +97,9 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 				items,
 				query,
 				total: items.length,
+				totalEntries: index.counts?.total ?? index.entries.length,
+				totalSamples: index.counts?.totalSamples ?? index.entries.length,
+				totalDocs: index.counts?.totalDocs ?? 0,
 				generatedAt: index.generatedAt.toISOString(),
 			},
 		};
@@ -122,6 +134,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 				name: entry.name,
 				path: entry.path,
 				code: entry.code,
+				kind: entry.kind ?? 'sample',
 			},
 		};
 	}
@@ -129,12 +142,19 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 	if (normalizedMethod === 'POST' && pathname === '/refresh') {
 		try {
 			const index = await refresh();
+			const counts = index.counts ?? {
+				total: index.entries.length,
+				totalSamples: index.entries.length,
+				totalDocs: 0,
+			};
 			return {
 				statusCode: 200,
 				headers: baseHeaders,
 				body: {
 					status: 'refreshed',
-					totalSamples: index.entries.length,
+					totalEntries: counts.total,
+					totalSamples: counts.totalSamples,
+					totalDocs: counts.totalDocs,
 					generatedAt: index.generatedAt.toISOString(),
 				},
 			};

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -40,7 +40,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			headers: baseHeaders,
 			body: {
 				message: 'KoliBri MCP backend is running.',
-				endpoints: ['/health', '/samples', '/sample?id=<component/sample>'],
+				endpoints: ['/health', '/samples', '/sample?id=<component/sample>', '/concepts', '/concept?id=<concept/identifier>'],
 			},
 		};
 	}
@@ -50,6 +50,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 		const counts = index.counts ?? {
 			total: index.entries.length,
 			totalSamples: index.entries.length,
+			totalConcepts: 0,
 			totalDocs: 0,
 		};
 		const isHealthy = counts.total > 0;
@@ -57,7 +58,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 		// Debug information for Vercel
 		console.log('[health] Total entries:', counts.total);
 		console.log('[health] Sample entries:', counts.totalSamples);
-		console.log('[health] Markdown entries:', counts.totalDocs);
+		console.log('[health] Concept entries:', counts.totalConcepts ?? counts.totalDocs);
 		console.log('[health] Index generated at:', index.generatedAt);
 		console.log('[health] Is healthy:', isHealthy);
 
@@ -69,7 +70,8 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 				healthy: isHealthy,
 				totalEntries: counts.total,
 				totalSamples: counts.totalSamples,
-				totalDocs: counts.totalDocs,
+				totalConcepts: counts.totalConcepts ?? counts.totalDocs ?? 0,
+				totalDocs: counts.totalDocs ?? counts.totalConcepts ?? 0,
 				message: isHealthy ? `System healthy with ${counts.total} entries available` : 'No entries found - system may not be properly initialized',
 				generatedAt: index.generatedAt.toISOString(),
 				debug: {
@@ -83,7 +85,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 	if (normalizedMethod === 'GET' && pathname === '/samples') {
 		const index = await getIndex();
 		const query = requestUrl.searchParams.get('q') ?? '';
-		const items = index.list(query).map((entry) => ({
+		const items = index.list(query, { kinds: ['sample'] }).map((entry) => ({
 			group: entry.group,
 			id: entry.id,
 			name: entry.name,
@@ -99,7 +101,8 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 				total: items.length,
 				totalEntries: index.counts?.total ?? index.entries.length,
 				totalSamples: index.counts?.totalSamples ?? index.entries.length,
-				totalDocs: index.counts?.totalDocs ?? 0,
+				totalConcepts: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? 0,
+				totalDocs: index.counts?.totalDocs ?? index.counts?.totalConcepts ?? 0,
 				generatedAt: index.generatedAt.toISOString(),
 			},
 		};
@@ -125,6 +128,14 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			};
 		}
 
+		if ((entry.kind ?? 'sample') !== 'sample') {
+			return {
+				statusCode: 400,
+				headers: baseHeaders,
+				body: { error: 'invalid_kind', expected: 'sample', actual: entry.kind ?? 'sample', id },
+			};
+		}
+
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
@@ -139,12 +150,72 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 		};
 	}
 
+	if (normalizedMethod === 'GET' && pathname === '/concepts') {
+		const index = await getIndex();
+		const query = requestUrl.searchParams.get('q') ?? '';
+		const items = index.list(query, { kinds: ['concept', 'doc'] }).map((entry) => ({
+			group: entry.group,
+			id: entry.id,
+			name: entry.name,
+			path: entry.path,
+			kind: entry.kind ?? 'concept',
+		}));
+		return {
+			statusCode: 200,
+			headers: baseHeaders,
+			body: {
+				items,
+				query,
+				total: items.length,
+				totalEntries: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? items.length,
+				totalConcepts: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? items.length,
+				totalDocs: index.counts?.totalDocs ?? index.counts?.totalConcepts ?? items.length,
+				generatedAt: index.generatedAt.toISOString(),
+			},
+		};
+	}
+
+	if (normalizedMethod === 'GET' && pathname === '/concept') {
+		const index = await getIndex();
+		const id = requestUrl.searchParams.get('id');
+		if (!id) {
+			return {
+				statusCode: 400,
+				headers: baseHeaders,
+				body: { error: 'missing_id' },
+			};
+		}
+
+		const entry = index.get(id);
+		if (!entry || !['concept', 'doc'].includes(entry.kind ?? 'sample')) {
+			return {
+				statusCode: 404,
+				headers: baseHeaders,
+				body: { error: 'not_found', id },
+			};
+		}
+
+		return {
+			statusCode: 200,
+			headers: baseHeaders,
+			body: {
+				id: entry.id,
+				group: entry.group,
+				name: entry.name,
+				path: entry.path,
+				code: entry.code,
+				kind: entry.kind ?? 'concept',
+			},
+		};
+	}
+
 	if (normalizedMethod === 'POST' && pathname === '/refresh') {
 		try {
 			const index = await refresh();
 			const counts = index.counts ?? {
 				total: index.entries.length,
 				totalSamples: index.entries.length,
+				totalConcepts: 0,
 				totalDocs: 0,
 			};
 			return {
@@ -154,7 +225,8 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 					status: 'refreshed',
 					totalEntries: counts.total,
 					totalSamples: counts.totalSamples,
-					totalDocs: counts.totalDocs,
+					totalConcepts: counts.totalConcepts ?? counts.totalDocs ?? 0,
+					totalDocs: counts.totalDocs ?? counts.totalConcepts ?? 0,
 					generatedAt: index.generatedAt.toISOString(),
 				},
 			};

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -8,6 +8,14 @@ function buildCorsHeaders() {
 	};
 }
 
+export const AI_HINTS_KEY = 'ai-hints';
+export const AI_HINTS_MESSAGE =
+	'KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit.';
+
+function withAiHints(body = {}) {
+	return { ...body, [AI_HINTS_KEY]: AI_HINTS_MESSAGE };
+}
+
 function normalizePathname(pathname) {
 	if (pathname === '/') {
 		return pathname;
@@ -38,10 +46,10 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
-			body: {
+			body: withAiHints({
 				message: 'KoliBri MCP backend is running.',
-				endpoints: ['/health', '/samples', '/sample?id=<component/sample>', '/concepts', '/concept?id=<concept/identifier>'],
-			},
+				endpoints: ['/health', '/samples', '/sample?id=sample/<component>/<sample>', '/concepts', '/concept?id=concept/<identifier>'],
+			}),
 		};
 	}
 
@@ -65,7 +73,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 		return {
 			statusCode: isHealthy ? 200 : 503,
 			headers: baseHeaders,
-			body: {
+			body: withAiHints({
 				status: isHealthy ? 'ok' : 'error',
 				healthy: isHealthy,
 				totalEntries: counts.total,
@@ -79,7 +87,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 					entriesLength: index.entries.length,
 					firstFewEntries: index.entries.slice(0, 3).map((e) => e.id),
 				},
-			},
+			}),
 		};
 	}
 	if (normalizedMethod === 'GET' && pathname === '/samples') {
@@ -95,7 +103,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
-			body: {
+			body: withAiHints({
 				items,
 				query,
 				total: items.length,
@@ -104,7 +112,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 				totalConcepts: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? 0,
 				totalDocs: index.counts?.totalDocs ?? index.counts?.totalConcepts ?? 0,
 				generatedAt: index.generatedAt.toISOString(),
-			},
+			}),
 		};
 	}
 
@@ -115,7 +123,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			return {
 				statusCode: 400,
 				headers: baseHeaders,
-				body: { error: 'missing_id' },
+				body: withAiHints({ error: 'missing_id' }),
 			};
 		}
 
@@ -124,7 +132,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			return {
 				statusCode: 404,
 				headers: baseHeaders,
-				body: { error: 'not_found', id },
+				body: withAiHints({ error: 'not_found', id }),
 			};
 		}
 
@@ -132,21 +140,21 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			return {
 				statusCode: 400,
 				headers: baseHeaders,
-				body: { error: 'invalid_kind', expected: 'sample', actual: entry.kind ?? 'sample', id },
+				body: withAiHints({ error: 'invalid_kind', expected: 'sample', actual: entry.kind ?? 'sample', id }),
 			};
 		}
 
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
-			body: {
+			body: withAiHints({
 				id: entry.id,
 				group: entry.group,
 				name: entry.name,
 				path: entry.path,
 				code: entry.code,
 				kind: entry.kind ?? 'sample',
-			},
+			}),
 		};
 	}
 
@@ -163,7 +171,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
-			body: {
+			body: withAiHints({
 				items,
 				query,
 				total: items.length,
@@ -171,7 +179,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 				totalConcepts: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? items.length,
 				totalDocs: index.counts?.totalDocs ?? index.counts?.totalConcepts ?? items.length,
 				generatedAt: index.generatedAt.toISOString(),
-			},
+			}),
 		};
 	}
 
@@ -182,7 +190,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			return {
 				statusCode: 400,
 				headers: baseHeaders,
-				body: { error: 'missing_id' },
+				body: withAiHints({ error: 'missing_id' }),
 			};
 		}
 
@@ -191,21 +199,21 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			return {
 				statusCode: 404,
 				headers: baseHeaders,
-				body: { error: 'not_found', id },
+				body: withAiHints({ error: 'not_found', id }),
 			};
 		}
 
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
-			body: {
+			body: withAiHints({
 				id: entry.id,
 				group: entry.group,
 				name: entry.name,
 				path: entry.path,
 				code: entry.code,
 				kind: entry.kind ?? 'concept',
-			},
+			}),
 		};
 	}
 
@@ -221,21 +229,21 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 			return {
 				statusCode: 200,
 				headers: baseHeaders,
-				body: {
+				body: withAiHints({
 					status: 'refreshed',
 					totalEntries: counts.total,
 					totalSamples: counts.totalSamples,
 					totalConcepts: counts.totalConcepts ?? counts.totalDocs ?? 0,
 					totalDocs: counts.totalDocs ?? counts.totalConcepts ?? 0,
 					generatedAt: index.generatedAt.toISOString(),
-				},
+				}),
 			};
 		} catch (error) {
 			console.error('[mcp] refresh failed', error);
 			return {
 				statusCode: 500,
 				headers: baseHeaders,
-				body: { error: 'refresh_failed' },
+				body: withAiHints({ error: 'refresh_failed' }),
 			};
 		}
 	}
@@ -243,6 +251,6 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex, re
 	return {
 		statusCode: 404,
 		headers: baseHeaders,
-		body: { error: 'not_found' },
+		body: withAiHints({ error: 'not_found' }),
 	};
 }

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -9,11 +9,64 @@ function buildCorsHeaders() {
 }
 
 export const AI_HINTS_KEY = 'ai-hints';
-export const AI_HINTS_MESSAGE =
-	'KoliBri Web Components müssen im Browser registriert werden; abhängig vom Projekt-Setup stehen unterschiedliche Integrationswege bereit.';
+export const AI_HINTS_MESSAGES = Object.freeze([
+	'Always register KoliBri Web Components in the browser runtime before rendering them.',
+	'Choose the integration guide that matches your project setup to load and bundle the components correctly.',
+]);
+
+function normalizeHints(value) {
+	if (Array.isArray(value)) {
+		return value.length > 0 ? value : AI_HINTS_MESSAGES;
+	}
+
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		return trimmed ? [trimmed] : AI_HINTS_MESSAGES;
+	}
+
+	return AI_HINTS_MESSAGES;
+}
 
 function withAiHints(body = {}) {
-	return { ...body, [AI_HINTS_KEY]: AI_HINTS_MESSAGE };
+	const normalizedHints = normalizeHints(body[AI_HINTS_KEY]);
+	return { ...body, [AI_HINTS_KEY]: normalizedHints };
+}
+
+function computeCountsFromEntries(entries = []) {
+	return entries.reduce(
+		(acc, entry) => {
+			const kind = entry?.kind ?? 'sample';
+			acc.total += 1;
+			if (kind === 'sample') {
+				acc.totalSamples += 1;
+				return acc;
+			}
+
+			if (kind === 'concept' || kind === 'doc') {
+				acc.totalConcepts += 1;
+				acc.totalDocs += 1;
+			}
+
+			return acc;
+		},
+		{ total: 0, totalSamples: 0, totalConcepts: 0, totalDocs: 0 },
+	);
+}
+
+function resolveCounts(index) {
+	if (!index) {
+		return computeCountsFromEntries();
+	}
+
+	const fallbackCounts = computeCountsFromEntries(index.entries ?? []);
+	const source = index.counts ?? {};
+
+	return {
+		total: typeof source.total === 'number' ? source.total : fallbackCounts.total,
+		totalSamples: typeof source.totalSamples === 'number' ? source.totalSamples : fallbackCounts.totalSamples,
+		totalConcepts: typeof source.totalConcepts === 'number' ? source.totalConcepts : fallbackCounts.totalConcepts,
+		totalDocs: typeof source.totalDocs === 'number' ? source.totalDocs : fallbackCounts.totalDocs,
+	};
 }
 
 function normalizePathname(pathname) {
@@ -43,30 +96,41 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 	}
 
 	if (normalizedMethod === 'GET' && pathname === '/') {
+		let index;
+		try {
+			index = await getIndex();
+		} catch (error) {
+			console.warn('[root] Unable to load index for overview response:', error);
+		}
+
+		const counts = resolveCounts(index);
+		const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt : undefined;
+
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
 			body: withAiHints({
 				message: 'KoliBri MCP backend is running.',
 				endpoints: ['/health', '/samples', '/sample?id=sample/<component>/<sample>', '/concepts', '/concept?id=concept/<identifier>'],
+				totalEntries: counts.total,
+				totalSamples: counts.totalSamples,
+				totalConcepts: counts.totalConcepts,
+				totalDocs: counts.totalDocs,
+				generatedAt: (generatedAt ?? new Date()).toISOString(),
+				buildMode: index?.buildMode ?? 'runtime',
 			}),
 		};
 	}
 
 	if (normalizedMethod === 'GET' && pathname === '/health') {
 		const index = await getIndex();
-		const counts = index.counts ?? {
-			total: index.entries.length,
-			totalSamples: index.entries.length,
-			totalConcepts: 0,
-			totalDocs: 0,
-		};
+		const counts = resolveCounts(index);
 		const isHealthy = counts.total > 0;
 
 		// Debug information for Vercel
 		console.log('[health] Total entries:', counts.total);
 		console.log('[health] Sample entries:', counts.totalSamples);
-		console.log('[health] Concept entries:', counts.totalConcepts ?? counts.totalDocs);
+		console.log('[health] Concept entries:', counts.totalConcepts);
 		console.log('[health] Index generated at:', index.generatedAt);
 		console.log('[health] Is healthy:', isHealthy);
 
@@ -78,8 +142,8 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				healthy: isHealthy,
 				totalEntries: counts.total,
 				totalSamples: counts.totalSamples,
-				totalConcepts: counts.totalConcepts ?? counts.totalDocs ?? 0,
-				totalDocs: counts.totalDocs ?? counts.totalConcepts ?? 0,
+				totalConcepts: counts.totalConcepts,
+				totalDocs: counts.totalDocs,
 				message: isHealthy ? `System healthy with ${counts.total} entries available` : 'No entries found - system may not be properly initialized',
 				generatedAt: index.generatedAt.toISOString(),
 				debug: {
@@ -90,6 +154,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 			}),
 		};
 	}
+
 	if (normalizedMethod === 'GET' && pathname === '/samples') {
 		const index = await getIndex();
 		const query = requestUrl.searchParams.get('q') ?? '';
@@ -100,6 +165,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 			path: entry.path,
 			kind: entry.kind ?? 'sample',
 		}));
+		const counts = resolveCounts(index);
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
@@ -107,10 +173,10 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				items,
 				query,
 				total: items.length,
-				totalEntries: index.counts?.total ?? index.entries.length,
-				totalSamples: index.counts?.totalSamples ?? index.entries.length,
-				totalConcepts: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? 0,
-				totalDocs: index.counts?.totalDocs ?? index.counts?.totalConcepts ?? 0,
+				totalEntries: counts.total,
+				totalSamples: counts.totalSamples,
+				totalConcepts: counts.totalConcepts,
+				totalDocs: counts.totalDocs,
 				generatedAt: index.generatedAt.toISOString(),
 			}),
 		};
@@ -168,6 +234,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 			path: entry.path,
 			kind: entry.kind ?? 'concept',
 		}));
+		const counts = resolveCounts(index);
 		return {
 			statusCode: 200,
 			headers: baseHeaders,
@@ -175,9 +242,9 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				items,
 				query,
 				total: items.length,
-				totalEntries: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? items.length,
-				totalConcepts: index.counts?.totalConcepts ?? index.counts?.totalDocs ?? items.length,
-				totalDocs: index.counts?.totalDocs ?? index.counts?.totalConcepts ?? items.length,
+				totalEntries: counts.totalConcepts,
+				totalConcepts: counts.totalConcepts,
+				totalDocs: counts.totalDocs,
 				generatedAt: index.generatedAt.toISOString(),
 			}),
 		};

--- a/packages/tools/mcp/src/cli.js
+++ b/packages/tools/mcp/src/cli.js
@@ -26,8 +26,8 @@ server.listen(PORT, () => {
 	console.log(`   GET  /mcp/health   - Server status`);
 	console.log(`   GET  /mcp/samples  - List all samples`);
 	console.log(`   GET  /mcp/sample   - Get specific sample`);
-	console.log(`   GET  /mcp/concepts - List concept docs`);
-	console.log(`   GET  /mcp/concept  - Get specific concept`);
+	console.log(`   GET  /mcp/docs - List docs`);
+	console.log(`   GET  /mcp/doc  - Get specific doc`);
 	console.log(`📚 Documentation: https://www.npmjs.com/package/@public-ui/mcp`);
 });
 

--- a/packages/tools/mcp/src/cli.js
+++ b/packages/tools/mcp/src/cli.js
@@ -26,7 +26,8 @@ server.listen(PORT, () => {
 	console.log(`   GET  /mcp/health   - Server status`);
 	console.log(`   GET  /mcp/samples  - List all samples`);
 	console.log(`   GET  /mcp/sample   - Get specific sample`);
-	console.log(`   POST /mcp/refresh  - Refresh index`);
+	console.log(`   GET  /mcp/concepts - List concept docs`);
+	console.log(`   GET  /mcp/concept  - Get specific concept`);
 	console.log(`📚 Documentation: https://www.npmjs.com/package/@public-ui/mcp`);
 });
 

--- a/packages/tools/mcp/src/index.js
+++ b/packages/tools/mcp/src/index.js
@@ -1,7 +1,7 @@
 import { startServer } from './server.js';
 
 // Export functions for Vercel API
-export { handleApiRequest } from './api-handler.js';
+export { handleApiRequest, AI_HINTS_KEY, AI_HINTS_MESSAGE } from './api-handler.js';
 export { buildSampleIndex } from './sample-index.js';
 
 // Only start server when executed directly

--- a/packages/tools/mcp/src/index.js
+++ b/packages/tools/mcp/src/index.js
@@ -1,7 +1,7 @@
 import { startServer } from './server.js';
 
 // Export functions for Vercel API
-export { handleApiRequest, AI_HINTS_KEY, AI_HINTS_MESSAGE } from './api-handler.js';
+export { handleApiRequest, AI_HINTS_KEY, AI_HINTS_MESSAGES } from './api-handler.js';
 export { buildSampleIndex } from './sample-index.js';
 
 // Only start server when executed directly

--- a/packages/tools/mcp/src/sample-index-runtime.js
+++ b/packages/tools/mcp/src/sample-index-runtime.js
@@ -54,12 +54,43 @@ function computeCounts(entries) {
 	);
 }
 
+function normalizeEntryId(entry) {
+	const kind = entry.kind ?? 'sample';
+	const isConcept = kind === 'concept' || kind === 'doc';
+	const expectedPrefix = isConcept ? 'concept' : 'sample';
+	if (typeof entry.id === 'string' && entry.id.startsWith(`${expectedPrefix}/`)) {
+		return entry;
+	}
+
+	const segments = [];
+	if (entry.group) {
+		const groupSegments = entry.group.split('/').filter(Boolean);
+		if (isConcept && groupSegments[0] === 'concepts') {
+			groupSegments.shift();
+		}
+		segments.push(...groupSegments);
+	}
+
+	if (entry.name) {
+		segments.push(entry.name);
+	} else if (entry.id) {
+		segments.push(...String(entry.id).split('/').filter(Boolean));
+	}
+
+	const normalized = {
+		...entry,
+		id: [expectedPrefix, ...segments.filter(Boolean)].join('/'),
+	};
+	return normalized;
+}
+
 class SampleIndex {
 	constructor(entries) {
-		this.entries = entries;
-		this.map = new Map(entries.map((entry) => [entry.id, entry]));
+		const normalizedEntries = entries.map((entry) => normalizeEntryId(entry));
+		this.entries = normalizedEntries;
+		this.map = new Map(normalizedEntries.map((entry) => [entry.id, entry]));
 		this.generatedAt = new Date();
-		const counts = computeCounts(entries);
+		const counts = computeCounts(normalizedEntries);
 		this.counts = {
 			total: counts.total,
 			byKind: counts.byKind,
@@ -146,8 +177,9 @@ export async function buildSampleIndex() {
 				}
 
 				const code = await readFile(absolutePath, 'utf8');
+				const sampleIdSegments = ['sample', group, name].filter(Boolean);
 				entries.push({
-					id: `${group}/${name}`,
+					id: sampleIdSegments.join('/'),
 					group,
 					name,
 					path: path.relative(REPO_ROOT, absolutePath),
@@ -312,9 +344,19 @@ async function collectMarkdownFromDirectory(directory, { groupPrefix, recursive,
 		const segments = withoutExtension.split('/').filter(Boolean);
 		const name = segments.pop() ?? withoutExtension;
 		const group = segments.length ? `${groupPrefix}/${segments.join('/')}` : groupPrefix;
+		const conceptIdSegments = ['concept'];
+		if (group.startsWith(`${groupPrefix}/`)) {
+			const relativeGroup = group.slice(groupPrefix.length + 1);
+			if (relativeGroup) {
+				conceptIdSegments.push(...relativeGroup.split('/'));
+			}
+		} else if (group !== groupPrefix) {
+			conceptIdSegments.push(...group.split('/'));
+		}
+		conceptIdSegments.push(name);
 
 		entries.push({
-			id: `${group}/${name}`,
+			id: conceptIdSegments.join('/'),
 			group,
 			name,
 			path: normalizedRepoPath,

--- a/packages/tools/mcp/src/sample-index-runtime.js
+++ b/packages/tools/mcp/src/sample-index-runtime.js
@@ -38,8 +38,8 @@ const SCENARIOS_DIR = path.join(SAMPLE_ROOT, 'scenarios');
 const DOCS_DIR = path.join(REPO_ROOT, 'docs');
 
 const MARKDOWN_SOURCES = [
-	{ directory: DOCS_DIR, groupPrefix: 'concepts', recursive: true },
-	{ directory: REPO_ROOT, groupPrefix: 'concepts', recursive: false },
+	{ directory: DOCS_DIR, groupPrefix: 'docs', recursive: true },
+	{ directory: REPO_ROOT, groupPrefix: 'docs', recursive: false },
 ];
 
 function computeCounts(entries) {
@@ -57,7 +57,7 @@ function computeCounts(entries) {
 function normalizeEntryId(entry) {
 	const kind = entry.kind ?? 'sample';
 	const isConcept = kind === 'concept' || kind === 'doc';
-	const expectedPrefix = isConcept ? 'concept' : 'sample';
+	const expectedPrefix = isConcept ? 'doc' : 'sample';
 	if (typeof entry.id === 'string' && entry.id.startsWith(`${expectedPrefix}/`)) {
 		return entry;
 	}
@@ -65,7 +65,7 @@ function normalizeEntryId(entry) {
 	const segments = [];
 	if (entry.group) {
 		const groupSegments = entry.group.split('/').filter(Boolean);
-		if (isConcept && groupSegments[0] === 'concepts') {
+		if (isConcept && groupSegments[0] === 'docs') {
 			groupSegments.shift();
 		}
 		segments.push(...groupSegments);

--- a/packages/tools/mcp/src/sample-index-runtime.js
+++ b/packages/tools/mcp/src/sample-index-runtime.js
@@ -38,8 +38,8 @@ const SCENARIOS_DIR = path.join(SAMPLE_ROOT, 'scenarios');
 const DOCS_DIR = path.join(REPO_ROOT, 'docs');
 
 const MARKDOWN_SOURCES = [
-	{ directory: DOCS_DIR, groupPrefix: 'docs', recursive: true },
-	{ directory: REPO_ROOT, groupPrefix: 'docs', recursive: false },
+	{ directory: DOCS_DIR, groupPrefix: 'concepts', recursive: true },
+	{ directory: REPO_ROOT, groupPrefix: 'concepts', recursive: false },
 ];
 
 function computeCounts(entries) {
@@ -64,17 +64,23 @@ class SampleIndex {
 			total: counts.total,
 			byKind: counts.byKind,
 			totalSamples: counts.byKind.get('sample') ?? counts.total,
-			totalDocs: counts.byKind.get('doc') ?? 0,
+			totalConcepts: counts.byKind.get('concept') ?? counts.byKind.get('doc') ?? 0,
+			totalDocs: counts.byKind.get('doc') ?? counts.byKind.get('concept') ?? 0,
 		};
 	}
 
-	list(query) {
+	list(query, options = {}) {
+		const kinds = options.kinds ? new Set(options.kinds) : undefined;
+		const normalizeKind = (entry) => entry.kind ?? 'sample';
+
+		let results = kinds ? this.entries.filter((entry) => kinds.has(normalizeKind(entry))) : this.entries;
+
 		if (!query) {
-			return this.entries;
+			return results;
 		}
 
 		const normalized = query.trim().toLowerCase();
-		return this.entries.filter(
+		return results.filter(
 			(entry) => entry.id.toLowerCase().includes(normalized) || entry.group.toLowerCase().includes(normalized) || entry.name.toLowerCase().includes(normalized),
 		);
 	}
@@ -314,7 +320,7 @@ async function collectMarkdownFromDirectory(directory, { groupPrefix, recursive,
 			path: normalizedRepoPath,
 			absolutePath,
 			code,
-			kind: 'doc',
+			kind: 'concept',
 		});
 	}
 

--- a/packages/tools/mcp/src/sample-index-runtime.js
+++ b/packages/tools/mcp/src/sample-index-runtime.js
@@ -30,15 +30,42 @@ const REPO_ROOT = findRepoRoot();
 const SAMPLE_ROOT = path.join(REPO_ROOT, 'packages/samples/react/src');
 const ROUTE_FILENAMES = ['routes.ts', 'routes.tsx'];
 const SAMPLE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
+const MARKDOWN_EXTENSIONS = ['.md', '.mdx'];
+const IGNORED_DIRECTORIES = new Set(['.git', '.github', '.nx', '.turbo', '.vercel', 'dist', 'build', 'node_modules']);
 
 const COMPONENTS_DIR = path.join(SAMPLE_ROOT, 'components');
 const SCENARIOS_DIR = path.join(SAMPLE_ROOT, 'scenarios');
+const DOCS_DIR = path.join(REPO_ROOT, 'docs');
+
+const MARKDOWN_SOURCES = [
+	{ directory: DOCS_DIR, groupPrefix: 'docs', recursive: true },
+	{ directory: REPO_ROOT, groupPrefix: 'docs', recursive: false },
+];
+
+function computeCounts(entries) {
+	return entries.reduce(
+		(acc, entry) => {
+			const kind = entry.kind ?? 'sample';
+			acc.total += 1;
+			acc.byKind.set(kind, (acc.byKind.get(kind) ?? 0) + 1);
+			return acc;
+		},
+		{ total: 0, byKind: new Map() },
+	);
+}
 
 class SampleIndex {
 	constructor(entries) {
 		this.entries = entries;
 		this.map = new Map(entries.map((entry) => [entry.id, entry]));
 		this.generatedAt = new Date();
+		const counts = computeCounts(entries);
+		this.counts = {
+			total: counts.total,
+			byKind: counts.byKind,
+			totalSamples: counts.byKind.get('sample') ?? counts.total,
+			totalDocs: counts.byKind.get('doc') ?? 0,
+		};
 	}
 
 	list(query) {
@@ -120,13 +147,20 @@ export async function buildSampleIndex() {
 					path: path.relative(REPO_ROOT, absolutePath),
 					absolutePath,
 					code,
+					kind: 'sample',
 				});
 			}
 		}
 	}
 
+	const markdownEntries = await collectMarkdownEntries();
+	entries.push(...markdownEntries);
+
 	entries.sort((a, b) => a.id.localeCompare(b.id));
 	console.log('[buildSampleIndex] Total entries found:', entries.length);
+	if (markdownEntries.length > 0) {
+		console.log('[buildSampleIndex] Markdown entries added:', markdownEntries.length);
+	}
 
 	return new SampleIndex(entries);
 }
@@ -153,6 +187,14 @@ async function safeReadDir(dir) {
 	try {
 		const entries = await readdir(dir, { withFileTypes: true });
 		return entries.filter((entry) => entry.isDirectory());
+	} catch {
+		return [];
+	}
+}
+
+async function readDirEntries(dir) {
+	try {
+		return await readdir(dir, { withFileTypes: true });
 	} catch {
 		return [];
 	}
@@ -203,6 +245,80 @@ async function parseRouteFile(filePath) {
 	const fnBody = `${importDeclarations.join('\n')}\nreturn ${content};`;
 	const routes = new Function(fnBody)();
 	return routes && typeof routes === 'object' ? routes : {};
+}
+
+async function collectMarkdownEntries() {
+	const entries = [];
+
+	for (const source of MARKDOWN_SOURCES) {
+		if (!(await pathExists(source.directory))) {
+			continue;
+		}
+
+		const sourceEntries = await collectMarkdownFromDirectory(source.directory, {
+			groupPrefix: source.groupPrefix,
+			recursive: source.recursive,
+			relativeRoot: source.directory,
+		});
+
+		entries.push(...sourceEntries);
+	}
+
+	return entries;
+}
+
+async function collectMarkdownFromDirectory(directory, { groupPrefix, recursive, relativeRoot }) {
+	const entries = [];
+	const dirents = await readDirEntries(directory);
+
+	for (const dirent of dirents) {
+		const absolutePath = path.join(directory, dirent.name);
+
+		if (dirent.isDirectory()) {
+			if (!recursive || IGNORED_DIRECTORIES.has(dirent.name)) {
+				continue;
+			}
+
+			const nestedEntries = await collectMarkdownFromDirectory(absolutePath, {
+				groupPrefix,
+				recursive: true,
+				relativeRoot,
+			});
+
+			entries.push(...nestedEntries);
+			continue;
+		}
+
+		if (!dirent.isFile()) {
+			continue;
+		}
+
+		const extension = path.extname(dirent.name).toLowerCase();
+		if (!MARKDOWN_EXTENSIONS.includes(extension)) {
+			continue;
+		}
+
+		const code = await readFile(absolutePath, 'utf8');
+		const repoRelativePath = path.relative(REPO_ROOT, absolutePath);
+		const normalizedRepoPath = repoRelativePath.split(path.sep).join('/');
+		const relativePath = path.relative(relativeRoot, absolutePath).split(path.sep).join('/');
+		const withoutExtension = relativePath.replace(/\.[^.]+$/, '');
+		const segments = withoutExtension.split('/').filter(Boolean);
+		const name = segments.pop() ?? withoutExtension;
+		const group = segments.length ? `${groupPrefix}/${segments.join('/')}` : groupPrefix;
+
+		entries.push({
+			id: `${group}/${name}`,
+			group,
+			name,
+			path: normalizedRepoPath,
+			absolutePath,
+			code,
+			kind: 'doc',
+		});
+	}
+
+	return entries;
 }
 
 async function resolveSamplePath(baseDir, relativeImport) {

--- a/packages/tools/mcp/src/sample-index.js
+++ b/packages/tools/mcp/src/sample-index.js
@@ -27,17 +27,22 @@ class SampleIndex {
 			total: counts.total,
 			byKind: counts.byKind,
 			totalSamples: counts.byKind.get('sample') ?? counts.total,
-			totalDocs: counts.byKind.get('doc') ?? 0,
+			totalConcepts: counts.byKind.get('concept') ?? counts.byKind.get('doc') ?? 0,
+			totalDocs: counts.byKind.get('doc') ?? counts.byKind.get('concept') ?? 0,
 		};
 	}
 
-	list(query) {
+	list(query, options = {}) {
+		const kinds = options.kinds ? new Set(options.kinds) : undefined;
+		const normalizeKind = (entry) => entry.kind ?? 'sample';
+		let results = kinds ? this.entries.filter((entry) => kinds.has(normalizeKind(entry))) : this.entries;
+
 		if (!query) {
-			return this.entries;
+			return results;
 		}
 
 		const normalized = query.trim().toLowerCase();
-		return this.entries.filter(
+		return results.filter(
 			(entry) => entry.id.toLowerCase().includes(normalized) || entry.group.toLowerCase().includes(normalized) || entry.name.toLowerCase().includes(normalized),
 		);
 	}

--- a/packages/tools/mcp/src/sample-index.js
+++ b/packages/tools/mcp/src/sample-index.js
@@ -7,7 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function normalizeEntryId(entry) {
 	const kind = entry.kind ?? 'sample';
 	const isConcept = kind === 'concept' || kind === 'doc';
-	const expectedPrefix = isConcept ? 'concept' : 'sample';
+	const expectedPrefix = isConcept ? 'doc' : 'sample';
 	if (typeof entry.id === 'string' && entry.id.startsWith(`${expectedPrefix}/`)) {
 		return entry;
 	}
@@ -15,7 +15,7 @@ function normalizeEntryId(entry) {
 	const segments = [];
 	if (entry.group) {
 		const groupSegments = entry.group.split('/').filter(Boolean);
-		if (isConcept && groupSegments[0] === 'concepts') {
+		if (isConcept && groupSegments[0] === 'docs') {
 			groupSegments.shift();
 		}
 		segments.push(...groupSegments);

--- a/packages/tools/mcp/src/sample-index.js
+++ b/packages/tools/mcp/src/sample-index.js
@@ -4,12 +4,31 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function computeCounts(entries) {
+	return entries.reduce(
+		(acc, entry) => {
+			const kind = entry.kind ?? 'sample';
+			acc.total += 1;
+			acc.byKind.set(kind, (acc.byKind.get(kind) ?? 0) + 1);
+			return acc;
+		},
+		{ total: 0, byKind: new Map() },
+	);
+}
+
 class SampleIndex {
 	constructor(entries, generatedAt = new Date(), buildMode = 'runtime') {
 		this.entries = entries;
 		this.map = new Map(entries.map((entry) => [entry.id, entry]));
 		this.generatedAt = generatedAt;
 		this.buildMode = buildMode;
+		const counts = computeCounts(entries);
+		this.counts = {
+			total: counts.total,
+			byKind: counts.byKind,
+			totalSamples: counts.byKind.get('sample') ?? counts.total,
+			totalDocs: counts.byKind.get('doc') ?? 0,
+		};
 	}
 
 	list(query) {

--- a/packages/tools/mcp/src/sample-index.js
+++ b/packages/tools/mcp/src/sample-index.js
@@ -4,6 +4,35 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function normalizeEntryId(entry) {
+	const kind = entry.kind ?? 'sample';
+	const isConcept = kind === 'concept' || kind === 'doc';
+	const expectedPrefix = isConcept ? 'concept' : 'sample';
+	if (typeof entry.id === 'string' && entry.id.startsWith(`${expectedPrefix}/`)) {
+		return entry;
+	}
+
+	const segments = [];
+	if (entry.group) {
+		const groupSegments = entry.group.split('/').filter(Boolean);
+		if (isConcept && groupSegments[0] === 'concepts') {
+			groupSegments.shift();
+		}
+		segments.push(...groupSegments);
+	}
+
+	if (entry.name) {
+		segments.push(entry.name);
+	} else if (entry.id) {
+		segments.push(...String(entry.id).split('/').filter(Boolean));
+	}
+
+	return {
+		...entry,
+		id: [expectedPrefix, ...segments.filter(Boolean)].join('/'),
+	};
+}
+
 function computeCounts(entries) {
 	return entries.reduce(
 		(acc, entry) => {
@@ -18,11 +47,12 @@ function computeCounts(entries) {
 
 class SampleIndex {
 	constructor(entries, generatedAt = new Date(), buildMode = 'runtime') {
-		this.entries = entries;
-		this.map = new Map(entries.map((entry) => [entry.id, entry]));
+		const normalizedEntries = entries.map((entry) => normalizeEntryId(entry));
+		this.entries = normalizedEntries;
+		this.map = new Map(normalizedEntries.map((entry) => [entry.id, entry]));
 		this.generatedAt = generatedAt;
 		this.buildMode = buildMode;
-		const counts = computeCounts(entries);
+		const counts = computeCounts(normalizedEntries);
 		this.counts = {
 			total: counts.total,
 			byKind: counts.byKind,

--- a/packages/tools/mcp/src/server.js
+++ b/packages/tools/mcp/src/server.js
@@ -14,7 +14,6 @@ export async function startServer(options = {}) {
 				method: request.method ?? 'GET',
 				url: request.url ?? '/',
 				getIndex: () => index,
-				refresh: () => rebuild(),
 			}),
 		)
 			.then((result) => respondWithResult(response, result))
@@ -37,11 +36,6 @@ export async function startServer(options = {}) {
 	server.listen(port, () => {
 		console.log(`[mcp] server listening on http://localhost:${port}`);
 	});
-
-	async function rebuild() {
-		index = await buildSampleIndex();
-		return index;
-	}
 
 	return server;
 }


### PR DESCRIPTION
## What changed?

The KoliBri MCP server (`packages/tools/mcp`) now indexes Markdown documentation (repo `docs/**` and root-level `*.md`) as `concept`/`doc` entries alongside the existing React component samples. Two new read endpoints are exposed — `GET /docs` (list, supports `?q=`) and `GET /doc?id=doc/<identifier>` — and every entry/response now carries a `kind` field plus an `ai-hints` string array; `/health`, `/samples` and the root overview report new count fields (`totalEntries`, `totalSamples`, `totalConcepts`, `totalDocs`). Two changes break the existing API contract: sample IDs are now namespaced (e.g. `button/basic` → `sample/button/basic`), and the `POST /refresh` endpoint has been removed (it now returns HTTP 410) because indexes are prebuilt at build time — the `refresh` argument was dropped from `handleApiRequest` and the server's `rebuild()` helper deleted. Supporting changes: `prestart` now runs `pnpm build` instead of `unbuild --stub`, and the landing page (`public/index.html`) gains sample/doc stat tiles and a VS Code integration section.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [x] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der KoliBri-MCP-Server (`packages/tools/mcp`) indiziert jetzt zusätzlich zu den React-Komponenten-Samples auch Markdown-Dokumentation (`docs/**` sowie Root-`*.md`) als `concept`/`doc`-Einträge. Zwei neue Lese-Endpunkte kommen hinzu — `GET /docs` (Liste, mit `?q=`) und `GET /doc?id=doc/<identifier>` — und jeder Eintrag bzw. jede Antwort enthält nun ein `kind`-Feld sowie ein `ai-hints`-String-Array; `/health`, `/samples` und die Root-Übersicht liefern neue Zählfelder (`totalEntries`, `totalSamples`, `totalConcepts`, `totalDocs`). Zwei Änderungen brechen den bestehenden API-Vertrag: Sample-IDs sind jetzt mit Präfix versehen (z. B. `button/basic` → `sample/button/basic`), und der Endpunkt `POST /refresh` wurde entfernt (liefert nun HTTP 410), da die Indizes zur Build-Zeit vorab eingebettet werden — das `refresh`-Argument von `handleApiRequest` wurde entfernt und der `rebuild()`-Helfer des Servers gelöscht. Ergänzend: `prestart` führt jetzt `pnpm build` statt `unbuild --stub` aus, und die Landing-Page (`public/index.html`) erhält Kacheln für Sample-/Doc-Zahlen sowie einen Abschnitt zur VS-Code-Integration.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

💥 Breaking Change

### Geänderte Dateien

- `packages/tools/mcp/src/api-handler.js` — Neue Endpunkte `/docs` und `/doc`, kind-basierte Filterung, `ai-hints` und Zählfelder in allen Antworten; `/refresh` liefert jetzt HTTP 410.
- `packages/tools/mcp/src/sample-index-runtime.js` — Einsammeln von Markdown-Dateien, ID-Normalisierung mit `sample/`- bzw. `doc/`-Präfix und Berechnung der Zählwerte.
- `packages/tools/mcp/src/sample-index.js` — ID-Normalisierung, kind-bewusste `list()`-Funktion und Zählwerte im Build-Index.
- `packages/tools/mcp/api/mcp.js` — Vercel-Handler: eingebettete Zählwerte, `ai-hints`, Entfernung der `refresh`-Logik.
- `packages/tools/mcp/src/server.js` — Entfernt `rebuild()`/`refresh` aus dem lokalen Server.
- `packages/tools/mcp/src/cli.js` — Startausgabe listet `/docs` und `/doc` statt `/refresh`.
- `packages/tools/mcp/src/index.js` — Exportiert zusätzlich `AI_HINTS_KEY` und `AI_HINTS_MESSAGES`.
- `packages/tools/mcp/package.json` — `prestart` führt nun `pnpm build` statt `unbuild --stub` aus.
- `packages/tools/mcp/public/index.html` — Stat-Kacheln für Samples/Docs und Abschnitt zur VS-Code-Integration.
- `packages/tools/mcp/README.md` — Dokumentation der neuen Endpunkte und des geänderten ID-Formats.
- `packages/tools/mcp/AGENTS.md` — Aktualisierte Endpunkt-Übersicht (Concept-/Doc-Endpunkte, kein Refresh).

</details>