### PR TITLE
ci: add visual snapshot comparison workflow

### DIFF
--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -1,0 +1,92 @@
+name: Visual Tests Snapshot Comparison
+
+on:
+  pull_request:
+
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  visual-tests-snapshots:
+    strategy:
+      matrix:
+        package: ['test-tag-name-transformer', 'theme-default', 'theme-bwst']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/pnpm-setup
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps firefox
+
+      - name: Build base branch
+        run: pnpm --filter @public-ui/sample-react^... build
+
+      - name: Generate base snapshots
+        run: pnpm --filter=@public-ui/${{ matrix.package }} test-update
+
+      - name: Store base snapshots
+        run: |
+          set -eo pipefail
+          PACKAGE="${{ matrix.package }}"
+          mkdir -p "/tmp/snapshots/${PACKAGE}"
+          if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
+            SNAPSHOT_DIR="packages/test-tag-name-transformer/snapshots"
+          else
+            THEME_DIR="${PACKAGE#theme-}"
+            SNAPSHOT_DIR="packages/themes/${THEME_DIR}/snapshots"
+          fi
+          if [ -d "$SNAPSHOT_DIR" ]; then
+            rsync -a "$SNAPSHOT_DIR/" "/tmp/snapshots/${PACKAGE}/"
+          fi
+
+      - name: Checkout head branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/pnpm-setup
+
+      - name: Restore base snapshots
+        run: |
+          set -eo pipefail
+          PACKAGE="${{ matrix.package }}"
+          if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
+            SNAPSHOT_DIR="packages/test-tag-name-transformer/snapshots"
+          else
+            THEME_DIR="${PACKAGE#theme-}"
+            SNAPSHOT_DIR="packages/themes/${THEME_DIR}/snapshots"
+          fi
+          rm -rf "$SNAPSHOT_DIR"
+          mkdir -p "$SNAPSHOT_DIR"
+          if [ -d "/tmp/snapshots/${PACKAGE}" ]; then
+            rsync -a "/tmp/snapshots/${PACKAGE}/" "$SNAPSHOT_DIR/"
+          fi
+
+      - name: Build head branch
+        run: pnpm --filter @public-ui/sample-react^... build
+
+      - name: Visual Tests
+        run: pnpm --filter=@public-ui/${{ matrix.package }} test
+
+      - uses: ./.github/actions/upload-reports
+        if: failure()
+        with:
+          name: report-base-snapshots-${{ matrix.package }}
+
+      - name: Upload base snapshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: base-snapshots-${{ matrix.package }}
+          path: /tmp/snapshots/${{ matrix.package }}
+          if-no-files-found: ignore


### PR DESCRIPTION
## What changed?

Adds a new GitHub Actions workflow `.github/workflows/visual-tests-base.yml` that runs on every pull request and compares visual test snapshots between the base and head branches without committing generated snapshot files. Using a matrix over `test-tag-name-transformer`, `theme-default`, and `theme-bwst`, the job checks out the base branch, installs the Firefox Playwright browser, builds the affected packages, and regenerates the base snapshots via `test-update`. The snapshots are stored under `/tmp/snapshots`; the workflow then checks out the head branch, restores the base snapshots into each package's `snapshots` directory, rebuilds, and runs the visual `test` command against them. On failure it uploads the test reports and base snapshots as artifacts. This targets the `release/2` line and is CI-only, with no impact on the published component library.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Fügt einen neuen GitHub-Actions-Workflow `.github/workflows/visual-tests-base.yml` hinzu, der bei jedem Pull Request die visuellen Test-Snapshots zwischen Basis- und Head-Branch vergleicht, ohne generierte Snapshot-Dateien zu committen. Über eine Matrix mit `test-tag-name-transformer`, `theme-default` und `theme-bwst` checkt der Job den Basis-Branch aus, installiert den Firefox-Playwright-Browser, baut die betroffenen Pakete und erzeugt die Basis-Snapshots per `test-update` neu. Die Snapshots werden unter `/tmp/snapshots` abgelegt; anschließend wird der Head-Branch ausgecheckt, die Basis-Snapshots werden in das jeweilige `snapshots`-Verzeichnis zurückgespielt, neu gebaut und der visuelle `test`-Befehl dagegen ausgeführt. Bei einem Fehler werden Testberichte und Basis-Snapshots als Artefakte hochgeladen. Der Workflow zielt auf die `release/2`-Linie und betrifft ausschließlich die CI, ohne Auswirkungen auf die veröffentlichte Komponentenbibliothek.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/visual-tests-base.yml` — Neuer Workflow, der Basis- und Head-Snapshots baut, zwischenspeichert, wiederherstellt und visuelle Tests dagegen ausführt; lädt bei Fehlern Reports und Snapshots als Artefakte hoch (Matrix mit `theme-bwst`).

</details>