### PR TITLE
ci: hardcode OpenCoDE sync matrix branches

### DIFF
--- a/.github/actions/opencode-sync/action.yml
+++ b/.github/actions/opencode-sync/action.yml
@@ -1,0 +1,53 @@
+name: Sync branch to OpenCoDE
+inputs:
+  branch:
+    description: Branch to synchronize with OpenCoDE
+    required: true
+  remote-name:
+    description: Name of the Git remote used for pushing
+    required: false
+    default: opencode
+  remote-url:
+    description: Authenticated Git remote URL for OpenCoDE
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Configure Git for tiny push chunks (~5MB)
+      shell: bash
+      run: |
+        git config --global safe.directory "$GITHUB_WORKSPACE"
+        git config --global pack.packSizeLimit 5m
+        git config --global pack.window 0
+        git config --global pack.threads 1
+        git config --global http.version HTTP/1.1
+        git config --global http.postBuffer 5242880 || true
+        git config --global http.lowSpeedLimit 0
+        git config --global http.lowSpeedTime 0
+
+    - name: Add remote and prefetch target branch (if exists)
+      shell: bash
+      env:
+        BRANCH: ${{ inputs.branch }}
+        REMOTE_NAME: ${{ inputs['remote-name'] }}
+        REMOTE_URL: ${{ inputs['remote-url'] }}
+      run: |
+        git remote remove "$REMOTE_NAME" 2>/dev/null || true
+        git remote add "$REMOTE_NAME" "$REMOTE_URL"
+        git fetch "$REMOTE_NAME" "$BRANCH" || true
+
+    - name: Push branch to OpenCoDE (forced, tiny chunks, with retries)
+      shell: bash
+      env:
+        BRANCH: ${{ inputs.branch }}
+        REMOTE_NAME: ${{ inputs['remote-name'] }}
+      run: |
+        set -e
+        for i in 1 2 3; do
+          git -c pack.packSizeLimit=5m -c pack.window=0 -c pack.threads=1 \
+            push "$REMOTE_NAME" "$BRANCH:$BRANCH" --force && exit 0
+          echo "Push failed for $BRANCH (attempt $i). Retrying in 10s…"
+          sleep 10
+        done
+        echo "::error::Failed to push $BRANCH after 3 attempts."
+        exit 1

--- a/.github/workflows/sync-to-opencode.yml
+++ b/.github/workflows/sync-to-opencode.yml
@@ -9,42 +9,23 @@ jobs:
   sync:
     if: github.repository == 'public-ui/kolibri'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - develop
+          - release/1
+          - release/2
+          - release/3
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: develop
+          ref: ${{ matrix.branch }}
 
-      - name: Configure Git for tiny push chunks (~5MB)
-        run: |
-          git config --global safe.directory "$GITHUB_WORKSPACE"
-          # sehr kleine Packs -> mehrere kleine HTTP-Requests statt eines großen
-          git config --global pack.packSizeLimit 5m
-          git config --global pack.window 0
-          git config --global pack.threads 1
-          # Fallbacks / Stabilität über HTTP
-          git config --global http.version HTTP/1.1
-          git config --global http.postBuffer 5242880 || true  # legacy, falls noch unterstützt
-          git config --global http.lowSpeedLimit 0
-          git config --global http.lowSpeedTime 0
-
-      - name: Add remote and prefetch target branch (if exists)
-        run: |
-          git remote add opencode "https://OC000005112572:${{ secrets.GITLAB_PERSONAL_ACCESS_TOKEN }}@gitlab.opencode.de/OC000005112572/kolibri.git"
-          # Prefetch, damit Git Deltas gegen die Remote-History bilden kann (reduziert Packgröße)
-          git fetch opencode develop || true
-
-      - name: Push develop to OpenCoDE (forced, tiny chunks, with retries)
-        env:
-          GIT_HTTP_MAX: 5m
-        run: |
-          set -e
-          # zusätzlicher, einmaliger Versuch mit expliziten -c Overrides
-          for i in 1 2 3; do
-            git -c pack.packSizeLimit=5m -c pack.window=0 -c pack.threads=1 \
-                push opencode develop:develop --force && break || {
-              echo "Push failed (attempt $i). Retrying in 10s…"
-              sleep 10
-            }
-          done
+      - name: Sync ${{ matrix.branch }} to OpenCoDE
+        uses: ./.github/actions/opencode-sync
+        with:
+          branch: ${{ matrix.branch }}
+          remote-url: https://OC000005112572:${{ secrets.GITLAB_PERSONAL_ACCESS_TOKEN }}@gitlab.opencode.de/OC000005112572/kolibri.git


### PR DESCRIPTION
## What changed?

The OpenCoDE mirror workflow was refactored from a single hardcoded `develop` push into a reusable composite action plus a build matrix. A new composite action `.github/actions/opencode-sync/action.yml` encapsulates the Git configuration (tiny ~5 MB pack chunks, HTTP/1.1), remote setup, and the forced push with retries. `.github/workflows/sync-to-opencode.yml` now checks out and syncs each branch via a `strategy.matrix` over `develop`, `release/1`, `release/2`, and `release/3` (with `fail-fast: false`), delegating the push logic to the composite action. This is a CI-only change with no impact on the published packages.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der OpenCoDE-Spiegelungs-Workflow wurde von einem einzelnen fest verdrahteten `develop`-Push in eine wiederverwendbare Composite-Action mit Build-Matrix umgebaut. Die neue Composite-Action `.github/actions/opencode-sync/action.yml` kapselt die Git-Konfiguration (kleine ~5 MB Pack-Chunks, HTTP/1.1), das Remote-Setup und den erzwungenen Push mit Retries. `.github/workflows/sync-to-opencode.yml` checkt nun über eine `strategy.matrix` jeden Branch (`develop`, `release/1`, `release/2`, `release/3`, mit `fail-fast: false`) aus und synchronisiert ihn über die Composite-Action. Reine CI-Änderung ohne Auswirkung auf die veröffentlichten Pakete.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/actions/opencode-sync/action.yml` — Neue Composite-Action mit Git-Konfiguration, Remote-Setup und erzwungenem Push inkl. Retry-Logik.
- `.github/workflows/sync-to-opencode.yml` — Umstellung auf eine Branch-Matrix (`develop`, `release/1`–`release/3`), die die Sync-Logik an die Composite-Action delegiert.

</details>