### PR TITLE
feat(mcp): add json-rpc initialize support

### DIFF
--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -5,9 +5,16 @@ const require = createRequire(import.meta.url);
 const packageJson = require('../package.json');
 
 const JSON_RPC_VERSION = '2.0';
+const MCP_PROTOCOL_VERSION = '2024-11-05';
 const SERVER_INFO = Object.freeze({
 	name: 'kolibri-mcp',
 	version: packageJson.version ?? '0.0.0',
+});
+const INITIALIZE_RESOURCE = Object.freeze({
+	uri: 'kolibri://initialize',
+	name: 'Getting started with the KoliBri MCP server',
+	description: 'Overview, usage instructions, and REST endpoints for Codex and other MCP clients.',
+	mimeType: 'text/markdown',
 });
 
 function buildCorsHeaders() {
@@ -110,6 +117,73 @@ function resolveCounts(index) {
 	};
 }
 
+function toNonEmptyString(value) {
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+
+	const trimmed = value.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function resolveProtocolVersion(requestedVersion) {
+	if (typeof requestedVersion === 'string') {
+		return requestedVersion.trim() || MCP_PROTOCOL_VERSION;
+	}
+
+	if (typeof requestedVersion === 'number' && Number.isFinite(requestedVersion)) {
+		return `${requestedVersion}`;
+	}
+
+	return MCP_PROTOCOL_VERSION;
+}
+
+function formatGeneratedAt(index) {
+	if (index?.generatedAt instanceof Date) {
+		return index.generatedAt.toISOString();
+	}
+
+	return new Date().toISOString();
+}
+
+function buildInitializeResourceText(index) {
+	const counts = resolveCounts(index);
+	const generatedAt = formatGeneratedAt(index);
+	return [
+		'# Welcome to the KoliBri MCP server',
+		'',
+		'This server exposes the KoliBri component and documentation samples to Model Context Protocol clients.',
+		'',
+		'## Getting started',
+		'- Call `resources/list` to discover available resources.',
+		`- Read the ${INITIALIZE_RESOURCE.uri} resource via resources/read for human-friendly usage instructions.`,
+		'- Use the REST endpoints if your client prefers HTTP access over JSON-RPC.',
+		'',
+		'## REST endpoints',
+		'- `GET /health` — Service health and index metadata.',
+		'- `GET /samples` — List of component samples (filterable with `?q=`).',
+		'- `GET /sample?id=sample/<component>/<sample>` — Retrieve a specific component sample.',
+		'- `GET /docs` — List of documentation entries.',
+		'- `GET /doc?id=doc/<identifier>` — Retrieve a specific documentation entry.',
+		'',
+		'## Sample statistics',
+		`- Total entries: ${counts.total}`,
+		`- Component samples: ${counts.totalSamples}`,
+		`- Documentation entries: ${counts.totalDocs}`,
+		`- Index generated at: ${generatedAt}`,
+		'',
+		'For more details, inspect the JSON payloads returned by the endpoints above or the metadata included in JSON-RPC responses.',
+	].join('\n');
+}
+
+function buildInitializeResource(index) {
+	const text = buildInitializeResourceText(index);
+	return {
+		...INITIALIZE_RESOURCE,
+		size: Buffer.byteLength(text, 'utf8'),
+	};
+}
+
 function normalizePathname(pathname) {
 	if (pathname === '/') {
 		return pathname;
@@ -195,7 +269,7 @@ function createJsonRpcError(id, code, message, data) {
 }
 
 async function handleJsonRpcRequest({ request, createResponse, getIndex }) {
-	const { id, method } = request;
+	const { id, method, params } = request;
 
 	switch (method) {
 		case 'initialize': {
@@ -207,21 +281,28 @@ async function handleJsonRpcRequest({ request, createResponse, getIndex }) {
 			}
 
 			const counts = resolveCounts(index);
-			const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt.toISOString() : new Date().toISOString();
+			const generatedAt = formatGeneratedAt(index);
+			const resource = buildInitializeResource(index);
 
 			return createResponse(
 				200,
 				createJsonRpcSuccess(id, {
+					protocolVersion: resolveProtocolVersion(params?.protocolVersion),
 					serverInfo: SERVER_INFO,
 					capabilities: {
-						resources: ['resources/list', 'resources/read'],
-						restApi: ['/health', '/samples', '/sample', '/docs', '/doc'],
+						resources: {
+							subscribe: false,
+							listChanged: false,
+						},
 					},
+					instructions: 'Call resources/list followed by resources/read for kolibri://initialize to receive full usage guidance.',
 					data: {
 						totalEntries: counts.total,
 						totalSamples: counts.totalSamples,
 						totalDocs: counts.totalDocs,
 						generatedAt,
+						resources: [resource],
+						restEndpoints: ['/health', '/samples', '/sample', '/docs', '/doc'],
 					},
 				}),
 			);
@@ -232,6 +313,60 @@ async function handleJsonRpcRequest({ request, createResponse, getIndex }) {
 			}
 
 			return createResponse(200, createJsonRpcSuccess(id, null));
+		}
+		case 'resources/list': {
+			if (id === undefined) {
+				return createResponse(204);
+			}
+
+			let index;
+			try {
+				index = await getIndex();
+			} catch (error) {
+				console.warn('[rpc] Unable to load index during resources/list:', error);
+			}
+
+			return createResponse(
+				200,
+				createJsonRpcSuccess(id, {
+					resources: [buildInitializeResource(index)],
+					nextCursor: null,
+				}),
+			);
+		}
+		case 'resources/read': {
+			if (id === undefined) {
+				return createResponse(204);
+			}
+
+			const uri = toNonEmptyString(params?.uri);
+			if (!uri) {
+				return createResponse(200, createJsonRpcError(id, -32602, 'Missing required parameter "uri"'));
+			}
+
+			if (uri !== INITIALIZE_RESOURCE.uri) {
+				return createResponse(200, createJsonRpcError(id, -32004, `Resource not found: ${uri}`, { uri }));
+			}
+
+			let index;
+			try {
+				index = await getIndex();
+			} catch (error) {
+				console.warn('[rpc] Unable to load index during resources/read:', error);
+			}
+
+			return createResponse(
+				200,
+				createJsonRpcSuccess(id, {
+					contents: [
+						{
+							uri: INITIALIZE_RESOURCE.uri,
+							mimeType: INITIALIZE_RESOURCE.mimeType,
+							text: buildInitializeResourceText(index),
+						},
+					],
+				}),
+			);
 		}
 		default:
 			if (id === undefined) {
@@ -300,6 +435,7 @@ export async function handleApiRequest({ method = 'GET', url = '/', headers = {}
 					'/docs?q=<query>',
 					'/doc?id=doc/<identifier>',
 				],
+				resources: [INITIALIZE_RESOURCE.uri],
 				totalEntries: counts.total,
 				totalSamples: counts.totalSamples,
 				totalDocs: counts.totalDocs,
@@ -400,7 +536,8 @@ export async function handleApiRequest({ method = 'GET', url = '/', headers = {}
 			items,
 			query,
 			total: items.length,
-			totalEntries: counts.totalDocs,
+			totalEntries: counts.total,
+			totalSamples: counts.totalSamples,
 			totalDocs: counts.totalDocs,
 			generatedAt: index.generatedAt.toISOString(),
 		});
@@ -435,5 +572,5 @@ export async function handleApiRequest({ method = 'GET', url = '/', headers = {}
 		});
 	}
 
-	return createResponse(404, { error: 'not_found' });
+	return createResponse(404, { error: 'not_found', path: pathname });
 }

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -1,4 +1,14 @@
+import { createRequire } from 'node:module';
 import { URL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json');
+
+const JSON_RPC_VERSION = '2.0';
+const SERVER_INFO = Object.freeze({
+	name: 'kolibri-mcp',
+	version: packageJson.version ?? '0.0.0',
+});
 
 function buildCorsHeaders() {
 	return {
@@ -116,15 +126,135 @@ function normalizePathname(pathname) {
 	return pathname;
 }
 
-export async function handleApiRequest({ method = 'GET', url = '/', getIndex } = {}) {
+function resolveContentType(headers = {}) {
+	for (const [name, value] of Object.entries(headers ?? {})) {
+		if (typeof value === 'string' && name.toLowerCase() === 'content-type') {
+			return value;
+		}
+	}
+
+	return '';
+}
+
+function tryParseJsonBody(rawBody, contentType) {
+	if (!rawBody) {
+		return { value: undefined };
+	}
+
+	const normalized = typeof contentType === 'string' ? contentType.toLowerCase() : '';
+	if (normalized && !normalized.includes('application/json')) {
+		return { value: undefined };
+	}
+
+	try {
+		return { value: JSON.parse(rawBody) };
+	} catch (error) {
+		return { error };
+	}
+}
+
+function toJsonRpcRequest(payload) {
+	if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+		return undefined;
+	}
+
+	if (payload.jsonrpc !== JSON_RPC_VERSION || typeof payload.method !== 'string') {
+		return undefined;
+	}
+
+	return {
+		id: Object.prototype.hasOwnProperty.call(payload, 'id') ? payload.id : undefined,
+		method: payload.method,
+		params: payload.params,
+	};
+}
+
+function createJsonRpcSuccess(id, result) {
+	return {
+		jsonrpc: JSON_RPC_VERSION,
+		id: id ?? null,
+		result,
+	};
+}
+
+function createJsonRpcError(id, code, message, data) {
+	return {
+		jsonrpc: JSON_RPC_VERSION,
+		id: id ?? null,
+		error: data
+			? {
+					code,
+					message,
+					data,
+				}
+			: {
+					code,
+					message,
+				},
+	};
+}
+
+async function handleJsonRpcRequest({ request, createResponse, getIndex }) {
+	const { id, method } = request;
+
+	switch (method) {
+		case 'initialize': {
+			let index;
+			try {
+				index = await getIndex();
+			} catch (error) {
+				console.warn('[rpc] Unable to load index during initialize:', error);
+			}
+
+			const counts = resolveCounts(index);
+			const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt.toISOString() : new Date().toISOString();
+
+			return createResponse(
+				200,
+				createJsonRpcSuccess(id, {
+					serverInfo: SERVER_INFO,
+					capabilities: {
+						resources: ['resources/list', 'resources/read'],
+						restApi: ['/health', '/samples', '/sample', '/docs', '/doc'],
+					},
+					data: {
+						totalEntries: counts.total,
+						totalSamples: counts.totalSamples,
+						totalDocs: counts.totalDocs,
+						generatedAt,
+					},
+				}),
+			);
+		}
+		case 'initialized': {
+			if (id === undefined) {
+				return createResponse(204);
+			}
+
+			return createResponse(200, createJsonRpcSuccess(id, null));
+		}
+		default:
+			if (id === undefined) {
+				return createResponse(204);
+			}
+
+			return createResponse(200, createJsonRpcError(id, -32601, `Method not found: ${method}`));
+	}
+}
+
+export async function handleApiRequest({ method = 'GET', url = '/', headers = {}, body = '', getIndex } = {}) {
 	const startTime = Date.now();
 	const baseHeaders = buildCorsHeaders();
 	const normalizedMethod = method.toUpperCase();
 	const requestUrl = new URL(url, 'http://localhost');
 	const pathname = normalizePathname(requestUrl.pathname);
+	const rawBody = typeof body === 'string' ? body : '';
+	const contentType = resolveContentType(headers);
+	const { value: parsedJsonBody, error: jsonError } = tryParseJsonBody(rawBody, contentType);
+	const jsonRpcRequest = normalizedMethod === 'POST' ? toJsonRpcRequest(parsedJsonBody) : undefined;
 
 	// Helper function to create response and log it
-	const createResponse = (statusCode, body = {}) => {
+	const createResponse = (statusCode, body) => {
 		const responseTime = Date.now() - startTime;
 		logRequest(normalizedMethod, url, pathname, statusCode, responseTime);
 		return {
@@ -136,6 +266,14 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 
 	if (normalizedMethod === 'OPTIONS') {
 		return createResponse(204);
+	}
+
+	if (jsonError) {
+		return createResponse(400, { error: 'invalid_json' });
+	}
+
+	if (jsonRpcRequest) {
+		return handleJsonRpcRequest({ request: jsonRpcRequest, createResponse, getIndex });
 	}
 
 	if ((normalizedMethod === 'GET' || normalizedMethod === 'POST') && pathname === '/') {

--- a/packages/tools/mcp/src/server.js
+++ b/packages/tools/mcp/src/server.js
@@ -9,28 +9,51 @@ export async function startServer(options = {}) {
 	let index = await buildSampleIndex();
 
 	const server = createServer((request, response) => {
-		Promise.resolve(
-			handleApiRequest({
-				method: request.method ?? 'GET',
-				url: request.url ?? '/',
-				getIndex: () => index,
-			}),
-		)
-			.then((result) => respondWithResult(response, result))
-			.catch((error) => {
-				console.error('[mcp] request failed', error);
-				if (!response.headersSent) {
-					respondWithResult(response, {
-						statusCode: 500,
-						headers: {
-							'Access-Control-Allow-Origin': '*',
-							'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-							'Access-Control-Allow-Headers': 'Content-Type',
-						},
-						body: { error: 'internal_error' },
-					});
-				}
-			});
+		const chunks = [];
+		request.on('data', (chunk) => {
+			chunks.push(chunk);
+		});
+		request.on('end', () => {
+			const rawBody = chunks.length > 0 ? Buffer.concat(chunks).toString('utf8') : '';
+			Promise.resolve(
+				handleApiRequest({
+					method: request.method ?? 'GET',
+					url: request.url ?? '/',
+					headers: request.headers ?? {},
+					body: rawBody,
+					getIndex: () => index,
+				}),
+			)
+				.then((result) => respondWithResult(response, result))
+				.catch((error) => {
+					console.error('[mcp] request failed', error);
+					if (!response.headersSent) {
+						respondWithResult(response, {
+							statusCode: 500,
+							headers: {
+								'Access-Control-Allow-Origin': '*',
+								'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+								'Access-Control-Allow-Headers': 'Content-Type',
+							},
+							body: { error: 'internal_error' },
+						});
+					}
+				});
+		});
+		request.on('error', (error) => {
+			console.error('[mcp] request stream failed', error);
+			if (!response.headersSent) {
+				respondWithResult(response, {
+					statusCode: 500,
+					headers: {
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+						'Access-Control-Allow-Headers': 'Content-Type',
+					},
+					body: { error: 'request_stream_error' },
+				});
+			}
+		});
 	});
 
 	server.listen(port, () => {

--- a/packages/tools/mcp/test/api-handler.test.js
+++ b/packages/tools/mcp/test/api-handler.test.js
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { handleApiRequest } from '../src/api-handler.js';
+
+const SAMPLE_ENTRIES = [
+	{
+		id: 'sample/button/basic',
+		group: 'components/button',
+		name: 'basic',
+		path: 'packages/samples/react/src/routes/button/basic.tsx',
+		code: "export const Sample = () => 'button-basic';",
+		kind: 'sample',
+	},
+	{
+		id: 'doc/getting-started',
+		group: 'docs',
+		name: 'getting-started',
+		path: 'docs/getting-started.md',
+		code: '# Getting Started',
+		kind: 'doc',
+	},
+];
+
+const entryMap = new Map(SAMPLE_ENTRIES.map((entry) => [entry.id, entry]));
+
+const MOCK_INDEX = {
+	entries: SAMPLE_ENTRIES,
+	counts: { total: SAMPLE_ENTRIES.length, totalSamples: 1, totalDocs: 1 },
+	generatedAt: new Date('2024-01-02T03:04:05.000Z'),
+	buildMode: 'runtime',
+	list(query, options = {}) {
+		const kinds = options.kinds ? new Set(options.kinds) : undefined;
+		let results = kinds ? SAMPLE_ENTRIES.filter((entry) => kinds.has(entry.kind ?? 'sample')) : SAMPLE_ENTRIES;
+		const normalizedQuery = typeof query === 'string' ? query.trim().toLowerCase() : '';
+		if (!normalizedQuery) {
+			return results;
+		}
+
+		return results.filter((entry) => `${entry.id} ${entry.name} ${entry.group}`.toLowerCase().includes(normalizedQuery));
+	},
+	get(id) {
+		return entryMap.get(id);
+	},
+};
+
+async function invokeJsonRpc(method, params, id = 'test-id') {
+	const response = await handleApiRequest({
+		method: 'POST',
+		url: 'http://localhost/mcp/',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+		getIndex: async () => MOCK_INDEX,
+	});
+
+	return response;
+}
+
+test('initialize returns MCP-compliant capabilities and initialize resource metadata', async () => {
+	const response = await invokeJsonRpc('initialize', {
+		protocolVersion: '2024-05-30',
+		capabilities: {},
+		clientInfo: { name: 'node-test', version: '1.0.0' },
+	});
+
+	assert.equal(response.statusCode, 200);
+	assert.equal(response.body.jsonrpc, '2.0');
+	assert.equal(response.body.id, 'test-id');
+
+	const result = response.body.result;
+	assert.equal(result.protocolVersion, '2024-05-30');
+	assert.deepEqual(result.serverInfo.name, 'kolibri-mcp');
+	assert.ok(result.capabilities);
+	assert.ok(result.capabilities.resources);
+	assert.equal(Array.isArray(result.capabilities.resources), false);
+	assert.deepEqual(result.capabilities.resources, { subscribe: false, listChanged: false });
+	assert.equal(result.instructions.includes('resources/list'), true);
+
+	assert.ok(Array.isArray(result.data.resources));
+	const resource = result.data.resources[0];
+	assert.equal(resource.uri, 'kolibri://initialize');
+	assert.equal(resource.mimeType, 'text/markdown');
+	assert.ok(resource.size > 0);
+});
+
+test('resources/list exposes the initialize resource with a non-empty size', async () => {
+	const response = await invokeJsonRpc('resources/list', {});
+
+	assert.equal(response.statusCode, 200);
+	assert.equal(response.body.jsonrpc, '2.0');
+	const { resources, nextCursor } = response.body.result;
+	assert.equal(Array.isArray(resources), true);
+	assert.equal(resources.length >= 1, true);
+	const initializeResource = resources[0];
+	assert.equal(initializeResource.uri, 'kolibri://initialize');
+	assert.equal(initializeResource.mimeType, 'text/markdown');
+	assert.ok(initializeResource.size > 0);
+	assert.equal(nextCursor, null);
+});
+
+test('resources/read returns markdown instructions containing sample statistics', async () => {
+	const response = await invokeJsonRpc('resources/read', { uri: 'kolibri://initialize' }, 'read-id');
+
+	assert.equal(response.statusCode, 200);
+	assert.equal(response.body.id, 'read-id');
+	const [{ uri, mimeType, text }] = response.body.result.contents;
+	assert.equal(uri, 'kolibri://initialize');
+	assert.equal(mimeType, 'text/markdown');
+	assert.equal(text.includes('Total entries: 2'), true);
+	assert.equal(text.includes('Component samples: 1'), true);
+	assert.equal(text.includes('Documentation entries: 1'), true);
+	assert.equal(text.includes('Index generated at: 2024-01-02T03:04:05.000Z'), true);
+});
+
+test('resources/read returns an error for unknown URIs', async () => {
+	const response = await invokeJsonRpc('resources/read', { uri: 'kolibri://missing' });
+
+	assert.equal(response.statusCode, 200);
+	assert.equal(response.body.error.code, -32004);
+	assert.equal(response.body.error.message.includes('Resource not found'), true);
+	assert.deepEqual(response.body.error.data, { uri: 'kolibri://missing' });
+});


### PR DESCRIPTION
## Summary
- add JSON-RPC handshake handling to the MCP API handler, including content-type parsing and initialize responses
- buffer HTTP request bodies in the HTTP server and forward headers/body to the request handler

## Testing
- pnpm --filter @public-ui/mcp test

------
https://chatgpt.com/codex/tasks/task_e_68fca8b56ce0832bbc480e2b9be837b7