### PR TITLE
Add PopoverButton visual snapshot coverage

### DIFF
--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -1,15 +1,44 @@
 import { KolHeading, KolPopoverButton, KolToolbar } from '@public-ui/react-v19';
 import type { FC } from 'react';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useToasterService } from '../../hooks/useToasterService';
 import { SampleDescription } from '../SampleDescription';
 
 export const PopoverButtonBasic: FC = () => {
-	const { dummyClickEventHandler } = useToasterService();
+        const { dummyClickEventHandler } = useToasterService();
+        const helpPopoverRef = useRef<HTMLKolPopoverButtonElement | null>(null);
 
-	const dummyEventHandler = {
-		onClick: dummyClickEventHandler,
-	};
+        useEffect(() => {
+                let isActive = true;
+                type NativePopoverElement = HTMLElement & {
+                        hidePopover?: () => void;
+                        showPopover?: () => void;
+                };
+                let popoverElement: NativePopoverElement | undefined;
+
+                const openPopover = async () => {
+                        await customElements.whenDefined('kol-popover-button');
+                        if (!isActive) {
+                                return;
+                        }
+
+                        popoverElement = helpPopoverRef.current
+                                ?.shadowRoot?.querySelector('[popover]') as NativePopoverElement | undefined;
+
+                        popoverElement?.showPopover?.();
+                };
+
+                void openPopover();
+
+                return () => {
+                        isActive = false;
+                        popoverElement?.hidePopover?.();
+                };
+        }, []);
+
+        const dummyEventHandler = {
+                onClick: dummyClickEventHandler,
+        };
 
 	const TOOLBAR_ITEMS = [
 		{
@@ -47,7 +76,14 @@ export const PopoverButtonBasic: FC = () => {
 
 				<KolHeading _label="Info icon with help text" _level={2}></KolHeading>
 
-				<KolPopoverButton _label="Help" _icons="codicon codicon-info" _popoverAlign="right" _tooltipAlign="bottom" _hideLabel>
+                                <KolPopoverButton
+                                        _label="Help"
+                                        _icons="codicon codicon-info"
+                                        _popoverAlign="right"
+                                        _tooltipAlign="bottom"
+                                        _hideLabel
+                                        ref={helpPopoverRef}
+                                >
 					<div className="w-sm p-2 border border-solid border-gray">
 						<KolHeading _label="Help Information" _level={3}></KolHeading>
 						<p>

--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -10,29 +10,25 @@ export const PopoverButtonBasic: FC = () => {
 
         useEffect(() => {
                 let isActive = true;
-                type NativePopoverElement = HTMLElement & {
-                        hidePopover?: () => void;
-                        showPopover?: () => void;
-                };
-                let popoverElement: NativePopoverElement | undefined;
 
                 const openPopover = async () => {
-                        await customElements.whenDefined('kol-popover-button');
+                        const popoverHost = helpPopoverRef.current;
+                        await popoverHost?.componentOnReady?.();
                         if (!isActive) {
                                 return;
                         }
 
-                        popoverElement = helpPopoverRef.current
-                                ?.shadowRoot?.querySelector('[popover]') as NativePopoverElement | undefined;
-
-                        popoverElement?.showPopover?.();
+                        const popover = popoverHost?.shadowRoot?.querySelector('[popover]') as
+                                | (HTMLElement & { showPopover?: () => void })
+                                | null;
+                        popover?.showPopover?.();
                 };
 
                 void openPopover();
 
                 return () => {
                         isActive = false;
-                        popoverElement?.hidePopover?.();
+                        helpPopoverRef.current?.hidePopover?.();
                 };
         }, []);
 

--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -566,17 +566,25 @@ ROUTES.set('nav/basic', {
 	},
 });
 ROUTES.set('pagination/basic', {
-	snapshot: {
-		zoom: {
-			skip: true,
-		},
-	},
+        snapshot: {
+                zoom: {
+                        skip: true,
+                },
+        },
+});
+ROUTES.set('popover-button/basic', {
+        snapshot: {
+                waitForTimeout: 250,
+                zoom: {
+                        skip: true,
+                },
+        },
 });
 ROUTES.set('progress/basic', {
-	snapshot: {
-		zoom: {
-			skip: true,
-		},
+        snapshot: {
+                zoom: {
+                        skip: true,
+                },
 	},
 });
 ROUTES.set('quote/basic', {


### PR DESCRIPTION
## Summary
- ensure the PopoverButton help sample opens its popover automatically for snapshots
- add the PopoverButton route to the visual test suite with a short wait time

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa51288264832b913f3f139cd00b1a