### PR TITLE
feat(mcp): improve landing page with copy buttons and branding

### DIFF
--- a/.github/workflows/mcp-vercel.yml
+++ b/.github/workflows/mcp-vercel.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - release/*
     paths:
       - '.github/workflows/mcp-vercel.yml'
       - 'packages/samples/react/**'

--- a/packages/tools/mcp/package.json
+++ b/packages/tools/mcp/package.json
@@ -42,7 +42,7 @@
 	},
 	"scripts": {
 		"build": "node prebuild.js && unbuild",
-		"format": "prettier --check src",
+		"format": "prettier --check public src",
 		"prestart": "pnpm build",
 		"start": "node dist/index.mjs"
 	},

--- a/packages/tools/mcp/prettier.config.cjs
+++ b/packages/tools/mcp/prettier.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+	printWidth: 160,
+	singleQuote: true,
+	useTabs: true,
+};

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -37,10 +37,9 @@
 			}
 
 			.logo {
-				width: 80px;
-				height: 80px;
+				width: 125px;
+				height: 125px;
 				margin: 0 auto 1rem;
-				background: #667eea;
 				border-radius: 50%;
 				display: flex;
 				align-items: center;
@@ -108,6 +107,51 @@
 				font-family: 'Courier New', monospace;
 				margin: 0.5rem 0;
 				overflow-x: auto;
+				white-space: pre;
+				display: block;
+			}
+			.endpoint-inline {
+				background: #1a202c;
+				color: #90cdf4;
+				padding: 0.2em 0.5em;
+				border-radius: 4px;
+				font-family: 'Courier New', monospace;
+				margin: 0.2em 0.2em;
+				font-size: 1em;
+				white-space: nowrap;
+				display: inline;
+			}
+			.copy-btn {
+				background: #edf2f7;
+				color: #2d3748;
+				border: none;
+				border-radius: 4px;
+				padding: 0.3em 0.6em;
+				font-size: 1em;
+				cursor: pointer;
+				position: absolute;
+				top: 8px;
+				right: 8px;
+				opacity: 0.7;
+				transition: opacity 0.2s;
+				z-index: 2;
+			}
+			.copy-btn:focus,
+			.copy-btn:hover {
+				opacity: 1;
+				outline: 2px solid #667eea;
+			}
+			.endpoint-inline + .copy-btn {
+				position: relative;
+				top: 0;
+				right: 0;
+				margin-left: 0.5em;
+				opacity: 0.7;
+				z-index: 2;
+				background: #edf2f7;
+				color: #2d3748;
+				border-radius: 4px;
+				padding: 0.3em 0.6em;
 			}
 
 			.method {
@@ -157,12 +201,20 @@
 			a:hover {
 				text-decoration: underline;
 			}
+
+			/* Removed duplicate .copy-btn rules for clarity and consistency */
+
+			.relative {
+				position: relative;
+			}
 		</style>
 	</head>
 	<body>
 		<div class="container">
 			<div class="header">
-				<div class="logo">K</div>
+				<div class="logo">
+					<img src="https://github.com/public-ui/kolibri/raw/refs/heads/develop/kolibri.logo.svg" alt="KoliBri Logo" />
+				</div>
 				<h1>KoliBri MCP API</h1>
 				<p class="subtitle">Model Context Protocol Backend for KoliBri Examples</p>
 				<span class="status">🟢 Online</span>
@@ -212,6 +264,12 @@
 						<code class="endpoint"><a href="/mcp/doc?id=doc/README" style="color: #90cdf4">/mcp/doc?id=doc/README</a></code>
 					</div>
 					<p class="description">Retrieve a specific documentation document including its Markdown source</p>
+
+					<div>
+						<span class="method get">GET</span>
+						<code class="endpoint"><a href="/mcp/doc?id=doc/README.md" style="color: #90cdf4">/mcp/doc?id=doc/README.md</a></code>
+					</div>
+					<p class="description">Retrieve a specific documentation document including its Markdown source (with .md extension)</p>
 				</div>
 				<p class="description" style="margin-top: 1rem">
 					Note: The indices are generated during the build process. Manual <code>refresh</code> is not available in deployments.
@@ -224,16 +282,25 @@
 
 				<div style="margin-top: 1rem">
 					<h3 style="color: #2d3748; margin-bottom: 0.5rem; font-size: 1.1rem">Option 1: Local Installation</h3>
-					<div class="endpoint">npm install -g @public-ui/mcp</div>
+					<span style="position: relative; display: inline-block">
+						<code class="endpoint"> npm install -g @public-ui/mcp</code>
+						<button class="copy-btn" aria-label="Copy code" tabindex="0" style="position: absolute; top: 8px; right: 8px">📋</button>
+					</span>
 					<p class="description">Install the MCP package globally and create an <code>mcp.json</code>:</p>
-					<div class="endpoint" style="white-space: pre-wrap; font-size: 0.9rem">
-						{ "servers": { "kolibri-mcp": { "command": "npx", "args": ["@public-ui/mcp"] } }, "inputs": [] }
+					<div style="position: relative">
+						<pre
+							style="margin: 0"
+						><code class="endpoint" style="font-size: 0.9rem">{ "servers": { "kolibri-mcp": { "command": "npx", "args": ["@public-ui/mcp"] } }, "inputs": [] }</code></pre>
+						<button class="copy-btn" aria-label="Copy code" tabindex="0" style="position: absolute; top: 8px; right: 8px">📋</button>
 					</div>
 
 					<h3 style="color: #2d3748; margin-bottom: 0.5rem; margin-top: 1.5rem; font-size: 1.1rem">Option 2: Remote Server (Recommended)</h3>
 					<p class="description">Use the hosted server without local installation in your <code>mcp.json</code>:</p>
-					<div class="endpoint" style="white-space: pre-wrap; font-size: 0.9rem">
-						{ "servers": { "kolibri-mcp": { "url": "https://public-ui-kolibri-mcp.vercel.app/mcp/", "type": "http" } }, "inputs": [] }
+					<div style="position: relative">
+						<pre
+							style="margin: 0"
+						><code class="endpoint" style="font-size: 0.9rem">{ "servers": { "kolibri-mcp": { "url": "https://public-ui-kolibri-mcp.vercel.app/mcp/", "type": "http" } }, "inputs": [] }</code></pre>
+						<button class="copy-btn" aria-label="Copy code" tabindex="0" style="position: absolute; top: 8px; right: 8px">📋</button>
 					</div>
 					<div style="background: #fff3cd; padding: 1rem; border-radius: 6px; margin-top: 1rem; border-left: 4px solid #ffc107">
 						<strong style="color: #856404">⚡ Remote Advantage:</strong>
@@ -242,26 +309,34 @@
 
 					<h3 style="color: #2d3748; margin-bottom: 0.5rem; margin-top: 1.5rem; font-size: 1.1rem">Setup</h3>
 					<p class="description">Create an <code>mcp.json</code> file in your project directory or use the global configuration:</p>
-					<div class="endpoint" style="background: #1a202c; color: #90cdf4">
-						# Local file in project echo '{ "servers": { ... } }' > mcp.json # Or globally for all projects ~/.config/mcp/mcp.json
+					<div style="position: relative">
+						<pre style="margin: 0"><code class="endpoint" style="background: #1a202c; color: #90cdf4"># Local file in project
+ echo '{ "servers": { ... } }' > mcp.json
+# Or globally for all projects
+~/.config/mcp/mcp.json
+</code></pre>
+						<button class="copy-btn" aria-label="Copy code" tabindex="0" style="position: absolute; top: 8px; right: 8px">📋</button>
 					</div>
 					<p class="description">In GitHub Copilot Chat you can now write:</p>
-					<div class="endpoint" style="background: #2d3748; color: #90cdf4">
-						@kolibri show me a button sample @kolibri how do I implement a KoliBri table? @kolibri create an accessible form
+					<div style="position: relative">
+						<pre style="margin: 0"><code class="endpoint" style="background: #2d3748; color: #90cdf4">@kolibri show me a button sample
+@kolibri how do I implement a KoliBri table?
+@kolibri create an accessible form
+</code></pre>
+						<button class="copy-btn" aria-label="Copy code" tabindex="0" style="position: absolute; top: 8px; right: 8px">📋</button>
 					</div>
-
 					<div style="background: #e6fffa; padding: 1rem; border-radius: 6px; margin-top: 1rem; border-left: 4px solid #38a169">
 						<strong style="color: #2d3748">💡 Tip:</strong>
 						<span style="color: #2d3748" id="tip-text">
-							The MCP Server gives you access to all KoliBri component samples and documentation files directly in VS Code!</span
-						>
+							The MCP Server gives you access to all KoliBri component samples and documentation files directly in VS Code!
+						</span>
 					</div>
 				</div>
 			</div>
 
 			<div class="footer">
 				<p>
-					📚 <a href="https://public-ui.github.io/en" target="_blank">KoliBri Documentation</a> | 🔗
+					<a href="https://public-ui.github.io/en" target="_blank">KoliBri Documentation</a> | 🔗
 					<a href="https://github.com/public-ui/kolibri" target="_blank">GitHub Repository</a>
 				</p>
 				<p style="margin-top: 0.5rem; font-size: 0.9rem">Powered by KoliBri • Made with ❤️ by ITZBund</p>
@@ -331,6 +406,42 @@
 						docCountElement.textContent = '–';
 					}
 				});
+
+			// Copy code logic for all .copy-btn buttons
+			function copyCodeToClipboard(code) {
+				if (navigator.clipboard) {
+					navigator.clipboard.writeText(code);
+				} else {
+					const textarea = document.createElement('textarea');
+					textarea.value = code;
+					document.body.appendChild(textarea);
+					textarea.select();
+					document.execCommand('copy');
+					document.body.removeChild(textarea);
+				}
+			}
+
+			document.addEventListener('DOMContentLoaded', function () {
+				const copyButtons = document.querySelectorAll('.copy-btn');
+				copyButtons.forEach(function (btn) {
+					btn.addEventListener('click', function (e) {
+						let code = '';
+						const parent = btn.parentElement;
+						if (parent.querySelector('code.endpoint-inline')) {
+							code = parent.querySelector('code.endpoint-inline').textContent;
+						} else if (parent.querySelector('code.endpoint')) {
+							code = parent.querySelector('code.endpoint').textContent;
+						}
+						if (code) {
+							copyCodeToClipboard(code);
+							btn.textContent = '✅';
+							setTimeout(() => {
+								btn.textContent = '📋';
+							}, 1500);
+						}
+					});
+				});
+			});
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
## What changed?

Improves the MCP server's landing page (`packages/tools/mcp/public/index.html`). The placeholder "K" logo is replaced with the real KoliBri SVG logo, and code/endpoint snippets get copy-to-clipboard buttons (with a `navigator.clipboard` path and a `document.execCommand` fallback) plus proper `<pre>`/`<code>` formatting so multi-line examples render correctly. A documented endpoint for fetching docs with the `.md` extension (`/mcp/doc?id=doc/README.md`) is added. Tooling changes: a `prettier.config.cjs` is added for the package and the `format` script now also checks the `public` folder. The workflow trigger change from a companion PR (`release/*` on push/PR) is reverted here.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Verbessert die Landing-Page des MCP-Servers (`packages/tools/mcp/public/index.html`). Das Platzhalter-Logo „K" wird durch das echte KoliBri-SVG-Logo ersetzt, und Code-/Endpunkt-Snippets erhalten Copy-to-Clipboard-Buttons (mit `navigator.clipboard`-Pfad und `document.execCommand`-Fallback) sowie korrektes `<pre>`/`<code>`-Markup, damit mehrzeilige Beispiele richtig dargestellt werden. Ein dokumentierter Endpunkt zum Abruf von Docs mit `.md`-Endung (`/mcp/doc?id=doc/README.md`) wird ergänzt. Tooling: Eine `prettier.config.cjs` wird für das Paket hinzugefügt und das `format`-Skript prüft nun auch den `public`-Ordner. Die Workflow-Trigger-Änderung aus einem begleitenden PR (`release/*` bei push/PR) wird hier zurückgenommen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/tools/mcp/public/index.html` — Echtes KoliBri-Logo, Copy-Buttons mit Fallback, `<pre>`/`<code>`-Formatierung, `.md`-Doc-Endpunkt.
- `packages/tools/mcp/prettier.config.cjs` — Neue Prettier-Konfiguration für das Paket.
- `packages/tools/mcp/package.json` — `format`-Skript prüft zusätzlich den `public`-Ordner.
- `.github/workflows/mcp-vercel.yml` — Rücknahme des `release/*`-Triggers für push/pull_request.

</details>