### PR TITLE
fix(collapsible): move overflow-hidden to the wrapper-animation element

### DIFF
--- a/packages/components/src/components/link.scss
+++ b/packages/components/src/components/link.scss
@@ -8,6 +8,7 @@
 
 	:is(a, button) {
 		display: inline-flex;
+		max-width: fit-content;
 		align-items: baseline;
 		place-items: center;
 		text-align: left;

--- a/packages/components/src/functional-components/Collapsible/collapsible.scss
+++ b/packages/components/src/functional-components/Collapsible/collapsible.scss
@@ -8,18 +8,19 @@
 			/* Forces the element into its own GPU compositing layer (via 3D transform). Helps prevent rendering/layout bugs (e.g. #7511) and may improve animation performance. */
 			transform: translateZ(0);
 			display: grid;
-			/**
-			 * The `overflow: hidden` ensures that the content is not visible during the animated
-			 * opening and closing. This should also cut off overlays containing content, but it
-			 *does not.
-			 */
-			overflow: hidden;
 			grid-template-rows: 0fr;
 			transition: grid-template-rows 0.3s;
 		}
 
 		&__wrapper-animation {
 			min-height: 0;
+			/**
+			 * The `overflow: hidden` ensures that the content is not visible during the animated
+			 * opening and closing. This should also cut off overlays containing content, but it
+			 *does not.
+			*/
+			overflow: hidden;
+
 			/* This property is important to keep in sync with the visual transition (template-rows). Without it interactive elements within the accordion would stay focusable. */
 			visibility: hidden;
 			transition: visibility 0.3s;


### PR DESCRIPTION
## What changed?

This fixes how content is clipped during the Collapsible open/close animation. In `packages/components/src/functional-components/Collapsible/collapsible.scss`, the `overflow: hidden` declaration was moved off the outer grid container (which drives the `grid-template-rows: 0fr → 1fr` transition) and onto the inner `&__wrapper-animation` element, so clipping now happens on the actually animated wrapper instead of the transitioning grid track. In `packages/components/src/components/link.scss`, `max-width: fit-content` was added to the `:is(a, button)` selector so links/buttons shrink to their content width rather than stretching, avoiding overflow. No public API or component props changed — this is purely a styling fix for rendering behaviour in accordions/details and links.

## Linked issues

- Closes #8512 — improve overflow-hidden handling for Collapsible slots

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung korrigiert, wie Inhalte während der Öffnungs-/Schließ-Animation der Collapsible-Komponente abgeschnitten werden. In `packages/components/src/functional-components/Collapsible/collapsible.scss` wurde die Deklaration `overflow: hidden` vom äußeren Grid-Container (der die Transition `grid-template-rows: 0fr → 1fr` steuert) auf das innere Element `&__wrapper-animation` verschoben, sodass das Abschneiden nun am tatsächlich animierten Wrapper statt an der sich verändernden Grid-Spur erfolgt. In `packages/components/src/components/link.scss` wurde dem Selektor `:is(a, button)` `max-width: fit-content` hinzugefügt, damit Links/Buttons auf ihre Inhaltsbreite schrumpfen und nicht überlaufen. Es wurden keine öffentliche API und keine Komponenten-Props geändert – es handelt sich um eine reine Styling-Korrektur des Rendering-Verhaltens in Accordions/Details und Links.

### Verknüpfte Tickets

- Schließt #8512 — Verbesserung der overflow-hidden-Behandlung für Collapsible-Slots

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/functional-components/Collapsible/collapsible.scss` — `overflow: hidden` vom äußeren Grid-Container auf das innere Element `&__wrapper-animation` verschoben.
- `packages/components/src/components/link.scss` — `max-width: fit-content` zum Selektor `:is(a, button)` hinzugefügt, um Überlauf zu vermeiden.

</details>