### PR TITLE
test: add date-in-form e2e scenario ensuring enter on date icon does not submit

### DIFF
--- a/packages/samples/react/e2e/date-in-form.spec.ts
+++ b/packages/samples/react/e2e/date-in-form.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('date-in-form', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/#/scenarios/date-in-form');
+	});
+
+	test('Enter on date icon', async ({ page }) => {
+		const errorLogs: string[] = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') {
+				errorLogs.push(msg.text());
+			}
+		});
+
+		const kolInputDate = page.locator('.kol-input-date');
+		await expect(kolInputDate).toHaveCount(1);
+
+		await kolInputDate.click();
+		await page.keyboard.press('Enter');
+		await page.waitForTimeout(500);
+		await expect(errorLogs).toHaveLength(1);
+
+		await kolInputDate.click();
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('Enter');
+		await page.waitForTimeout(500);
+		await expect(errorLogs).toHaveLength(1);
+	});
+});

--- a/packages/samples/react/src/scenarios/date-in-form.tsx
+++ b/packages/samples/react/src/scenarios/date-in-form.tsx
@@ -1,0 +1,24 @@
+import { KolButton, KolForm, KolInputDate } from '@public-ui/react-v19';
+import type { FC } from 'react';
+import React from 'react';
+import { SampleDescription } from '../components/SampleDescription';
+
+export const DateInForm: FC = () => (
+	<>
+		<SampleDescription>
+			<p>KolForm with KolInputDate inside to make sure enter on the date icon does not submit the form.</p>
+		</SampleDescription>
+
+		<KolForm
+			_on={{
+				onSubmit: () => {
+					console.error('submitted');
+					alert('submitted');
+				},
+			}}
+		>
+			<KolInputDate _label="date" _name="datum" />
+			<KolButton _label="Submit" _type="submit" />
+		</KolForm>
+	</>
+);

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -11,12 +11,14 @@ import { StaticForm } from './static-form';
 import { TableHorizontalScrollAdvanced } from './horizontal-scrollbar-advanced';
 import { ToolbarItemOrder } from './toolbar-item-order';
 import { TooltipPositioning } from './tooltip-positioning';
+import { DateInForm } from './date-in-form';
 
 export const SCENARIO_ROUTES: Routes = {
 	scenarios: {
 		'appointment-form': AppointmentForm,
 		'change-tabindex': ChangeTabindex,
 		'custom-tooltip-css-properties': CustomTooltipCssProperties,
+		'date-in-form': DateInForm,
 		'disabled-interactive-scenario': DisabledInteractiveElements,
 		'focus-elements': FocusElements,
 		'input-group-with-error': InputGroupWithError,


### PR DESCRIPTION
## What changed?

Adds a regression e2e test (and the sample scenario it drives) covering a `KolInputDate` placed inside a `KolForm`. The new Playwright spec `packages/samples/react/e2e/date-in-form.spec.ts` navigates to the new `date-in-form` scenario and asserts that pressing <kbd>Enter</kbd> on the date icon does not submit the surrounding form (the form's `onSubmit` logs an error, so the test verifies exactly one console error occurs across the interactions). The scenario component `packages/samples/react/src/scenarios/date-in-form.tsx` and its registration in `scenarios/routes.ts` are added. Test/sample-only change with no component source changes.

## Linked issues

- Refs #8444 — date icon Enter should not submit the form

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Fügt einen Regressions-e2e-Test (und das dazugehörige Sample-Szenario) hinzu, der eine `KolInputDate` innerhalb einer `KolForm` abdeckt. Der neue Playwright-Spec `packages/samples/react/e2e/date-in-form.spec.ts` navigiert zum neuen `date-in-form`-Szenario und prüft, dass ein <kbd>Enter</kbd> auf dem Datums-Icon das umgebende Formular nicht absendet (der `onSubmit` des Formulars loggt einen Fehler, sodass der Test genau einen Konsolenfehler über die Interaktionen erwartet). Die Szenario-Komponente `packages/samples/react/src/scenarios/date-in-form.tsx` sowie deren Registrierung in `scenarios/routes.ts` werden ergänzt. Reine Test-/Sample-Änderung ohne Änderungen am Komponenten-Quellcode.

### Verknüpfte Tickets

- Referenziert #8444 — Enter auf dem Datums-Icon soll das Formular nicht absenden

### Art der Änderung

🔧 Intern (Test)

### Geänderte Dateien

- `packages/samples/react/e2e/date-in-form.spec.ts` — Neuer Playwright-Test für das Enter-auf-Datums-Icon-Verhalten.
- `packages/samples/react/src/scenarios/date-in-form.tsx` — Neues Sample-Szenario (`KolForm` mit `KolInputDate`).
- `packages/samples/react/src/scenarios/routes.ts` — Registrierung des neuen Szenarios.

</details>