### PR TITLE
fix(samples): wrap react-hook-form sample with KolForm component

### DIFF
--- a/packages/samples/react/src/scenarios/react-hook-form/basic.tsx
+++ b/packages/samples/react/src/scenarios/react-hook-form/basic.tsx
@@ -14,9 +14,8 @@ import {
 	KolSingleSelectController,
 	KolTextareaController,
 } from '@public-ui/react-hook-form-adapter';
-import { KolButton } from '@public-ui/react-v19';
-import type { FC } from 'react';
-import React from 'react';
+import { KolButton, KolForm } from '@public-ui/react-v19';
+import React, { type BaseSyntheticEvent, type FC } from 'react';
 import type { FieldErrors, SubmitHandler } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 
@@ -122,62 +121,74 @@ export const RHFBasic: FC = () => {
 	return (
 		<>
 			<SampleDescription>
-				<p>This sample demonstrates a form using React Hook Form with KoliBri adapters. All inputs are validated, and error messages are shown on submit.</p>
+				<p>
+					This sample demonstrates a form using React Hook Form with KoliBri adapters wrapped in a KolForm. All inputs are validated, and error messages are
+					shown on submit.
+				</p>
 			</SampleDescription>
 
-			<form onSubmit={handleSubmit(onSubmit, onError)} className="grid gap-4 w-full max-w-xl">
-				<KolInputTextController name="firstName" control={control} _label="First Name" rules={{ required: 'First name is required' }} _required />
-				<KolInputTextController name="lastName" control={control} _label="Last Name" rules={{ required: 'Last name is required' }} _required />
-				<KolInputEmailController name="email" control={control} _label="Email" rules={{ required: 'Email is required' }} _required />
-				<KolInputPasswordController name="password" control={control} _label="Password" rules={{ required: 'Password is required' }} _required />
-				<KolInputNumberController name="age" control={control} _label="Age" rules={{ required: 'Age is required', min: 0 }} _required />
-				<KolInputRangeController name="volume" control={control} _label="Volume (0–100)" _min={0} _max={100} />
-				<KolInputDateController name="birthday" control={control} _label="Birthday" rules={{ required: 'Birthday is required' }} />
-				<KolInputColorController name="favoriteColor" control={control} _label="Favorite Color" id="favoriteColor" />
-				<KolInputFileController name="cv" control={control} _label="Upload CV" rules={{ required: 'Please upload your CV' }} _required />
-				<KolTextareaController name="bio" control={control} _label="Bio" rules={{ required: 'Please provide a short bio' }} _required />
-				<KolComboboxController
-					control={control}
-					rules={{ required: 'Please select a country' }}
-					name="country"
-					_label="Country"
-					_suggestions={COUNTRY_SUGGESTIONS}
-					_required
-				/>
-				<KolSelectController
-					control={control}
-					rules={{ required: 'Please select a language' }}
-					name="language"
-					_label="Preferred Language"
-					_options={languageOptions}
-					_required
-				/>
-				<KolSingleSelectController
-					rules={{ required: 'Please select a framework' }}
-					control={control}
-					name="framework"
-					_label="Favorite Framework"
-					_options={frameworkOptions}
-					_required
-				/>
-				<KolInputRadioController
-					control={control}
-					rules={{ required: 'Please select your gender' }}
-					name="gender"
-					_label="Gender"
-					_options={genderOptions}
-					_required
-				/>
-				<KolInputCheckboxController
-					name="termsAccepted"
-					control={control}
-					_label="I accept the terms and conditions"
-					rules={{ required: 'You must accept the terms' }}
-					_required
-				/>
+			<KolForm
+				className="w-full max-w-xl"
+				_on={{
+					onSubmit: (event) => {
+						void handleSubmit(onSubmit, onError)(event as unknown as BaseSyntheticEvent);
+					},
+				}}
+			>
+				<div className="grid gap-4">
+					<KolInputTextController name="firstName" control={control} _label="First Name" rules={{ required: 'First name is required' }} _required />
+					<KolInputTextController name="lastName" control={control} _label="Last Name" rules={{ required: 'Last name is required' }} _required />
+					<KolInputEmailController name="email" control={control} _label="Email" rules={{ required: 'Email is required' }} _required />
+					<KolInputPasswordController name="password" control={control} _label="Password" rules={{ required: 'Password is required' }} _required />
+					<KolInputNumberController name="age" control={control} _label="Age" rules={{ required: 'Age is required', min: 0 }} _required />
+					<KolInputRangeController name="volume" control={control} _label="Volume (0–100)" _min={0} _max={100} />
+					<KolInputDateController name="birthday" control={control} _label="Birthday" rules={{ required: 'Birthday is required' }} />
+					<KolInputColorController name="favoriteColor" control={control} _label="Favorite Color" id="favoriteColor" />
+					<KolInputFileController name="cv" control={control} _label="Upload CV" rules={{ required: 'Please upload your CV' }} _required />
+					<KolTextareaController name="bio" control={control} _label="Bio" rules={{ required: 'Please provide a short bio' }} _required />
+					<KolComboboxController
+						control={control}
+						rules={{ required: 'Please select a country' }}
+						name="country"
+						_label="Country"
+						_suggestions={COUNTRY_SUGGESTIONS}
+						_required
+					/>
+					<KolSelectController
+						control={control}
+						rules={{ required: 'Please select a language' }}
+						name="language"
+						_label="Preferred Language"
+						_options={languageOptions}
+						_required
+					/>
+					<KolSingleSelectController
+						rules={{ required: 'Please select a framework' }}
+						control={control}
+						name="framework"
+						_label="Favorite Framework"
+						_options={frameworkOptions}
+						_required
+					/>
+					<KolInputRadioController
+						control={control}
+						rules={{ required: 'Please select your gender' }}
+						name="gender"
+						_label="Gender"
+						_options={genderOptions}
+						_required
+					/>
+					<KolInputCheckboxController
+						name="termsAccepted"
+						control={control}
+						_label="I accept the terms and conditions"
+						rules={{ required: 'You must accept the terms' }}
+						_required
+					/>
 
-				<KolButton _label="Submit" _type="submit" />
-			</form>
+					<KolButton _label="Submit" _type="submit" />
+				</div>
+			</KolForm>
 		</>
 	);
 };


### PR DESCRIPTION
## Summary
Internal change — replaces the native `<form>` element in the React Hook Form scenario with `KolForm`, forwarding the submit handler through `KolForm`.

## Changes
- Replace native `<form>` with `<KolForm>` in the React Hook Form sample
- Forward `onSubmit` handler through `KolForm`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Änderung — ersetzt das native `<form>`-Element im React-Hook-Form-Beispiel durch `KolForm`.

## Änderungen
- Natives `<form>` durch `<KolForm>` im React-Hook-Form-Sample ersetzt
- `onSubmit`-Handler durch `KolForm` weitergeleitet
</details>