### PR TITLE
refactor(components): restrict msg prop type by removing unsupported alert properties

### DIFF
--- a/packages/components/src/schema/props/msg.ts
+++ b/packages/components/src/schema/props/msg.ts
@@ -5,7 +5,7 @@ import { objectObjectHandler, parseJson, watchValidator } from '../utils';
 import { isObject, isString } from '../validators';
 
 /* types */
-export type MsgPropType = Omit<AlertProps, '_label' | '_variant'> & { _description: string };
+export type MsgPropType = Omit<AlertProps, '_level' | '_on' | '_label' | '_hasCloser' | '_variant'> & { _description: string };
 
 /**
  * Defines the properties for a message rendered as Alert component.


### PR DESCRIPTION
## Summary
Tightens the `MsgPropType` by excluding additional `AlertProps` properties (`_level`, `_on`, `_hasCloser`) that are not supported when used as a message prop.

## Changes
- Update `MsgPropType` in `schema/props/msg.ts` to omit `_level`, `_on`, and `_hasCloser` from `AlertProps`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Schränkt `MsgPropType` ein, indem zusätzliche `AlertProps`-Properties (`_level`, `_on`, `_hasCloser`) ausgeschlossen werden, die bei Verwendung als Nachrichten-Prop nicht unterstützt werden.

## Änderungen
- `MsgPropType` in `schema/props/msg.ts` aktualisiert: `_level`, `_on` und `_hasCloser` werden jetzt aus `AlertProps` ausgeschlossen
</details>