### PR TITLE
refactor(table)!: remove deprecated _sort prop

### DIFF
--- a/packages/components/src/schema/components/table.ts
+++ b/packages/components/src/schema/components/table.ts
@@ -9,17 +9,12 @@ import type { KoliBriPaginationProps } from './pagination';
 
 export type KoliBriTableSelectedHead = { key: string; label: string; sortDirection: KoliBriSortDirection };
 
-export type KoliBriSortFunction = (data: KoliBriTableDataType[]) => KoliBriTableDataType[];
 export type KoliBriDataCompareFn = (a: KoliBriTableDataType, b: KoliBriTableDataType, sortDirection?: KoliBriSortDirection) => number;
 
 export type KoliBriTableHeaderCellWithLogic = KoliBriTableHeaderCell & {
-	compareFn?: KoliBriDataCompareFn;
-	/**
-	 * @deprecated Use `compareFn` instead. Will be removed in v4.
-	 */
-	_sort?: KoliBriSortFunction;
-	sortDirection?: KoliBriSortDirection;
-	headerCell?: true;
+        compareFn?: KoliBriDataCompareFn;
+        sortDirection?: KoliBriSortDirection;
+        headerCell?: true;
 };
 
 export type KoliBriTableHeaders = {


### PR DESCRIPTION
## What changed?

In `packages/components/src/schema/components/table.ts` the deprecated `_sort` property is removed from `KoliBriTableHeaderCellWithLogic`, and the associated exported `KoliBriSortFunction` type is deleted entirely. Sorting is now expressed exclusively through `compareFn` (`KoliBriDataCompareFn`). Because `_sort` and `KoliBriSortFunction` were part of the public type surface, this is a breaking change for any consumer still passing a `_sort` sort function or referencing the `KoliBriSortFunction` type. Consumers must migrate their column sorting logic to the `compareFn` signature `(a, b, sortDirection?) => number`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [x] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/schema/components/table.ts` wird die veraltete Eigenschaft `_sort` aus `KoliBriTableHeaderCellWithLogic` entfernt und der zugehörige exportierte Typ `KoliBriSortFunction` vollständig gelöscht. Sortierung wird nun ausschließlich über `compareFn` (`KoliBriDataCompareFn`) ausgedrückt. Da `_sort` und `KoliBriSortFunction` Teil der öffentlichen Typ-Schnittstelle waren, handelt es sich um eine Breaking Change für alle Nutzer, die noch eine `_sort`-Sortierfunktion übergeben oder den Typ `KoliBriSortFunction` verwenden. Nutzer müssen ihre Spalten-Sortierlogik auf die `compareFn`-Signatur `(a, b, sortDirection?) => number` umstellen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

💥 Breaking Change

### Geänderte Dateien

- `packages/components/src/schema/components/table.ts` — Entfernt die veraltete `_sort`-Eigenschaft aus `KoliBriTableHeaderCellWithLogic` sowie den exportierten Typ `KoliBriSortFunction`; Sortierung erfolgt nur noch über `compareFn`.

</details>