### PR TITLE
fix(mcp): fix sse session routing for mcp transport

### DIFF
--- a/packages/tools/mcp/api/dist-types.d.ts
+++ b/packages/tools/mcp/api/dist-types.d.ts
@@ -54,3 +54,9 @@ declare module '../dist/search.mjs' {
 
 	export function searchEntries(entries: SampleEntry[], query: string, options?: SearchOptions): SearchResult[];
 }
+
+declare module '../dist/index.mjs' {
+	import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+	export function createKolibriMcpServer(): Server;
+}

--- a/packages/tools/mcp/api/message.ts
+++ b/packages/tools/mcp/api/message.ts
@@ -1,36 +1,103 @@
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { IncomingMessage } from 'node:http';
+import { getSession } from './session-store.js';
 
-/**
- * Message Endpoint for MCP Server
- * POST /api/message - Receives JSON-RPC messages from client via SSE transport
- *
- * Note: This endpoint is handled by the SSEServerTransport in api/sse.ts
- * The SDK automatically routes messages through this endpoint.
- */
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-	// CORS headers
+const SESSION_HEADER = 'mcp-session-id';
+const SESSION_QUERY_KEY = 'sessionId';
+
+type MessageRequest = IncomingMessage & { auth?: AuthInfo };
+
+type HeaderValue = string | string[] | undefined;
+
+type QueryValue = string | string[] | string[][] | undefined;
+
+function setCorsHeaders(res: VercelResponse): void {
 	res.setHeader('Access-Control-Allow-Origin', '*');
 	res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-	res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+	res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id');
+	res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+	res.setHeader('Cache-Control', 'no-store');
+}
+
+function pickFirstValue(value: HeaderValue | QueryValue): string | undefined {
+	if (Array.isArray(value)) {
+		for (const entry of value) {
+			if (Array.isArray(entry)) {
+				const nested = pickFirstValue(entry);
+				if (nested) {
+					return nested;
+				}
+				continue;
+			}
+
+			if (entry && entry.trim().length > 0) {
+				return entry;
+			}
+		}
+		return undefined;
+	}
+
+	if (typeof value === 'string' && value.trim().length > 0) {
+		return value;
+	}
+
+	return undefined;
+}
+
+function resolveSessionId(req: VercelRequest): string | undefined {
+	const headerValue = pickFirstValue(req.headers[SESSION_HEADER]);
+	if (headerValue) {
+		return headerValue;
+	}
+
+	const queryValue = pickFirstValue(req.query?.[SESSION_QUERY_KEY] as QueryValue);
+	if (queryValue) {
+		return queryValue;
+	}
+
+	return undefined;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+	setCorsHeaders(res);
 
 	if (req.method === 'OPTIONS') {
-		return res.status(204).end();
+		res.status(204).end();
+		return;
 	}
 
 	if (req.method !== 'POST') {
-		return res.status(405).json({ error: 'Method not allowed. Use POST to send messages.' });
+		res.status(405).json({ error: 'Method not allowed. Use POST to send messages.' });
+		return;
 	}
 
-	// Messages are handled by the SSEServerTransport
-	// This endpoint should not be called directly
-	// The SSE transport in api/sse.ts manages the message flow
+	const sessionId = resolveSessionId(req);
 
-	return res.status(200).json({
-		jsonrpc: '2.0',
-		id: req.body?.id ?? null,
-		error: {
-			code: -32601,
-			message: 'Message endpoint should be used via SSE connection. Connect to /api/sse first.',
-		},
-	});
+	if (!sessionId) {
+		res.status(400).json({
+			error: 'Missing session identifier. Connect to /api/sse first and reuse the provided sessionId.',
+		});
+		return;
+	}
+
+	const session = getSession(sessionId);
+
+	if (!session) {
+		res.status(404).json({
+			error: `Unknown session: ${sessionId}. Establish a new SSE connection first.`,
+		});
+		return;
+	}
+
+	res.setHeader('Mcp-Session-Id', sessionId);
+
+	try {
+		await session.transport.handlePostMessage(req as MessageRequest, res, req.body);
+	} catch (error) {
+		console.error(`[api/message] Failed to handle message for session ${sessionId}`, error);
+		if (!res.headersSent) {
+			res.status(500).json({ error: 'Failed to process message' });
+		}
+	}
 }

--- a/packages/tools/mcp/api/session-store.ts
+++ b/packages/tools/mcp/api/session-store.ts
@@ -1,0 +1,35 @@
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+
+export interface McpSessionRecord {
+	server: Server;
+	transport: SSEServerTransport;
+}
+
+const SESSION_STORE_SYMBOL = Symbol.for('kolibri.mcp.sessionStore');
+
+type GlobalWithSessionStore = typeof globalThis & {
+	[SESSION_STORE_SYMBOL]?: Map<string, McpSessionRecord>;
+};
+
+function getSessionStore(): Map<string, McpSessionRecord> {
+	const globalScope = globalThis as GlobalWithSessionStore;
+
+	if (!globalScope[SESSION_STORE_SYMBOL]) {
+		globalScope[SESSION_STORE_SYMBOL] = new Map<string, McpSessionRecord>();
+	}
+
+	return globalScope[SESSION_STORE_SYMBOL]!;
+}
+
+export function setSession(sessionId: string, record: McpSessionRecord): void {
+	getSessionStore().set(sessionId, record);
+}
+
+export function getSession(sessionId: string): McpSessionRecord | undefined {
+	return getSessionStore().get(sessionId);
+}
+
+export function deleteSession(sessionId: string): void {
+	getSessionStore().delete(sessionId);
+}

--- a/packages/tools/mcp/api/sse.ts
+++ b/packages/tools/mcp/api/sse.ts
@@ -1,209 +1,83 @@
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-// Runtime imports from built artifacts (available after GitHub Actions build)
-// Type declarations are in ./dist-types.d.ts
-import { getAllEntries, getEntryById } from '../dist/data.mjs';
-import { searchEntries, type SearchResult } from '../dist/search.mjs';
+import { createKolibriMcpServer } from '../dist/index.mjs';
+import { deleteSession, setSession } from './session-store.js';
 
-// Global MCP Server instance
-let mcpServer: Server | null = null;
+const MESSAGE_ENDPOINT = '/api/message';
 
-function getMcpServer(): Server {
-	if (!mcpServer) {
-		mcpServer = new Server(
-			{
-				name: '@public-ui/mcp',
-				version: '1.0.0',
-			},
-			{
-				capabilities: {
-					tools: {},
-				},
-			},
-		);
-
-		// Register tools/list handler
-		mcpServer.setRequestHandler(ListToolsRequestSchema, async () => {
-			return {
-				tools: [
-					{
-						name: 'hello_kolibri',
-						description: 'A simple test tool that returns a greeting from KoliBri',
-						inputSchema: {
-							type: 'object',
-							properties: {
-								name: {
-									type: 'string',
-									description: 'The name to greet',
-								},
-							},
-						},
-					},
-					{
-						name: 'search',
-						description: 'Search for KoliBri component samples and documentation using fuzzy search',
-						inputSchema: {
-							type: 'object',
-							properties: {
-								query: {
-									type: 'string',
-									description: 'Search query to find samples or docs',
-								},
-								kind: {
-									type: 'string',
-									enum: ['sample', 'doc'],
-									description: 'Filter by kind: "sample" for component examples or "doc" for documentation',
-								},
-								limit: {
-									type: 'number',
-									description: 'Maximum number of results to return (default: 10)',
-								},
-							},
-							required: ['query'],
-						},
-					},
-					{
-						name: 'get_entry',
-						description: 'Get a specific sample or documentation entry by its ID',
-						inputSchema: {
-							type: 'object',
-							properties: {
-								id: {
-									type: 'string',
-									description: 'Entry ID (e.g., "button/basic" or "docs/getting-started")',
-								},
-							},
-							required: ['id'],
-						},
-					},
-				],
-			};
-		});
-
-		// Register tools/call handler
-		mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
-			const { name, arguments: args } = request.params;
-
-			if (name === 'hello_kolibri') {
-				const userName = (args as { name?: string })?.name ?? 'World';
-				return {
-					content: [
-						{
-							type: 'text',
-							text: `Hello ${userName}! This is KoliBri MCP Server via SSE on Vercel.`,
-						},
-					],
-				};
-			}
-
-			if (name === 'search') {
-				const { query, kind, limit } = args as { query: string; kind?: 'sample' | 'doc'; limit?: number };
-
-				if (!query || query.trim().length === 0) {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: 'Error: Query parameter is required and cannot be empty',
-							},
-						],
-					};
-				}
-
-				const allEntries = getAllEntries();
-				const results = searchEntries(allEntries, query, {
-					kind,
-					limit: limit ?? 10,
-				});
-
-				const resultText = results.map((result: SearchResult) => {
-					const { item, score } = result;
-					return `- [${item.kind}] ${item.id}: ${item.name}\n  Description: ${item.description ?? 'N/A'}\n  Match score: ${(score * 100).toFixed(1)}%\n  Tags: ${item.tags?.join(', ') ?? 'none'}`;
-				});
-
-				return {
-					content: [
-						{
-							type: 'text',
-							text: `Found ${results.length} result(s) for "${query}":\n\n${resultText.join('\n\n')}`,
-						},
-					],
-				};
-			}
-
-			if (name === 'get_entry') {
-				const { id } = args as { id: string };
-
-				if (!id) {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: 'Error: ID parameter is required',
-							},
-						],
-					};
-				}
-
-				const entry = getEntryById(id);
-
-				if (!entry) {
-					return {
-						content: [
-							{
-								type: 'text',
-								text: `Error: Entry with ID "${id}" not found`,
-							},
-						],
-					};
-				}
-
-				return {
-					content: [
-						{
-							type: 'text',
-							text: `# ${entry.name}\n\nID: ${entry.id}\nKind: ${entry.kind}\nGroup: ${entry.group ?? 'N/A'}\nDescription: ${entry.description ?? 'N/A'}\nTags: ${entry.tags?.join(', ') ?? 'none'}\n\n## Code\n\n\`\`\`\n${entry.code ?? 'No code available'}\n\`\`\``,
-						},
-					],
-				};
-			}
-
-			throw new Error(`Unknown tool: ${name}`);
-		});
-	}
-
-	return mcpServer;
-}
-
-/**
- * SSE Endpoint for MCP Server
- * GET /api/sse - Establishes SSE connection with MCP protocol
- */
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-	// Only allow GET requests for SSE
-	if (req.method !== 'GET') {
-		return res.status(405).json({ error: 'Method not allowed. Use GET for SSE connection.' });
-	}
-
-	// CORS headers
+function setCorsHeaders(res: VercelResponse): void {
 	res.setHeader('Access-Control-Allow-Origin', '*');
 	res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-	res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+	res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id');
+	res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+	res.setHeader('X-Accel-Buffering', 'no');
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+	setCorsHeaders(res);
+
+	if (req.method === 'OPTIONS') {
+		res.status(204).end();
+		return;
+	}
+
+	if (req.method !== 'GET') {
+		res.status(405).json({ error: 'Method not allowed. Use GET for SSE connection.' });
+		return;
+	}
+
+	let sessionId: string | null = null;
+	let cleanupRequested = false;
+	let server: ReturnType<typeof createKolibriMcpServer> | null = null;
+	let transport: SSEServerTransport | null = null;
 
 	try {
-		const server = getMcpServer();
+		server = createKolibriMcpServer();
+		transport = new SSEServerTransport(MESSAGE_ENDPOINT, res);
 
-		// Create SSE transport
-		const transport = new SSEServerTransport('/api/message', res);
+		sessionId = transport.sessionId;
+		res.setHeader('Mcp-Session-Id', sessionId);
 
-		// Connect server to transport
+		server.onclose = () => {
+			if (sessionId) {
+				deleteSession(sessionId);
+				if (!cleanupRequested) {
+					console.log(`[api/sse] Session ${sessionId} closed`);
+				}
+			}
+		};
+
+		transport.onerror = (error) => {
+			if (sessionId) {
+				console.error(`[api/sse] Transport error for session ${sessionId}`, error);
+			} else {
+				console.error('[api/sse] Transport error before session established', error);
+			}
+		};
+
+		setSession(transport.sessionId, { server, transport });
+
 		await server.connect(transport);
 
-		console.log('[api/sse] MCP Server connected via SSE');
+		console.log(`[api/sse] Session ${transport.sessionId} connected`);
 	} catch (error) {
-		console.error('[api/sse] Error:', error);
-		res.status(500).json({ error: 'Failed to establish SSE connection' });
+		cleanupRequested = true;
+		if (sessionId) {
+			deleteSession(sessionId);
+		}
+
+		if (server) {
+			await server.close().catch((closeError) => {
+				console.error('[api/sse] Failed to close server after error', closeError);
+			});
+		}
+
+		console.error('[api/sse] Error establishing SSE connection', error);
+
+		if (!res.headersSent) {
+			res.status(500).json({ error: 'Failed to establish SSE connection' });
+		} else {
+			res.end();
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Internal change — adds a shared session store so SSE connections can be resolved by the message endpoint; reuses the MCP server factory in serverless handlers.

## Changes
- Add shared session store for SSE connection resolution
- Reuse MCP server factory in `/api/sse` and `/api/message` routes
- Handle sessions, headers, and errors in SSE/message routes

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Änderung — fügt einen gemeinsamen Session-Store hinzu, damit SSE-Verbindungen durch den Message-Endpunkt aufgelöst werden können.

## Änderungen
- Gemeinsamen Session-Store für SSE-Verbindungsauflösung hinzugefügt
- MCP-Server-Factory in `/api/sse`- und `/api/message`-Routen wiederverwendet
- Session-, Header- und Fehler-Handling in SSE/Message-Routen ergänzt
</details>