### PR TITLE
fix: improve accessibility by adding role and aria-live to pagination

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -3,6 +3,7 @@
 This package contains the Stencil based web component library for KoliBri.
 
 Use `pnpm --filter @public-ui/components build` to build the library or `pnpm start` for development.
+Always run a build before linting so the generated component typings exist for the check.
 
 ## Structure
 

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -497,7 +497,7 @@ export class KolTableStateful implements TableAPI {
 
 		return (
 			<div class="pagination">
-				<span>
+				<span role="status" aria-live="polite">
 					{translate('kol-table-visible-range', {
 						placeholders: {
 							start: this.pageEndSlice > 0 ? (this.pageStartSlice + 1).toString() : '0',


### PR DESCRIPTION
## What changed?

Improves the accessibility of the stateful table's pagination status. In `packages/components/src/components/table-stateful/shadow.tsx`, the `<span>` that renders the visible-range text (e.g. "1–10 of 42") now carries `role="status"` and `aria-live="polite"`, so assistive technology announces the range whenever the user pages through the table. A note is also added to `packages/components/AGENTS.md` reminding contributors to run a build before linting so the generated component typings exist for the check.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Verbessert die Barrierefreiheit der Paginierungs-Statusanzeige der Stateful-Tabelle. In `packages/components/src/components/table-stateful/shadow.tsx` erhält das `<span>`, das den sichtbaren Bereich anzeigt (z. B. „1–10 von 42"), nun `role="status"` und `aria-live="polite"`, sodass assistive Technologien den Bereich beim Blättern ankündigen. Zusätzlich wird in `packages/components/AGENTS.md` ein Hinweis ergänzt, dass vor dem Linting ein Build laufen muss, damit die generierten Komponenten-Typings für die Prüfung vorhanden sind.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/table-stateful/shadow.tsx` — Paginierungs-`<span>` erhält `role="status"` und `aria-live="polite"` für Screenreader-Ansagen.
- `packages/components/AGENTS.md` — Hinweis ergänzt, vor dem Linting einen Build auszuführen.

</details>