### PR TITLE
feat(mcp): accept POST on the root endpoint and drop the concept kind

### DIFF
--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -292,10 +292,6 @@
 						docCount = data.totalDocs;
 					} else if (typeof data.docs === 'number') {
 						docCount = data.docs;
-					} else if (typeof data.totalConcepts === 'number') {
-						docCount = data.totalConcepts;
-					} else if (typeof data.concepts === 'number') {
-						docCount = data.concepts;
 					}
 
 					const sampleCountElement = document.getElementById('sample-count');

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -42,14 +42,13 @@ function computeCountsFromEntries(entries = []) {
 				return acc;
 			}
 
-			if (kind === 'concept' || kind === 'doc') {
-				acc.totalConcepts += 1;
+			if (kind === 'doc') {
 				acc.totalDocs += 1;
 			}
 
 			return acc;
 		},
-		{ total: 0, totalSamples: 0, totalConcepts: 0, totalDocs: 0 },
+		{ total: 0, totalSamples: 0, totalDocs: 0 },
 	);
 }
 
@@ -64,7 +63,6 @@ function resolveCounts(index) {
 	return {
 		total: typeof source.total === 'number' ? source.total : fallbackCounts.total,
 		totalSamples: typeof source.totalSamples === 'number' ? source.totalSamples : fallbackCounts.totalSamples,
-		totalConcepts: typeof source.totalConcepts === 'number' ? source.totalConcepts : fallbackCounts.totalConcepts,
 		totalDocs: typeof source.totalDocs === 'number' ? source.totalDocs : fallbackCounts.totalDocs,
 	};
 }
@@ -114,7 +112,6 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				endpoints: ['/health', '/samples', '/sample?id=sample/<component>/<sample>', '/docs', '/doc?id=doc/<identifier>'],
 				totalEntries: counts.total,
 				totalSamples: counts.totalSamples,
-				totalConcepts: counts.totalConcepts,
 				totalDocs: counts.totalDocs,
 				generatedAt: (generatedAt ?? new Date()).toISOString(),
 				buildMode: index?.buildMode ?? 'runtime',
@@ -130,7 +127,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		// Debug information for Vercel
 		console.log('[health] Total entries:', counts.total);
 		console.log('[health] Sample entries:', counts.totalSamples);
-		console.log('[health] Concept entries:', counts.totalConcepts);
+		console.log('[health] Doc entries:', counts.totalDocs);
 		console.log('[health] Index generated at:', index.generatedAt);
 		console.log('[health] Is healthy:', isHealthy);
 
@@ -142,7 +139,6 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				healthy: isHealthy,
 				totalEntries: counts.total,
 				totalSamples: counts.totalSamples,
-				totalConcepts: counts.totalConcepts,
 				totalDocs: counts.totalDocs,
 				message: isHealthy ? `System healthy with ${counts.total} entries available` : 'No entries found - system may not be properly initialized',
 				generatedAt: index.generatedAt.toISOString(),
@@ -175,7 +171,6 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				total: items.length,
 				totalEntries: counts.total,
 				totalSamples: counts.totalSamples,
-				totalConcepts: counts.totalConcepts,
 				totalDocs: counts.totalDocs,
 				generatedAt: index.generatedAt.toISOString(),
 			}),
@@ -227,7 +222,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 	if (normalizedMethod === 'GET' && pathname === '/docs') {
 		const index = await getIndex();
 		const query = requestUrl.searchParams.get('q') ?? '';
-		const items = index.list(query, { kinds: ['concept', 'doc'] }).map((entry) => ({
+		const items = index.list(query, { kinds: ['doc'] }).map((entry) => ({
 			group: entry.group,
 			id: entry.id,
 			name: entry.name,
@@ -243,7 +238,6 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 				query,
 				total: items.length,
 				totalEntries: counts.totalDocs,
-				totalConcepts: counts.totalConcepts,
 				totalDocs: counts.totalDocs,
 				generatedAt: index.generatedAt.toISOString(),
 			}),
@@ -262,7 +256,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		}
 
 		const entry = index.get(id);
-		if (!entry || !['concept', 'doc'].includes(entry.kind ?? 'sample')) {
+		if (!entry || entry.kind !== 'doc') {
 			return {
 				statusCode: 404,
 				headers: baseHeaders,

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -95,7 +95,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		return { statusCode: 204, headers: baseHeaders };
 	}
 
-	if (normalizedMethod === 'GET' && pathname === '/') {
+	if ((normalizedMethod === 'GET' || normalizedMethod === 'POST') && pathname === '/') {
 		let index;
 		try {
 			index = await getIndex();

--- a/packages/tools/mcp/src/sample-index-runtime.js
+++ b/packages/tools/mcp/src/sample-index-runtime.js
@@ -56,8 +56,8 @@ function computeCounts(entries) {
 
 function normalizeEntryId(entry) {
 	const kind = entry.kind ?? 'sample';
-	const isConcept = kind === 'concept' || kind === 'doc';
-	const expectedPrefix = isConcept ? 'doc' : 'sample';
+	const isDoc = kind === 'doc';
+	const expectedPrefix = isDoc ? 'doc' : 'sample';
 	if (typeof entry.id === 'string' && entry.id.startsWith(`${expectedPrefix}/`)) {
 		return entry;
 	}
@@ -65,7 +65,7 @@ function normalizeEntryId(entry) {
 	const segments = [];
 	if (entry.group) {
 		const groupSegments = entry.group.split('/').filter(Boolean);
-		if (isConcept && groupSegments[0] === 'docs') {
+		if (isDoc && groupSegments[0] === 'docs') {
 			groupSegments.shift();
 		}
 		segments.push(...groupSegments);
@@ -95,8 +95,7 @@ class SampleIndex {
 			total: counts.total,
 			byKind: counts.byKind,
 			totalSamples: counts.byKind.get('sample') ?? counts.total,
-			totalConcepts: counts.byKind.get('concept') ?? counts.byKind.get('doc') ?? 0,
-			totalDocs: counts.byKind.get('doc') ?? counts.byKind.get('concept') ?? 0,
+			totalDocs: counts.byKind.get('doc') ?? 0,
 		};
 	}
 
@@ -344,25 +343,25 @@ async function collectMarkdownFromDirectory(directory, { groupPrefix, recursive,
 		const segments = withoutExtension.split('/').filter(Boolean);
 		const name = segments.pop() ?? withoutExtension;
 		const group = segments.length ? `${groupPrefix}/${segments.join('/')}` : groupPrefix;
-		const conceptIdSegments = ['concept'];
+		const docIdSegments = ['doc'];
 		if (group.startsWith(`${groupPrefix}/`)) {
 			const relativeGroup = group.slice(groupPrefix.length + 1);
 			if (relativeGroup) {
-				conceptIdSegments.push(...relativeGroup.split('/'));
+				docIdSegments.push(...relativeGroup.split('/'));
 			}
 		} else if (group !== groupPrefix) {
-			conceptIdSegments.push(...group.split('/'));
+			docIdSegments.push(...group.split('/'));
 		}
-		conceptIdSegments.push(name);
+		docIdSegments.push(name);
 
 		entries.push({
-			id: conceptIdSegments.join('/'),
+			id: docIdSegments.join('/'),
 			group,
 			name,
 			path: normalizedRepoPath,
 			absolutePath,
 			code,
-			kind: 'concept',
+			kind: 'doc',
 		});
 	}
 

--- a/packages/tools/mcp/src/sample-index.js
+++ b/packages/tools/mcp/src/sample-index.js
@@ -6,8 +6,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function normalizeEntryId(entry) {
 	const kind = entry.kind ?? 'sample';
-	const isConcept = kind === 'concept' || kind === 'doc';
-	const expectedPrefix = isConcept ? 'doc' : 'sample';
+	const isDoc = kind === 'doc';
+	const expectedPrefix = isDoc ? 'doc' : 'sample';
 	if (typeof entry.id === 'string' && entry.id.startsWith(`${expectedPrefix}/`)) {
 		return entry;
 	}
@@ -15,7 +15,7 @@ function normalizeEntryId(entry) {
 	const segments = [];
 	if (entry.group) {
 		const groupSegments = entry.group.split('/').filter(Boolean);
-		if (isConcept && groupSegments[0] === 'docs') {
+		if (isDoc && groupSegments[0] === 'docs') {
 			groupSegments.shift();
 		}
 		segments.push(...groupSegments);
@@ -57,8 +57,7 @@ class SampleIndex {
 			total: counts.total,
 			byKind: counts.byKind,
 			totalSamples: counts.byKind.get('sample') ?? counts.total,
-			totalConcepts: counts.byKind.get('concept') ?? counts.byKind.get('doc') ?? 0,
-			totalDocs: counts.byKind.get('doc') ?? counts.byKind.get('concept') ?? 0,
+			totalDocs: counts.byKind.get('doc') ?? 0,
 		};
 	}
 


### PR DESCRIPTION
## What changed?

This PR reworks the KoliBri MCP server in `packages/tools/mcp`. In `src/api-handler.js` the root endpoint (`/`) now handles `POST` in addition to `GET`, so the health/info payload can be requested via POST (needed for the MCP server registration flow). The bulk of the change removes the legacy `concept` entry kind and consolidates all documentation entries under the single `doc` kind: `src/sample-index-runtime.js` and `src/sample-index.js` now emit and normalize `kind: 'doc'` (dropping the `concept`/`doc` alias handling), the `/docs` and `/doc` endpoints filter strictly on `kind === 'doc'`, and the redundant `totalConcepts` counter is removed from every API response and from the `public/index.html` doc-count display. No consumer migration is required because `totalConcepts` was always mirrored by `totalDocs`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR überarbeitet den KoliBri-MCP-Server in `packages/tools/mcp`. In `src/api-handler.js` verarbeitet der Root-Endpunkt (`/`) jetzt neben `GET` auch `POST`, sodass die Health-/Info-Antwort per POST abgefragt werden kann (erforderlich für den Registrierungs-Flow des MCP-Servers). Der größte Teil der Änderung entfernt die veraltete Entry-Art `concept` und führt alle Dokumentations-Einträge unter der einzigen Art `doc` zusammen: `src/sample-index-runtime.js` und `src/sample-index.js` erzeugen und normalisieren nun `kind: 'doc'` (die `concept`/`doc`-Alias-Behandlung entfällt), die Endpunkte `/docs` und `/doc` filtern strikt auf `kind === 'doc'`, und der redundante Zähler `totalConcepts` wird aus jeder API-Antwort sowie aus der Doc-Anzeige in `public/index.html` entfernt. Für Konsumenten ist keine Migration nötig, da `totalConcepts` stets von `totalDocs` gespiegelt wurde.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/tools/mcp/src/api-handler.js` — Root-Endpunkt akzeptiert nun `POST`; `totalConcepts` aus allen Antworten entfernt; `/docs` und `/doc` filtern strikt auf `kind === 'doc'`; Debug-Log auf Doc-Einträge umgestellt.
- `packages/tools/mcp/src/sample-index-runtime.js` — Index-Erzeugung liefert `kind: 'doc'` statt `concept`, `totalConcepts` entfernt und `isConcept`-Prüfung durch `isDoc` ersetzt.
- `packages/tools/mcp/src/sample-index.js` — ID-Normalisierung und Zählung auf `doc` umgestellt; `totalConcepts` entfernt.
- `packages/tools/mcp/public/index.html` — `totalConcepts`/`concepts`-Fallback-Zweige aus der Doc-Zähler-Anzeige entfernt.

</details>