### PR TITLE
refactor(mcp): rename entry retrieval tool to fetch

### DIFF
--- a/packages/tools/mcp/AGENTS.md
+++ b/packages/tools/mcp/AGENTS.md
@@ -226,7 +226,7 @@ Features:
 
 - Uses Express.js for HTTP handling
 - Provides `POST /mcp` endpoint for MCP protocol communication
-- Supports `search` and `get_entry` tools
+- Supports `search` and `fetch` tools
 - Includes an `info` resource for server metadata
 - **Loads static index at startup** from `shared/sample-index.json`
 - Currently serves 163 entries: 142 samples + 21 docs
@@ -323,7 +323,7 @@ Fuzzy search for KoliBri component samples and documentation.
 }
 ```
 
-### 3. `get_entry`
+### 3. `fetch`
 
 Retrieve a specific sample or documentation entry by ID.
 

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -69,7 +69,7 @@ MCP_LOGGING=true PORT=8080 node dist/mcp.mjs
 
 When enabled, logs include:
 
-- **[TOOL]** - Tool invocations (search, get_entry) with parameters and results
+- **[TOOL]** - Tool invocations (search, fetch) with parameters and results
 - **[RESOURCE]** - Resource accesses (info, best-practices)
 - **[ERROR]** - Error conditions and failures
 
@@ -136,7 +136,7 @@ Search for KoliBri component samples and documentation using fuzzy search powere
 }
 ```
 
-### 3. `get_entry`
+### 3. `fetch`
 
 Get a specific sample or documentation entry by its ID.
 
@@ -148,8 +148,8 @@ Get a specific sample or documentation entry by its ID.
 
 ```json
 {
-	"name": "get_entry",
-	"arguments": { "id": "button/basic" }
+        "name": "fetch",
+        "arguments": { "id": "button/basic" }
 }
 ```
 
@@ -209,7 +209,7 @@ echo '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","a
 **Get a specific sample:**
 
 ```bash
-echo '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_entry","arguments":{"id":"button/basic"}}}' | npx @public-ui/mcp
+echo '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"fetch","arguments":{"id":"button/basic"}}}' | npx @public-ui/mcp
 ```
 
 ## Development

--- a/packages/tools/mcp/api/index.js
+++ b/packages/tools/mcp/api/index.js
@@ -80,7 +80,7 @@ function createKolibriMcpServer() {
 				content: [
 					{
 						type: 'text',
-						text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}\n\n💡 Tip: Use 'get_entry' with any ID above to see the full code.`,
+                                                text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}\n\n💡 Tip: Use 'fetch' with any ID above to see the full code.`,
 					},
 				],
 				structuredContent: output,
@@ -88,9 +88,9 @@ function createKolibriMcpServer() {
 		},
 	);
 
-	// Add get_entry tool to retrieve specific samples/docs
-	server.registerTool(
-		'get_entry',
+        // Add fetch tool to retrieve specific samples/docs
+        server.registerTool(
+                'fetch',
 		{
 			title: 'Get Sample or Doc Entry',
 			description: 'Get a specific sample or documentation entry by its ID. Parameter: id (required string, e.g. "button/basic" or "docs/getting-started")',
@@ -103,15 +103,15 @@ function createKolibriMcpServer() {
 				name: z.string(),
 			},
 		},
-		async ({ id }) => {
+                async ({ id }) => {
 			const idStr = String(id ?? '');
-			if (!idStr) {
+                        if (!idStr) {
 				throw new Error('ID parameter is required');
 			}
 
 			const entry = getEntryById(idStr);
 
-			if (!entry) {
+                        if (!entry) {
 				throw new Error(`Entry with ID "${idStr}" not found`);
 			}
 

--- a/packages/tools/mcp/docs/LOGGING.md
+++ b/packages/tools/mcp/docs/LOGGING.md
@@ -34,7 +34,7 @@ function log(type: 'info' | 'tool' | 'resource' | 'error', message: string, data
 
 2. **[TOOL]** - Tool invocations
    - `search` called/completed (with query, kind, limit, result count)
-   - `get_entry` called/completed (with ID, kind)
+   - `fetch` called/completed (with ID, kind)
 
 3. **[RESOURCE]** - Resource accesses
    - `info` accessed
@@ -103,13 +103,13 @@ const server = createKolibriMcpServer();
 }
 ```
 
-### get_entry Tool Example
+### fetch Tool Example
 
 ```
-[2025-11-06T09:45:24.123Z] [TOOL] get_entry called {
+[2025-11-06T09:45:24.123Z] [TOOL] fetch called {
   "id": "sample/button/basic"
 }
-[2025-11-06T09:45:24.145Z] [TOOL] get_entry completed {
+[2025-11-06T09:45:24.145Z] [TOOL] fetch completed {
   "id": "sample/button/basic",
   "kind": "sample"
 }
@@ -132,7 +132,7 @@ const server = createKolibriMcpServer();
 ### Error Example
 
 ```
-[2025-11-06T09:45:25.789Z] [ERROR] get_entry failed: entry not found {
+[2025-11-06T09:45:25.789Z] [ERROR] fetch failed: entry not found {
   "id": "non-existent-id"
 }
 ```

--- a/packages/tools/mcp/openapi.yaml
+++ b/packages/tools/mcp/openapi.yaml
@@ -75,14 +75,14 @@ paths:
                     arguments:
                       query: button
                       limit: 5
-              get_entry:
-                summary: Get specific entry
+              fetch:
+                summary: Fetch specific entry
                 value:
                   jsonrpc: '2.0'
                   id: 4
                   method: tools/call
                   params:
-                    name: get_entry
+                    name: fetch
                     arguments:
                       id: button/basic
       responses:

--- a/packages/tools/mcp/src/mcp.ts
+++ b/packages/tools/mcp/src/mcp.ts
@@ -112,7 +112,7 @@ function configureServer(server: McpServer): McpServer {
 				})),
 			};
 
-			const resultText = results
+                        const resultText = results
 				.map((result, index) => {
 					const { item, score } = result;
 					const codePreview = item.code ? `\n  Code preview: ${item.code.substring(0, 150).replace(/\n/g, ' ')}...` : '';
@@ -124,7 +124,7 @@ function configureServer(server: McpServer): McpServer {
 				content: [
 					{
 						type: 'text',
-						text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}\n\n💡 Tip: Use 'get_entry' with any ID above to see the full code.`,
+                                                text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}\n\n💡 Tip: Use 'fetch' with any ID above to see the full code.`,
 					},
 				],
 				structuredContent: output,
@@ -132,12 +132,12 @@ function configureServer(server: McpServer): McpServer {
 		},
 	);
 
-	// Add get_entry tool to retrieve specific samples/docs
-	server.registerTool(
-		'get_entry',
+        // Add fetch tool to retrieve specific samples/docs
+        server.registerTool(
+                'fetch',
 		{
 			title: 'Get Sample or Doc Entry',
-			description: 'Get a specific sample or documentation entry by its ID. Parameter: id (required string, e.g. "button/basic" or "docs/getting-started")',
+                        description: 'Get a specific sample or documentation entry by its ID. Parameter: id (required string, e.g. "button/basic" or "docs/getting-started")',
 			inputSchema: {
 				id: z.string(),
 			},
@@ -147,23 +147,23 @@ function configureServer(server: McpServer): McpServer {
 				name: z.string(),
 			},
 		},
-		async ({ id }) => {
-			log('tool', 'get_entry called', { id });
+                async ({ id }) => {
+                        log('tool', 'fetch called', { id });
 
 			const idStr = String(id ?? '');
-			if (!idStr) {
-				log('error', 'get_entry failed: empty id');
+                        if (!idStr) {
+                                log('error', 'fetch failed: empty id');
 				throw new Error('ID parameter is required');
 			}
 
 			const entry = getEntryById(idStr);
 
-			if (!entry) {
-				log('error', 'get_entry failed: entry not found', { id: idStr });
+                        if (!entry) {
+                                log('error', 'fetch failed: entry not found', { id: idStr });
 				throw new Error(`Entry with ID "${idStr}" not found`);
 			}
 
-			log('tool', 'get_entry completed', { id: idStr, kind: entry.kind });
+                        log('tool', 'fetch completed', { id: idStr, kind: entry.kind });
 
 			const output = {
 				id: entry.id,
@@ -259,7 +259,7 @@ ${PACKAGE_DESCRIPTION ?? ''}
 ## Additional Resources
 
 Use the 'search' tool to find specific component examples and implementation details.
-Use the 'get_entry' tool to retrieve full code samples for specific components.
+Use the 'fetch' tool to retrieve full code samples for specific components.
 `;
 
 			return {

--- a/packages/tools/mcp/test-vercel-api.mjs
+++ b/packages/tools/mcp/test-vercel-api.mjs
@@ -77,13 +77,13 @@ async function runTests() {
 		},
 	});
 
-	// Test 5: Get specific entry
-	await testRequest('tools/call', {
-		name: 'get_entry',
-		arguments: {
-			id: 'button/basic',
-		},
-	});
+        // Test 5: Fetch specific entry
+        await testRequest('tools/call', {
+                name: 'fetch',
+                arguments: {
+                        id: 'button/basic',
+                },
+        });
 
 	// Test 6: List resources
 	await testRequest('resources/list', {});

--- a/packages/tools/mcp/test/demo-logging.mjs
+++ b/packages/tools/mcp/test/demo-logging.mjs
@@ -14,7 +14,7 @@ console.log('   Environment variable: MCP_LOGGING');
 console.log('   Values: "true" or "1" to enable\n');
 
 console.log('🔍 When enabled, logs will show:');
-console.log('   • [TOOL] Tool invocations (search, get_entry)');
+console.log('   • [TOOL] Tool invocations (search, fetch)');
 console.log('   • [RESOURCE] Resource accesses (info, best-practices)');
 console.log('   • [ERROR] Error conditions\n');
 

--- a/packages/tools/mcp/test/example-mcp-logging.mjs
+++ b/packages/tools/mcp/test/example-mcp-logging.mjs
@@ -10,7 +10,7 @@ console.log('==========================================\n');
 console.log('When MCP_LOGGING=true, you will see logs for:\n');
 
 console.log('1️⃣  TOOL CALLS');
-console.log('   When AI agents invoke tools like search or get_entry:\n');
+console.log('   When AI agents invoke tools like search or fetch:\n');
 console.log('   Example: search tool');
 console.log('   [2025-11-06T10:00:00.123Z] [TOOL] search called {');
 console.log('     "query": "button",');
@@ -23,11 +23,11 @@ console.log('     "resultCount": 5,');
 console.log('     "options": { "limit": 10, "kind": "sample" }');
 console.log('   }\n');
 
-console.log('   Example: get_entry tool');
-console.log('   [2025-11-06T10:00:01.234Z] [TOOL] get_entry called {');
+console.log('   Example: fetch tool');
+console.log('   [2025-11-06T10:00:01.234Z] [TOOL] fetch called {');
 console.log('     "id": "sample/button/basic"');
 console.log('   }');
-console.log('   [2025-11-06T10:00:01.256Z] [TOOL] get_entry completed {');
+console.log('   [2025-11-06T10:00:01.256Z] [TOOL] fetch completed {');
 console.log('     "id": "sample/button/basic",');
 console.log('     "kind": "sample"');
 console.log('   }\n');
@@ -44,7 +44,7 @@ console.log('   }\n');
 console.log('3️⃣  ERROR CONDITIONS');
 console.log('   When something goes wrong:\n');
 console.log('   [2025-11-06T10:00:03.123Z] [ERROR] search failed: empty query');
-console.log('   [2025-11-06T10:00:03.234Z] [ERROR] get_entry failed: entry not found {');
+console.log('   [2025-11-06T10:00:03.234Z] [ERROR] fetch failed: entry not found {');
 console.log('     "id": "non-existent"');
 console.log('   }\n');
 

--- a/packages/tools/mcp/test/test-logging.sh
+++ b/packages/tools/mcp/test/test-logging.sh
@@ -46,10 +46,10 @@ curl -s -X POST http://localhost:3000/mcp \
 sleep 1
 
 echo ""
-echo "Sending test request to get_entry..."
+echo "Sending test request to fetch..."
 curl -s -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_entry","arguments":{"id":"sample/button/basic"}}}' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fetch","arguments":{"id":"sample/button/basic"}}}' \
   > /dev/null
 
 sleep 1


### PR DESCRIPTION
## Summary

Internal refactoring — renamed the MCP entry retrieval tool for clarity and consistency with naming conventions.

## Changes

- Renamed MCP entry retrieval tool to `fetch`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Internes Refactoring — MCP-Entry-Abruf-Tool aus Gründen der Klarheit und Einheitlichkeit umbenannt.

## Änderungen

- MCP-Entry-Abruf-Tool in `fetch` umbenannt

</details>