### PR TITLE
chore: document table _sort deprecation without runtime changes

### DIFF
--- a/packages/components/src/schema/components/table.ts
+++ b/packages/components/src/schema/components/table.ts
@@ -14,6 +14,10 @@ export type KoliBriDataCompareFn = (a: KoliBriTableDataType, b: KoliBriTableData
 
 export type KoliBriTableHeaderCellWithLogic = KoliBriTableHeaderCell & {
 	compareFn?: KoliBriDataCompareFn;
+	/**
+	 * @deprecated Use `compareFn` instead. Will be removed in v4.
+	 */
+	_sort?: KoliBriSortFunction;
 	sortDirection?: KoliBriSortDirection;
 	headerCell?: true;
 };


### PR DESCRIPTION
## What changed?

The exported table type `KoliBriTableHeaderCellWithLogic` in `packages/components/src/schema/components/table.ts` gains an optional `_sort?: KoliBriSortFunction` property annotated with a `@deprecated` JSDoc that tells consumers to use `compareFn` instead and that `_sort` will be removed in v4. This is a pure type/schema-documentation change: the earlier `KolTableStateful` runtime updates that converted `_sort` into `compareFn` were reverted, and the header validation test was restored to its previous scope, so there is no runtime behavior change. The net effect is that TypeScript consumers still see `_sort` as a valid (but clearly deprecated) header-cell property while being steered toward `compareFn`. No consumer action is strictly required now, though `_sort` usage should be migrated before v4.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der exportierte Tabellen-Typ `KoliBriTableHeaderCellWithLogic` in `packages/components/src/schema/components/table.ts` erhält eine optionale Eigenschaft `_sort?: KoliBriSortFunction`, versehen mit einem `@deprecated`-JSDoc, der Konsumenten anweist, stattdessen `compareFn` zu verwenden, und darauf hinweist, dass `_sort` in v4 entfernt wird. Es handelt sich um eine reine Typ-/Schema-Dokumentationsänderung: Die zuvor eingeführten `KolTableStateful`-Laufzeitanpassungen, die `_sort` in `compareFn` umwandelten, wurden zurückgenommen, und der Header-Validierungstest wurde auf seinen vorherigen Umfang zurückgesetzt, sodass sich das Laufzeitverhalten nicht ändert. Damit bleibt `_sort` für TypeScript-Konsumenten eine gültige, aber klar als veraltet gekennzeichnete Header-Cell-Eigenschaft, die auf `compareFn` verweist. Ein sofortiges Handeln ist nicht zwingend erforderlich, `_sort`-Verwendungen sollten jedoch vor v4 migriert werden.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/schema/components/table.ts` — optionale, als `@deprecated` markierte Eigenschaft `_sort?: KoliBriSortFunction` zum Typ `KoliBriTableHeaderCellWithLogic` hinzugefügt (Hinweis auf `compareFn`, Entfernung in v4); keine Laufzeitänderung.

</details>