### PR TITLE
fix: prevent InputDate calendar icon from submitting forms

### DIFF
--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -123,8 +123,17 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 		this.controller.onFacade.onInput(event, true, remappedValue);
 	};
 
+	private readonly isNativeCalendarIconFocused = (): boolean => {
+		if (!this.inputRef || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+			return false;
+		}
+
+		const computedStyle = window.getComputedStyle(this.inputRef, 'focus-visible');
+		return computedStyle.getPropertyValue('content') === 'native-icon-focused';
+	};
+
 	private readonly onKeyDown = (event: KeyboardEvent) => {
-		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+		if ((event.code === 'Enter' || event.code === 'NumpadEnter') && !this.isNativeCalendarIconFocused()) {
 			propagateSubmitEventToForm({
 				form: this.host,
 				ref: this.inputRef,

--- a/packages/components/src/components/input-date/style.scss
+++ b/packages/components/src/components/input-date/style.scss
@@ -1,2 +1,28 @@
 @use '../style' as *;
 @use '../input-line' as *;
+
+@layer kol-component {
+	/**
+	 * Workaround for detecting focus state of the native date input's calendar icon.
+	 * The `:focus-visible` pseudo class does not work on the icon itself, but only on the input element.
+	 * By using the `content` property we can detect whether the icon is focused by inspecting the computed style in JS.
+	 * This should be replaced once native focus detection for the icon is available.
+	 */
+	:host {
+		input[type='date'],
+		input[type='datetime-local'],
+		input[type='month'],
+		input[type='time'],
+		input[type='week'] {
+			content: 'native-icon-focused';
+		}
+
+		input[type='date']:focus-visible,
+		input[type='datetime-local']:focus-visible,
+		input[type='month']:focus-visible,
+		input[type='time']:focus-visible,
+		input[type='week']:focus-visible {
+			content: 'native-icon-not-focused';
+		}
+	}
+}


### PR DESCRIPTION
## What changed?

This fixes `kol-input-date` (`packages/components/src/components/input-date/shadow.tsx`) so that pressing Enter while the native calendar picker icon has focus no longer triggers a form submit. A new private `isNativeCalendarIconFocused()` helper reads the computed `content` value of the input's `:focus-visible` style via `window.getComputedStyle`, and the `onKeyDown` handler now only calls `propagateSubmitEventToForm` for Enter/NumpadEnter when the calendar icon is not focused. A companion CSS workaround in `style.scss` sets a sentinel `content` value (`native-icon-focused` vs `native-icon-not-focused`) on the date/datetime-local/month/time/week inputs inside a `@layer kol-component` block, since `:focus-visible` cannot be observed on the native icon directly. The helper safely no-ops in non-browser environments (no `inputRef` or missing `window.getComputedStyle`).

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung behebt in `kol-input-date` (`packages/components/src/components/input-date/shadow.tsx`), dass das Drücken der Enter-Taste bei fokussiertem nativem Kalender-Icon fälschlicherweise ein Formular absendet. Eine neue private Hilfsmethode `isNativeCalendarIconFocused()` liest über `window.getComputedStyle` den berechneten `content`-Wert des `:focus-visible`-Stils des Eingabefelds aus, und der `onKeyDown`-Handler ruft `propagateSubmitEventToForm` bei Enter/NumpadEnter nur noch dann auf, wenn das Kalender-Icon nicht fokussiert ist. Ein begleitender CSS-Workaround in `style.scss` setzt innerhalb eines `@layer kol-component`-Blocks einen Sentinel-`content`-Wert (`native-icon-focused` bzw. `native-icon-not-focused`) auf die Eingabefelder vom Typ date/datetime-local/month/time/week, da `:focus-visible` nicht direkt am nativen Icon beobachtet werden kann. Die Hilfsmethode verhält sich in Nicht-Browser-Umgebungen (fehlende `inputRef` oder fehlendes `window.getComputedStyle`) sicher neutral.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-date/shadow.tsx` — Neue `isNativeCalendarIconFocused()`-Methode ergänzt und `onKeyDown` so angepasst, dass bei fokussiertem Kalender-Icon kein Formular-Submit ausgelöst wird.
- `packages/components/src/components/input-date/style.scss` — CSS-Workaround im `@layer kol-component` hinzugefügt, der über die `content`-Eigenschaft den Fokuszustand des nativen Kalender-Icons per JS erkennbar macht.

</details>