### PR TITLE
ci: skip base snapshot generation when package is missing on base branch

### DIFF
--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -21,18 +21,43 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Determine package paths
+        id: package-paths
+        shell: bash
+        run: |
+          set -eo pipefail
+          PACKAGE="${{ matrix.package }}"
+          if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
+            PACKAGE_DIR="packages/test-tag-name-transformer"
+          else
+            THEME_DIR="${PACKAGE#theme-}"
+            PACKAGE_DIR="packages/themes/${THEME_DIR}"
+          fi
+          SNAPSHOT_DIR="${PACKAGE_DIR}/snapshots"
+          echo "package_dir=${PACKAGE_DIR}" >> "$GITHUB_OUTPUT"
+          echo "snapshot_dir=${SNAPSHOT_DIR}" >> "$GITHUB_OUTPUT"
+          if [ -d "${PACKAGE_DIR}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping base snapshot generation because ${PACKAGE_DIR} does not exist on the base branch."
+          fi
+
       - uses: ./.github/actions/pnpm-setup
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps firefox
 
       - name: Build base branch
+        if: steps.package-paths.outputs.exists == 'true'
         run: pnpm --filter @public-ui/sample-react^... build
 
       - name: Generate base snapshots
+        if: steps.package-paths.outputs.exists == 'true'
         run: pnpm --filter=@public-ui/${{ matrix.package }} test-update
 
       - name: Store base snapshots
+        if: steps.package-paths.outputs.exists == 'true'
         run: |
           set -eo pipefail
           PACKAGE="${{ matrix.package }}"
@@ -57,6 +82,7 @@ jobs:
       - uses: ./.github/actions/pnpm-setup
 
       - name: Restore base snapshots
+        if: steps.package-paths.outputs.exists == 'true'
         run: |
           set -eo pipefail
           PACKAGE="${{ matrix.package }}"
@@ -84,7 +110,7 @@ jobs:
           name: report-base-snapshots-${{ matrix.package }}
 
       - name: Upload base snapshots
-        if: failure()
+        if: failure() && steps.package-paths.outputs.exists == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: base-snapshots-${{ matrix.package }}


### PR DESCRIPTION
## What changed?

Reworked `.github/workflows/visual-tests-base.yml` so the visual-regression base-snapshot job no longer fails when the matrix package does not yet exist on the base branch. A new "Determine package paths" step derives the package directory (either `packages/test-tag-name-transformer` or `packages/themes/<theme>`) and its snapshot directory, then sets an `exists` output based on whether that directory is present. The "Build base branch", "Generate base snapshots", "Store base snapshots", "Restore base snapshots" and "Upload base snapshots" steps are now gated on `steps.package-paths.outputs.exists == 'true'`, so they are skipped for a package that is absent on the base branch. This lets the workflow proceed instead of erroring out for newly added packages. No runtime or library code is affected.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Workflow `.github/workflows/visual-tests-base.yml` wurde so überarbeitet, dass der Job zur Erzeugung der Basis-Snapshots für die visuellen Regressionstests nicht mehr fehlschlägt, wenn das Matrix-Paket auf dem Basis-Branch noch nicht existiert. Ein neuer Schritt "Determine package paths" ermittelt das Paketverzeichnis (entweder `packages/test-tag-name-transformer` oder `packages/themes/<theme>`) sowie das zugehörige Snapshot-Verzeichnis und setzt eine `exists`-Ausgabe, je nachdem ob dieses Verzeichnis vorhanden ist. Die Schritte "Build base branch", "Generate base snapshots", "Store base snapshots", "Restore base snapshots" und "Upload base snapshots" werden nun über `steps.package-paths.outputs.exists == 'true'` gesteuert und für auf dem Basis-Branch nicht vorhandene Pakete übersprungen. Dadurch kann der Workflow für neu hinzugefügte Pakete weiterlaufen, statt abzubrechen. Laufzeit- oder Bibliothekscode ist nicht betroffen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/visual-tests-base.yml` — Neuer Schritt zur Ermittlung der Paketpfade und Absicherung der Snapshot-Schritte über eine `exists`-Bedingung, damit fehlende Pakete übersprungen statt als Fehler behandelt werden.

</details>