### PR TITLE
fix: improve accessibility by adding role and aria-live to pagination

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -3,6 +3,7 @@
 This package contains the Stencil based web component library for KoliBri.
 
 Use `pnpm --filter @public-ui/components build` to build the library or `pnpm start` for development.
+Always run a build before linting so the generated component typings exist for the check.
 
 ## Structure
 

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -459,7 +459,7 @@ export class KolTableStateful implements TableAPI {
 		});
 		return (
 			<div class={`kol-table-stateful__pagination kol-table-stateful__pagination--${this.state._paginationPosition}`}>
-				<span>
+				<span role="status" aria-live="polite">
 					{translate('kol-table-visible-range', {
 						placeholders: {
 							start: this.pageEndSlice > 0 ? (this.pageStartSlice + 1).toString() : '0',


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/table-stateful/shadow.tsx`, the `<span>` that renders the "visible range" pagination text (e.g. "1–10 of 42") now carries `role="status"` and `aria-live="polite"`. This turns the range indicator into an ARIA live region, so assistive technologies announce the updated range whenever the user pages through a stateful table. A note is also added to `packages/components/AGENTS.md` reminding contributors to run a build before linting so that generated component typings exist for the check. No public API changes.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/table-stateful/shadow.tsx` erhält das `<span>`, das den Text des sichtbaren Bereichs der Paginierung anzeigt (z. B. „1–10 von 42"), nun `role="status"` und `aria-live="polite"`. Dadurch wird die Bereichsanzeige zu einer ARIA-Live-Region, sodass Screenreader die aktualisierte Bereichsangabe ansagen, sobald der Nutzer durch eine zustandsbehaftete Tabelle blättert. Zusätzlich wird in `packages/components/AGENTS.md` ein Hinweis ergänzt, vor dem Linten einen Build auszuführen, damit die generierten Komponenten-Typdefinitionen für die Prüfung vorhanden sind. Keine Änderungen an der öffentlichen API.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung (Barrierefreiheit)

### Geänderte Dateien

- `packages/components/src/components/table-stateful/shadow.tsx` — Paginierungs-Bereichsanzeige mit `role="status"` und `aria-live="polite"` versehen, damit Screenreader Bereichsänderungen ansagen.
- `packages/components/AGENTS.md` — Hinweis ergänzt, vor dem Linten zu bauen, damit generierte Typdefinitionen vorliegen.

</details>