### PR TITLE
Add MCP initialize endpoint and SSE stream

### DIFF
--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -33,6 +33,16 @@ The server will start on `http://localhost:3030` and provide the following endpo
 - `GET /mcp/concepts` - List Markdown concept documentation
 - `GET /mcp/concept?id=concept/README` - Get a specific concept document
 
+#### MCP Protocol Endpoints
+
+For HTTP-based Model Context Protocol clients, additional routes are available:
+
+- `POST /mcp/initialize` – returns `serverInfo`, supported capabilities, resource counts and usage instructions used during the MCP handshake
+- `GET /mcp/events` – Server-Sent Events stream emitting an initial `ready` notification, index metadata and periodic heartbeat events to keep the connection alive
+- `POST /mcp/messages` – placeholder endpoint that currently responds with `501` because this MCP server is read-only and does not accept message invocations
+
+All endpoints are also reachable with the `/api/mcp/*` prefix when the service runs behind a platform router such as Vercel.
+
 The sample and concept indexes are prebuilt for deployments, therefore no manual refresh endpoint is exposed in production.
 
 ### Integration with AI Tools

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -19,6 +19,15 @@ const normalizeHints = (value) => {
 
 const withAiHints = (body = {}) => ({ ...body, [AI_HINTS_KEY]: normalizeHints(body[AI_HINTS_KEY]) });
 
+const JSON_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+const PATH_PREFIXES = ['/api/mcp', '/mcp'];
+
+const BASE_CORS_HEADERS = Object.freeze({
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+});
+
 const computeCountsFromEntries = (entries = []) =>
 	entries.reduce(
 		(acc, entry) => {
@@ -51,15 +60,139 @@ const resolveCounts = (index) => {
 	};
 };
 
+const applyCorsHeaders = (response, headers = BASE_CORS_HEADERS) => {
+	Object.entries(headers).forEach(([key, value]) => {
+		response.setHeader(key, value);
+	});
+};
+
+const normalizeRequestPath = (pathname) => {
+	if (pathname === '/') {
+		return pathname;
+	}
+
+	for (const prefix of PATH_PREFIXES) {
+		if (pathname.startsWith(prefix)) {
+			const suffix = pathname.slice(prefix.length) || '/';
+			return suffix.startsWith('/') ? suffix : `/${suffix}`;
+		}
+	}
+
+	return pathname;
+};
+
+const readJsonBody = (request) =>
+	new Promise((resolve, reject) => {
+		const chunks = [];
+
+		request.on('data', (chunk) => {
+			chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+		});
+
+		request.on('end', () => {
+			if (chunks.length === 0) {
+				resolve(undefined);
+				return;
+			}
+
+			const raw = Buffer.concat(chunks).toString('utf8').trim();
+			if (!raw) {
+				resolve(undefined);
+				return;
+			}
+
+			try {
+				resolve(JSON.parse(raw));
+			} catch (error) {
+				const parseError = new SyntaxError('Invalid JSON body');
+				parseError.code = 'INVALID_JSON_BODY';
+				parseError.cause = error;
+				reject(parseError);
+			}
+		});
+
+		request.on('error', (error) => {
+			reject(error);
+		});
+	});
+
+const handleEventStream = async ({ request, response, getIndex }) => {
+	response.status(200);
+	applyCorsHeaders(response);
+	response.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+	response.setHeader('Cache-Control', 'no-cache, no-transform');
+	response.setHeader('Connection', 'keep-alive');
+	response.flushHeaders?.();
+
+	const send = (data) => {
+		response.write(data);
+	};
+
+	send('event: ready\ndata: {}\n\n');
+
+	try {
+		const index = await getIndex();
+		const counts = resolveCounts(index);
+		const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt.toISOString() : index?.generatedAt;
+		const payload = {
+			totalEntries: counts.total,
+			totalSamples: counts.totalSamples,
+			totalConcepts: counts.totalConcepts,
+			totalDocs: counts.totalDocs,
+			generatedAt,
+			buildMode: index?.buildMode ?? 'runtime',
+		};
+		send(`event: resources/list_changed\ndata: ${JSON.stringify(payload)}\n\n`);
+	} catch (error) {
+		console.warn('[api/mcp] Unable to send SSE payload:', error);
+	}
+
+	const heartbeatInterval = setInterval(() => {
+		send('event: heartbeat\ndata: {}\n\n');
+	}, 15000);
+
+	const cleanup = () => {
+		clearInterval(heartbeatInterval);
+		if (!response.writableEnded) {
+			response.end();
+		}
+	};
+
+	request.on('close', cleanup);
+	request.on('error', cleanup);
+	request.on('aborted', cleanup);
+};
+
+const resolveBodyOrRespond = async (bodyPromise, response) => {
+	try {
+		const value = await bodyPromise;
+		return { ok: true, value };
+	} catch (error) {
+		if (error?.code === 'INVALID_JSON_BODY') {
+			response.status(400);
+			applyCorsHeaders(response);
+			response.setHeader('Content-Type', 'application/json; charset=utf-8');
+			response.json(
+				withAiHints({
+					error: 'invalid_json',
+					message: 'Request body must be valid JSON.',
+				}),
+			);
+			return { ok: false };
+		}
+
+		throw error;
+	}
+};
+
 // Vercel Serverless Function für /api/mcp/*
 export default async function handler(request, response) {
-	// CORS Headers setzen
-	response.setHeader('Access-Control-Allow-Origin', '*');
-	response.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
-	response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+	const method = request.method ?? 'GET';
+	const normalizedMethod = method.toUpperCase();
 
-	// OPTIONS Request für CORS Preflight
-	if (request.method === 'OPTIONS') {
+	applyCorsHeaders(response);
+
+	if (normalizedMethod === 'OPTIONS') {
 		response.status(204).end();
 		return;
 	}
@@ -82,6 +215,8 @@ export default async function handler(request, response) {
 		// URL für API Handler vorbereiten
 		const baseUrl = `https://${request.headers.host}`;
 		const fullUrl = new URL(request.url, baseUrl);
+		const pathname = normalizeRequestPath(fullUrl.pathname);
+		const bodyPromise = JSON_METHODS.has(normalizedMethod) ? readJsonBody(request) : Promise.resolve(undefined);
 
 		if (useEmbeddedData) {
 			// Verwende eingebettete Sample-Daten (schneller und zuverlässiger)
@@ -115,9 +250,22 @@ export default async function handler(request, response) {
 
 			const getIndex = async () => mockIndex;
 
+			if (normalizedMethod === 'GET' && pathname === '/events') {
+				await handleEventStream({ request, response, getIndex });
+				return;
+			}
+
+			const bodyResult = await resolveBodyOrRespond(bodyPromise, response);
+			if (!bodyResult.ok) {
+				return;
+			}
+
+			const body = bodyResult.value;
+
 			const result = await handleApiRequest({
 				method: request.method || 'GET',
 				url: fullUrl.toString(),
+				body,
 				getIndex,
 			});
 
@@ -140,10 +288,23 @@ export default async function handler(request, response) {
 				return cachedIndex;
 			};
 
+			if (normalizedMethod === 'GET' && pathname === '/events') {
+				await handleEventStream({ request, response, getIndex });
+				return;
+			}
+
+			const bodyResult = await resolveBodyOrRespond(bodyPromise, response);
+			if (!bodyResult.ok) {
+				return;
+			}
+
+			const body = bodyResult.value;
+
 			// API Handler aufrufen
 			const result = await handleApiRequest({
 				method: request.method || 'GET',
 				url: fullUrl.toString(),
+				body,
 				getIndex,
 			});
 

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -1,10 +1,34 @@
 import { URL } from 'node:url';
 
+const MCP_SERVER_INFO = Object.freeze({
+	name: 'kolibri-mcp',
+	version: process.env.MCP_SERVER_VERSION ?? '3.0.7-rc.3',
+	description: 'Model Context Protocol backend exposing KoliBri samples and concept documentation.',
+});
+
+const MCP_CAPABILITIES = Object.freeze({
+	resources: {
+		listChanged: true,
+	},
+	prompts: {},
+	tools: {},
+	sse: {
+		events: true,
+	},
+});
+
+const MCP_INSTRUCTIONS = Object.freeze([
+	'Use GET /mcp/samples (or /api/mcp/samples) to list available component examples.',
+	'Use GET /mcp/sample?id=sample/<component>/<sample> (or /api/mcp/sample?...) to retrieve source code for a specific example.',
+	'Use GET /mcp/docs and GET /mcp/doc?id=concept/<identifier> (or the /api equivalents) for Markdown concept documentation.',
+	'Open the Server-Sent Events stream at GET /mcp/events to receive readiness and heartbeat notifications.',
+]);
+
 function buildCorsHeaders() {
 	return {
 		'Access-Control-Allow-Origin': '*',
 		'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-		'Access-Control-Allow-Headers': 'Content-Type',
+		'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 	};
 }
 
@@ -93,6 +117,55 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 
 	if (normalizedMethod === 'OPTIONS') {
 		return { statusCode: 204, headers: baseHeaders };
+	}
+
+	if (normalizedMethod === 'POST' && pathname === '/initialize') {
+		let index;
+		try {
+			index = await getIndex();
+		} catch (error) {
+			console.warn('[initialize] Unable to load index for initialize response:', error);
+		}
+
+		const counts = resolveCounts(index);
+		const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt.toISOString() : undefined;
+		const buildMode = index?.buildMode ?? 'runtime';
+
+		return {
+			statusCode: 200,
+			headers: baseHeaders,
+			body: {
+				serverInfo: MCP_SERVER_INFO,
+				capabilities: MCP_CAPABILITIES,
+				resources: {
+					samples: {
+						total: counts.totalSamples,
+					},
+					docs: {
+						total: counts.totalDocs,
+					},
+				},
+				instructions: MCP_INSTRUCTIONS,
+				sampleIndex: {
+					totalEntries: counts.total,
+					totalSamples: counts.totalSamples,
+					totalConcepts: counts.totalConcepts,
+					generatedAt,
+					buildMode,
+				},
+			},
+		};
+	}
+
+	if (normalizedMethod === 'POST' && pathname === '/messages') {
+		return {
+			statusCode: 501,
+			headers: baseHeaders,
+			body: withAiHints({
+				error: 'messages_not_supported',
+				message: 'Diese MCP-Instanz stellt nur lesende Ressourcen-Endpunkte bereit. Nutzen Sie die /mcp/*-GET-Routen, um Inhalte abzurufen.',
+			}),
+		};
 	}
 
 	if (normalizedMethod === 'GET' && pathname === '/') {

--- a/packages/tools/mcp/src/server.js
+++ b/packages/tools/mcp/src/server.js
@@ -1,32 +1,61 @@
 import { createServer } from 'node:http';
+import { URL } from 'node:url';
 import { buildSampleIndex } from './sample-index.js';
 import { handleApiRequest } from './api-handler.js';
 
 const DEFAULT_PORT = Number.parseInt(process.env.PORT ?? '3030', 10);
+const JSON_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+const PATH_PREFIXES = ['/api/mcp', '/mcp'];
+
+const BASE_CORS_HEADERS = Object.freeze({
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+	'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+});
 
 export async function startServer(options = {}) {
 	const port = Number.parseInt(`${options.port ?? DEFAULT_PORT}`, 10);
 	let index = await buildSampleIndex();
 
 	const server = createServer((request, response) => {
-		Promise.resolve(
-			handleApiRequest({
-				method: request.method ?? 'GET',
-				url: request.url ?? '/',
-				getIndex: () => index,
-			}),
-		)
+		const method = request.method ?? 'GET';
+		const url = request.url ?? '/';
+		const normalizedMethod = method.toUpperCase();
+		const requestUrl = new URL(url, 'http://localhost');
+		const pathname = normalizeRequestPath(requestUrl.pathname);
+
+		if (normalizedMethod === 'GET' && pathname === '/events') {
+			handleEventStream({ request, response, getIndex: () => index });
+			return;
+		}
+
+		const readBody = JSON_METHODS.has(normalizedMethod) ? readJsonBody(request) : Promise.resolve(undefined);
+
+		readBody
+			.then((body) =>
+				handleApiRequest({
+					method,
+					url,
+					body,
+					getIndex: () => index,
+				}),
+			)
 			.then((result) => respondWithResult(response, result))
 			.catch((error) => {
+				if (error?.code === 'INVALID_JSON_BODY') {
+					respondWithResult(response, {
+						statusCode: 400,
+						headers: BASE_CORS_HEADERS,
+						body: { error: 'invalid_json', message: 'Request body must be valid JSON.' },
+					});
+					return;
+				}
+
 				console.error('[mcp] request failed', error);
 				if (!response.headersSent) {
 					respondWithResult(response, {
 						statusCode: 500,
-						headers: {
-							'Access-Control-Allow-Origin': '*',
-							'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-							'Access-Control-Allow-Headers': 'Content-Type',
-						},
+						headers: BASE_CORS_HEADERS,
 						body: { error: 'internal_error' },
 					});
 				}
@@ -61,4 +90,103 @@ function respondWithResult(response, result) {
 	}
 
 	response.end(JSON.stringify(result.body, null, 2));
+}
+
+function normalizeRequestPath(pathname) {
+	if (pathname === '/') {
+		return pathname;
+	}
+
+	for (const prefix of PATH_PREFIXES) {
+		if (pathname.startsWith(prefix)) {
+			const suffix = pathname.slice(prefix.length) || '/';
+			return suffix.startsWith('/') ? suffix : `/${suffix}`;
+		}
+	}
+
+	return pathname;
+}
+
+function readJsonBody(request) {
+	return new Promise((resolve, reject) => {
+		const chunks = [];
+
+		request.on('data', (chunk) => {
+			chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+		});
+
+		request.on('end', () => {
+			if (chunks.length === 0) {
+				resolve(undefined);
+				return;
+			}
+
+			const raw = Buffer.concat(chunks).toString('utf8').trim();
+			if (!raw) {
+				resolve(undefined);
+				return;
+			}
+
+			try {
+				resolve(JSON.parse(raw));
+			} catch (error) {
+				const parseError = new SyntaxError('Invalid JSON body');
+				parseError.code = 'INVALID_JSON_BODY';
+				parseError.cause = error;
+				reject(parseError);
+			}
+		});
+
+		request.on('error', (error) => {
+			reject(error);
+		});
+	});
+}
+
+function handleEventStream({ request, response, getIndex }) {
+	if (response.headersSent) {
+		return;
+	}
+
+	response.writeHead(200, {
+		...BASE_CORS_HEADERS,
+		'Content-Type': 'text/event-stream; charset=utf-8',
+		'Cache-Control': 'no-cache, no-transform',
+		Connection: 'keep-alive',
+	});
+
+	const send = (data) => {
+		response.write(data);
+	};
+
+	send('event: ready\ndata: {}\n\n');
+
+	Promise.resolve()
+		.then(() => getIndex())
+		.then((index) => {
+			const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt.toISOString() : undefined;
+			const payload = {
+				totalEntries: index?.entries?.length ?? 0,
+				buildMode: index?.buildMode ?? 'runtime',
+				generatedAt,
+			};
+			send(`event: resources/list_changed\ndata: ${JSON.stringify(payload)}\n\n`);
+		})
+		.catch((error) => {
+			console.warn('[sse] Unable to send initial index metadata:', error);
+		});
+
+	const heartbeatInterval = setInterval(() => {
+		send('event: heartbeat\ndata: {}\n\n');
+	}, 15000);
+
+	const cleanup = () => {
+		clearInterval(heartbeatInterval);
+		if (!response.writableEnded) {
+			response.end();
+		}
+	};
+
+	request.on('close', cleanup);
+	request.on('error', cleanup);
 }


### PR DESCRIPTION
## Summary
- add an HTTP `POST /mcp/initialize` handler that returns server metadata, capabilities, and a read-only `messages` response for MCP clients
- teach the Node server and Vercel function to parse JSON payloads, serve the `/mcp/events` SSE stream, and share consistent CORS headers
- document the additional MCP protocol routes for HTTP clients in the package README

## Testing
- pnpm --filter @public-ui/mcp build

------
https://chatgpt.com/codex/tasks/task_e_68e6078e8008832ba40cec6393dbcf1e