### PR TITLE
feat: forward kolFocus to smart button in badge

### DIFF
--- a/packages/components/src/components/badge/badge.e2e.ts
+++ b/packages/components/src/components/badge/badge.e2e.ts
@@ -45,4 +45,28 @@ test.describe('kol-badge', () => {
 			});
 		});
 	});
+
+	test('should focus the smart button when kolFocus is called', async ({ page }) => {
+		const BADGE_PROPS = { _label: `Smart Button` };
+		await page.setContent(`<kol-badge _label="Badge with Button" _smart-button='${JSON.stringify(BADGE_PROPS)}'></kol-badge>`);
+		await page.waitForChanges();
+
+		const result = await page.locator('kol-badge').evaluate(async (badge: HTMLKolBadgeElement) => {
+			// Call kolFocus and check what gets focused
+			await badge.kolFocus();
+
+			// Wait for focus to be applied
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			// Check the focused element in the badge's shadow DOM
+			const shadowActiveElement = badge.shadowRoot?.activeElement;
+
+			return {
+				shadowActiveElementTag: shadowActiveElement?.tagName,
+			};
+		});
+
+		// The native button should be focused in the badge's shadow DOM
+		expect(result.shadowActiveElementTag).toBe('BUTTON');
+	});
 });

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -1,6 +1,6 @@
-import type { BadgeAPI, BadgeStates, ButtonProps, KoliBriIconsProp, LabelPropType, PropColor, Stringified } from '../../schema';
+import type { BadgeAPI, BadgeStates, ButtonProps, FocusableElement, KoliBriIconsProp, LabelPropType, PropColor, Stringified } from '../../schema';
 import { featureHint, handleColorChange, objectObjectHandler, parseJson, setState, validateColor, validateIcons } from '../../schema';
-import { Component, h, Prop, State, Watch } from '@stencil/core';
+import { Component, h, Method, Prop, State, Watch } from '@stencil/core';
 import { KolSpanFc } from '../../functional-components';
 
 import { nonce } from '../../utils/dev.utils';
@@ -17,14 +17,20 @@ featureHint(`[KolBadge] Optimierung des _color-Properties (rgba, rgb, hex usw.).
 	},
 	shadow: true,
 })
-export class KolBadge implements BadgeAPI {
+export class KolBadge implements BadgeAPI, FocusableElement {
 	private bgColorStr = '#000';
 	private colorStr = '#fff';
 	private readonly id = nonce();
+	private smartButtonRef?: HTMLKolButtonWcElement;
+
+	private readonly catchSmartButtonRef = (ref?: HTMLKolButtonWcElement) => {
+		this.smartButtonRef = ref;
+	};
 
 	private renderSmartButton(props: ButtonProps): JSX.Element {
 		return (
 			<KolButtonWcTag
+				ref={this.catchSmartButtonRef}
 				class="kol-badge__smart-button"
 				_ariaControls={this.id}
 				_customClass={props._customClass}
@@ -38,6 +44,14 @@ export class KolBadge implements BadgeAPI {
 				_buttonVariant={props._variant}
 			></KolButtonWcTag>
 		);
+	}
+
+	/**
+	 * Sets focus on the internal element.
+	 */
+	@Method()
+	public async kolFocus(): Promise<void> {
+		await this.smartButtonRef?.kolFocus();
 	}
 
 	public render(): JSX.Element {


### PR DESCRIPTION
## What changed?

The `kol-badge` component now implements the `FocusableElement` interface and exposes a public `kolFocus()` method. A `ref` callback (`catchSmartButtonRef`) captures the internal smart button instance, and `kolFocus()` forwards the focus call to that button's own `kolFocus()`. The change is in `packages/components/src/components/badge/shadow.tsx` (new `@Method()`, added imports for `Method` and `FocusableElement`) and is covered by a new Playwright end-to-end test in `badge.e2e.ts` that asserts the native button inside the badge's shadow DOM receives focus.

## Linked issues

No linked issues.

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `kol-badge`-Komponente implementiert nun das `FocusableElement`-Interface und stellt eine öffentliche `kolFocus()`-Methode bereit. Ein `ref`-Callback (`catchSmartButtonRef`) hält die Instanz des internen Smart-Buttons, und `kolFocus()` leitet den Fokus-Aufruf an dessen eigenes `kolFocus()` weiter. Betroffen ist `packages/components/src/components/badge/shadow.tsx` (neue `@Method()`, zusätzliche Imports für `Method` und `FocusableElement`); abgesichert wird das Verhalten durch einen neuen Playwright-E2E-Test in `badge.e2e.ts`, der prüft, dass der native Button im Shadow-DOM des Badges den Fokus erhält.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

✨ Neues Feature

### Geänderte Dateien

- `packages/components/src/components/badge/shadow.tsx` — Badge implementiert `FocusableElement`, hält eine Referenz auf den Smart-Button und leitet `kolFocus()` weiter.
- `packages/components/src/components/badge/badge.e2e.ts` — Neuer E2E-Test, der den Fokus auf den internen Button verifiziert.

</details>