### PR TITLE
fix(popover-button): hide button tooltip while popover is open

### DIFF
--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -1,6 +1,7 @@
 import { autoUpdate } from '@floating-ui/dom';
 import type { JSX } from '@stencil/core';
 import { Component, h, Method, Prop, State, Watch } from '@stencil/core';
+import clsx from 'clsx';
 import { KolButtonWcTag } from '../../core/component-names';
 import type {
 	AccessKeyPropType,
@@ -117,7 +118,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 
 	public render(): JSX.Element {
 		return (
-			<div class="kol-popover-button">
+			<div class={clsx('kol-popover-button', { 'kol-popover-button--open': this.popoverOpen })}>
 				<KolButtonWcTag
 					_accessKey={this._accessKey}
 					_aria-controls="popover"

--- a/packages/components/src/components/popover-button/style.scss
+++ b/packages/components/src/components/popover-button/style.scss
@@ -6,4 +6,10 @@
 @layer kol-component {
 	@include kol-button-styles('kol-button');
 	@include kol-popover-button-styles;
+
+	.kol-popover-button--open {
+		.kol-button__tooltip {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
## What changed?

The popover button no longer shows its (icon-only) button tooltip while the popover itself is open. In `packages/components/src/components/popover-button/component.tsx` the root element now receives a `kol-popover-button--open` BEM modifier (via `clsx`) whenever `popoverOpen` is true. The matching rule in `packages/components/src/components/popover-button/style.scss` sets `.kol-popover-button--open .kol-button__tooltip { display: none; }`, so the tooltip is suppressed while the popover is visible and does not overlap or duplicate the popover content. No public API changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Popover-Button zeigt seinen (reinen Icon-)Button-Tooltip nicht mehr an, während das Popover geöffnet ist. In `packages/components/src/components/popover-button/component.tsx` erhält das Wurzelelement jetzt einen `kol-popover-button--open`-BEM-Modifier (via `clsx`), sobald `popoverOpen` true ist. Die passende Regel in `packages/components/src/components/popover-button/style.scss` setzt `.kol-popover-button--open .kol-button__tooltip { display: none; }`, sodass der Tooltip bei geöffnetem Popover unterdrückt wird und sich nicht mit dem Popover-Inhalt überlagert oder ihn dupliziert. Es wurde keine öffentliche API geändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/popover-button/component.tsx` — Fügt den `kol-popover-button--open`-Modifier hinzu, wenn das Popover offen ist.
- `packages/components/src/components/popover-button/style.scss` — Blendet den Button-Tooltip aus, solange das Popover geöffnet ist.

</details>