### PR TITLE
feat: extend MCP AI hints for icons and forms

### DIFF
--- a/docs/HOWTO_ICON_FONTS.md
+++ b/docs/HOWTO_ICON_FONTS.md
@@ -1,0 +1,58 @@
+# HOWTO: Bundle KoliBri Icon Fonts
+
+KoliBri ships the [`kol-icon`](https://public-ui.github.io/components/icon/) component to render pictograms. The component expects a font-based icon set such as [Codicon](https://github.com/microsoft/vscode-codicons) to be available at runtime. If the font files are missing, `kol-icon` falls back to empty boxes.
+
+This guide shows how to install and bundle the font assets that are published with `@public-ui/components`.
+
+## 1. Install the assets
+
+The icon fonts are part of the KoliBri component package. Ensure your project depends on it:
+
+```bash
+pnpm add @public-ui/components
+# or
+npm install @public-ui/components
+```
+
+After installation the font files live inside `node_modules/@public-ui/components/assets/codicons/`.
+
+## 2. Import the CSS next to your global styles
+
+The CSS file declares the `codicon` font-face and points to the matching `codicon.ttf` file. Import it once inside your application entry point or global stylesheet:
+
+```ts
+// main.ts / index.tsx
+import '@public-ui/components/assets/codicons/codicon.css';
+```
+
+For bundlers that do not understand CSS imports, copy `codicon.css` and `codicon.ttf` into your public assets folder and load them manually in `index.html`:
+
+```html
+<link rel="stylesheet" href="/assets/codicons/codicon.css" />
+```
+
+Make sure the relative path inside `codicon.css` still points to the TTF file after copying.
+
+## 3. Reference the icons from components
+
+Use Codicon class names via the `_icons` property. Multiple icons can be provided by separating classes with a space:
+
+```tsx
+<KolButton _label="Save" _icons="codicon codicon-save" />
+```
+
+The first class (`codicon`) ensures the font family is applied, the second selects the glyph.
+
+## 4. Serve the font file
+
+Verify that your build pipeline copies `codicon.ttf` into the final distribution folder. Frameworks such as Next.js, Vite, and Angular CLI automatically include imported assets when the CSS file is referenced. For custom setups, add a build step that copies the font file alongside your compiled assets:
+
+```bash
+cp node_modules/@public-ui/components/assets/codicons/codicon.ttf dist/assets/codicons/
+```
+
+## 5. Test your setup
+
+Load a page that renders `kol-icon` or any component using `_icons`. You should no longer see empty boxes. Browser developer tools let you check that the `codicon.ttf` file is requested successfully.
+
+Keeping the CSS import in place ensures AI agents and developers alike ship the correct assets whenever `kol-icon` is used.

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -102,7 +102,9 @@ Returns server status and metadata:
 	"generatedAt": "2024-05-28T08:15:30.000Z",
 	"ai-hints": [
 		"Always register KoliBri Web Components in the browser runtime before rendering them.",
-		"Choose the integration guide that matches your project setup to load and bundle the components correctly."
+		"Choose the integration guide that matches your project setup to load and bundle the components correctly.",
+		"Bundle the KoliBri icon font assets (for example codicon.css and codicon.ttf) so kol-icon glyphs can render.",
+		"Wrap input elements with <kol-form> and feed its _errorList to surface validation issues via the generated error summary."
 	]
 }
 ```
@@ -139,7 +141,9 @@ Returns the Markdown content together with metadata. Every sample or doc respons
 	"kind": "sample",
 	"ai-hints": [
 		"Always register KoliBri Web Components in the browser runtime before rendering them.",
-		"Choose the integration guide that matches your project setup to load and bundle the components correctly."
+		"Choose the integration guide that matches your project setup to load and bundle the components correctly.",
+		"Bundle the KoliBri icon font assets (for example codicon.css and codicon.ttf) so kol-icon glyphs can render.",
+		"Wrap input elements with <kol-form> and feed its _errorList to surface validation issues via the generated error summary."
 	]
 }
 ```
@@ -165,7 +169,7 @@ curl "http://localhost:3030/mcp/doc?id=doc/README"
 
 Returns the Markdown content together with metadata. Every sample or doc response exposes a `kind` field so that clients can distinguish between component examples and documentation entries.
 
-All JSON responses contain an `ai-hints` string array that reiterates in English that KoliBri Web Components must be registered in the browser and that integration steps vary with the chosen project setup.
+All JSON responses contain an `ai-hints` string array that reiterates in English that KoliBri Web Components must be registered, that the correct integration guide and icon font assets need to be bundled, and that `<kol-form>` with an `_errorList` exposes validation errors via its summary.
 
 ## 🛠️ Use Cases
 

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -2,6 +2,8 @@ const AI_HINTS_KEY = 'ai-hints';
 const AI_HINTS_MESSAGES = Object.freeze([
 	'Always register KoliBri Web Components in the browser runtime before rendering them.',
 	'Choose the integration guide that matches your project setup to load and bundle the components correctly.',
+	'Bundle the KoliBri icon font assets (for example codicon.css and codicon.ttf) so kol-icon glyphs can render.',
+	'Wrap input elements with <kol-form> and feed its _errorList to surface validation issues via the generated error summary.',
 ]);
 
 const normalizeHints = (value) => {

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -43,6 +43,8 @@ export const AI_HINTS_KEY = 'ai-hints';
 export const AI_HINTS_MESSAGES = Object.freeze([
 	'Always register KoliBri Web Components in the browser runtime before rendering them.',
 	'Choose the integration guide that matches your project setup to load and bundle the components correctly.',
+	'Bundle the KoliBri icon font assets (for example codicon.css and codicon.ttf) so kol-icon glyphs can render.',
+	'Wrap input elements with <kol-form> and feed its _errorList to surface validation issues via the generated error summary.',
 ]);
 
 function normalizeHints(value) {


### PR DESCRIPTION
## What changed?

Extends the MCP server's shared AI-hint set with two new guidance messages: one telling consumers to bundle the KoliBri icon font assets (e.g. `codicon.css` / `codicon.ttf`) so `kol-icon` glyphs render, and one explaining how to wrap inputs in `<kol-form>` and feed its `_errorList` to surface validation errors. The hints are added in both `packages/tools/mcp/api/mcp.js` and `packages/tools/mcp/src/api-handler.js` (the `AI_HINTS_MESSAGES` arrays), documented in the MCP `README.md`, and a new `docs/HOWTO_ICON_FONTS.md` guide explains how to install, import, and serve the codicon font files.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Erweitert das gemeinsame AI-Hint-Set des MCP-Servers um zwei neue Hinweise: einer weist Nutzer an, die KoliBri-Icon-Font-Assets (z. B. `codicon.css` / `codicon.ttf`) zu bündeln, damit `kol-icon`-Glyphen dargestellt werden; der zweite erklärt, wie man Eingaben mit `<kol-form>` umschließt und dessen `_errorList` nutzt, um Validierungsfehler anzuzeigen. Die Hinweise werden in `packages/tools/mcp/api/mcp.js` und `packages/tools/mcp/src/api-handler.js` (den `AI_HINTS_MESSAGES`-Arrays) ergänzt, in der MCP-`README.md` dokumentiert, und ein neuer Leitfaden `docs/HOWTO_ICON_FONTS.md` erklärt Installation, Import und Bereitstellung der Codicon-Font-Dateien.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/tools/mcp/api/mcp.js` — Zwei neue Einträge in `AI_HINTS_MESSAGES` (Icon-Fonts, `kol-form`/`_errorList`).
- `packages/tools/mcp/src/api-handler.js` — Gleiche neue AI-Hints im Handler-Set.
- `packages/tools/mcp/README.md` — Dokumentation der erweiterten AI-Hints.
- `docs/HOWTO_ICON_FONTS.md` — Neuer Leitfaden zum Bündeln der Codicon-Icon-Fonts für `kol-icon`.

</details>