### PR TITLE
fix: announce table empty hint via aria live

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -669,12 +669,17 @@ export class KolTableStateless implements TableStatelessAPI {
 		if ((cell as KoliBriTableHeaderCellWithLogic).headerCell) {
 			return this.renderHeadingCell(cell, rowIndex, colIndex, isVertical);
 		} else {
+			const isNoEntriesHintCell = typeof cell.render !== 'function' && cell.label === this.translateNoEntries;
+
 			return (
 				<td
 					key={`cell-${key}`}
 					class={clsx('kol-table__cell kol-table__cell--body', {
 						[`kol-table__cell--align-${cell.textAlign}`]: cell.textAlign,
 					})}
+					aria-atomic={isNoEntriesHintCell ? 'false' : undefined}
+					aria-live={isNoEntriesHintCell ? 'polite' : undefined}
+					aria-relevant={isNoEntriesHintCell ? 'text' : undefined}
 					colSpan={cell.colSpan}
 					rowSpan={cell.rowSpan}
 					style={{

--- a/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
@@ -240,3 +240,34 @@ exports[`kol-table-stateless-wc should render with _label="Table with two spanne
   </div>
 </kol-table-stateless-wc>
 `;
+
+exports[`kol-table-stateless-wc should render with _label="Table without data shows empty hint" _minWidth="400px" _headerCells={"horizontal":[[{"key":"header1","label":"Header 1","textAlign":"left"}]],"vertical":[]} _data=[] 1`] = `
+<kol-table-stateless-wc>
+  <div class="kol-table">
+    <div class="kol-table__scroll-container">
+      <table class="kol-table__table" style="min-width: max(400px, 0ch);">
+        <caption class="kol-table__caption kol-table__focus-element" id="caption">
+          Table without data shows empty hint
+        </caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--align-left kol-table__cell--header kol-table__cell--none" data-sort="sort-undefined" scope="col">
+              Header 1
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="1"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <td aria-atomic="false" aria-live="polite" aria-relevant="text" class="kol-table__cell kol-table__cell--body" colspan="1" rowspan="1">
+              kol-no-entries
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;

--- a/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
+++ b/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
@@ -95,5 +95,14 @@ executeSnapshotTests<TableStatelessProps>(
 				{ header1: 'Cell 2.1', header2: 'Cell 2.2' },
 			],
 		},
+		{
+			_label: 'Table without data shows empty hint',
+			_minWidth: '400px',
+			_headerCells: {
+				horizontal: [[{ key: 'header1', label: 'Header 1', textAlign: 'left' }]],
+				vertical: [],
+			},
+			_data: [],
+		},
 	],
 );


### PR DESCRIPTION
## What changed?

The stateless table component (`packages/components/src/components/table-stateless/component.tsx`) now renders the "no entries" placeholder cell inside an ARIA live region. When a cell holds the translated no-entries hint (`cell.label === this.translateNoEntries` and no custom render function), it is emitted with `aria-live="polite"`, `aria-relevant="text"` and `aria-atomic="false"`. As a result, assistive technology announces the hint the moment an empty table state appears — for example after a filter removes the last row — instead of leaving it silent. A snapshot test for the empty-table state was added to lock in the live-region markup. No public API or component property changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die zustandslose Tabellen-Komponente (`packages/components/src/components/table-stateless/component.tsx`) rendert die Platzhalterzelle für den "Keine Einträge"-Hinweis jetzt innerhalb eines ARIA-Live-Bereichs. Enthält eine Zelle den übersetzten Kein-Eintrag-Hinweis (`cell.label === this.translateNoEntries` und keine eigene Render-Funktion), wird sie mit `aria-live="polite"`, `aria-relevant="text"` und `aria-atomic="false"` ausgegeben. Dadurch kündigen assistive Technologien den Hinweis an, sobald ein leerer Tabellenzustand erscheint — etwa nachdem ein Filter die letzte Zeile entfernt hat — statt ihn stumm darzustellen. Ein Snapshot-Test für den leeren Tabellenzustand wurde ergänzt, um das Live-Region-Markup abzusichern. Es wurde keine öffentliche API oder Komponenten-Property geändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung (Barrierefreiheit)

### Geänderte Dateien

- `packages/components/src/components/table-stateless/component.tsx` — Ergänzt `aria-live`/`aria-atomic`/`aria-relevant` an der Zelle mit dem "Keine Einträge"-Hinweis.
- `packages/components/src/components/table-stateless/test/snapshot.spec.tsx` — Fügt einen Testfall für eine Tabelle ohne Daten hinzu.
- `packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap` — Neuer Snapshot für den leeren Tabellenzustand.

</details>