### PR TITLE
fix(mcp): allow vercel endpoint without trailing slash

### DIFF
--- a/packages/tools/mcp/vercel.json
+++ b/packages/tools/mcp/vercel.json
@@ -4,7 +4,7 @@
 	"buildCommand": "echo 'Skipping build - using pre-built artifacts'",
 	"rewrites": [
 		{
-			"source": "/mcp/(.*)",
+			"source": "/mcp/:path*",
 			"destination": "/api/index"
 		}
 	]


### PR DESCRIPTION
## Summary
Internal change — updates the MCP Vercel rewrite rule to accept optional trailing path segments.

## Changes
- Update `/api/mcp` rewrite rule to match requests with and without trailing slashes

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Änderung — aktualisiert die Vercel Rewrite-Regel für den MCP-Endpunkt, sodass optionale nachfolgende Pfadsegmente akzeptiert werden.

## Änderungen
- `/api/mcp`-Rewrite-Regel angepasst, um Anfragen mit und ohne abschließendem Slash zu matchen
</details>