### PR TITLE
feat(table): expose sort direction in compareFn

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -457,9 +457,12 @@ export class KolTableStateful implements TableAPI {
 			sortedData.sort((a: KoliBriTableDataType, b: KoliBriTableDataType) => {
 				for (let index = 0; index < this.sortData.length; index++) {
 					const data = this.sortData[index];
-					const result = data.compareFn(a, b);
-					if (result !== 0) {
-						return data.direction === 'ASC' ? result : -result;
+                                        const result = data.compareFn(a, b, data.direction);
+                                        if (result !== 0) {
+                                                if (data.direction === 'DESC' && data.compareFn.length < 3) {
+                                                        return -result;
+                                                }
+                                                return result;
 					}
 				}
 				return 0;

--- a/packages/components/src/schema/components/table.ts
+++ b/packages/components/src/schema/components/table.ts
@@ -10,7 +10,12 @@ export type KoliBriTableSelectedHead = { key: string; label: string; sortDirecti
 type KoliBriTableSort = <T>(data: T[]) => T[];
 
 export type KoliBriSortFunction = (data: KoliBriTableDataType[]) => KoliBriTableDataType[];
-export type KoliBriDataCompareFn = (a: KoliBriTableDataType, b: KoliBriTableDataType) => number;
+export type KoliBriDataCompareFn = (
+		a: KoliBriTableDataType,
+		b: KoliBriTableDataType,
+		sortDirection?: KoliBriSortDirection,
+)
+		=> number;
 
 export type KoliBriTableHeaderCellWithLogic = KoliBriTableHeaderCell & {
 	compareFn?: KoliBriDataCompareFn;

--- a/packages/samples/react/src/components/table/direction-aware-sort.tsx
+++ b/packages/samples/react/src/components/table/direction-aware-sort.tsx
@@ -1,0 +1,68 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { KolTable } from '@public-ui/react-v19';
+import type { KoliBriSortDirection, KoliBriTableDataType, KoliBriTableHeaders } from '@public-ui/components';
+import { SampleDescription } from '../SampleDescription';
+
+type TemperatureRow = {
+	city: string;
+	temperature: number;
+};
+
+const COMFORTABLE_TEMPERATURE = 22;
+
+const TEMPERATURE_DATA: TemperatureRow[] = [
+	{ city: 'Reykjavík', temperature: 6 },
+	{ city: 'Berlin', temperature: 21 },
+	{ city: 'Palma de Mallorca', temperature: 29 },
+	{ city: 'Cairo', temperature: 35 },
+	{ city: 'Helsinki', temperature: 14 },
+];
+
+const HEADERS: KoliBriTableHeaders = {
+	horizontal: [
+		[
+			{ label: 'City', key: 'city' },
+			{
+				label: 'Temperature (°C)',
+				key: 'temperature',
+				textAlign: 'right',
+				compareFn: (
+					rowA: KoliBriTableDataType,
+					rowB: KoliBriTableDataType,
+					direction: KoliBriSortDirection = 'ASC',
+				) => {
+					const temperatureA = (rowA as TemperatureRow).temperature;
+					const temperatureB = (rowB as TemperatureRow).temperature;
+					const differenceA = Math.abs(temperatureA - COMFORTABLE_TEMPERATURE);
+					const differenceB = Math.abs(temperatureB - COMFORTABLE_TEMPERATURE);
+
+					if (differenceA !== differenceB) {
+						return direction === 'DESC' ? differenceB - differenceA : differenceA - differenceB;
+					}
+
+					return direction === 'DESC' ? temperatureB - temperatureA : temperatureA - temperatureB;
+				},
+				render: (_element, _cell, row) => {
+					const difference = Math.abs((row as TemperatureRow).temperature - COMFORTABLE_TEMPERATURE);
+					return `${(row as TemperatureRow).temperature} °C (Δ ${difference} °C)`;
+				},
+			},
+		],
+	],
+};
+
+export const TableDirectionAwareSort: FC = () => (
+	<>
+		<SampleDescription>
+			<p>
+				This sample demonstrates how <code>compareFn</code> receives the current <code>sortDirection</code>. Ascending sorts show cities that are closest to 22&nbsp;°C first, descending sorts highlight the most extreme temperatures.
+			</p>
+		</SampleDescription>
+
+		<section className="w-full">
+			<KolTable _label="Direction aware compare function" _data={TEMPERATURE_DATA} _headers={HEADERS} className="block" />
+		</section>
+	</>
+);

--- a/packages/samples/react/src/components/table/routes.ts
+++ b/packages/samples/react/src/components/table/routes.ts
@@ -6,6 +6,7 @@ import { TableHorizontalScrollbar } from './horizontal-scrollbar';
 import { TableRenderCell } from './render-cell';
 import { TableSortData } from './sort-data';
 import { TableStateless } from './stateless';
+import { TableDirectionAwareSort } from './direction-aware-sort';
 import { TableWithFooter } from './with-footer';
 import { TableStatefulWithSelection } from './stateful-with-selection';
 import { TableStatefulWithSingleSelection } from './stateful-with-single-selection';
@@ -21,8 +22,9 @@ export const TABLE_ROUTES: Routes = {
 		'complex-headers': TableComplexHeaders,
 		'horizontal-scrollbar': TableHorizontalScrollbar,
 		'pagination-position': PaginationPosition,
-		'render-cell': TableRenderCell,
-		'sort-data': TableSortData,
+                'render-cell': TableRenderCell,
+                'direction-aware-sort': TableDirectionAwareSort,
+                'sort-data': TableSortData,
 		'with-footer': TableWithFooter,
 		'stateful-with-selection': TableStatefulWithSelection,
 		'stateful-with-single-selection': TableStatefulWithSingleSelection,


### PR DESCRIPTION
## Summary
- allow the table `compareFn` signature to receive the current sort direction
- use the provided sort direction when sorting and keep backwards compatibility for two-argument functions
- showcase the new behaviour in the React sample app with a direction-aware sorting example

## Testing
- pnpm --filter @public-ui/components build *(fails: rimraf missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fcb1b83278832bba0d08168843c3fa