### PR TITLE
fix(input-date): prevent form submission when pressing Enter on the calendar icon

### DIFF
--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -136,8 +136,16 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 		this.controller.onFacade.onInput(event, true, remappedValue);
 	};
 
+	private readonly isNativeCalendarIconFocused = (): boolean => {
+		if (!this.inputRef || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+			return false;
+		}
+		const computedStyle = window.getComputedStyle(this.inputRef, 'focus-visible');
+		return computedStyle.getPropertyValue('content') === 'native-icon-focused';
+	};
+
 	private readonly onKeyDown = (event: KeyboardEvent) => {
-		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+		if ((event.code === 'Enter' || event.code === 'NumpadEnter') && !this.isNativeCalendarIconFocused()) {
 			propagateSubmitEventToForm({
 				form: this.host,
 				ref: this.inputRef,

--- a/packages/components/src/components/input-date/style.scss
+++ b/packages/components/src/components/input-date/style.scss
@@ -10,4 +10,28 @@
 	@include kol-form-field;
 	@include kol-input-container;
 	@include kol-input;
+
+	/**
+	 * Workaround for detecting focus state of the native date input's calendar icon.
+	 * The `:focus-visible` pseudo class does not work on the icon itself, but only on the input element.
+	 * By using the `content` property we can detect whether the icon is focused by inspecting the computed style in JS.
+	 * This should be replaced once native focus detection for the icon is available.
+	 */
+	:host {
+		input[type='date'],
+		input[type='datetime-local'],
+		input[type='month'],
+		input[type='time'],
+		input[type='week'] {
+			content: 'native-icon-focused';
+		}
+
+		input[type='date']:focus-visible,
+		input[type='datetime-local']:focus-visible,
+		input[type='month']:focus-visible,
+		input[type='time']:focus-visible,
+		input[type='week']:focus-visible {
+			content: 'native-icon-not-focused';
+		}
+	}
 }


### PR DESCRIPTION
## What changed?

Fixes an issue where pressing Enter while the native calendar/picker icon of `kol-input-date` was focused submitted the surrounding form. In `packages/components/src/components/input-date/shadow.tsx`, a new `isNativeCalendarIconFocused()` helper inspects the input's computed `content` value, and `onKeyDown` now only propagates the submit event to the form when the icon is *not* focused. Because `:focus-visible` cannot target the native icon directly, `packages/components/src/components/input-date/style.scss` adds a workaround: the date-family inputs set `content: 'native-icon-focused'`, switched to `'native-icon-not-focused'` on `:focus-visible`, which JS reads back to distinguish icon focus from input focus. This is a targeted fix for the `release/3` line.

## Linked issues

- Refs #8444 — Prevent Enter on the InputDate calendar icon from submitting the form.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt ein Problem, bei dem das Drücken der Enter-Taste bei fokussiertem nativen Kalender-/Picker-Icon von `kol-input-date` das umgebende Formular abgeschickt hat. In `packages/components/src/components/input-date/shadow.tsx` prüft ein neuer Helfer `isNativeCalendarIconFocused()` den berechneten `content`-Wert des Inputs; `onKeyDown` leitet das Submit-Event nur noch dann an das Formular weiter, wenn das Icon *nicht* fokussiert ist. Da `:focus-visible` das native Icon nicht direkt ansprechen kann, ergänzt `packages/components/src/components/input-date/style.scss` einen Workaround: Die Datums-Inputs setzen `content: 'native-icon-focused'`, bei `:focus-visible` auf `'native-icon-not-focused'` — was per JS ausgelesen wird, um Icon-Fokus von Input-Fokus zu unterscheiden. Gezielter Fix für die `release/3`-Linie.

### Verknüpfte Tickets

- Referenziert #8444 — Enter auf dem Kalender-Icon der InputDate soll das Formular nicht absenden.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-date/shadow.tsx` — `isNativeCalendarIconFocused()`-Helfer; `onKeyDown` sendet Submit nur bei nicht fokussiertem Icon.
- `packages/components/src/components/input-date/style.scss` — CSS-`content`-Workaround zur Erkennung des Icon-Fokus über `:focus-visible`.

</details>