### PR TITLE
fix(mcp): update vercel routing for mcp server endpoint

### DIFF
--- a/packages/tools/mcp/QUICK_START_VERCEL.md
+++ b/packages/tools/mcp/QUICK_START_VERCEL.md
@@ -52,8 +52,8 @@ vercel --prod
 
 ```
 /                      → public/index.html (Landingpage)
-/mcp                   → api/index.ts (MCP Server Handler)
-/api/index             → api/index.ts (direkte API-Route)
+/mcp                   → api/index.js (MCP Server Handler)
+/api/index             → api/index.js (direkte API-Route)
 ```
 
 ### Dateistruktur für Vercel

--- a/packages/tools/mcp/VERCEL_DEPLOYMENT.md
+++ b/packages/tools/mcp/VERCEL_DEPLOYMENT.md
@@ -134,9 +134,8 @@ Für Claude Desktop oder andere MCP-Clients:
 
 Die Konfiguration in `vercel.json`:
 
-- **buildCommand**: Führt `pnpm run build` aus
-- **installCommand**: Installiert Dependencies mit `pnpm install --frozen-lockfile`
-- **rewrites**: Leitet `/mcp` zu `/api/index` um
+- **buildCommand**: Überspringt den Build, da dieser bereits in GitHub Actions erfolgt
+- **routes**: Leitet `^/mcp$` zur Serverless Function `api/index` und `^/$` zur statischen Landingpage `index.html`
 - **headers**: CORS-Header für Cross-Origin-Zugriffe
 - **functions**: Timeout-Konfiguration für Serverless Functions
 

--- a/packages/tools/mcp/vercel.json
+++ b/packages/tools/mcp/vercel.json
@@ -2,14 +2,14 @@
 	"$schema": "https://openapi.vercel.sh/vercel.json",
 	"version": 2,
 	"buildCommand": "echo 'Build was already done in GitHub Actions - skipping'",
-	"rewrites": [
+	"routes": [
 		{
-			"source": "/",
-			"destination": "/public/index.html"
+			"src": "^/mcp$",
+			"dest": "/api/index"
 		},
 		{
-			"source": "/mcp",
-			"destination": "/api/index"
+			"src": "^/$",
+			"dest": "/index.html"
 		}
 	],
 	"headers": [


### PR DESCRIPTION
## Summary
Internal change — updates Vercel configuration to map `/mcp` requests to the MCP server function and keeps the landing page on `/`.

## Changes
- Update `vercel.json` to route `/mcp` to the MCP handler
- Align deployment documentation with new routing behavior

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Änderung — aktualisiert die Vercel-Konfiguration, damit `/mcp`-Anfragen an die MCP-Server-Funktion weitergeleitet werden.

## Änderungen
- `vercel.json` aktualisiert: `/mcp` wird an den MCP-Handler geroutet
- Deployment-Dokumentation an neues Routing angepasst
</details>