### PR TITLE
feat(mcp): update landing page for streaming http support

### DIFF
--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -300,28 +300,36 @@
 					<img src="https://github.com/public-ui/kolibri/raw/refs/heads/develop/kolibri.logo.svg" alt="KoliBri Logo" />
 				</div>
 				<h1>KoliBri MCP API</h1>
-				<p class="subtitle">Model Context Protocol Backend for KoliBri Examples</p>
-				<span class="status">🟢 Online</span>
+                                <p class="subtitle">Model Context Protocol backend for KoliBri examples with streaming-native HTTP transport</p>
+                                <span class="status">📦 Prebuilt index (<!--BUILD:SAMPLE_COUNT-->__BUILD_SAMPLE_COUNT__ Samples, <!--BUILD:DOC_COUNT-->__BUILD_DOC_COUNT__ Docs)</span>
 				<div class="stats" aria-live="polite">
 					<div class="stat">
 						<span class="stat-label">Samples</span>
-						<span class="stat-value" id="sample-count">–</span>
+                                                <span class="stat-value" id="sample-count"><!--BUILD:SAMPLE_COUNT-->__BUILD_SAMPLE_COUNT__</span>
 					</div>
 					<div class="stat">
 						<span class="stat-label">Docs</span>
-						<span class="stat-value" id="doc-count">–</span>
+                                                <span class="stat-value" id="doc-count"><!--BUILD:DOC_COUNT-->__BUILD_DOC_COUNT__</span>
 					</div>
 				</div>
 			</div>
 
-			<div class="api-info">
-				<h2>📡 REST API Endpoints</h2>
-				<p class="description">This API provides structured information about KoliBri samples that can be used by AI agents.</p>
-				<p class="description">
-					Use the <code class="endpoint-inline">/mcp/http/*</code> base path for classic JSON requests (fetch, curl, etc.) and
-					<code class="endpoint-inline">/mcp/sse/*</code> for streaming Server-Sent Events. The auto-detecting
-					<code class="endpoint-inline">/mcp/mcp/*</code> routes remain available but negotiate the transport based on the request headers.
-				</p>
+                        <div class="api-info">
+                                <h2>📡 REST & Streaming Endpoints</h2>
+                                <p class="description">This API provides structured information about KoliBri samples that can be used by AI agents.</p>
+                                <p class="description">
+                                        Use the <code class="endpoint-inline">/mcp/http/*</code> base path for classic JSON requests (fetch, curl, etc.) and
+                                        <code class="endpoint-inline">/mcp/sse/*</code> for streaming Server-Sent Events. The auto-detecting
+                                        <code class="endpoint-inline">/mcp/mcp/*</code> routes remain available but negotiate the transport based on the request headers.
+                                </p>
+                                <div class="highlight-box info" style="margin-top: 1rem">
+                                        <strong style="color: #2d3748">🆕 Native MCP over HTTP:</strong>
+                                        <span style="color: #2d3748">
+                                                Clients that speak the Model Context Protocol can connect directly via
+                                                <code class="endpoint-inline">POST /mcp</code>. The server streams responses using the official
+                                                <code class="endpoint-inline">StreamableHTTPServerTransport</code>, so Copilot Chat, Claude Desktop, and other MCP clients receive incremental updates without polling.
+                                        </span>
+                                </div>
 
 				<div style="margin-top: 1rem">
 					<div>
@@ -423,7 +431,15 @@ echo '{ "servers": { ... } }' > mcp.json
 </code></pre>
 						<button class="copy-btn" aria-label="Copy code" tabindex="0">📋</button>
 					</div>
-					<p class="description">In GitHub Copilot Chat you can now write:</p>
+                                        <h3>Detailed VS Code steps</h3>
+                                        <ol class="description" style="padding-left: 1.25rem; color: #4a5568">
+                                                <li>Update VS Code and the GitHub Copilot Chat extension to the latest version (MCP support currently ships in the Insider/Preview channels).</li>
+                                                <li>Open <strong>Settings</strong> and enable <code>GitHub &gt; Copilot Chat: Allow MCP</code> so Copilot may load external servers.</li>
+                                                <li>Create or edit <code>mcp.json</code> (workspace root or <code>~/.config/mcp/mcp.json</code>) with the remote configuration shown above. Replace <code>&lt;origin&gt;</code> with the deployed server URL.</li>
+                                                <li>Reload VS Code. In the Copilot Chat panel choose <strong>Connections → kolibri-mcp</strong> to establish the streaming session.</li>
+                                                <li>Ask Copilot things like <code class="endpoint-inline">@kolibri-mcp search button</code> or <code class="endpoint-inline">@kolibri-mcp fetch sample/button/basic</code> to receive streamed answers.</li>
+                                        </ol>
+                                        <p class="description">In GitHub Copilot Chat you can now write:</p>
 					<div class="relative">
 						<pre style="margin: 0"><code class="endpoint">@kolibri show me a button sample
 @kolibri how do I implement a KoliBri table?
@@ -433,9 +449,9 @@ echo '{ "servers": { ... } }' > mcp.json
 					</div>
 					<div class="highlight-box info">
 						<strong style="color: #2d3748">💡 Tip:</strong>
-						<span style="color: #2d3748" id="tip-text">
-							The MCP Server gives you access to all KoliBri component samples and documentation files directly in VS Code!
-						</span>
+                                                <span style="color: #2d3748" id="tip-text">
+                                                        The MCP Server gives you access to all <!--BUILD:SAMPLE_COUNT-->__BUILD_SAMPLE_COUNT__ KoliBri component samples and <!--BUILD:DOC_COUNT-->__BUILD_DOC_COUNT__ documentation files directly in VS Code!
+                                                </span>
 					</div>
 				</div>
 			</div>
@@ -449,16 +465,57 @@ echo '{ "servers": { ... } }' > mcp.json
 			</div>
 		</div>
 
-		<script>
-			const remoteConfigElement = document.querySelector('[data-mcp-remote-config]');
-			if (remoteConfigElement) {
-				const origin = window.location.origin.replace(/\/$/, '');
-				remoteConfigElement.textContent = `{ "servers": { "kolibri-mcp": { "url": "${origin}/mcp/", "type": "http" } }, "inputs": [] }`;
-			}
+                <script>
+                        window.__KOLIBRI_MCP_COUNTS__ = Object.freeze({
+                                total: __BUILD_TOTAL_COUNT__ /*BUILD:TOTAL_COUNT*/,
+                                samples: __BUILD_SAMPLE_COUNT__ /*BUILD:SAMPLE_COUNT*/,
+                                docs: __BUILD_DOC_COUNT__ /*BUILD:DOC_COUNT*/,
+                        });
 
-			// Test API status when page loads
-			fetch('/mcp/http/health')
-				.then((response) => response.json())
+                        const remoteConfigElement = document.querySelector('[data-mcp-remote-config]');
+                        if (remoteConfigElement) {
+                                const origin = window.location.origin.replace(/\/$/, '');
+                                remoteConfigElement.textContent = `{ "servers": { "kolibri-mcp": { "url": "${origin}/mcp/", "type": "http" } }, "inputs": [] }`;
+                        }
+
+                        function applyCountsFromBuild(counts) {
+                                if (!counts) {
+                                        return;
+                                }
+
+                                const statusElement = document.querySelector('.status');
+                                const sampleCountElement = document.getElementById('sample-count');
+                                const docCountElement = document.getElementById('doc-count');
+                                const tipTextElement = document.getElementById('tip-text');
+
+                                const sampleCount = Number.parseInt(counts.samples ?? 0, 10) || 0;
+                                const docCount = Number.parseInt(counts.docs ?? 0, 10) || 0;
+
+                                if (sampleCountElement) {
+                                        sampleCountElement.textContent = sampleCount.toLocaleString();
+                                }
+
+                                if (docCountElement) {
+                                        docCountElement.textContent = docCount.toLocaleString();
+                                }
+
+                                if (statusElement) {
+                                        const docFragment = docCount > 0 ? `, ${docCount.toLocaleString()} Docs` : '';
+                                        statusElement.textContent = `📦 Prebuilt index (${sampleCount.toLocaleString()} Samples${docFragment})`;
+                                        statusElement.style.background = '#4a5568';
+                                }
+
+                                if (tipTextElement && sampleCount > 0) {
+                                        const docsText = docCount > 0 ? ` and ${docCount.toLocaleString()} documentation files` : '';
+                                        tipTextElement.textContent = `The MCP Server gives you access to all ${sampleCount.toLocaleString()} KoliBri component samples${docsText} directly in VS Code!`;
+                                }
+                        }
+
+                        applyCountsFromBuild(window.__KOLIBRI_MCP_COUNTS__);
+
+                        // Test API status when page loads
+                        fetch('/mcp/http/health')
+                                .then((response) => response.json())
 				.then((data) => {
 					console.log('API Status:', data);
 					const statusElement = document.querySelector('.status');
@@ -490,12 +547,12 @@ echo '{ "servers": { ... } }' > mcp.json
 						docCountElement.textContent = docCount.toLocaleString();
 					}
 
-					// Update tip text with dynamic numbers
-					if (tipTextElement && sampleCount > 0) {
-						const samplesText = sampleCount > 0 ? `${sampleCount.toLocaleString()}+ ` : '';
-						const docsText = docCount > 0 ? ` and ${docCount.toLocaleString()} documentation files` : '';
-						tipTextElement.textContent = `The MCP Server gives you access to all ${samplesText}KoliBri component samples${docsText} directly in VS Code!`;
-					}
+                                        // Update tip text with dynamic numbers
+                                        if (tipTextElement && sampleCount > 0) {
+                                                const samplesText = sampleCount > 0 ? sampleCount.toLocaleString() : '0';
+                                                const docsText = docCount > 0 ? ` and ${docCount.toLocaleString()} documentation files` : '';
+                                                tipTextElement.textContent = `The MCP Server gives you access to all ${samplesText} KoliBri component samples${docsText} directly in VS Code!`;
+                                        }
 
 					if (data.healthy && sampleCount > 0) {
 						const docText = docCount > 0 ? `, ${docCount.toLocaleString()} Docs` : '';

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -315,80 +315,25 @@
 			</div>
 
                         <div class="api-info">
-                                <h2>📡 REST & Streaming Endpoints</h2>
-                                <p class="description">This API provides structured information about KoliBri samples that can be used by AI agents.</p>
-                                <p class="description">
-                                        Use the <code class="endpoint-inline">/mcp/http/*</code> base path for classic JSON requests (fetch, curl, etc.) and
-                                        <code class="endpoint-inline">/mcp/sse/*</code> for streaming Server-Sent Events. The auto-detecting
-                                        <code class="endpoint-inline">/mcp/mcp/*</code> routes remain available but negotiate the transport based on the request headers.
-                                </p>
+                                <h2>📡 Streaming MCP Endpoint</h2>
+                                <p class="description">This server exposes the Model Context Protocol directly over HTTP and streams responses so that AI copilots see updates as soon as they are generated.</p>
                                 <div class="highlight-box info" style="margin-top: 1rem">
-                                        <strong style="color: #2d3748">🆕 Native MCP over HTTP:</strong>
+                                        <strong style="color: #2d3748">🆕 Stream-first transport:</strong>
                                         <span style="color: #2d3748">
-                                                Clients that speak the Model Context Protocol can connect directly via
-                                                <code class="endpoint-inline">POST /mcp</code>. The server streams responses using the official
-                                                <code class="endpoint-inline">StreamableHTTPServerTransport</code>, so Copilot Chat, Claude Desktop, and other MCP clients receive incremental updates without polling.
+                                                Connect with <code class="endpoint-inline">POST /mcp</code> and keep the request open. The
+                                                <code class="endpoint-inline">StreamableHTTPServerTransport</code> sends newline-delimited JSON frames, allowing Claude Desktop, Copilot Chat, and every MCP client to process tool output incrementally without polling.
                                         </span>
                                 </div>
-
-				<div style="margin-top: 1rem">
-					<div>
-						<span class="method get">GET</span>
-						<code class="endpoint"><a href="/mcp/http/samples" style="color: #90cdf4">/mcp/http/samples</a></code>
-					</div>
-					<p class="description">
-						List of all available samples. Add the
-						<code class="endpoint-inline">?q=&lt;search&gt;</code>
-						query parameter to perform a fuzzy search across component names, tags, titles, descriptions and the component folder path. The search is tolerant
-						to typos and partial matches, so even short tokens can surface the relevant sample.
-					</p>
-					<div class="relative" style="margin-bottom: 0.75rem">
-						<code class="endpoint"><a href="/mcp/http/samples?q=btn" style="color: #90cdf4">/mcp/http/samples?q=btn</a></code>
-						<button class="copy-btn" aria-label="Copy fuzzy search endpoint" tabindex="0">📋</button>
-					</div>
-					<p class="description">
-						The example above demonstrates fuzzy matching&mdash;the short token
-						<code class="endpoint-inline">btn</code> still returns button samples.
-					</p>
-					<div class="relative" style="margin-bottom: 0.75rem">
-						<code class="endpoint"><a href="/mcp/http/samples?q=table%20responsive" style="color: #90cdf4">/mcp/http/samples?q=table%20responsive</a></code>
-						<button class="copy-btn" aria-label="Copy multi-word search endpoint" tabindex="0">📋</button>
-					</div>
-					<p class="description">Combine multiple words with spaces to narrow the result set&mdash;this request filters for responsive table samples.</p>
-
-					<div>
-						<span class="method get">GET</span>
-						<code class="endpoint"><a href="/mcp/http/sample?id=sample/button/basic" style="color: #90cdf4">/mcp/http/sample?id=sample/button/basic</a></code>
-					</div>
-					<p class="description">Path and source code of a specific sample</p>
-
-					<div>
-						<span class="method get">GET</span>
-						<code class="endpoint"><a href="/mcp/http/docs" style="color: #90cdf4">/mcp/http/docs</a></code>
-					</div>
-					<p class="description">List of Markdown-based documentation documents</p>
-
-					<div>
-						<span class="method get">GET</span>
-						<code class="endpoint"><a href="/mcp/http/doc?id=doc/README" style="color: #90cdf4">/mcp/http/doc?id=doc/README</a></code>
-					</div>
-					<p class="description">Retrieve a specific documentation document including its Markdown source</p>
-
-					<div>
-						<span class="method get">GET</span>
-						<code class="endpoint"><a href="/mcp/http/doc?id=doc/README.md" style="color: #90cdf4">/mcp/http/doc?id=doc/README.md</a></code>
-					</div>
-					<p class="description">Retrieve a specific documentation document including its Markdown source (with .md extension)</p>
-
-					<p class="description">
-						Need streaming updates? Swap the prefix to <code class="endpoint-inline">/mcp/sse/*</code>, for example
-						<code class="endpoint-inline">/mcp/sse/samples</code> to receive the sample list via Server-Sent Events.
-					</p>
-				</div>
-				<p class="description" style="margin-top: 1rem">
-					Note: The indices are generated during the build process. Manual <code>refresh</code> is not available in deployments.
-				</p>
-			</div>
+                                <p class="description" style="margin-top: 1rem">
+                                        Each request follows the JSON-RPC messages defined by the MCP specification. Submit a <code class="endpoint-inline">tools/list</code> call to discover all available tools, then issue <code class="endpoint-inline">tools/call</code> messages on the same HTTP stream to execute them.
+                                </p>
+                                <p class="description">
+                                        Use your preferred MCP client to explore the toolbox visually. Applications such as Claude Desktop or the VS Code MCP extension render the tool catalog, argument schemas, and streaming responses automatically once they connect to <code class="endpoint-inline">/mcp</code>.
+                                </p>
+                                <p class="description" style="margin-top: 1rem">
+                                        Note: The indices are generated during the build process. Manual <code>refresh</code> is not available in deployments.
+                                </p>
+                        </div>
 
 			<div class="api-info">
 				<h2>🔧 VS Code Integration</h2>

--- a/packages/tools/mcp/public/index.html
+++ b/packages/tools/mcp/public/index.html
@@ -513,69 +513,6 @@ echo '{ "servers": { ... } }' > mcp.json
 
                         applyCountsFromBuild(window.__KOLIBRI_MCP_COUNTS__);
 
-                        // Test API status when page loads
-                        fetch('/mcp/http/health')
-                                .then((response) => response.json())
-				.then((data) => {
-					console.log('API Status:', data);
-					const statusElement = document.querySelector('.status');
-
-					// Extract sample count with fallback logic
-					let sampleCount = 0;
-					if (typeof data.totalSamples === 'number') {
-						sampleCount = data.totalSamples;
-					} else if (typeof data.samples === 'number') {
-						sampleCount = data.samples;
-					} else if (typeof data.total === 'number') {
-						sampleCount = data.total;
-					}
-
-					// Extract doc count with fallback logic
-					let docCount = 0;
-					if (typeof data.totalDocs === 'number') {
-						docCount = data.totalDocs;
-					} else if (typeof data.docs === 'number') {
-						docCount = data.docs;
-					}
-
-					const sampleCountElement = document.getElementById('sample-count');
-					const docCountElement = document.getElementById('doc-count');
-					const tipTextElement = document.getElementById('tip-text');
-
-					if (sampleCountElement && docCountElement) {
-						sampleCountElement.textContent = sampleCount.toLocaleString();
-						docCountElement.textContent = docCount.toLocaleString();
-					}
-
-                                        // Update tip text with dynamic numbers
-                                        if (tipTextElement && sampleCount > 0) {
-                                                const samplesText = sampleCount > 0 ? sampleCount.toLocaleString() : '0';
-                                                const docsText = docCount > 0 ? ` and ${docCount.toLocaleString()} documentation files` : '';
-                                                tipTextElement.textContent = `The MCP Server gives you access to all ${samplesText} KoliBri component samples${docsText} directly in VS Code!`;
-                                        }
-
-					if (data.healthy && sampleCount > 0) {
-						const docText = docCount > 0 ? `, ${docCount.toLocaleString()} Docs` : '';
-						statusElement.textContent = `🟢 Online (${sampleCount.toLocaleString()} Samples${docText})`;
-						statusElement.style.background = '#38a169';
-					} else {
-						statusElement.textContent = '🟡 No samples found';
-						statusElement.style.background = '#d69e2e';
-					}
-				})
-				.catch((error) => {
-					console.warn('API not reachable:', error);
-					const statusElement = document.querySelector('.status');
-					statusElement.textContent = '🔴 Offline';
-					statusElement.style.background = '#e53e3e';
-					const sampleCountElement = document.getElementById('sample-count');
-					const docCountElement = document.getElementById('doc-count');
-					if (sampleCountElement && docCountElement) {
-						sampleCountElement.textContent = '–';
-						docCountElement.textContent = '–';
-					}
-				});
-
 			// Copy code logic for all .copy-btn buttons
 			function copyCodeToClipboard(code) {
 				if (navigator.clipboard) {

--- a/packages/tools/mcp/scripts/generate-sample-index.mjs
+++ b/packages/tools/mcp/scripts/generate-sample-index.mjs
@@ -18,6 +18,8 @@ const __dirname = path.dirname(__filename);
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 const SHARED_DIR = path.join(PACKAGE_ROOT, 'shared');
 const OUTPUT_FILE = path.join(SHARED_DIR, 'sample-index.json');
+const PUBLIC_DIR = path.join(PACKAGE_ROOT, 'public');
+const LANDING_PAGE = path.join(PUBLIC_DIR, 'index.html');
 
 // Robust repo root detection
 function findRepoRoot() {
@@ -378,8 +380,11 @@ async function main() {
 		// Write index to shared directory
 		await writeFile(OUTPUT_FILE, JSON.stringify(index, null, 2), 'utf8');
 
-		console.log(`[generate-sample-index] ✅ Successfully wrote ${index.entries.length} entries to ${OUTPUT_FILE}`);
-		process.exit(0);
+                console.log(`[generate-sample-index] ✅ Successfully wrote ${index.entries.length} entries to ${OUTPUT_FILE}`);
+
+                await updateLandingPageCounts(index);
+
+                process.exit(0);
 	} catch (error) {
 		console.error('[generate-sample-index] ❌ Failed to generate sample index:', error);
 		process.exit(1);
@@ -387,3 +392,94 @@ async function main() {
 }
 
 main();
+
+async function updateLandingPageCounts(index) {
+        try {
+                const html = await readFile(LANDING_PAGE, 'utf8');
+
+                const counts = index?.metadata?.counts ?? {};
+                const markers = [
+                        {
+                                placeholder: '__BUILD_TOTAL_COUNT__',
+                                htmlComment: '<!--BUILD:TOTAL_COUNT-->',
+                                jsComment: '/*BUILD:TOTAL_COUNT*/',
+                                value: Number.isFinite(counts.total) ? String(counts.total) : '0',
+                        },
+                        {
+                                placeholder: '__BUILD_SAMPLE_COUNT__',
+                                htmlComment: '<!--BUILD:SAMPLE_COUNT-->',
+                                jsComment: '/*BUILD:SAMPLE_COUNT*/',
+                                value: Number.isFinite(counts.totalSamples) ? String(counts.totalSamples) : '0',
+                        },
+                        {
+                                placeholder: '__BUILD_DOC_COUNT__',
+                                htmlComment: '<!--BUILD:DOC_COUNT-->',
+                                jsComment: '/*BUILD:DOC_COUNT*/',
+                                value: Number.isFinite(counts.totalDocs) ? String(counts.totalDocs) : '0',
+                        },
+                ];
+
+                const escapeRegExp = (input) => input.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+                let updated = html;
+                let changed = false;
+
+                for (const marker of markers) {
+                        const { placeholder, htmlComment, jsComment, value } = marker;
+
+                        if (updated.includes(`${htmlComment}${placeholder}`)) {
+                                const next = updated.replaceAll(`${htmlComment}${placeholder}`, `${htmlComment}${value}`);
+                                if (next !== updated) {
+                                        changed = true;
+                                        updated = next;
+                                }
+                        }
+
+                        const htmlPattern = new RegExp(`${escapeRegExp(htmlComment)}\s*([0-9][0-9,]*)`, 'g');
+                        const htmlReplaced = updated.replace(htmlPattern, `${htmlComment}${value}`);
+                        if (htmlReplaced !== updated) {
+                                changed = true;
+                                updated = htmlReplaced;
+                        }
+
+                        if (updated.includes(`${placeholder} ${jsComment}`)) {
+                                const next = updated.replaceAll(`${placeholder} ${jsComment}`, `${value} ${jsComment}`);
+                                if (next !== updated) {
+                                        changed = true;
+                                        updated = next;
+                                }
+                        }
+
+                        const jsPattern = new RegExp(`([0-9][0-9,]*)\s*${escapeRegExp(jsComment)}`, 'g');
+                        const jsReplaced = updated.replace(jsPattern, `${value} ${jsComment}`);
+                        if (jsReplaced !== updated) {
+                                changed = true;
+                                updated = jsReplaced;
+                        }
+                }
+
+                if (changed) {
+                        await writeFile(LANDING_PAGE, updated, 'utf8');
+                        console.log(
+                                `[generate-sample-index] ✅ Updated landing page counts in ${path.relative(
+                                        PACKAGE_ROOT,
+                                        LANDING_PAGE,
+                                )}`,
+                        );
+                } else {
+                        console.warn(
+                                `[generate-sample-index] ⚠️ No landing page placeholders replaced. Check tokens in ${path.relative(
+                                        PACKAGE_ROOT,
+                                        LANDING_PAGE,
+                                )}`,
+                        );
+                }
+        } catch (error) {
+                console.warn(
+                        `[generate-sample-index] ⚠️ Unable to update landing page counts (${error.message}). Ensure ${path.relative(
+                                PACKAGE_ROOT,
+                                LANDING_PAGE,
+                        )} contains __BUILD_* placeholders.`,
+                );
+        }
+}


### PR DESCRIPTION
## Summary
Internal change — refreshes the MCP landing page to highlight streaming HTTP access and step-by-step VS Code setup guidance; extends the sample index generator to inject build-time counters.

## Changes
- Update `index.template.html` to highlight streaming HTTP access and VS Code setup
- Extend sample index generator to inject sample/doc count at build time

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Änderung — aktualisiert die MCP-Landingpage, um Streaming-HTTP-Zugang und VS-Code-Setup-Anleitung hervorzuheben.

## Änderungen
- `index.template.html` auf Streaming-HTTP und VS-Code-Setup aktualisiert
- Sample-Index-Generator um Build-Zeit-Counter erweitert
</details>