### PR TITLE
docs: fix markdown formatting in MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,34 +6,48 @@ New major versions of KoliBri are developed with the aim of simplifying maintena
 
 This means that components, features or functionalities may be removed and technological prerequisites created to promote future innovative change.
 
-- **Maintenance and care strategy:**<br/>
+- **Maintenance and care strategy:**
+
   We will always maintain the latest and previous major version of KoliBri. This means that we will fix bugs and close security gaps for these versions. For all other versions, we will no longer provide bug fixes or security updates without further notice.
-- **Further development:**<br/>
+
+- **Further development:**
+
   We will always continue to develop the latest major version of KoliBri. This means that we will provide new features and functionalities for these versions. For all other versions, we will no longer provide any new features or functionalities without further ado.
-- **Save an executable version before migration:**<br/>
+
+- **Save an executable version before migration:**
+
   Before the migration takes place, we recommend checking in an executable version so that there are no uncommitted changes to the source code to be migrated. This means that all changes can be easily tracked and checked during and after the migration.
-- **Migrationstool:**<br/>
+
+- **Migrationstool:**
+
   We provide a migration tool that generally supports the migration of source code with KoliBri. This tool is able to migrate most breaking changes automatically. Further information can be found in the [Tool-Dokumentation (EN)](https://www.npmjs.com/package/@public-ui/kolibri-cli).
-- **Help and feedback:**<br/>
+
+- **Help and feedback:**
+
   If there are any problems with the migration, we are happy to help. Please open an [Issue on GitHub](https://github.com/public-ui/kolibri/issues/new/choose).
 
 ## Migration from version 1 to version 2
 
 ### Notes on upgrading to version 2
 
-1. **New features in version 2 already available from version 1.7:**<br/>
+1. **New features in version 2 already available from version 1.7:**
+
    Most of the new features introduced in version 2 are already available from version 1.7 and higher. This means that applications based on version 1.7 or higher may already have the necessary functions to enable a smooth migration.
 
-2. **Removed properties, components and functionalities were already marked as obsolete in version 1.7 and higher:**<br/>
+2. **Removed properties, components and functionalities were already marked as obsolete in version 1.7 and higher:**
+
    All features, components and functionalities that were removed in version 2 were already marked as deprecated in version 1.7 and higher. So if you have regularly updated your code base, you should already be prepared to replace these elements.
 
-3. **Migration from version 1.7 minimizes potential changes:**<br/>
+3. **Migration from version 1.7 minimizes potential changes:**
+
    A migration from version 1.7 and higher to version 2 will probably require the least adjustments. The likelihood of incompatibilities is low, as most changes and removals have already been marked as obsolete in previous versions.
 
-4. **Migration from version 1.4 is possible:**<br/>
+4. **Migration from version 1.4 is possible:**
+
    Although a migration from version 1.7 is recommended, it is also possible to migrate from version 1.4 to version 2. Please note, however, that this may require additional adjustments, as some of the necessary functions may only be available from version 1.7.
 
-5. **Note simplified registration:**<br/>
+5. **Note simplified registration:**
+
    We have simplified the modularization of KoliBri in version 1 and for version 2. The module `@public-ui/core` has been removed and the functionalities moved to the module `@public-ui/components`.
 
 ```diff
@@ -63,16 +77,24 @@ You can find more information about Breaking Changes in the documentation [BREAK
 
 ### Migration with migration tool
 
-1. **Preparation:**<br/>
+1. **Preparation:**
+
    The project is on an earlier version, all dependencies are installed, the project is executable and all changes are checked in and safely pushed.
-2. **Execute migration:**<br/>
+
+2. **Execute migration:**
+
    Execute the following command to perform the migration: `npx @public-ui/kolibri-cli migrate src`
-3. **Check migration:**<br/>
+
+3. **Check migration:**
+
    Check the changes and run the application to make sure everything works as expected.
 
 ### Perform migration manually
 
-1. **Preparation:**<br/>
+1. **Preparation:**
+
    The project is on an earlier version, all dependencies are installed, the project is executable and all changes are checked in and safely pushed.
-2. **Perform migration:**<br/>
+
+2. **Perform migration:**
+
    Carry out the migration by making the breaking changes in the respective documentation.


### PR DESCRIPTION
## What changed?

Documentation-only change to a single file (`MIGRATION.md`). Hard line breaks (`<br/>`) after the bold labels in the migration list items were replaced with proper blank lines, so each label and its following paragraph render as separate blocks in Markdown instead of relying on inline `<br/>` tags. The wording and structure of the migration guidance are unchanged; only the Markdown formatting was corrected. No code, API, or runtime behaviour is affected.

## Linked issues

- Refs #8707 — related tooling/documentation work.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Reine Dokumentationsänderung an einer einzigen Datei (`MIGRATION.md`). Harte Zeilenumbrüche (`<br/>`) nach den fett gesetzten Bezeichnungen in den Migrations-Listeneinträgen wurden durch echte Leerzeilen ersetzt, sodass Bezeichnung und zugehöriger Absatz in Markdown als getrennte Blöcke gerendert werden, statt auf Inline-`<br/>`-Tags zu setzen. Wortlaut und Struktur der Migrationshinweise bleiben unverändert; korrigiert wurde ausschließlich die Markdown-Formatierung. Kein Code, keine API und kein Laufzeitverhalten sind betroffen.

### Verknüpfte Tickets

- Referenziert #8707 — zugehörige Tooling-/Dokumentationsarbeit.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `MIGRATION.md` — Ersetzt `<br/>`-Zeilenumbrüche durch Leerzeilen für korrektes Markdown-Rendering (nur Formatierung).

</details>