### PR TITLE
fix(theme): show focus-like outline on button hover

### DIFF
--- a/packages/themes/default/src/mixins/button.scss
+++ b/packages/themes/default/src/mixins/button.scss
@@ -68,6 +68,9 @@
 				--text-background-color: var(--color-primary-variant);
 				--text-border-color: var(--color-primary-variant);
 				--text-color: var(--color-light);
+
+				position: relative;
+				@include focus-outline;
 			}
 		}
 
@@ -75,6 +78,7 @@
 			&:not([disabled], [aria-disabled='true']):hover {
 				--text-background-color: var(--color-danger);
 				--text-border-color: var(--color-danger);
+				outline-color: var(--color-danger);
 			}
 		}
 


### PR DESCRIPTION
## What changed?

This PR adds a visible focus-style outline to buttons on hover in the default theme (`packages/themes/default/src/mixins/button.scss`). On hover, the primary button now sets `position: relative` and applies the shared `focus-outline` mixin, and the danger variant sets its `outline-color` to `--color-danger` so the hover outline matches the button's semantic color. This improves the visual affordance and accessibility of the hover state without changing button markup or the component API.

## Linked issues

- Closes #8707 — Button hover effect: buttons lacked a clear focus-like outline on hover.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR ergänzt im Default-Theme (`packages/themes/default/src/mixins/button.scss`) eine sichtbare, fokusähnliche Outline für Buttons im Hover-Zustand. Beim Hover setzt der Primary-Button nun `position: relative` und nutzt das gemeinsame `focus-outline`-Mixin; die Danger-Variante setzt ihre `outline-color` auf `--color-danger`, sodass die Hover-Outline zur semantischen Farbe des Buttons passt. Das verbessert die visuelle Erkennbarkeit und Barrierefreiheit des Hover-Zustands, ohne Button-Markup oder die Komponenten-API zu ändern.

### Verknüpfte Tickets

- Schließt #8707 — Button-Hover-Effekt: Buttons hatten im Hover keine klare, fokusähnliche Outline.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/themes/default/src/mixins/button.scss` — Fokusähnliche Hover-Outline für Primary- und Danger-Buttons ergänzt.

</details>