### PR TITLE
feat(table): pass sort direction to custom compareFn

### DIFF
--- a/packages/components/src/schema/components/table.ts
+++ b/packages/components/src/schema/components/table.ts
@@ -1,16 +1,16 @@
 import type { Generic } from 'adopted-style-sheets';
 
-import type { PropLabel, StatefulPropTableCallbacks, PropTableData, PropTableDataFoot, PropTableSelection } from '../props';
-import type { KoliBriTableDataType, KoliBriTableHeaderCell, Stringified, KoliBriSortDirection, KoliBriTableSelection } from '../types';
-import type { KoliBriPaginationProps } from './pagination';
+import type { PropLabel, PropTableData, PropTableDataFoot, PropTableSelection, StatefulPropTableCallbacks } from '../props';
 import type { PropPaginationPosition } from '../props/pagination-position';
+import type { KoliBriSortDirection, KoliBriTableDataType, KoliBriTableHeaderCell, KoliBriTableSelection, Stringified } from '../types';
+import type { KoliBriPaginationProps } from './pagination';
 
 export type KoliBriTableSelectedHead = { key: string; label: string; sortDirection: KoliBriSortDirection };
 
 type KoliBriTableSort = <T>(data: T[]) => T[];
 
 export type KoliBriSortFunction = (data: KoliBriTableDataType[]) => KoliBriTableDataType[];
-export type KoliBriDataCompareFn = (a: KoliBriTableDataType, b: KoliBriTableDataType) => number;
+export type KoliBriDataCompareFn = (a: KoliBriTableDataType, b: KoliBriTableDataType, sortDirection?: KoliBriSortDirection) => number;
 
 export type KoliBriTableHeaderCellWithLogic = KoliBriTableHeaderCell & {
 	compareFn?: KoliBriDataCompareFn;

--- a/packages/samples/react/src/components/table/direction-aware-sort.tsx
+++ b/packages/samples/react/src/components/table/direction-aware-sort.tsx
@@ -1,0 +1,65 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import type { KoliBriTableHeaders } from '@public-ui/components';
+import { KolTable } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+type TemperatureRow = {
+	city: string;
+	temperature: number;
+};
+
+const COMFORTABLE_TEMPERATURE = 22;
+
+const TEMPERATURE_DATA: TemperatureRow[] = [
+	{ city: 'Reykjavík', temperature: 6 },
+	{ city: 'Berlin', temperature: 21 },
+	{ city: 'Palma de Mallorca', temperature: 29 },
+	{ city: 'Cairo', temperature: 35 },
+	{ city: 'Helsinki', temperature: 14 },
+];
+
+const HEADERS: KoliBriTableHeaders = {
+	horizontal: [
+		[
+			{ label: 'City', key: 'city' },
+			{
+				label: 'Temperature (°C)',
+				key: 'temperature',
+				textAlign: 'right',
+				compareFn: (rowA, rowB, direction = 'ASC') => {
+					const temperatureA = (rowA as TemperatureRow).temperature;
+					const temperatureB = (rowB as TemperatureRow).temperature;
+					const differenceA = Math.abs(temperatureA - COMFORTABLE_TEMPERATURE);
+					const differenceB = Math.abs(temperatureB - COMFORTABLE_TEMPERATURE);
+
+					if (differenceA !== differenceB) {
+						return direction === 'DESC' ? differenceB - differenceA : differenceA - differenceB;
+					}
+
+					return direction === 'DESC' ? temperatureB - temperatureA : temperatureA - temperatureB;
+				},
+				render: (_element, _cell, row) => {
+					const difference = Math.abs((row as TemperatureRow).temperature - COMFORTABLE_TEMPERATURE);
+					return `${(row as TemperatureRow).temperature} °C (Δ ${difference} °C)`;
+				},
+			},
+		],
+	],
+};
+
+export const TableDirectionAwareSort: FC = () => (
+	<>
+		<SampleDescription>
+			<p>
+				This sample demonstrates how <code>compareFn</code> receives the current <code>sortDirection</code>. Ascending sorts show cities that are closest to
+				22&nbsp;°C first, descending sorts highlight the most extreme temperatures.
+			</p>
+		</SampleDescription>
+
+		<section className="w-full">
+			<KolTable _label="Direction aware compare function" _data={TEMPERATURE_DATA} _headers={HEADERS} className="block" />
+		</section>
+	</>
+);

--- a/packages/samples/react/src/components/table/routes.ts
+++ b/packages/samples/react/src/components/table/routes.ts
@@ -1,19 +1,20 @@
 import { Routes } from '../../shares/types';
-import { PaginationPosition } from './pagination-position';
 import { TableColumnAlignment } from './column-alignment';
 import { TableComplexHeaders } from './complex-headers';
+import { TableDirectionAwareSort } from './direction-aware-sort';
 import { TableHorizontalScrollbar } from './horizontal-scrollbar';
-import { TableRenderCell } from './render-cell';
-import { TableSortData } from './sort-data';
-import { TableStateless } from './stateless';
-import { TableWithFooter } from './with-footer';
-import { TableStatefulWithSelection } from './stateful-with-selection';
-import { TableStatefulWithSingleSelection } from './stateful-with-single-selection';
-import { TableStatelessWithSelection } from './stateless-with-selection';
-import { TableStatelessWithSingleSelection } from './stateless-with-single-selection';
-import { TableWithPagination } from './with-pagination';
 import { InteractiveChildElements } from './interactive-child-elements';
 import { MultiSortTable } from './multi-sort';
+import { PaginationPosition } from './pagination-position';
+import { TableRenderCell } from './render-cell';
+import { TableSortData } from './sort-data';
+import { TableStatefulWithSelection } from './stateful-with-selection';
+import { TableStatefulWithSingleSelection } from './stateful-with-single-selection';
+import { TableStateless } from './stateless';
+import { TableStatelessWithSelection } from './stateless-with-selection';
+import { TableStatelessWithSingleSelection } from './stateless-with-single-selection';
+import { TableWithFooter } from './with-footer';
+import { TableWithPagination } from './with-pagination';
 
 export const TABLE_ROUTES: Routes = {
 	table: {
@@ -23,6 +24,7 @@ export const TABLE_ROUTES: Routes = {
 		'pagination-position': PaginationPosition,
 		'render-cell': TableRenderCell,
 		'sort-data': TableSortData,
+		'direction-aware-sort': TableDirectionAwareSort,
 		'with-footer': TableWithFooter,
 		'stateful-with-selection': TableStatefulWithSelection,
 		'stateful-with-single-selection': TableStatefulWithSingleSelection,


### PR DESCRIPTION
## What changed?

This is the `release/2` variant of the direction-aware table compare-function change. The public compare-function type `KoliBriDataCompareFn` (`packages/components/src/schema/components/table.ts`) now accepts the current sort direction as an optional third argument: `(a, b, sortDirection?: KoliBriSortDirection) => number`. A new React sample (`packages/samples/react/src/components/table/direction-aware-sort.tsx`, wired into `routes.ts`, using `KolTable`) demonstrates a direction-aware compare function that sorts cities by their distance from a comfortable 22 °C. The `routes.ts` import ordering was also normalized. The new parameter is optional, so existing compare functions keep working unchanged (non-breaking).

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies ist die `release/2`-Variante der richtungsabhängigen Tabellen-Vergleichsfunktion. Der öffentliche Vergleichsfunktions-Typ `KoliBriDataCompareFn` (`packages/components/src/schema/components/table.ts`) akzeptiert nun die aktuelle Sortierrichtung als optionales drittes Argument: `(a, b, sortDirection?: KoliBriSortDirection) => number`. Ein neues React-Beispiel (`packages/samples/react/src/components/table/direction-aware-sort.tsx`, eingebunden in `routes.ts`, mit `KolTable`) demonstriert eine richtungsabhängige Vergleichsfunktion, die Städte nach ihrer Abweichung von angenehmen 22 °C sortiert. Zusätzlich wurde die Import-Reihenfolge in `routes.ts` normalisiert. Der neue Parameter ist optional, bestehende Vergleichsfunktionen funktionieren unverändert weiter (nicht breaking).

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/schema/components/table.ts` — Ergänzt den optionalen `sortDirection`-Parameter in `KoliBriDataCompareFn`.
- `packages/samples/react/src/components/table/direction-aware-sort.tsx` (neu) & `routes.ts` — Beispiel für eine richtungsabhängige Vergleichsfunktion und normalisierte Import-Reihenfolge.

</details>