### PR TITLE
feat(table): pass sort direction to custom compareFn

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -434,7 +434,7 @@ export class KolTableStateful implements TableAPI {
 			sortedData.sort((a: KoliBriTableDataType, b: KoliBriTableDataType) => {
 				for (let index = 0; index < this.sortData.length; index++) {
 					const data = this.sortData[index];
-					const result = data.compareFn(a, b);
+					const result = data.compareFn(a, b, data.direction);
 					if (result !== 0) {
 						return data.direction === 'ASC' ? result : -result;
 					}

--- a/packages/components/src/schema/components/table.ts
+++ b/packages/components/src/schema/components/table.ts
@@ -7,7 +7,10 @@ import type { PropTableSettings } from '../props/table-settings';
 import type { KoliBriSortDirection, KoliBriTableDataType, KoliBriTableHeaderCell, KoliBriTableSelection, Stringified } from '../types';
 import type { KoliBriPaginationProps } from './pagination';
 
-export type KoliBriDataCompareFn = (a: KoliBriTableDataType, b: KoliBriTableDataType) => number;
+export type KoliBriTableSelectedHead = { key: string; label: string; sortDirection: KoliBriSortDirection };
+
+export type KoliBriSortFunction = (data: KoliBriTableDataType[]) => KoliBriTableDataType[];
+export type KoliBriDataCompareFn = (a: KoliBriTableDataType, b: KoliBriTableDataType, sortDirection?: KoliBriSortDirection) => number;
 
 export type KoliBriTableHeaderCellWithLogic = KoliBriTableHeaderCell & {
 	compareFn?: KoliBriDataCompareFn;

--- a/packages/samples/react/src/components/table/direction-aware-sort.tsx
+++ b/packages/samples/react/src/components/table/direction-aware-sort.tsx
@@ -1,0 +1,65 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import type { KoliBriTableHeaders } from '@public-ui/components';
+import { KolTableStateful } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+type TemperatureRow = {
+	city: string;
+	temperature: number;
+};
+
+const COMFORTABLE_TEMPERATURE = 22;
+
+const TEMPERATURE_DATA: TemperatureRow[] = [
+	{ city: 'Reykjavík', temperature: 6 },
+	{ city: 'Berlin', temperature: 21 },
+	{ city: 'Palma de Mallorca', temperature: 29 },
+	{ city: 'Cairo', temperature: 35 },
+	{ city: 'Helsinki', temperature: 14 },
+];
+
+const HEADERS: KoliBriTableHeaders = {
+	horizontal: [
+		[
+			{ label: 'City', key: 'city' },
+			{
+				label: 'Temperature (°C)',
+				key: 'temperature',
+				textAlign: 'right',
+				compareFn: (rowA, rowB, direction = 'ASC') => {
+					const temperatureA = (rowA as TemperatureRow).temperature;
+					const temperatureB = (rowB as TemperatureRow).temperature;
+					const differenceA = Math.abs(temperatureA - COMFORTABLE_TEMPERATURE);
+					const differenceB = Math.abs(temperatureB - COMFORTABLE_TEMPERATURE);
+
+					if (differenceA !== differenceB) {
+						return direction === 'DESC' ? differenceB - differenceA : differenceA - differenceB;
+					}
+
+					return direction === 'DESC' ? temperatureB - temperatureA : temperatureA - temperatureB;
+				},
+				render: (_element, _cell, row) => {
+					const difference = Math.abs((row as TemperatureRow).temperature - COMFORTABLE_TEMPERATURE);
+					return `${(row as TemperatureRow).temperature} °C (Δ ${difference} °C)`;
+				},
+			},
+		],
+	],
+};
+
+export const TableDirectionAwareSort: FC = () => (
+	<>
+		<SampleDescription>
+			<p>
+				This sample demonstrates how <code>compareFn</code> receives the current <code>sortDirection</code>. Ascending sorts show cities that are closest to
+				22&nbsp;°C first, descending sorts highlight the most extreme temperatures.
+			</p>
+		</SampleDescription>
+
+		<section className="w-full">
+			<KolTableStateful _minWidth="100%" _label="Direction aware compare function" _data={TEMPERATURE_DATA} _headers={HEADERS} className="block" />
+		</section>
+	</>
+);

--- a/packages/samples/react/src/components/table/routes.ts
+++ b/packages/samples/react/src/components/table/routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '../../shares/types';
 import { TableColumnAlignment } from './column-alignment';
 import { TableComplexHeaders } from './complex-headers';
+import { TableDirectionAwareSort } from './direction-aware-sort';
 import { TableHorizontalScrollbar } from './horizontal-scrollbar';
 import { InteractiveChildElements } from './interactive-child-elements';
 import { MultiSortTable } from './multi-sort';
@@ -31,6 +32,7 @@ export const TABLE_ROUTES: Routes = {
 		'predefined-settings': PredefinedSettings,
 		'render-cell': TableRenderCell,
 		'sort-data': TableSortData,
+		'direction-aware-sort': TableDirectionAwareSort,
 		'stateful-with-selection': TableStatefulWithSelection,
 		'stateless-with-settings-menu': TableStatelessWithSettingsMenu,
 		'stateful-with-single-selection': TableStatefulWithSingleSelection,


### PR DESCRIPTION
## What changed?

The public table compare-function type `KoliBriDataCompareFn` (`packages/components/src/schema/components/table.ts`) now receives the current sort direction as an optional third argument: `(a, b, sortDirection?: KoliBriSortDirection) => number`. In `packages/components/src/components/table-stateful/shadow.tsx`, the sort loop now passes `data.direction` into `compareFn(a, b, data.direction)`, so a custom compare function can produce direction-aware ordering instead of a single fixed order that is merely inverted for descending. A new React sample (`packages/samples/react/src/components/table/direction-aware-sort.tsx`, wired into `routes.ts`) demonstrates the feature by sorting cities by their distance from a comfortable 22 °C. The new parameter is optional, so existing compare functions keep working unchanged (non-breaking).

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der öffentliche Vergleichsfunktions-Typ `KoliBriDataCompareFn` (`packages/components/src/schema/components/table.ts`) erhält jetzt die aktuelle Sortierrichtung als optionales drittes Argument: `(a, b, sortDirection?: KoliBriSortDirection) => number`. In `packages/components/src/components/table-stateful/shadow.tsx` übergibt die Sortier-Schleife nun `data.direction` an `compareFn(a, b, data.direction)`, sodass eine eigene Vergleichsfunktion richtungsabhängig sortieren kann, statt nur eine feste Reihenfolge zu liefern, die für absteigend lediglich invertiert wird. Ein neues React-Beispiel (`packages/samples/react/src/components/table/direction-aware-sort.tsx`, eingebunden in `routes.ts`) demonstriert dies, indem Städte nach ihrer Abweichung von angenehmen 22 °C sortiert werden. Der neue Parameter ist optional, bestehende Vergleichsfunktionen funktionieren unverändert weiter (nicht breaking).

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/schema/components/table.ts` — Ergänzt den optionalen `sortDirection`-Parameter in `KoliBriDataCompareFn`.
- `packages/components/src/components/table-stateful/shadow.tsx` — Übergibt die aktuelle Sortierrichtung an `compareFn`.
- `packages/samples/react/src/components/table/direction-aware-sort.tsx` (neu) & `routes.ts` — Beispiel für eine richtungsabhängige Vergleichsfunktion.

</details>