### PR TITLE
ci: run format in dependency updater and drop parallel flags from ci checks

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -61,6 +61,8 @@ jobs:
         run: pnpm run update
       - name: Reinstall dependencies
         run: pnpm i --no-frozen-lockfile
+      - name: format code
+        run: pnpm format:all -w
 
       - name: Check for changes
         id: verify-changed-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Build
         run: pnpm -r build
       - name: Format
-        run: pnpm -r --parallel format
+        run: pnpm -r format
       - name: Lint
-        run: pnpm -r --parallel lint
+        run: pnpm -r lint
       - name: Unit Tests
-        run: pnpm -r --parallel test:unit
+        run: pnpm -r test:unit
       - name: Unused
-        run: pnpm -r --parallel unused
+        run: pnpm -r unused
 
   e2e-tests:
     continue-on-error: true

--- a/packages/adapters/react-hook-form-adapter/tsconfig.json
+++ b/packages/adapters/react-hook-form-adapter/tsconfig.json
@@ -17,8 +17,5 @@
 		"strict": true,
 		"skipLibCheck": true
 	},
-	"exclude": [
-		"node_modules",
-		"dist",
-	]
+	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## What changed?

Adjusted CI tooling and applied a formatting fix. In `.github/workflows/auto-dependency-updater.yml` a new "format code" step (`pnpm format:all -w`) runs after dependencies are updated and reinstalled, so automatically bumped dependencies land already formatted. In `.github/workflows/ci.yml` the `format`, `lint`, `test:unit` and `unused` steps drop the `--parallel` flag (from `pnpm -r --parallel <task>` to `pnpm -r <task>`), so these checks now run sequentially. Finally, `packages/adapters/react-hook-form-adapter/tsconfig.json` has its `exclude` array reformatted onto a single line with the trailing comma removed. No runtime or library code changes.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Anpassungen an der CI-Infrastruktur sowie eine Formatierungskorrektur. In `.github/workflows/auto-dependency-updater.yml` läuft nach dem Aktualisieren und Neuinstallieren der Abhängigkeiten ein neuer Schritt "format code" (`pnpm format:all -w`), damit automatisch aktualisierte Abhängigkeiten bereits formatiert übernommen werden. In `.github/workflows/ci.yml` entfällt bei den Schritten `format`, `lint`, `test:unit` und `unused` das `--parallel`-Flag (von `pnpm -r --parallel <task>` zu `pnpm -r <task>`), sodass diese Prüfungen nun sequenziell ausgeführt werden. Zuletzt wird in `packages/adapters/react-hook-form-adapter/tsconfig.json` das `exclude`-Array einzeilig formatiert und das nachgestellte Komma entfernt. Kein Laufzeit- oder Bibliothekscode ist betroffen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/auto-dependency-updater.yml` — Neuer Schritt `pnpm format:all -w` nach der Aktualisierung der Abhängigkeiten.
- `.github/workflows/ci.yml` — Entfernt das `--parallel`-Flag bei `format`, `lint`, `test:unit` und `unused`.
- `packages/adapters/react-hook-form-adapter/tsconfig.json` — `exclude`-Array einzeilig formatiert, nachgestelltes Komma entfernt.

</details>