### PR TITLE
fix(hydrate-server): keep cleanup sync while serialized

### DIFF
--- a/packages/tools/hydrate-server/src/renderer.ts
+++ b/packages/tools/hydrate-server/src/renderer.ts
@@ -47,6 +47,58 @@ const mergeHydrateOptions = (base: Record<string, unknown> | undefined, override
 	...(overrides ?? {}),
 });
 
+class AsyncMutex {
+	private queue: Array<() => void> = [];
+	private locked = false;
+
+	public async acquire(): Promise<() => void> {
+		return new Promise<() => void>((resolve) => {
+			const release = this.createReleaseCallback();
+
+			if (!this.locked) {
+				this.locked = true;
+				resolve(release);
+				return;
+			}
+
+			this.queue.push(() => resolve(release));
+		});
+	}
+
+	public async runExclusive<T>(callback: () => Promise<T>): Promise<T>;
+	public async runExclusive<T>(callback: () => T): Promise<T>;
+	public async runExclusive<T>(callback: () => Promise<T> | T): Promise<T> {
+		const release = await this.acquire();
+
+		try {
+			return await callback();
+		} finally {
+			release();
+		}
+	}
+
+	private createReleaseCallback(): () => void {
+		let released = false;
+
+		return () => {
+			if (released) {
+				return;
+			}
+
+			released = true;
+			const next = this.queue.shift();
+			if (next) {
+				next();
+				return;
+			}
+
+			this.locked = false;
+		};
+	}
+}
+
+const rendererMutex = new AsyncMutex();
+
 // Global isolated renderer instance for resource management
 let globalIsolatedRenderer: IsolatedHydrateRenderer | null = null;
 
@@ -64,10 +116,25 @@ export const getIsolatedRenderer = (baseRenderer: HydrateRenderer): IsolatedHydr
  * Cleanup the global isolated renderer
  */
 export const cleanupGlobalRenderer = (): void => {
-	if (globalIsolatedRenderer) {
-		globalIsolatedRenderer.destroy();
-		globalIsolatedRenderer = null;
-	}
+	const cleanupPromise = rendererMutex.runExclusive(() => {
+		if (globalIsolatedRenderer) {
+			globalIsolatedRenderer.destroy();
+			globalIsolatedRenderer = null;
+		}
+	});
+
+	void cleanupPromise.catch((error) => {
+		if (typeof queueMicrotask === 'function') {
+			queueMicrotask(() => {
+				throw error;
+			});
+			return;
+		}
+
+		setTimeout(() => {
+			throw error;
+		}, 0);
+	});
 };
 
 /**
@@ -101,33 +168,35 @@ export const hydrateFragmentForServer = async (
 	// Extract timeout from options or use default
 	const timeoutMs = (effectiveOptions.timeout as number) || 5000;
 
-	// Use shared isolated renderer for server efficiency
-	const isolatedRenderer = getIsolatedRenderer(renderer);
+	return rendererMutex.runExclusive(async () => {
+		// Use shared isolated renderer for server efficiency
+		const isolatedRenderer = getIsolatedRenderer(renderer);
 
-	try {
-		// Race between rendering and timeout to prevent hanging
-		const renderPromise = isolatedRenderer.render(html, effectiveOptions);
-		const timeoutPromise = createTimeoutPromise(timeoutMs, html);
+		try {
+			// Race between rendering and timeout to prevent hanging
+			const renderPromise = isolatedRenderer.render(html, effectiveOptions);
+			const timeoutPromise = createTimeoutPromise(timeoutMs, html);
 
-		const result = await Promise.race([renderPromise, timeoutPromise]);
+			const result = await Promise.race([renderPromise, timeoutPromise]);
 
-		return {
-			html: typeof result.html === 'string' ? result.html : html,
-			components: coerceComponents(result.components),
-			hydratedCount: coerceHydratedCount(result.hydratedCount),
-			diagnostics: normalizeDiagnostics(result.diagnostics),
-		};
-	} catch (error) {
-		// Log renderer stats for debugging
-		const stats = isolatedRenderer.getStats();
-		console.warn(`Hydration failed with ${stats.activeTimers} active timers:`, error);
+			return {
+				html: typeof result.html === 'string' ? result.html : html,
+				components: coerceComponents(result.components),
+				hydratedCount: coerceHydratedCount(result.hydratedCount),
+				diagnostics: normalizeDiagnostics(result.diagnostics),
+			};
+		} catch (error) {
+			// Log renderer stats for debugging
+			const stats = isolatedRenderer.getStats();
+			console.warn(`Hydration failed with ${stats.activeTimers} active timers:`, error);
 
-		// Force cleanup on timeout/error
-		isolatedRenderer.destroy();
-		globalIsolatedRenderer = null;
+			// Force cleanup on timeout/error
+			isolatedRenderer.destroy();
+			globalIsolatedRenderer = null;
 
-		throw error;
-	}
+			throw error;
+		}
+	});
 };
 
 export const hydrateFragment = async (


### PR DESCRIPTION
## What changed?

The hydrate-server renderer now serializes all access to the shared global renderer through a new in-file `AsyncMutex` class in `packages/tools/hydrate-server/src/renderer.ts`. `cleanupGlobalRenderer` stays synchronous (its signature remains `(): void`) but internally schedules the destroy/reset work via `rendererMutex.runExclusive`, and any cleanup error is re-thrown asynchronously (via `queueMicrotask`, falling back to `setTimeout`) instead of surfacing as an unhandled promise rejection. `hydrateFragmentForServer` is wrapped in the same mutex so rendering and cleanup can no longer interleave and corrupt the shared `globalIsolatedRenderer`. This fixes a race condition without changing the public function signatures.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Renderer des hydrate-server serialisiert nun jeden Zugriff auf den gemeinsam genutzten globalen Renderer über eine neue, dateiinterne `AsyncMutex`-Klasse in `packages/tools/hydrate-server/src/renderer.ts`. `cleanupGlobalRenderer` bleibt synchron (Signatur weiterhin `(): void`), plant die eigentliche Aufräumarbeit (destroy/Reset) aber intern über `rendererMutex.runExclusive`, und ein etwaiger Fehler beim Aufräumen wird asynchron erneut geworfen (über `queueMicrotask`, ersatzweise `setTimeout`), statt als unbehandelte Promise-Rejection aufzutreten. `hydrateFragmentForServer` wird durch denselben Mutex geschützt, sodass Rendering und Aufräumen sich nicht mehr verschränken und den gemeinsamen `globalIsolatedRenderer` beschädigen können. Dies behebt eine Race-Condition, ohne die öffentlichen Funktionssignaturen zu ändern.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/tools/hydrate-server/src/renderer.ts` — Neue `AsyncMutex`-Klasse und `rendererMutex` hinzugefügt; `cleanupGlobalRenderer` bleibt synchron, führt die Aufräumarbeit aber über den Mutex aus und meldet Fehler asynchron; `hydrateFragmentForServer` wird im Mutex ausgeführt, um Race-Conditions am globalen Renderer zu verhindern.

</details>