### PR TITLE
docs: document MCP search query usage

### DIFF
--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -315,7 +315,25 @@
 						<span class="method get">GET</span>
 						<code class="endpoint"><a href="/mcp/samples" style="color: #90cdf4">/mcp/samples</a></code>
 					</div>
-					<p class="description">List of all available samples (optional filter with ?q=filter)</p>
+					<p class="description">
+						List of all available samples. Add the
+						<code class="endpoint-inline">?q=&lt;search&gt;</code>
+						query parameter to perform a fuzzy search across component names, tags, titles, descriptions and the component folder path. The search is tolerant
+						to typos and partial matches, so even short tokens can surface the relevant sample.
+					</p>
+					<div class="relative" style="margin-bottom: 0.75rem">
+						<code class="endpoint"><a href="/mcp/samples?q=btn" style="color: #90cdf4">/mcp/samples?q=btn</a></code>
+						<button class="copy-btn" aria-label="Copy fuzzy search endpoint" tabindex="0">📋</button>
+					</div>
+					<p class="description">
+						The example above demonstrates fuzzy matching&mdash;the short token
+						<code class="endpoint-inline">btn</code> still returns button samples.
+					</p>
+					<div class="relative" style="margin-bottom: 0.75rem">
+						<code class="endpoint"><a href="/mcp/samples?q=table%20responsive" style="color: #90cdf4">/mcp/samples?q=table%20responsive</a></code>
+						<button class="copy-btn" aria-label="Copy multi-word search endpoint" tabindex="0">📋</button>
+					</div>
+					<p class="description">Combine multiple words with spaces to narrow the result set&mdash;this request filters for responsive table samples.</p>
 
 					<div>
 						<span class="method get">GET</span>


### PR DESCRIPTION
## What changed?

Documentation-only change to the MCP tool's landing page (`packages/tools/mcp/public/index.html`). The description of the `GET /mcp/samples` endpoint was expanded to explain the `?q=<search>` query parameter, clarifying that it performs a typo-tolerant fuzzy search across component names, tags, titles, descriptions and the component folder path. Two ready-to-copy example requests were added — `?q=btn` (demonstrating fuzzy matching of a short token to button samples) and `?q=table%20responsive` (demonstrating multi-word queries) — each with a copy button. No server logic, API, or component code was changed; only the static documentation page.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Reine Dokumentationsänderung an der Landingpage des MCP-Tools (`packages/tools/mcp/public/index.html`). Die Beschreibung des Endpunkts `GET /mcp/samples` wurde erweitert, um den Query-Parameter `?q=<search>` zu erklären: Er führt eine tippfehlertolerante Fuzzy-Suche über Komponentennamen, Tags, Titel, Beschreibungen und den Komponenten-Ordnerpfad durch. Zwei direkt kopierbare Beispiel-Requests wurden ergänzt — `?q=btn` (zeigt Fuzzy-Matching eines kurzen Tokens auf Button-Beispiele) und `?q=table%20responsive` (zeigt mehrwortige Abfragen) — jeweils mit Kopier-Button. Es wurde keine Server-Logik, API oder Komponenten-Code geändert; nur die statische Dokumentationsseite.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/mcp/public/index.html` — Dokumentiert den `?q=`-Suchparameter des `/mcp/samples`-Endpunkts inkl. kopierbarer Beispielanfragen.

</details>