### PR TITLE
fix(samples): execute button click after kolFocus in popover-button basic sample

### DIFF
--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -9,8 +9,13 @@ export const PopoverButtonBasic: FC = () => {
 	const buttonRef = React.useRef<HTMLKolPopoverButtonElement>(null);
 
 	useEffect(() => {
-		buttonRef.current?.kolFocus();
-		// es muesste noch ein Klick ausgefuehrt werden
+		const run = async () => {
+			await buttonRef.current?.kolFocus();
+			if (buttonRef.current instanceof HTMLButtonElement) {
+				buttonRef.current.click();
+			}
+		};
+		run();
 	}, []);
 
 	const dummyEventHandler = {


### PR DESCRIPTION
## What changed?

The `PopoverButtonBasic` React sample (`packages/samples/react/src/components/popover-button/basic.tsx`) previously only called `buttonRef.current?.kolFocus()` inside its `useEffect`, leaving a `// es muesste noch ein Klick ausgefuehrt werden` TODO where the click was never performed. The effect is now wrapped in an async `run` helper that `await`s `kolFocus()` and then, when `buttonRef.current` is an `HTMLButtonElement`, invokes `.click()` on it. This makes the sample deterministically open the popover after focusing, which is what the accompanying visual snapshot test expects. Only the demo/sample source is touched; no library component or public API changes.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das React-Beispiel `PopoverButtonBasic` (`packages/samples/react/src/components/popover-button/basic.tsx`) rief in seinem `useEffect` bisher nur `buttonRef.current?.kolFocus()` auf und ließ an der Stelle mit dem TODO-Kommentar `// es muesste noch ein Klick ausgefuehrt werden` den eigentlichen Klick aus. Der Effect wird nun in eine asynchrone `run`-Hilfsfunktion gekapselt, die `kolFocus()` per `await` abwartet und anschließend, sofern `buttonRef.current` eine `HTMLButtonElement`-Instanz ist, `.click()` aufruft. Dadurch öffnet das Beispiel den Popover nach dem Fokussieren deterministisch, was der zugehörige visuelle Snapshot-Test erwartet. Betroffen ist ausschließlich der Beispiel-/Demo-Quelltext; es gibt keine Änderungen an Bibliothekskomponenten oder öffentlicher API.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/samples/react/src/components/popover-button/basic.tsx` — `useEffect` in eine asynchrone `run`-Funktion umgestellt, die nach `await kolFocus()` per `.click()` den Button betätigt (statt nur zu fokussieren).

</details>