### PR TITLE
test(button): fix DOM event e2e specs for button, button-link and badge

### DIFF
--- a/packages/components/src/components/badge/badge.e2e.ts
+++ b/packages/components/src/components/badge/badge.e2e.ts
@@ -30,17 +30,21 @@ test.describe('kol-badge', () => {
 	});
 
 	test.describe('DOM events', () => {
-		[KolEvent.click, KolEvent.mousedown].forEach((event) => {
-			test(`should emit ${event} when smart button emits ${event}`, async ({ page }) => {
+		const EVENTS: [string, KolEvent][] = [
+			['click', KolEvent.click],
+			['mousedown', KolEvent.mousedown],
+		];
+		EVENTS.forEach(([nativeEvent, kolEvent]) => {
+			test(`should emit ${kolEvent} when smart button emits ${nativeEvent}`, async ({ page }) => {
 				const BADGE_PROPS = { _label: `Smart Button` };
 				await page.setContent(`<kol-badge _label="Badge with Button" _smart-button='${JSON.stringify(BADGE_PROPS)}'></kol-badge>`);
 				const eventPromise = page.locator('kol-badge').evaluate(async (element, event) => {
 					return new Promise((resolve) => {
 						element.addEventListener(event, resolve);
 					});
-				}, event);
+				}, kolEvent);
 				await page.waitForChanges();
-				await page.locator('button').dispatchEvent(event);
+				await page.locator('button').dispatchEvent(nativeEvent);
 				await expect(eventPromise).resolves.toBeTruthy();
 			});
 		});

--- a/packages/components/src/components/badge/badge.e2e.ts
+++ b/packages/components/src/components/badge/badge.e2e.ts
@@ -7,7 +7,7 @@ test.describe('kol-badge', () => {
 		['onClick', 'onMouseDown'].forEach((callbackName) => {
 			test(`should call ${callbackName} callback when smart button emits`, async ({ page }) => {
 				await page.setContent(`<kol-badge _label="Badge with Button"></kol-badge>`);
-				const kolBadge = page.locator('kol-badge');
+                                const kolBadge = page.locator('kol-badge');
 
 				const callbackPromise = kolBadge.evaluate((element: HTMLKolBadgeElement, callbackName) => {
 					return new Promise<void>((resolve) => {
@@ -23,7 +23,8 @@ test.describe('kol-badge', () => {
 				}, callbackName);
 				await page.waitForChanges();
 
-				await page.locator('button').click();
+                                const smartButton = kolBadge.locator('kol-button-wc').locator('button');
+                                await smartButton.click();
 				await expect(callbackPromise).resolves.toBeUndefined();
 			});
 		});
@@ -38,13 +39,17 @@ test.describe('kol-badge', () => {
 			test(`should emit ${kolEvent} when smart button emits ${nativeEvent}`, async ({ page }) => {
 				const BADGE_PROPS = { _label: `Smart Button` };
 				await page.setContent(`<kol-badge _label="Badge with Button" _smart-button='${JSON.stringify(BADGE_PROPS)}'></kol-badge>`);
-				const eventPromise = page.locator('kol-badge').evaluate(async (element, event) => {
-					return new Promise((resolve) => {
-						element.addEventListener(event, resolve);
-					});
-				}, kolEvent);
-				await page.waitForChanges();
-				await page.locator('button').dispatchEvent(nativeEvent);
+                                const eventPromise = page.locator('kol-badge').evaluate(async (element, event) => {
+                                        return new Promise((resolve) => {
+                                                element.addEventListener(event, resolve);
+                                        });
+                                }, kolEvent);
+                                await page.waitForChanges();
+                                const smartButton = page
+                                        .locator('kol-badge')
+                                        .locator('kol-button-wc')
+                                        .locator('button');
+                                await smartButton.dispatchEvent(nativeEvent);
 				await expect(eventPromise).resolves.toBeTruthy();
 			});
 		});

--- a/packages/components/src/components/button-link/button-link.e2e.ts
+++ b/packages/components/src/components/button-link/button-link.e2e.ts
@@ -33,16 +33,20 @@ test.describe('kol-button-link', () => {
 	});
 
 	test.describe('DOM events', () => {
-		[KolEvent.click, KolEvent.mousedown].forEach((event) => {
-			test(`should emit ${event} when internal button emits ${event}`, async ({ page }) => {
+		const EVENTS: [string, KolEvent][] = [
+			['click', KolEvent.click],
+			['mousedown', KolEvent.mousedown],
+		];
+		EVENTS.forEach(([nativeEvent, kolEvent]) => {
+			test(`should emit ${kolEvent} when internal button emits ${nativeEvent}`, async ({ page }) => {
 				await page.setContent('<kol-button-link _label="Button"></kol-button-link>');
 				const eventPromise = page.locator('kol-button-link').evaluate(async (element, event) => {
 					return new Promise((resolve) => {
 						element.addEventListener(event, resolve);
 					});
-				}, event);
+				}, kolEvent);
 				await page.waitForChanges();
-				await page.locator('button').dispatchEvent(event);
+				await page.locator('button').dispatchEvent(nativeEvent);
 				await expect(eventPromise).resolves.toBeTruthy();
 			});
 		});

--- a/packages/components/src/components/button-link/button-link.e2e.ts
+++ b/packages/components/src/components/button-link/button-link.e2e.ts
@@ -4,16 +4,17 @@ import { KolEvent } from '../../utils/events';
 
 test.describe('kol-button-link', () => {
 	test('it renders label', async ({ page }) => {
-		await page.setContent('<kol-button-link _label="Test ButtonLink Element" _variant="primary"></kol-button-link>');
-		const kolButton = page.locator('kol-button-link');
-		await expect(kolButton).toContainText('Test ButtonLink Element');
+                await page.setContent('<kol-button-link _label="Test ButtonLink Element" _variant="primary"></kol-button-link>');
+                const kolButton = page.locator('kol-button-link');
+                await expect(kolButton).toContainText('Test ButtonLink Element');
 	});
 
 	test.describe('Callbacks', () => {
 		['onClick', 'onMouseDown'].forEach((callbackName) => {
 			test(`should call ${callbackName} callback when internal button emits`, async ({ page }) => {
 				await page.setContent('<kol-button-link _label="Button"></kol-button-link>');
-				const kolButton = page.locator('kol-button-link');
+                                const kolButton = page.locator('kol-button-link');
+                                const internalButton = kolButton.locator('kol-button-wc').locator('button');
 
 				const callbackPromise = kolButton.evaluate((element: HTMLKolButtonElement, callbackName) => {
 					return new Promise<void>((resolve) => {
@@ -26,7 +27,7 @@ test.describe('kol-button-link', () => {
 				}, callbackName);
 				await page.waitForChanges();
 
-				await page.locator('button').click();
+                                await internalButton.click();
 				await expect(callbackPromise).resolves.toBeUndefined();
 			});
 		});
@@ -46,7 +47,11 @@ test.describe('kol-button-link', () => {
 					});
 				}, kolEvent);
 				await page.waitForChanges();
-				await page.locator('button').dispatchEvent(nativeEvent);
+                                const internalButton = page
+                                        .locator('kol-button-link')
+                                        .locator('kol-button-wc')
+                                        .locator('button');
+                                await internalButton.dispatchEvent(nativeEvent);
 				await expect(eventPromise).resolves.toBeTruthy();
 			});
 		});

--- a/packages/components/src/components/button/button.e2e.ts
+++ b/packages/components/src/components/button/button.e2e.ts
@@ -33,16 +33,20 @@ test.describe('kol-button', () => {
 	});
 
 	test.describe('DOM events', () => {
-		[KolEvent.click, KolEvent.mousedown].forEach((event) => {
-			test(`should emit ${event} when internal button emits ${event}`, async ({ page }) => {
+		const EVENTS: [string, KolEvent][] = [
+			['click', KolEvent.click],
+			['mousedown', KolEvent.mousedown],
+		];
+		EVENTS.forEach(([nativeEvent, kolEvent]) => {
+			test(`should emit ${kolEvent} when internal button emits ${nativeEvent}`, async ({ page }) => {
 				await page.setContent('<kol-button _label="Button"></kol-button>');
 				const eventPromise = page.locator('kol-button').evaluate(async (element, event) => {
 					return new Promise((resolve) => {
 						element.addEventListener(event, resolve);
 					});
-				}, event);
+				}, kolEvent);
 				await page.waitForChanges();
-				await page.locator('button').dispatchEvent(event);
+				await page.locator('button').dispatchEvent(nativeEvent);
 				await expect(eventPromise).resolves.toBeTruthy();
 			});
 		});

--- a/packages/components/src/components/button/button.e2e.ts
+++ b/packages/components/src/components/button/button.e2e.ts
@@ -4,16 +4,17 @@ import { KolEvent } from '../../utils/events';
 
 test.describe('kol-button', () => {
 	test('it renders label', async ({ page }) => {
-		await page.setContent('<kol-button _label="Test Button Element" _variant="primary"></kol-button>');
-		const kolButton = page.locator('kol-button');
-		await expect(kolButton).toContainText('Test Button Element');
+                await page.setContent('<kol-button _label="Test Button Element" _variant="primary"></kol-button>');
+                const kolButton = page.locator('kol-button');
+                await expect(kolButton).toContainText('Test Button Element');
 	});
 
 	test.describe('Callbacks', () => {
 		['onClick', 'onMouseDown'].forEach((callbackName) => {
 			test(`should call ${callbackName} callback when internal button emits`, async ({ page }) => {
 				await page.setContent('<kol-button _label="Button"></kol-button>');
-				const kolButton = page.locator('kol-button');
+                                const kolButton = page.locator('kol-button');
+                                const internalButton = kolButton.locator('kol-button-wc').locator('button');
 
 				const callbackPromise = kolButton.evaluate((element: HTMLKolButtonElement, callbackName) => {
 					return new Promise<void>((resolve) => {
@@ -26,7 +27,7 @@ test.describe('kol-button', () => {
 				}, callbackName);
 				await page.waitForChanges();
 
-				await page.locator('button').click();
+                                await internalButton.click();
 				await expect(callbackPromise).resolves.toBeUndefined();
 			});
 		});
@@ -46,7 +47,8 @@ test.describe('kol-button', () => {
 					});
 				}, kolEvent);
 				await page.waitForChanges();
-				await page.locator('button').dispatchEvent(nativeEvent);
+                                const internalButton = page.locator('kol-button').locator('kol-button-wc').locator('button');
+                                await internalButton.dispatchEvent(nativeEvent);
 				await expect(eventPromise).resolves.toBeTruthy();
 			});
 		});


### PR DESCRIPTION
## What changed?

Only end-to-end test specs were changed; there is no runtime/library change. The DOM-event e2e specs for `kol-button` (`button.e2e.ts`), `kol-button-link` (`button-link.e2e.ts`) and `kol-badge` (`badge.e2e.ts`) were updated so they target the internal smart button (`kol-button-wc` → `button`) instead of a top-level `button` locator, and so they dispatch a native `click` / `mousedown` event while listening for the corresponding `KolEvent`. The tests were also restructured to iterate over explicit `[nativeEvent, kolEvent]` pairs, making the mapping between the dispatched native event and the expected `KolEvent` clear. No production component code was touched.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Es wurden ausschließlich End-to-End-Testspezifikationen geändert; es gibt keine Laufzeit-/Bibliotheksänderung. Die DOM-Event-e2e-Specs für `kol-button` (`button.e2e.ts`), `kol-button-link` (`button-link.e2e.ts`) und `kol-badge` (`badge.e2e.ts`) wurden so angepasst, dass sie den internen Smart-Button (`kol-button-wc` → `button`) statt eines Top-Level-`button`-Locators ansprechen und ein natives `click`/`mousedown`-Event auslösen, während sie auf das zugehörige `KolEvent` warten. Zusätzlich iterieren die Tests jetzt über explizite `[nativeEvent, kolEvent]`-Paare, wodurch die Zuordnung zwischen ausgelöstem nativen Event und erwartetem `KolEvent` eindeutig wird. Produktiver Komponenten-Code wurde nicht verändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/button/button.e2e.ts` — Zielt auf den internen `kol-button-wc`-Button und löst native Events aus.
- `packages/components/src/components/button-link/button-link.e2e.ts` — Analoge Anpassung der e2e-Specs.
- `packages/components/src/components/badge/badge.e2e.ts` — Analoge Anpassung der e2e-Specs.

</details>