### PR TITLE
feat: add initialize endpoint and SSE streaming to MCP server

### DIFF
--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -27,6 +27,7 @@ npx @public-ui/mcp
 
 The server will start on `http://localhost:3030` and provide the following endpoints:
 
+- `POST /mcp/initialize` - Discover available resources and capabilities
 - `GET /mcp/health` - Server status and content counts
 - `GET /mcp/samples` - List all available component examples
 - `GET /mcp/sample?id=sample/button/basic` - Get specific sample source code
@@ -86,6 +87,16 @@ Each sample includes:
 - ✅ **Responsive design patterns**
 
 ## 🔌 API Reference
+
+### POST /mcp/initialize
+
+Returns the server capabilities, available resources, and content counters so MCP clients can configure themselves without hard-coding endpoints.
+
+```bash
+curl -X POST http://localhost:3030/mcp/initialize
+```
+
+The response includes protocol metadata, streaming support information, and the exact endpoints exposed by the server.
 
 ### GET /mcp/health
 
@@ -170,6 +181,15 @@ curl "http://localhost:3030/mcp/doc?id=doc/README"
 Returns the Markdown content together with metadata. Every sample or doc response exposes a `kind` field so that clients can distinguish between component examples and documentation entries.
 
 All JSON responses contain an `ai-hints` string array that reiterates in English that KoliBri Web Components must be registered, that the correct integration guide and icon font assets need to be bundled, and that `<kol-form>` with an `_errorList` exposes validation errors via its summary.
+
+### 🔁 Server-Sent Events Streaming
+
+Collection endpoints (`/mcp/samples` and `/mcp/docs`) also support **Server-Sent Events (SSE)** to stream large result sets progressively. Request streaming responses by either:
+
+- Sending the header `Accept: text/event-stream`
+- Adding the query parameter `stream=1`
+
+The server emits a `meta` event with the query context followed by one event per resource (`sample` or `doc`) and an `end` event once streaming is complete. This enables MCP clients to render results immediately without waiting for the entire payload.
 
 ## 🛠️ Use Cases
 

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -115,37 +115,37 @@ export default async function handler(request, response) {
 
 			const getIndex = async () => mockIndex;
 
-                        const result = await handleApiRequest({
-                                method: request.method || 'GET',
-                                url: fullUrl.toString(),
-                                headers: request.headers || {},
-                                getIndex,
-                        });
+			const result = await handleApiRequest({
+				method: request.method || 'GET',
+				url: fullUrl.toString(),
+				headers: request.headers || {},
+				getIndex,
+			});
 
-                        response.status(result.statusCode);
-                        Object.entries(result.headers).forEach(([key, value]) => {
-                                response.setHeader(key, value);
-                        });
+			response.status(result.statusCode);
+			Object.entries(result.headers).forEach(([key, value]) => {
+				response.setHeader(key, value);
+			});
 
-                        if (result.stream) {
-                                response.flushHeaders?.();
-                                try {
-                                        for await (const chunk of result.stream) {
-                                                response.write(chunk);
-                                        }
-                                } finally {
-                                        response.end();
-                                }
-                                return;
-                        }
+			if (result.stream) {
+				response.flushHeaders?.();
+				try {
+					for await (const chunk of result.stream) {
+						response.write(chunk);
+					}
+				} finally {
+					response.end();
+				}
+				return;
+			}
 
-                        const responseBody = result.body ?? {};
-                        if (fullUrl.pathname === '/') {
-                                response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
-                        } else {
-                                response.json(responseBody);
-                        }
-                } else {
+			const responseBody = result.body ?? {};
+			if (fullUrl.pathname === '/') {
+				response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
+			} else {
+				response.json(responseBody);
+			}
+		} else {
 			// Fallback: Verwende Build-Artefakte (kann auf Vercel problematisch sein)
 			const { handleApiRequest, buildSampleIndex } = await import('../dist/index.mjs');
 
@@ -159,38 +159,38 @@ export default async function handler(request, response) {
 			};
 
 			// API Handler aufrufen
-                        const result = await handleApiRequest({
-                                method: request.method || 'GET',
-                                url: fullUrl.toString(),
-                                headers: request.headers || {},
-                                getIndex,
-                        });
+			const result = await handleApiRequest({
+				method: request.method || 'GET',
+				url: fullUrl.toString(),
+				headers: request.headers || {},
+				getIndex,
+			});
 
-                        // Response senden
-                        response.status(result.statusCode);
-                        Object.entries(result.headers).forEach(([key, value]) => {
-                                response.setHeader(key, value);
-                        });
+			// Response senden
+			response.status(result.statusCode);
+			Object.entries(result.headers).forEach(([key, value]) => {
+				response.setHeader(key, value);
+			});
 
-                        if (result.stream) {
-                                response.flushHeaders?.();
-                                try {
-                                        for await (const chunk of result.stream) {
-                                                response.write(chunk);
-                                        }
-                                } finally {
-                                        response.end();
-                                }
-                                return;
-                        }
+			if (result.stream) {
+				response.flushHeaders?.();
+				try {
+					for await (const chunk of result.stream) {
+						response.write(chunk);
+					}
+				} finally {
+					response.end();
+				}
+				return;
+			}
 
-                        const responseBody = result.body ?? {};
-                        if (fullUrl.pathname === '/') {
-                                response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
-                        } else {
-                                response.json(responseBody);
-                        }
-                }
+			const responseBody = result.body ?? {};
+			if (fullUrl.pathname === '/') {
+				response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
+			} else {
+				response.json(responseBody);
+			}
+		}
 	} catch (error) {
 		console.error('[api/mcp] Handler error:', error);
 

--- a/packages/tools/mcp/api/mcp.js
+++ b/packages/tools/mcp/api/mcp.js
@@ -115,23 +115,37 @@ export default async function handler(request, response) {
 
 			const getIndex = async () => mockIndex;
 
-			const result = await handleApiRequest({
-				method: request.method || 'GET',
-				url: fullUrl.toString(),
-				getIndex,
-			});
+                        const result = await handleApiRequest({
+                                method: request.method || 'GET',
+                                url: fullUrl.toString(),
+                                headers: request.headers || {},
+                                getIndex,
+                        });
 
-			response.status(result.statusCode);
-			Object.entries(result.headers).forEach(([key, value]) => {
-				response.setHeader(key, value);
-			});
-			const responseBody = result.body ?? {};
-			if (fullUrl.pathname === '/') {
-				response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
-			} else {
-				response.json(responseBody);
-			}
-		} else {
+                        response.status(result.statusCode);
+                        Object.entries(result.headers).forEach(([key, value]) => {
+                                response.setHeader(key, value);
+                        });
+
+                        if (result.stream) {
+                                response.flushHeaders?.();
+                                try {
+                                        for await (const chunk of result.stream) {
+                                                response.write(chunk);
+                                        }
+                                } finally {
+                                        response.end();
+                                }
+                                return;
+                        }
+
+                        const responseBody = result.body ?? {};
+                        if (fullUrl.pathname === '/') {
+                                response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
+                        } else {
+                                response.json(responseBody);
+                        }
+                } else {
 			// Fallback: Verwende Build-Artefakte (kann auf Vercel problematisch sein)
 			const { handleApiRequest, buildSampleIndex } = await import('../dist/index.mjs');
 
@@ -145,24 +159,38 @@ export default async function handler(request, response) {
 			};
 
 			// API Handler aufrufen
-			const result = await handleApiRequest({
-				method: request.method || 'GET',
-				url: fullUrl.toString(),
-				getIndex,
-			});
+                        const result = await handleApiRequest({
+                                method: request.method || 'GET',
+                                url: fullUrl.toString(),
+                                headers: request.headers || {},
+                                getIndex,
+                        });
 
-			// Response senden
-			response.status(result.statusCode);
-			Object.entries(result.headers).forEach(([key, value]) => {
-				response.setHeader(key, value);
-			});
-			const responseBody = result.body ?? {};
-			if (fullUrl.pathname === '/') {
-				response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
-			} else {
-				response.json(responseBody);
-			}
-		}
+                        // Response senden
+                        response.status(result.statusCode);
+                        Object.entries(result.headers).forEach(([key, value]) => {
+                                response.setHeader(key, value);
+                        });
+
+                        if (result.stream) {
+                                response.flushHeaders?.();
+                                try {
+                                        for await (const chunk of result.stream) {
+                                                response.write(chunk);
+                                        }
+                                } finally {
+                                        response.end();
+                                }
+                                return;
+                        }
+
+                        const responseBody = result.body ?? {};
+                        if (fullUrl.pathname === '/') {
+                                response.json(responseBody[AI_HINTS_KEY] ? responseBody : withAiHints(responseBody));
+                        } else {
+                                response.json(responseBody);
+                        }
+                }
 	} catch (error) {
 		console.error('[api/mcp] Handler error:', error);
 

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -13,10 +13,10 @@ function buildCorsHeaders() {
 }
 
 function logRequest(method, url, pathname, statusCode, responseTime) {
-        // Only log if MCP_DEBUG is enabled
-        if (!process.env.MCP_DEBUG) {
-                return;
-        }
+	// Only log if MCP_DEBUG is enabled
+	if (!process.env.MCP_DEBUG) {
+		return;
+	}
 
 	// Skip logging for root path requests to reduce noise
 	if (pathname === '/') {
@@ -38,33 +38,33 @@ function logRequest(method, url, pathname, statusCode, responseTime) {
 		statusColor = '\x1b[31m'; // Red for 4xx and 5xx
 	}
 
-        console.log(
-                `\x1b[90m[${timestamp}]\x1b[0m ${methodFormatted} ${statusColor}${statusFormatted}\x1b[0m ${timeFormatted} ${pathname}${url !== pathname ? ` (${url})` : ''}`,
-        );
+	console.log(
+		`\x1b[90m[${timestamp}]\x1b[0m ${methodFormatted} ${statusColor}${statusFormatted}\x1b[0m ${timeFormatted} ${pathname}${url !== pathname ? ` (${url})` : ''}`,
+	);
 }
 
 const STREAMING_HEADERS = {
-        'Content-Type': 'text/event-stream; charset=utf-8',
-        'Cache-Control': 'no-cache, no-transform',
-        Connection: 'keep-alive',
-        'X-Accel-Buffering': 'no',
+	'Content-Type': 'text/event-stream; charset=utf-8',
+	'Cache-Control': 'no-cache, no-transform',
+	Connection: 'keep-alive',
+	'X-Accel-Buffering': 'no',
 };
 
 function createSseStream({ meta = {}, items = [], itemEventName = 'item' } = {}) {
-        const enrichedMeta = withAiHints(meta);
-        return (async function* streamGenerator() {
-                yield ': connected\n\n';
-                yield `event: meta\ndata: ${JSON.stringify(enrichedMeta)}\n\n`;
+	const enrichedMeta = withAiHints(meta);
+	return (async function* streamGenerator() {
+		yield ': connected\n\n';
+		yield `event: meta\ndata: ${JSON.stringify(enrichedMeta)}\n\n`;
 
-                let index = 0;
-                for (const item of items) {
-                        const payload = { index, ...item };
-                        yield `event: ${itemEventName}\ndata: ${JSON.stringify(payload)}\n\n`;
-                        index += 1;
-                }
+		let index = 0;
+		for (const item of items) {
+			const payload = { index, ...item };
+			yield `event: ${itemEventName}\ndata: ${JSON.stringify(payload)}\n\n`;
+			index += 1;
+		}
 
-                yield `event: end\ndata: ${JSON.stringify({ total: items.length })}\n\n`;
-        })();
+		yield `event: end\ndata: ${JSON.stringify({ total: items.length })}\n\n`;
+	})();
 }
 
 export const AI_HINTS_KEY = 'ai-hints';
@@ -145,37 +145,36 @@ function normalizePathname(pathname) {
 }
 
 export async function handleApiRequest({ method = 'GET', url = '/', headers = {}, getIndex } = {}) {
-        const startTime = Date.now();
-        const baseHeaders = buildCorsHeaders();
-        const normalizedMethod = method.toUpperCase();
-        const requestUrl = new URL(url, 'http://localhost');
-        const pathname = normalizePathname(requestUrl.pathname);
-        const acceptsHeader = `${headers.accept ?? ''}`.toLowerCase();
-        const wantsStream =
-                acceptsHeader.includes('text/event-stream') ||
-                ['1', 'true', 'yes'].includes((requestUrl.searchParams.get('stream') ?? '').toLowerCase()) ||
-                (requestUrl.searchParams.get('format') ?? '').toLowerCase() === 'sse';
+	const startTime = Date.now();
+	const baseHeaders = buildCorsHeaders();
+	const normalizedMethod = method.toUpperCase();
+	const requestUrl = new URL(url, 'http://localhost');
+	const pathname = normalizePathname(requestUrl.pathname);
+	const acceptsHeader = `${headers.accept ?? ''}`.toLowerCase();
+	const wantsStream =
+		acceptsHeader.includes('text/event-stream') ||
+		['1', 'true', 'yes'].includes((requestUrl.searchParams.get('stream') ?? '').toLowerCase()) ||
+		(requestUrl.searchParams.get('format') ?? '').toLowerCase() === 'sse';
 
-        // Helper function to create response and log it
-        const finalizeResponse = (statusCode, { body, headers: extraHeaders = {}, stream } = {}) => {
-                const responseTime = Date.now() - startTime;
-                logRequest(normalizedMethod, url, pathname, statusCode, responseTime);
-                return {
-                        statusCode,
-                        headers: { ...baseHeaders, ...extraHeaders },
-                        body,
-                        stream,
-                };
-        };
+	// Helper function to create response and log it
+	const finalizeResponse = (statusCode, { body, headers: extraHeaders = {}, stream } = {}) => {
+		const responseTime = Date.now() - startTime;
+		logRequest(normalizedMethod, url, pathname, statusCode, responseTime);
+		return {
+			statusCode,
+			headers: { ...baseHeaders, ...extraHeaders },
+			body,
+			stream,
+		};
+	};
 
-        const createResponse = (statusCode, body = {}, headersOverride = {}) =>
-                finalizeResponse(statusCode, { body, headers: headersOverride });
+	const createResponse = (statusCode, body = {}, headersOverride = {}) => finalizeResponse(statusCode, { body, headers: headersOverride });
 
-        const createStreamResponse = (statusCode, { meta = {}, items = [], itemEventName = 'item' } = {}) =>
-                finalizeResponse(statusCode, {
-                        headers: { ...STREAMING_HEADERS },
-                        stream: createSseStream({ meta, items, itemEventName }),
-                });
+	const createStreamResponse = (statusCode, { meta = {}, items = [], itemEventName = 'item' } = {}) =>
+		finalizeResponse(statusCode, {
+			headers: { ...STREAMING_HEADERS },
+			stream: createSseStream({ meta, items, itemEventName }),
+		});
 
 	if (normalizedMethod === 'OPTIONS') {
 		return createResponse(204);
@@ -192,100 +191,98 @@ export async function handleApiRequest({ method = 'GET', url = '/', headers = {}
 		const counts = resolveCounts(index);
 		const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt : undefined;
 
-                return createResponse(
-                        200,
-                        withAiHints({
-                                message: 'KoliBri MCP backend is running.',
-                                endpoints: [
-                                        '/initialize',
-                                        '/health',
-                                        '/samples',
-                                        '/samples?q=<query>',
-                                        '/samples?stream=1',
-                                        '/sample?id=sample/<component>/<sample>',
-                                        '/docs',
-                                        '/docs?q=<query>',
-                                        '/docs?stream=1',
-                                        '/doc?id=doc/<identifier>',
-                                ],
-                                totalEntries: counts.total,
-                                totalSamples: counts.totalSamples,
-                                totalDocs: counts.totalDocs,
-                                generatedAt: (generatedAt ?? new Date()).toISOString(),
-                                buildMode: index?.buildMode ?? 'runtime',
-                                streaming: { sse: true },
-                        }),
-                );
-        }
+		return createResponse(
+			200,
+			withAiHints({
+				message: 'KoliBri MCP backend is running.',
+				endpoints: [
+					'/initialize',
+					'/health',
+					'/samples',
+					'/samples?q=<query>',
+					'/samples?stream=1',
+					'/sample?id=sample/<component>/<sample>',
+					'/docs',
+					'/docs?q=<query>',
+					'/docs?stream=1',
+					'/doc?id=doc/<identifier>',
+				],
+				totalEntries: counts.total,
+				totalSamples: counts.totalSamples,
+				totalDocs: counts.totalDocs,
+				generatedAt: (generatedAt ?? new Date()).toISOString(),
+				buildMode: index?.buildMode ?? 'runtime',
+				streaming: { sse: true },
+			}),
+		);
+	}
 
-        if ((normalizedMethod === 'POST' || normalizedMethod === 'GET') && pathname === '/initialize') {
-                const index = await getIndex();
-                const counts = resolveCounts(index);
-                const generatedAt = index.generatedAt instanceof Date ? index.generatedAt : new Date();
+	if ((normalizedMethod === 'POST' || normalizedMethod === 'GET') && pathname === '/initialize') {
+		const index = await getIndex();
+		const counts = resolveCounts(index);
+		const generatedAt = index.generatedAt instanceof Date ? index.generatedAt : new Date();
 
-                return createResponse(
-                        200,
-                        withAiHints({
-                                protocol: '2024-11-05',
-                                server: {
-                                        name: PACKAGE_NAME ?? 'KoliBri MCP Server',
-                                        version: PACKAGE_VERSION,
-                                        description:
-                                                PACKAGE_DESCRIPTION ??
-                                                'Model Context Protocol server providing access to KoliBri samples and documentation.',
-                                        homepage: PACKAGE_HOMEPAGE ?? 'https://public-ui.github.io',
-                                },
-                                capabilities: {
-                                        streaming: { sse: true },
-                                        filters: ['q'],
-                                },
-                                resources: [
-                                        {
-                                                id: 'samples',
-                                                name: 'Component Samples',
-                                                endpoint: '/samples',
-                                                kind: 'collection',
-                                                streaming: true,
-                                                methods: ['GET'],
-                                                params: ['q'],
-                                        },
-                                        {
-                                                id: 'sample',
-                                                name: 'Component Sample Detail',
-                                                endpoint: '/sample',
-                                                kind: 'item',
-                                                streaming: false,
-                                                methods: ['GET'],
-                                                params: ['id'],
-                                        },
-                                        {
-                                                id: 'docs',
-                                                name: 'Documentation Entries',
-                                                endpoint: '/docs',
-                                                kind: 'collection',
-                                                streaming: true,
-                                                methods: ['GET'],
-                                                params: ['q'],
-                                        },
-                                        {
-                                                id: 'doc',
-                                                name: 'Documentation Detail',
-                                                endpoint: '/doc',
-                                                kind: 'item',
-                                                streaming: false,
-                                                methods: ['GET'],
-                                                params: ['id'],
-                                        },
-                                ],
-                                totals: {
-                                        total: counts.total,
-                                        samples: counts.totalSamples,
-                                        docs: counts.totalDocs,
-                                },
-                                generatedAt: generatedAt.toISOString(),
-                        }),
-                );
-        }
+		return createResponse(
+			200,
+			withAiHints({
+				protocol: '2024-11-05',
+				server: {
+					name: PACKAGE_NAME ?? 'KoliBri MCP Server',
+					version: PACKAGE_VERSION,
+					description: PACKAGE_DESCRIPTION ?? 'Model Context Protocol server providing access to KoliBri samples and documentation.',
+					homepage: PACKAGE_HOMEPAGE ?? 'https://public-ui.github.io',
+				},
+				capabilities: {
+					streaming: { sse: true },
+					filters: ['q'],
+				},
+				resources: [
+					{
+						id: 'samples',
+						name: 'Component Samples',
+						endpoint: '/samples',
+						kind: 'collection',
+						streaming: true,
+						methods: ['GET'],
+						params: ['q'],
+					},
+					{
+						id: 'sample',
+						name: 'Component Sample Detail',
+						endpoint: '/sample',
+						kind: 'item',
+						streaming: false,
+						methods: ['GET'],
+						params: ['id'],
+					},
+					{
+						id: 'docs',
+						name: 'Documentation Entries',
+						endpoint: '/docs',
+						kind: 'collection',
+						streaming: true,
+						methods: ['GET'],
+						params: ['q'],
+					},
+					{
+						id: 'doc',
+						name: 'Documentation Detail',
+						endpoint: '/doc',
+						kind: 'item',
+						streaming: false,
+						methods: ['GET'],
+						params: ['id'],
+					},
+				],
+				totals: {
+					total: counts.total,
+					samples: counts.totalSamples,
+					docs: counts.totalDocs,
+				},
+				generatedAt: generatedAt.toISOString(),
+			}),
+		);
+	}
 
 	if (normalizedMethod === 'GET' && pathname === '/health') {
 		const index = await getIndex();
@@ -315,39 +312,39 @@ export async function handleApiRequest({ method = 'GET', url = '/', headers = {}
 		});
 	}
 
-        if (normalizedMethod === 'GET' && pathname === '/samples') {
-                const index = await getIndex();
-                const query = requestUrl.searchParams.get('q') ?? '';
-                const items = index.list(query, { kinds: ['sample'] }).map((entry) => ({
-                        group: entry.group,
-                        id: entry.id,
-                        name: entry.name,
-                        path: entry.path,
-                        kind: entry.kind ?? 'sample',
-                }));
-                const counts = resolveCounts(index);
-                const meta = {
-                        query,
-                        total: items.length,
-                        totalEntries: counts.total,
-                        totalSamples: counts.totalSamples,
-                        totalDocs: counts.totalDocs,
-                        generatedAt: index.generatedAt.toISOString(),
-                };
+	if (normalizedMethod === 'GET' && pathname === '/samples') {
+		const index = await getIndex();
+		const query = requestUrl.searchParams.get('q') ?? '';
+		const items = index.list(query, { kinds: ['sample'] }).map((entry) => ({
+			group: entry.group,
+			id: entry.id,
+			name: entry.name,
+			path: entry.path,
+			kind: entry.kind ?? 'sample',
+		}));
+		const counts = resolveCounts(index);
+		const meta = {
+			query,
+			total: items.length,
+			totalEntries: counts.total,
+			totalSamples: counts.totalSamples,
+			totalDocs: counts.totalDocs,
+			generatedAt: index.generatedAt.toISOString(),
+		};
 
-                if (wantsStream) {
-                        return createStreamResponse(200, {
-                                meta,
-                                items,
-                                itemEventName: 'sample',
-                        });
-                }
+		if (wantsStream) {
+			return createStreamResponse(200, {
+				meta,
+				items,
+				itemEventName: 'sample',
+			});
+		}
 
-                return createResponse(200, {
-                        items,
-                        ...meta,
-                });
-        }
+		return createResponse(200, {
+			items,
+			...meta,
+		});
+	}
 
 	if (normalizedMethod === 'GET' && pathname === '/sample') {
 		const index = await getIndex();
@@ -375,38 +372,38 @@ export async function handleApiRequest({ method = 'GET', url = '/', headers = {}
 		});
 	}
 
-        if (normalizedMethod === 'GET' && pathname === '/docs') {
-                const index = await getIndex();
-                const query = requestUrl.searchParams.get('q') ?? '';
-                const items = index.list(query, { kinds: ['doc'] }).map((entry) => ({
-                        group: entry.group,
-                        id: entry.id,
-                        name: entry.name,
-                        path: entry.path,
-                        kind: entry.kind ?? 'doc',
-                }));
-                const counts = resolveCounts(index);
-                const meta = {
-                        query,
-                        total: items.length,
-                        totalEntries: counts.totalDocs,
-                        totalDocs: counts.totalDocs,
-                        generatedAt: index.generatedAt.toISOString(),
-                };
+	if (normalizedMethod === 'GET' && pathname === '/docs') {
+		const index = await getIndex();
+		const query = requestUrl.searchParams.get('q') ?? '';
+		const items = index.list(query, { kinds: ['doc'] }).map((entry) => ({
+			group: entry.group,
+			id: entry.id,
+			name: entry.name,
+			path: entry.path,
+			kind: entry.kind ?? 'doc',
+		}));
+		const counts = resolveCounts(index);
+		const meta = {
+			query,
+			total: items.length,
+			totalEntries: counts.totalDocs,
+			totalDocs: counts.totalDocs,
+			generatedAt: index.generatedAt.toISOString(),
+		};
 
-                if (wantsStream) {
-                        return createStreamResponse(200, {
-                                meta,
-                                items,
-                                itemEventName: 'doc',
-                        });
-                }
+		if (wantsStream) {
+			return createStreamResponse(200, {
+				meta,
+				items,
+				itemEventName: 'doc',
+			});
+		}
 
-                return createResponse(200, {
-                        items,
-                        ...meta,
-                });
-        }
+		return createResponse(200, {
+			items,
+			...meta,
+		});
+	}
 
 	if (normalizedMethod === 'GET' && pathname === '/doc') {
 		const index = await getIndex();

--- a/packages/tools/mcp/src/api-handler.js
+++ b/packages/tools/mcp/src/api-handler.js
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { URL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { version: PACKAGE_VERSION, name: PACKAGE_NAME, description: PACKAGE_DESCRIPTION, homepage: PACKAGE_HOMEPAGE } = require('../package.json');
 
 function buildCorsHeaders() {
 	return {
@@ -9,10 +13,10 @@ function buildCorsHeaders() {
 }
 
 function logRequest(method, url, pathname, statusCode, responseTime) {
-	// Only log if MCP_DEBUG is enabled
-	if (!process.env.MCP_DEBUG) {
-		return;
-	}
+        // Only log if MCP_DEBUG is enabled
+        if (!process.env.MCP_DEBUG) {
+                return;
+        }
 
 	// Skip logging for root path requests to reduce noise
 	if (pathname === '/') {
@@ -34,9 +38,33 @@ function logRequest(method, url, pathname, statusCode, responseTime) {
 		statusColor = '\x1b[31m'; // Red for 4xx and 5xx
 	}
 
-	console.log(
-		`\x1b[90m[${timestamp}]\x1b[0m ${methodFormatted} ${statusColor}${statusFormatted}\x1b[0m ${timeFormatted} ${pathname}${url !== pathname ? ` (${url})` : ''}`,
-	);
+        console.log(
+                `\x1b[90m[${timestamp}]\x1b[0m ${methodFormatted} ${statusColor}${statusFormatted}\x1b[0m ${timeFormatted} ${pathname}${url !== pathname ? ` (${url})` : ''}`,
+        );
+}
+
+const STREAMING_HEADERS = {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+};
+
+function createSseStream({ meta = {}, items = [], itemEventName = 'item' } = {}) {
+        const enrichedMeta = withAiHints(meta);
+        return (async function* streamGenerator() {
+                yield ': connected\n\n';
+                yield `event: meta\ndata: ${JSON.stringify(enrichedMeta)}\n\n`;
+
+                let index = 0;
+                for (const item of items) {
+                        const payload = { index, ...item };
+                        yield `event: ${itemEventName}\ndata: ${JSON.stringify(payload)}\n\n`;
+                        index += 1;
+                }
+
+                yield `event: end\ndata: ${JSON.stringify({ total: items.length })}\n\n`;
+        })();
 }
 
 export const AI_HINTS_KEY = 'ai-hints';
@@ -116,23 +144,38 @@ function normalizePathname(pathname) {
 	return pathname;
 }
 
-export async function handleApiRequest({ method = 'GET', url = '/', getIndex } = {}) {
-	const startTime = Date.now();
-	const baseHeaders = buildCorsHeaders();
-	const normalizedMethod = method.toUpperCase();
-	const requestUrl = new URL(url, 'http://localhost');
-	const pathname = normalizePathname(requestUrl.pathname);
+export async function handleApiRequest({ method = 'GET', url = '/', headers = {}, getIndex } = {}) {
+        const startTime = Date.now();
+        const baseHeaders = buildCorsHeaders();
+        const normalizedMethod = method.toUpperCase();
+        const requestUrl = new URL(url, 'http://localhost');
+        const pathname = normalizePathname(requestUrl.pathname);
+        const acceptsHeader = `${headers.accept ?? ''}`.toLowerCase();
+        const wantsStream =
+                acceptsHeader.includes('text/event-stream') ||
+                ['1', 'true', 'yes'].includes((requestUrl.searchParams.get('stream') ?? '').toLowerCase()) ||
+                (requestUrl.searchParams.get('format') ?? '').toLowerCase() === 'sse';
 
-	// Helper function to create response and log it
-	const createResponse = (statusCode, body = {}) => {
-		const responseTime = Date.now() - startTime;
-		logRequest(normalizedMethod, url, pathname, statusCode, responseTime);
-		return {
-			statusCode,
-			headers: baseHeaders,
-			body,
-		};
-	};
+        // Helper function to create response and log it
+        const finalizeResponse = (statusCode, { body, headers: extraHeaders = {}, stream } = {}) => {
+                const responseTime = Date.now() - startTime;
+                logRequest(normalizedMethod, url, pathname, statusCode, responseTime);
+                return {
+                        statusCode,
+                        headers: { ...baseHeaders, ...extraHeaders },
+                        body,
+                        stream,
+                };
+        };
+
+        const createResponse = (statusCode, body = {}, headersOverride = {}) =>
+                finalizeResponse(statusCode, { body, headers: headersOverride });
+
+        const createStreamResponse = (statusCode, { meta = {}, items = [], itemEventName = 'item' } = {}) =>
+                finalizeResponse(statusCode, {
+                        headers: { ...STREAMING_HEADERS },
+                        stream: createSseStream({ meta, items, itemEventName }),
+                });
 
 	if (normalizedMethod === 'OPTIONS') {
 		return createResponse(204);
@@ -149,27 +192,100 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		const counts = resolveCounts(index);
 		const generatedAt = index?.generatedAt instanceof Date ? index.generatedAt : undefined;
 
-		return createResponse(
-			200,
-			withAiHints({
-				message: 'KoliBri MCP backend is running.',
-				endpoints: [
-					'/health',
-					'/samples',
-					'/samples?q=<query>',
-					'/sample?id=sample/<component>/<sample>',
-					'/docs',
-					'/docs?q=<query>',
-					'/doc?id=doc/<identifier>',
-				],
-				totalEntries: counts.total,
-				totalSamples: counts.totalSamples,
-				totalDocs: counts.totalDocs,
-				generatedAt: (generatedAt ?? new Date()).toISOString(),
-				buildMode: index?.buildMode ?? 'runtime',
-			}),
-		);
-	}
+                return createResponse(
+                        200,
+                        withAiHints({
+                                message: 'KoliBri MCP backend is running.',
+                                endpoints: [
+                                        '/initialize',
+                                        '/health',
+                                        '/samples',
+                                        '/samples?q=<query>',
+                                        '/samples?stream=1',
+                                        '/sample?id=sample/<component>/<sample>',
+                                        '/docs',
+                                        '/docs?q=<query>',
+                                        '/docs?stream=1',
+                                        '/doc?id=doc/<identifier>',
+                                ],
+                                totalEntries: counts.total,
+                                totalSamples: counts.totalSamples,
+                                totalDocs: counts.totalDocs,
+                                generatedAt: (generatedAt ?? new Date()).toISOString(),
+                                buildMode: index?.buildMode ?? 'runtime',
+                                streaming: { sse: true },
+                        }),
+                );
+        }
+
+        if ((normalizedMethod === 'POST' || normalizedMethod === 'GET') && pathname === '/initialize') {
+                const index = await getIndex();
+                const counts = resolveCounts(index);
+                const generatedAt = index.generatedAt instanceof Date ? index.generatedAt : new Date();
+
+                return createResponse(
+                        200,
+                        withAiHints({
+                                protocol: '2024-11-05',
+                                server: {
+                                        name: PACKAGE_NAME ?? 'KoliBri MCP Server',
+                                        version: PACKAGE_VERSION,
+                                        description:
+                                                PACKAGE_DESCRIPTION ??
+                                                'Model Context Protocol server providing access to KoliBri samples and documentation.',
+                                        homepage: PACKAGE_HOMEPAGE ?? 'https://public-ui.github.io',
+                                },
+                                capabilities: {
+                                        streaming: { sse: true },
+                                        filters: ['q'],
+                                },
+                                resources: [
+                                        {
+                                                id: 'samples',
+                                                name: 'Component Samples',
+                                                endpoint: '/samples',
+                                                kind: 'collection',
+                                                streaming: true,
+                                                methods: ['GET'],
+                                                params: ['q'],
+                                        },
+                                        {
+                                                id: 'sample',
+                                                name: 'Component Sample Detail',
+                                                endpoint: '/sample',
+                                                kind: 'item',
+                                                streaming: false,
+                                                methods: ['GET'],
+                                                params: ['id'],
+                                        },
+                                        {
+                                                id: 'docs',
+                                                name: 'Documentation Entries',
+                                                endpoint: '/docs',
+                                                kind: 'collection',
+                                                streaming: true,
+                                                methods: ['GET'],
+                                                params: ['q'],
+                                        },
+                                        {
+                                                id: 'doc',
+                                                name: 'Documentation Detail',
+                                                endpoint: '/doc',
+                                                kind: 'item',
+                                                streaming: false,
+                                                methods: ['GET'],
+                                                params: ['id'],
+                                        },
+                                ],
+                                totals: {
+                                        total: counts.total,
+                                        samples: counts.totalSamples,
+                                        docs: counts.totalDocs,
+                                },
+                                generatedAt: generatedAt.toISOString(),
+                        }),
+                );
+        }
 
 	if (normalizedMethod === 'GET' && pathname === '/health') {
 		const index = await getIndex();
@@ -199,27 +315,39 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		});
 	}
 
-	if (normalizedMethod === 'GET' && pathname === '/samples') {
-		const index = await getIndex();
-		const query = requestUrl.searchParams.get('q') ?? '';
-		const items = index.list(query, { kinds: ['sample'] }).map((entry) => ({
-			group: entry.group,
-			id: entry.id,
-			name: entry.name,
-			path: entry.path,
-			kind: entry.kind ?? 'sample',
-		}));
-		const counts = resolveCounts(index);
-		return createResponse(200, {
-			items,
-			query,
-			total: items.length,
-			totalEntries: counts.total,
-			totalSamples: counts.totalSamples,
-			totalDocs: counts.totalDocs,
-			generatedAt: index.generatedAt.toISOString(),
-		});
-	}
+        if (normalizedMethod === 'GET' && pathname === '/samples') {
+                const index = await getIndex();
+                const query = requestUrl.searchParams.get('q') ?? '';
+                const items = index.list(query, { kinds: ['sample'] }).map((entry) => ({
+                        group: entry.group,
+                        id: entry.id,
+                        name: entry.name,
+                        path: entry.path,
+                        kind: entry.kind ?? 'sample',
+                }));
+                const counts = resolveCounts(index);
+                const meta = {
+                        query,
+                        total: items.length,
+                        totalEntries: counts.total,
+                        totalSamples: counts.totalSamples,
+                        totalDocs: counts.totalDocs,
+                        generatedAt: index.generatedAt.toISOString(),
+                };
+
+                if (wantsStream) {
+                        return createStreamResponse(200, {
+                                meta,
+                                items,
+                                itemEventName: 'sample',
+                        });
+                }
+
+                return createResponse(200, {
+                        items,
+                        ...meta,
+                });
+        }
 
 	if (normalizedMethod === 'GET' && pathname === '/sample') {
 		const index = await getIndex();
@@ -247,26 +375,38 @@ export async function handleApiRequest({ method = 'GET', url = '/', getIndex } =
 		});
 	}
 
-	if (normalizedMethod === 'GET' && pathname === '/docs') {
-		const index = await getIndex();
-		const query = requestUrl.searchParams.get('q') ?? '';
-		const items = index.list(query, { kinds: ['doc'] }).map((entry) => ({
-			group: entry.group,
-			id: entry.id,
-			name: entry.name,
-			path: entry.path,
-			kind: entry.kind ?? 'doc',
-		}));
-		const counts = resolveCounts(index);
-		return createResponse(200, {
-			items,
-			query,
-			total: items.length,
-			totalEntries: counts.totalDocs,
-			totalDocs: counts.totalDocs,
-			generatedAt: index.generatedAt.toISOString(),
-		});
-	}
+        if (normalizedMethod === 'GET' && pathname === '/docs') {
+                const index = await getIndex();
+                const query = requestUrl.searchParams.get('q') ?? '';
+                const items = index.list(query, { kinds: ['doc'] }).map((entry) => ({
+                        group: entry.group,
+                        id: entry.id,
+                        name: entry.name,
+                        path: entry.path,
+                        kind: entry.kind ?? 'doc',
+                }));
+                const counts = resolveCounts(index);
+                const meta = {
+                        query,
+                        total: items.length,
+                        totalEntries: counts.totalDocs,
+                        totalDocs: counts.totalDocs,
+                        generatedAt: index.generatedAt.toISOString(),
+                };
+
+                if (wantsStream) {
+                        return createStreamResponse(200, {
+                                meta,
+                                items,
+                                itemEventName: 'doc',
+                        });
+                }
+
+                return createResponse(200, {
+                        items,
+                        ...meta,
+                });
+        }
 
 	if (normalizedMethod === 'GET' && pathname === '/doc') {
 		const index = await getIndex();

--- a/packages/tools/mcp/src/server.js
+++ b/packages/tools/mcp/src/server.js
@@ -5,34 +5,34 @@ import { buildSampleIndex } from './sample-index.js';
 const DEFAULT_PORT = Number.parseInt(process.env.PORT ?? '3030', 10);
 
 export async function startServer(options = {}) {
-        const port = Number.parseInt(`${options.port ?? DEFAULT_PORT}`, 10);
-        let index = await buildSampleIndex();
+	const port = Number.parseInt(`${options.port ?? DEFAULT_PORT}`, 10);
+	let index = await buildSampleIndex();
 
-        const server = createServer((request, response) => {
-                Promise.resolve(
-                        handleApiRequest({
-                                method: request.method ?? 'GET',
-                                url: request.url ?? '/',
-                                headers: request.headers ?? {},
-                                getIndex: () => index,
-                        }),
-                )
-                        .then((result) => respondWithResult(response, result))
-                        .catch((error) => {
-                                console.error('[mcp] request failed', error);
-                                if (!response.headersSent) {
-                                        return respondWithResult(response, {
-                                                statusCode: 500,
-                                                headers: {
-                                                        'Access-Control-Allow-Origin': '*',
-                                                        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-                                                        'Access-Control-Allow-Headers': 'Content-Type',
-                                                },
-                                                body: { error: 'internal_error' },
-                                        });
-                                }
-                        });
-        });
+	const server = createServer((request, response) => {
+		Promise.resolve(
+			handleApiRequest({
+				method: request.method ?? 'GET',
+				url: request.url ?? '/',
+				headers: request.headers ?? {},
+				getIndex: () => index,
+			}),
+		)
+			.then((result) => respondWithResult(response, result))
+			.catch((error) => {
+				console.error('[mcp] request failed', error);
+				if (!response.headersSent) {
+					return respondWithResult(response, {
+						statusCode: 500,
+						headers: {
+							'Access-Control-Allow-Origin': '*',
+							'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+							'Access-Control-Allow-Headers': 'Content-Type',
+						},
+						body: { error: 'internal_error' },
+					});
+				}
+			});
+	});
 
 	server.listen(port, () => {
 		console.log(`[mcp] server listening on http://localhost:${port}`);
@@ -42,49 +42,49 @@ export async function startServer(options = {}) {
 }
 
 async function respondWithResult(response, result) {
-        if (response.headersSent) {
-                return;
-        }
+	if (response.headersSent) {
+		return;
+	}
 
-        const headers = { ...result.headers };
-        if (!result.stream) {
-                headers['Content-Type'] = headers['Content-Type'] ?? 'application/json; charset=utf-8';
-        }
+	const headers = { ...result.headers };
+	if (!result.stream) {
+		headers['Content-Type'] = headers['Content-Type'] ?? 'application/json; charset=utf-8';
+	}
 
-        for (const [name, value] of Object.entries(headers)) {
-                response.setHeader(name, value);
-        }
+	for (const [name, value] of Object.entries(headers)) {
+		response.setHeader(name, value);
+	}
 
-        response.statusCode = result.statusCode;
+	response.statusCode = result.statusCode;
 
-        if (result.stream) {
-                try {
-                        for await (const chunk of result.stream) {
-                                if (response.writableEnded) {
-                                        break;
-                                }
-                                response.write(chunk);
-                        }
-                } catch (streamError) {
-                        console.error('[mcp] failed to stream response', streamError);
-                        if (!response.headersSent) {
-                                response.statusCode = 500;
-                                response.setHeader('Content-Type', 'application/json; charset=utf-8');
-                                response.end(JSON.stringify({ error: 'stream_error' }));
-                                return;
-                        }
-                }
+	if (result.stream) {
+		try {
+			for await (const chunk of result.stream) {
+				if (response.writableEnded) {
+					break;
+				}
+				response.write(chunk);
+			}
+		} catch (streamError) {
+			console.error('[mcp] failed to stream response', streamError);
+			if (!response.headersSent) {
+				response.statusCode = 500;
+				response.setHeader('Content-Type', 'application/json; charset=utf-8');
+				response.end(JSON.stringify({ error: 'stream_error' }));
+				return;
+			}
+		}
 
-                if (!response.writableEnded) {
-                        response.end();
-                }
-                return;
-        }
+		if (!response.writableEnded) {
+			response.end();
+		}
+		return;
+	}
 
-        if (result.body === undefined) {
-                response.end();
-                return;
-        }
+	if (result.body === undefined) {
+		response.end();
+		return;
+	}
 
-        response.end(JSON.stringify(result.body, null, 2));
+	response.end(JSON.stringify(result.body, null, 2));
 }

--- a/packages/tools/mcp/src/server.js
+++ b/packages/tools/mcp/src/server.js
@@ -5,33 +5,34 @@ import { buildSampleIndex } from './sample-index.js';
 const DEFAULT_PORT = Number.parseInt(process.env.PORT ?? '3030', 10);
 
 export async function startServer(options = {}) {
-	const port = Number.parseInt(`${options.port ?? DEFAULT_PORT}`, 10);
-	let index = await buildSampleIndex();
+        const port = Number.parseInt(`${options.port ?? DEFAULT_PORT}`, 10);
+        let index = await buildSampleIndex();
 
-	const server = createServer((request, response) => {
-		Promise.resolve(
-			handleApiRequest({
-				method: request.method ?? 'GET',
-				url: request.url ?? '/',
-				getIndex: () => index,
-			}),
-		)
-			.then((result) => respondWithResult(response, result))
-			.catch((error) => {
-				console.error('[mcp] request failed', error);
-				if (!response.headersSent) {
-					respondWithResult(response, {
-						statusCode: 500,
-						headers: {
-							'Access-Control-Allow-Origin': '*',
-							'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-							'Access-Control-Allow-Headers': 'Content-Type',
-						},
-						body: { error: 'internal_error' },
-					});
-				}
-			});
-	});
+        const server = createServer((request, response) => {
+                Promise.resolve(
+                        handleApiRequest({
+                                method: request.method ?? 'GET',
+                                url: request.url ?? '/',
+                                headers: request.headers ?? {},
+                                getIndex: () => index,
+                        }),
+                )
+                        .then((result) => respondWithResult(response, result))
+                        .catch((error) => {
+                                console.error('[mcp] request failed', error);
+                                if (!response.headersSent) {
+                                        return respondWithResult(response, {
+                                                statusCode: 500,
+                                                headers: {
+                                                        'Access-Control-Allow-Origin': '*',
+                                                        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+                                                        'Access-Control-Allow-Headers': 'Content-Type',
+                                                },
+                                                body: { error: 'internal_error' },
+                                        });
+                                }
+                        });
+        });
 
 	server.listen(port, () => {
 		console.log(`[mcp] server listening on http://localhost:${port}`);
@@ -40,25 +41,50 @@ export async function startServer(options = {}) {
 	return server;
 }
 
-function respondWithResult(response, result) {
-	if (response.headersSent) {
-		return;
-	}
+async function respondWithResult(response, result) {
+        if (response.headersSent) {
+                return;
+        }
 
-	response.statusCode = result.statusCode;
-	const headers = {
-		'Content-Type': 'application/json; charset=utf-8',
-		...result.headers,
-	};
+        const headers = { ...result.headers };
+        if (!result.stream) {
+                headers['Content-Type'] = headers['Content-Type'] ?? 'application/json; charset=utf-8';
+        }
 
-	for (const [name, value] of Object.entries(headers)) {
-		response.setHeader(name, value);
-	}
+        for (const [name, value] of Object.entries(headers)) {
+                response.setHeader(name, value);
+        }
 
-	if (result.body === undefined) {
-		response.end();
-		return;
-	}
+        response.statusCode = result.statusCode;
 
-	response.end(JSON.stringify(result.body, null, 2));
+        if (result.stream) {
+                try {
+                        for await (const chunk of result.stream) {
+                                if (response.writableEnded) {
+                                        break;
+                                }
+                                response.write(chunk);
+                        }
+                } catch (streamError) {
+                        console.error('[mcp] failed to stream response', streamError);
+                        if (!response.headersSent) {
+                                response.statusCode = 500;
+                                response.setHeader('Content-Type', 'application/json; charset=utf-8');
+                                response.end(JSON.stringify({ error: 'stream_error' }));
+                                return;
+                        }
+                }
+
+                if (!response.writableEnded) {
+                        response.end();
+                }
+                return;
+        }
+
+        if (result.body === undefined) {
+                response.end();
+                return;
+        }
+
+        response.end(JSON.stringify(result.body, null, 2));
 }


### PR DESCRIPTION
## What changed?

Adds a new `POST/GET /mcp/initialize` endpoint in `packages/tools/mcp/src/api-handler.js` that returns MCP protocol metadata, server capabilities, the list of available resources (`samples`, `sample`, `docs`, `doc`) with their methods/params, and content totals so MCP clients can self-configure without hard-coding endpoints. The same handler gains Server-Sent Events (SSE) streaming for the collection endpoints `/mcp/samples` and `/mcp/docs`, activated via an `Accept: text/event-stream` header or a `stream=1`/`format=sse` query parameter; a new `createSseStream` generator emits a `meta` event, one event per item (`sample`/`doc`), and an `end` event. The Node server (`src/server.js`) and the serverless handler (`api/mcp.js`) were extended to forward request headers and to consume and write the async stream to the response. The MCP `README.md` documents the initialize handshake and the SSE streaming options. Purely additive — existing JSON responses are unchanged when streaming is not requested.

## Linked issues

No linked issues.

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ergänzt einen neuen `POST/GET /mcp/initialize`-Endpunkt in `packages/tools/mcp/src/api-handler.js`, der MCP-Protokoll-Metadaten, Server-Fähigkeiten, die Liste der verfügbaren Ressourcen (`samples`, `sample`, `docs`, `doc`) samt Methoden/Parametern sowie Inhalts-Zähler zurückgibt, damit sich MCP-Clients ohne fest verdrahtete Endpunkte selbst konfigurieren können. Derselbe Handler erhält Server-Sent-Events-Streaming (SSE) für die Sammel-Endpunkte `/mcp/samples` und `/mcp/docs`, aktiviert über den Header `Accept: text/event-stream` oder den Query-Parameter `stream=1`/`format=sse`; ein neuer `createSseStream`-Generator sendet ein `meta`-Event, ein Event pro Eintrag (`sample`/`doc`) und ein `end`-Event. Der Node-Server (`src/server.js`) und der Serverless-Handler (`api/mcp.js`) wurden erweitert, um Request-Header weiterzureichen und den asynchronen Stream in die Antwort zu schreiben. Die MCP-`README.md` dokumentiert den Initialize-Handshake und die SSE-Streaming-Optionen. Rein additiv — bestehende JSON-Antworten bleiben unverändert, wenn kein Streaming angefordert wird.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

✨ Neues Feature

### Geänderte Dateien

- `packages/tools/mcp/src/api-handler.js` — Neuer `/initialize`-Endpunkt, SSE-Streaming-Erkennung und `createSseStream`-Generator für die Sammel-Endpunkte.
- `packages/tools/mcp/src/server.js` — Node-Server reicht Header weiter und schreibt den asynchronen SSE-Stream in die Antwort.
- `packages/tools/mcp/api/mcp.js` — Serverless-Handler reicht Header weiter und streamt Chunks an die Response.
- `packages/tools/mcp/README.md` — Dokumentation des Initialize-Handshakes und der SSE-Streaming-Optionen.

</details>