### PR TITLE
style(mcp): improve landing page responsiveness for small screens

### DIFF
--- a/.github/workflows/mcp-vercel.yml
+++ b/.github/workflows/mcp-vercel.yml
@@ -3,7 +3,7 @@ name: Vercel MCP-Deploy
 on:
   push:
     branches:
-      - develop
+      - release/3
     paths:
       - '.github/workflows/mcp-vercel.yml'
       - 'packages/samples/react/**'
@@ -56,7 +56,7 @@ jobs:
           jq '.entries | length' dist/samples.json || echo "Could not count samples"
       - name: Deploy to Vercel (production)
         id: deploy_prod
-        if: github.ref == 'refs/heads/develop' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.ref == 'refs/heads/release/3' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         working-directory: packages/tools/mcp
         run: |
           set -eo pipefail

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -12,50 +12,50 @@
 				box-sizing: border-box;
 			}
 
-                        body {
-                                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-                                line-height: 1.6;
-                                color: #333;
-                                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-                                min-height: 100vh;
-                                display: flex;
-                                align-items: center;
-                                justify-content: center;
-                                padding: 2.5rem;
-                        }
+			body {
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+				line-height: 1.6;
+				color: #333;
+				background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+				min-height: 100vh;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				padding: 2.5rem;
+			}
 
-                        .container {
-                                width: min(100%, 800px);
-                                margin: 0 auto;
-                                padding: 2rem;
-                                background: white;
-                                border-radius: 12px;
-                                box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
-                        }
+			.container {
+				width: min(100%, 800px);
+				margin: 0 auto;
+				padding: 2rem;
+				background: white;
+				border-radius: 12px;
+				box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+			}
 
 			.header {
 				text-align: center;
 				margin-bottom: 2rem;
 			}
 
-                        .logo {
-                                width: clamp(96px, 18vw, 125px);
-                                height: clamp(96px, 18vw, 125px);
-                                margin: 0 auto 1rem;
-                                border-radius: 50%;
-                                display: flex;
-                                align-items: center;
-                                justify-content: center;
-                                color: white;
-                                font-size: 2rem;
-                                font-weight: bold;
-                        }
+			.logo {
+				width: clamp(96px, 18vw, 125px);
+				height: clamp(96px, 18vw, 125px);
+				margin: 0 auto 1rem;
+				border-radius: 50%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				color: white;
+				font-size: 2rem;
+				font-weight: bold;
+			}
 
-                        .logo img {
-                                width: 100%;
-                                height: auto;
-                                display: block;
-                        }
+			.logo img {
+				width: 100%;
+				height: auto;
+				display: block;
+			}
 
 			h1 {
 				color: #2d3748;
@@ -63,11 +63,11 @@
 				font-size: 2.5rem;
 			}
 
-                        .subtitle {
-                                color: #718096;
-                                font-size: 1.1rem;
-                                margin-bottom: 2rem;
-                        }
+			.subtitle {
+				color: #718096;
+				font-size: 1.1rem;
+				margin-bottom: 2rem;
+			}
 
 			.stats {
 				display: grid;
@@ -107,17 +107,17 @@
 				border-left: 4px solid #667eea;
 			}
 
-                        .endpoint {
-                                background: #1a202c;
-                                color: white;
-                                padding: 1rem;
-                                border-radius: 6px;
-                                font-family: 'Courier New', monospace;
-                                margin: 0.5rem 0;
-                                overflow-x: auto;
-                                white-space: pre;
-                                display: block;
-                        }
+			.endpoint {
+				background: #1a202c;
+				color: white;
+				padding: 1rem;
+				border-radius: 6px;
+				font-family: 'Courier New', monospace;
+				margin: 0.5rem 0;
+				overflow-x: auto;
+				white-space: pre;
+				display: block;
+			}
 			.endpoint-inline {
 				background: #1a202c;
 				color: #90cdf4;
@@ -212,77 +212,77 @@
 
 			/* Removed duplicate .copy-btn rules for clarity and consistency */
 
-                        .relative {
-                                position: relative;
-                        }
+			.relative {
+				position: relative;
+			}
 
-                        @media (max-width: 900px) {
-                                body {
-                                        padding: 2rem;
-                                }
+			@media (max-width: 900px) {
+				body {
+					padding: 2rem;
+				}
 
-                                h1 {
-                                        font-size: 2.2rem;
-                                }
+				h1 {
+					font-size: 2.2rem;
+				}
 
-                                .subtitle {
-                                        font-size: 1rem;
-                                }
-                        }
+				.subtitle {
+					font-size: 1rem;
+				}
+			}
 
-                        @media (max-width: 640px) {
-                                body {
-                                        align-items: flex-start;
-                                        padding: 1.5rem;
-                                }
+			@media (max-width: 640px) {
+				body {
+					align-items: flex-start;
+					padding: 1.5rem;
+				}
 
-                                .container {
-                                        padding: 1.75rem;
-                                }
+				.container {
+					padding: 1.75rem;
+				}
 
-                                h1 {
-                                        font-size: 1.9rem;
-                                }
+				h1 {
+					font-size: 1.9rem;
+				}
 
-                                .subtitle {
-                                        margin-bottom: 1.5rem;
-                                }
+				.subtitle {
+					margin-bottom: 1.5rem;
+				}
 
-                                .api-info {
-                                        padding: 1.25rem;
-                                }
+				.api-info {
+					padding: 1.25rem;
+				}
 
-                                .stat {
-                                        padding: 0.85rem;
-                                }
-                        }
+				.stat {
+					padding: 0.85rem;
+				}
+			}
 
-                        @media (max-width: 480px) {
-                                body {
-                                        padding: 1.25rem;
-                                }
+			@media (max-width: 480px) {
+				body {
+					padding: 1.25rem;
+				}
 
-                                .container {
-                                        padding: 1.5rem;
-                                }
+				.container {
+					padding: 1.5rem;
+				}
 
-                                h1 {
-                                        font-size: 1.7rem;
-                                }
+				h1 {
+					font-size: 1.7rem;
+				}
 
-                                .subtitle {
-                                        font-size: 0.95rem;
-                                }
+				.subtitle {
+					font-size: 0.95rem;
+				}
 
-                                .endpoint {
-                                        font-size: 0.9rem;
-                                }
+				.endpoint {
+					font-size: 0.9rem;
+				}
 
-                                .copy-btn {
-                                        top: 6px;
-                                        right: 6px;
-                                }
-                        }
+				.copy-btn {
+					top: 6px;
+					right: 6px;
+				}
+			}
 		</style>
 	</head>
 	<body>

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -12,43 +12,50 @@
 				box-sizing: border-box;
 			}
 
-			body {
-				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-				line-height: 1.6;
-				color: #333;
-				background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-				min-height: 100vh;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-			}
+                        body {
+                                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                                line-height: 1.6;
+                                color: #333;
+                                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                                min-height: 100vh;
+                                display: flex;
+                                align-items: center;
+                                justify-content: center;
+                                padding: 2.5rem;
+                        }
 
-			.container {
-				max-width: 800px;
-				margin: 0 auto;
-				padding: 2rem;
-				background: white;
-				border-radius: 12px;
-				box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
-			}
+                        .container {
+                                width: min(100%, 800px);
+                                margin: 0 auto;
+                                padding: 2rem;
+                                background: white;
+                                border-radius: 12px;
+                                box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+                        }
 
 			.header {
 				text-align: center;
 				margin-bottom: 2rem;
 			}
 
-			.logo {
-				width: 125px;
-				height: 125px;
-				margin: 0 auto 1rem;
-				border-radius: 50%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				color: white;
-				font-size: 2rem;
-				font-weight: bold;
-			}
+                        .logo {
+                                width: clamp(96px, 18vw, 125px);
+                                height: clamp(96px, 18vw, 125px);
+                                margin: 0 auto 1rem;
+                                border-radius: 50%;
+                                display: flex;
+                                align-items: center;
+                                justify-content: center;
+                                color: white;
+                                font-size: 2rem;
+                                font-weight: bold;
+                        }
+
+                        .logo img {
+                                width: 100%;
+                                height: auto;
+                                display: block;
+                        }
 
 			h1 {
 				color: #2d3748;
@@ -56,11 +63,11 @@
 				font-size: 2.5rem;
 			}
 
-			.subtitle {
-				color: #718096;
-				font-size: 1.1rem;
-				margin-bottom: 2rem;
-			}
+                        .subtitle {
+                                color: #718096;
+                                font-size: 1.1rem;
+                                margin-bottom: 2rem;
+                        }
 
 			.stats {
 				display: grid;
@@ -100,17 +107,17 @@
 				border-left: 4px solid #667eea;
 			}
 
-			.endpoint {
-				background: #1a202c;
-				color: white;
-				padding: 1rem;
-				border-radius: 6px;
-				font-family: 'Courier New', monospace;
-				margin: 0.5rem 0;
-				overflow-x: auto;
-				white-space: pre;
-				display: block;
-			}
+                        .endpoint {
+                                background: #1a202c;
+                                color: white;
+                                padding: 1rem;
+                                border-radius: 6px;
+                                font-family: 'Courier New', monospace;
+                                margin: 0.5rem 0;
+                                overflow-x: auto;
+                                white-space: pre;
+                                display: block;
+                        }
 			.endpoint-inline {
 				background: #1a202c;
 				color: #90cdf4;
@@ -205,9 +212,77 @@
 
 			/* Removed duplicate .copy-btn rules for clarity and consistency */
 
-			.relative {
-				position: relative;
-			}
+                        .relative {
+                                position: relative;
+                        }
+
+                        @media (max-width: 900px) {
+                                body {
+                                        padding: 2rem;
+                                }
+
+                                h1 {
+                                        font-size: 2.2rem;
+                                }
+
+                                .subtitle {
+                                        font-size: 1rem;
+                                }
+                        }
+
+                        @media (max-width: 640px) {
+                                body {
+                                        align-items: flex-start;
+                                        padding: 1.5rem;
+                                }
+
+                                .container {
+                                        padding: 1.75rem;
+                                }
+
+                                h1 {
+                                        font-size: 1.9rem;
+                                }
+
+                                .subtitle {
+                                        margin-bottom: 1.5rem;
+                                }
+
+                                .api-info {
+                                        padding: 1.25rem;
+                                }
+
+                                .stat {
+                                        padding: 0.85rem;
+                                }
+                        }
+
+                        @media (max-width: 480px) {
+                                body {
+                                        padding: 1.25rem;
+                                }
+
+                                .container {
+                                        padding: 1.5rem;
+                                }
+
+                                h1 {
+                                        font-size: 1.7rem;
+                                }
+
+                                .subtitle {
+                                        font-size: 0.95rem;
+                                }
+
+                                .endpoint {
+                                        font-size: 0.9rem;
+                                }
+
+                                .copy-btn {
+                                        top: 6px;
+                                        right: 6px;
+                                }
+                        }
 		</style>
 	</head>
 	<body>

--- a/packages/tools/mcp/src/index.js
+++ b/packages/tools/mcp/src/index.js
@@ -2,6 +2,7 @@ import { startServer } from './server.js';
 
 // Export functions for Vercel API
 export { AI_HINTS_KEY, AI_HINTS_MESSAGES, handleApiRequest } from './api-handler.js';
+export { hasSearchableQuery, performFuzzySearch } from './fuzzy-search.js';
 export { buildSampleIndex, SampleIndex } from './sample-index.js';
 
 // Only start server when executed directly


### PR DESCRIPTION
## What changed?

This PR improves the responsiveness of the MCP tool landing page (`packages/tools/mcp/public/index.html`). The container now uses `width: min(100%, 800px)` instead of a fixed `max-width`, the logo scales fluidly via `clamp(96px, 18vw, 125px)`, and three breakpoints (`900px`, `640px`, `480px`) adjust body padding, heading/subtitle typography, and inner spacing for mobile screens. Additionally, the Vercel MCP deploy workflow (`.github/workflows/mcp-vercel.yml`) now triggers on the `release/3` branch instead of `develop`, and `packages/tools/mcp/src/index.js` re-exports `hasSearchableQuery` and `performFuzzySearch` from the fuzzy-search module. No consumer-facing component API is affected.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR verbessert die Responsivität der MCP-Tool-Landingpage (`packages/tools/mcp/public/index.html`). Der Container nutzt jetzt `width: min(100%, 800px)` statt einer festen `max-width`, das Logo skaliert fließend über `clamp(96px, 18vw, 125px)`, und drei Breakpoints (`900px`, `640px`, `480px`) passen Body-Padding, Überschriften-/Untertitel-Typografie sowie Innenabstände für mobile Bildschirme an. Zusätzlich löst der Vercel-MCP-Deploy-Workflow (`.github/workflows/mcp-vercel.yml`) nun auf dem Branch `release/3` statt `develop` aus, und `packages/tools/mcp/src/index.js` re-exportiert `hasSearchableQuery` und `performFuzzySearch` aus dem Fuzzy-Search-Modul. Keine öffentliche Komponenten-API ist betroffen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/tools/mcp/public/index.html` — Responsives Layout: fluide Container-/Logo-Größen und Media-Queries für 900/640/480 px.
- `.github/workflows/mcp-vercel.yml` — Deploy-Trigger von `develop` auf `release/3` umgestellt.
- `packages/tools/mcp/src/index.js` — Re-Export der Fuzzy-Search-Funktionen `hasSearchableQuery` und `performFuzzySearch`.

</details>