### PR TITLE
test(mcp): add fuzzy search coverage for sample index queries

### DIFF
--- a/packages/tools/mcp/package.json
+++ b/packages/tools/mcp/package.json
@@ -44,7 +44,9 @@
 		"build": "node prebuild.js && unbuild",
 		"format": "prettier --check public src",
 		"prestart": "pnpm build",
-		"start": "node dist/index.mjs"
+		"start": "node dist/index.mjs",
+		"test": "node --test",
+		"test-update": "node --test"
 	},
 	"devDependencies": {
 		"prettier": "3.6.2",

--- a/packages/tools/mcp/src/index.js
+++ b/packages/tools/mcp/src/index.js
@@ -2,7 +2,7 @@ import { startServer } from './server.js';
 
 // Export functions for Vercel API
 export { handleApiRequest, AI_HINTS_KEY, AI_HINTS_MESSAGES } from './api-handler.js';
-export { buildSampleIndex } from './sample-index.js';
+export { buildSampleIndex, SampleIndex } from './sample-index.js';
 
 // Only start server when executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/packages/tools/mcp/src/sample-index.js
+++ b/packages/tools/mcp/src/sample-index.js
@@ -46,7 +46,7 @@ function computeCounts(entries) {
 	);
 }
 
-class SampleIndex {
+export class SampleIndex {
 	constructor(entries, generatedAt = new Date(), buildMode = 'runtime') {
 		const normalizedEntries = entries.map((entry) => normalizeEntryId(entry));
 		this.entries = normalizedEntries;

--- a/packages/tools/mcp/test/fuzzy-search.test.js
+++ b/packages/tools/mcp/test/fuzzy-search.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { hasSearchableQuery, performFuzzySearch } from '../src/fuzzy-search.js';
+import { SampleIndex } from '../src/sample-index.js';
+
+const SAMPLE_ENTRIES = [
+	{
+		id: 'sample/button/basic',
+		group: 'components/button',
+		name: 'basic',
+		title: 'Basic Button',
+		description: 'Default button style for generic actions',
+		tags: ['button', 'action'],
+		keywords: ['button', 'default'],
+		kind: 'sample',
+	},
+	{
+		id: 'sample/button/primary',
+		group: 'components/button',
+		name: 'primary',
+		title: 'Primary Button',
+		description: 'Primary call-to-action button variant',
+		tags: ['button', 'primary'],
+		keywords: ['button', 'primary'],
+		kind: 'sample',
+	},
+	{
+		id: 'sample/form/text-input',
+		group: 'components/form',
+		name: 'text-input',
+		title: 'Text Input Field',
+		description: 'Form field for textual user input',
+		tags: ['form'],
+		keywords: ['input', 'form'],
+		kind: 'sample',
+	},
+	{
+		id: 'doc/guides/accessibility',
+		group: 'docs/guides',
+		name: 'accessibility',
+		title: 'Accessibility Guide',
+		description: 'Documentation on accessible components',
+		tags: ['guides'],
+		keywords: ['accessibility', 'guide'],
+		kind: 'doc',
+	},
+];
+
+const index = new SampleIndex(SAMPLE_ENTRIES);
+
+function ids(result) {
+	return result.map((entry) => entry.id);
+}
+
+test('hasSearchableQuery rejects empty or whitespace only queries', () => {
+	assert.equal(hasSearchableQuery(undefined), false);
+	assert.equal(hasSearchableQuery(null), false);
+	assert.equal(hasSearchableQuery(''), false);
+	assert.equal(hasSearchableQuery('   '), false);
+	assert.equal(hasSearchableQuery('button'), true);
+});
+
+test('performFuzzySearch returns all entries unchanged for empty queries', () => {
+	const result = performFuzzySearch(SAMPLE_ENTRIES, '   ');
+	assert.strictEqual(result, SAMPLE_ENTRIES);
+});
+
+test('performFuzzySearch treats queries case-insensitively and prioritises multi-token matches', () => {
+	const results = performFuzzySearch(SAMPLE_ENTRIES, 'PRIMARY BUTTON');
+	assert.deepStrictEqual(ids(results).slice(0, 2), ['sample/button/primary', 'sample/button/basic']);
+	assert.ok(ids(results).every((id, index) => index < 2 || id !== 'sample/form/text-input'));
+});
+
+test('SampleIndex.list reuses fuzzy search with trimmed queries', () => {
+	const trimmed = index.list('  button  ');
+	const plain = index.list('button');
+	assert.deepStrictEqual(ids(trimmed), ids(plain));
+});
+
+test('SampleIndex.list filters entries by kind before searching', () => {
+	const docResults = index.list('guide', { kinds: ['doc'] });
+	assert.deepStrictEqual(ids(docResults), ['doc/guides/accessibility']);
+
+	const sampleResults = index.list('guide', { kinds: ['sample'] });
+	assert.deepStrictEqual(ids(sampleResults), []);
+});


### PR DESCRIPTION
## What changed?

Adds automated test coverage for the MCP server's fuzzy sample/doc search. A new `node:test` suite (`packages/tools/mcp/test/fuzzy-search.test.js`) exercises `hasSearchableQuery` and `performFuzzySearch`, covering empty/whitespace queries, case-insensitivity, multi-token ranking, kind filtering, and query trimming via `SampleIndex.list`. To make the suite runnable, the `SampleIndex` class is now exported from `packages/tools/mcp/src/sample-index.js` (and re-exported from `src/index.js`), and `test` / `test-update` scripts (`node --test`) are added to the package's `package.json`. No production runtime behavior changes.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ergänzt automatisierte Testabdeckung für die Fuzzy-Suche des MCP-Servers. Eine neue `node:test`-Suite (`packages/tools/mcp/test/fuzzy-search.test.js`) prüft `hasSearchableQuery` und `performFuzzySearch` — inklusive leerer/whitespace-Queries, Groß-/Kleinschreibungs-Unabhängigkeit, Multi-Token-Ranking, Filterung nach `kind` und Query-Trimming über `SampleIndex.list`. Damit die Suite lauffähig ist, wird die Klasse `SampleIndex` nun aus `packages/tools/mcp/src/sample-index.js` exportiert (und in `src/index.js` re-exportiert), und `test` / `test-update` Skripte (`node --test`) werden in der `package.json` des Pakets ergänzt. Keine Änderung des produktiven Laufzeitverhaltens.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/mcp/test/fuzzy-search.test.js` — Neue `node:test`-Suite für die Fuzzy-Suche.
- `packages/tools/mcp/src/sample-index.js` — `SampleIndex` wird als benannter Export bereitgestellt.
- `packages/tools/mcp/src/index.js` — `SampleIndex` wird zusätzlich re-exportiert.
- `packages/tools/mcp/package.json` — `test`/`test-update`-Skripte (`node --test`) ergänzt.

</details>