### PR TITLE
fix(collapsible): move overflow-hidden to inner wrapper and constrain link width

### DIFF
--- a/packages/components/src/components/@shared/_kol-link-mixin.scss
+++ b/packages/components/src/components/@shared/_kol-link-mixin.scss
@@ -10,6 +10,7 @@
 	.#{$block-classname} {
 		$root: &;
 		display: inline-flex;
+		max-width: fit-content;
 
 		align-items: baseline;
 		place-items: center;

--- a/packages/components/src/functional-components/Collapsible/collapsible.scss
+++ b/packages/components/src/functional-components/Collapsible/collapsible.scss
@@ -21,18 +21,18 @@
 			/* Forces the element into its own GPU compositing layer (via 3D transform). Helps prevent rendering/layout bugs (e.g. #7511) and may improve animation performance. */
 			transform: translateZ(0);
 			display: grid;
-			/**
-			 * The `overflow: hidden` ensures that the content is not visible during the animated
-			 * opening and closing. This should also cut off overlays containing content, but it
-			 *does not.
-			 */
-			overflow: hidden;
 			grid-template-rows: 0fr;
 			transition: grid-template-rows 0.3s;
 		}
 
 		&__wrapper-animation {
 			min-height: 0;
+			/**
+			 * The `overflow: hidden` ensures that the content is not visible during the animated
+			 * opening and closing. This should also cut off overlays containing content, but it
+			 *does not.
+			 */
+			overflow: hidden;
 			/* This property is important to keep in sync with the visual transition (template-rows). Without it interactive elements within the accordion would stay focusable. */
 			visibility: hidden;
 			transition: visibility 0.3s;


### PR DESCRIPTION
## What changed?

This PR adjusts CSS to fix how `overflow: hidden` interacts with the Collapsible animation. In `packages/components/src/functional-components/Collapsible/collapsible.scss`, the `overflow: hidden` declaration (and its explanatory comment) is moved off the outer animated grid container (`&__animation`, which uses `transform: translateZ(0)` and the `grid-template-rows` transition) onto the inner `&__wrapper-animation` element (which already carries `min-height: 0` and `visibility: hidden`). This keeps content clipped during the open/close animation while placing the clip on the correct element. Additionally, `packages/components/src/components/@shared/_kol-link-mixin.scss` gains `max-width: fit-content` on the link block so the inline-flex link no longer stretches wider than its content. No public API or component contract changes.

## Linked issues

- Refs #8512 — overflow-hidden clipping in Collapsible slots cuts off overlay/slot content

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR passt CSS an, um das Zusammenspiel von `overflow: hidden` mit der Animation der Collapsible-Komponente zu korrigieren. In `packages/components/src/functional-components/Collapsible/collapsible.scss` wird die Deklaration `overflow: hidden` (samt erläuterndem Kommentar) vom äußeren animierten Grid-Container (`&__animation`, mit `transform: translateZ(0)` und dem `grid-template-rows`-Übergang) auf das innere Element `&__wrapper-animation` verschoben (das bereits `min-height: 0` und `visibility: hidden` besitzt). Dadurch bleibt der Inhalt während der Auf-/Zu-Animation abgeschnitten, jedoch auf dem korrekten Element. Zusätzlich erhält der Link-Block in `packages/components/src/components/@shared/_kol-link-mixin.scss` die Eigenschaft `max-width: fit-content`, damit der als inline-flex dargestellte Link nicht breiter wird als sein Inhalt. Keine Änderung an der öffentlichen API oder am Komponenten-Vertrag.

### Verknüpfte Tickets

- Referenziert #8512 — overflow-hidden-Clipping in Collapsible-Slots schneidet Overlay-/Slot-Inhalte ab

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/functional-components/Collapsible/collapsible.scss` — `overflow: hidden` vom äußeren animierten Grid-Container auf das innere `&__wrapper-animation`-Element verschoben.
- `packages/components/src/components/@shared/_kol-link-mixin.scss` — `max-width: fit-content` zum Link-Block ergänzt, damit der Link nicht breiter als sein Inhalt wird.

</details>