### PR TITLE
fix(mcp): refine search metadata output format

### DIFF
--- a/packages/tools/mcp/api/index.js
+++ b/packages/tools/mcp/api/index.js
@@ -6,6 +6,12 @@ import { searchEntries } from '../dist/search.mjs';
 
 const KIND_OPTIONS = ['doc', 'sample', 'scenario'];
 
+const normalizeTags = (tags) => (Array.isArray(tags) ? tags : []);
+const formatTagsForText = (tags) => {
+	const normalized = normalizeTags(tags);
+	return normalized.length > 0 ? normalized.join(', ') : 'none';
+};
+
 // Package info - read from environment or use defaults
 const PACKAGE_VERSION = process.env.npm_package_version || '3.0.7';
 const PACKAGE_NAME = '@public-ui/mcp';
@@ -51,38 +57,40 @@ function createKolibriMcpServer() {
 
 			const results = searchEntries(allEntries, queryStr, searchOptions);
 
-			const output = {
+			const structuredContent = {
 				query: queryStr,
 				totalResults: results.length,
-				results: results.map((result) => ({
-					id: result.item.id,
-					kind: result.item.kind,
-					name: result.item.name,
-					group: result.item.group ?? 'N/A',
-					description: result.item.description ?? 'N/A',
-					tags: result.item.tags ?? [],
-					score: result.score,
-					code: result.item.code ?? 'No code available',
-					path: result.item.path ?? 'N/A',
+				results: results.map(({ item, score }) => ({
+					id: item.id,
+					kind: item.kind,
+					name: item.name,
+					group: item.group ?? 'N/A',
+					description: item.description ?? 'N/A',
+					tags: normalizeTags(item.tags),
+					score: score ?? 1,
+					path: item.path ?? 'N/A',
 				})),
 			};
 
-			const resultText = results
-				.map((result, index) => {
-					const { item, score } = result;
-					const codePreview = item.code ? `\n  Code preview: ${item.code.substring(0, 150).replace(/\n/g, ' ')}...` : '';
-					return `${index + 1}. [${item.kind}] ${item.id}: ${item.name}\n   Description: ${item.description ?? 'N/A'}\n   Match score: ${(score * 100).toFixed(1)}%\n   Tags: ${item.tags?.join(', ') ?? 'none'}${codePreview}`;
-				})
-				.join('\n\n');
+			const resultText = results.length
+				? results
+						.map(({ item, score }, index) => {
+							const matchScore = ((score ?? 1) * 100).toFixed(1);
+							const pathLine = item.path ? `\n   Path: ${item.path}` : '';
+							return `${index + 1}. [${item.kind}] ${item.id}: ${item.name}\n   Description: ${item.description ?? 'N/A'}\n   Match score: ${matchScore}%\n   Tags: ${formatTagsForText(item.tags)}${pathLine}`;
+						})
+						.join('\n\n')
+				: 'No matches found.';
+			const tipText = results.length ? "\n\n💡 Tip: Use 'fetch' with any ID above to see full entry details." : '';
 
 			return {
 				content: [
 					{
 						type: 'text',
-						text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}\n\n💡 Tip: Use 'fetch' with any ID above to see the full code.`,
+						text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}${tipText}`,
 					},
 				],
-				structuredContent: output,
+				structuredContent,
 			};
 		},
 	);

--- a/packages/tools/mcp/src/mcp.ts
+++ b/packages/tools/mcp/src/mcp.ts
@@ -13,6 +13,32 @@ function isValidKind(value: unknown): value is KindOption {
 	return typeof value === 'string' && (KIND_OPTIONS as readonly string[]).includes(value);
 }
 
+interface StructuredSearchResultEntry {
+	id: string;
+	kind: KindOption;
+	name: string;
+	group: string;
+	description: string;
+	tags: string[];
+	score: number;
+	path: string;
+}
+
+interface StructuredSearchResult {
+	query: string;
+	totalResults: number;
+	results: StructuredSearchResultEntry[];
+}
+
+function normalizeTags(tags?: string[]): string[] {
+	return Array.isArray(tags) ? tags : [];
+}
+
+function formatTagsForText(tags?: string[]): string {
+	const normalized = normalizeTags(tags);
+	return normalized.length > 0 ? normalized.join(', ') : 'none';
+}
+
 const require = createRequire(import.meta.url);
 const {
 	version: PACKAGE_VERSION = '0.0.0',
@@ -99,38 +125,40 @@ function configureServer(server: McpServer): McpServer {
 				options: searchOptions,
 			});
 
-			const output = {
+			const structuredContent: StructuredSearchResult = {
 				query: queryStr,
 				totalResults: results.length,
-				results: results.map((result) => ({
-					id: result.item.id,
-					kind: result.item.kind,
-					name: result.item.name,
-					group: result.item.group ?? 'N/A',
-					description: result.item.description ?? 'N/A',
-					tags: result.item.tags ?? [],
-					score: result.score,
-					code: result.item.code ?? 'No code available',
-					path: result.item.path ?? 'N/A',
+				results: results.map(({ item, score }) => ({
+					id: item.id,
+					kind: item.kind,
+					name: item.name,
+					group: item.group ?? 'N/A',
+					description: item.description ?? 'N/A',
+					tags: normalizeTags(item.tags),
+					score: score ?? 1,
+					path: item.path ?? 'N/A',
 				})),
 			};
 
-			const resultText = results
-				.map((result, index) => {
-					const { item, score } = result;
-					const codePreview = item.code ? `\n  Code preview: ${item.code.substring(0, 150).replace(/\n/g, ' ')}...` : '';
-					return `${index + 1}. [${item.kind}] ${item.id}: ${item.name}\n   Description: ${item.description ?? 'N/A'}\n   Match score: ${(score * 100).toFixed(1)}%\n   Tags: ${item.tags?.join(', ') ?? 'none'}${codePreview}`;
-				})
-				.join('\n\n');
+			const resultText = results.length
+				? results
+						.map(({ item, score }, index) => {
+							const matchScore = ((score ?? 1) * 100).toFixed(1);
+							const pathLine = item.path ? `\n   Path: ${item.path}` : '';
+							return `${index + 1}. [${item.kind}] ${item.id}: ${item.name}\n   Description: ${item.description ?? 'N/A'}\n   Match score: ${matchScore}%\n   Tags: ${formatTagsForText(item.tags)}${pathLine}`;
+						})
+						.join('\n\n')
+				: 'No matches found.';
+			const tipText = results.length ? "\n\n💡 Tip: Use 'fetch' with any ID above to see full entry details." : '';
 
 			return {
 				content: [
 					{
 						type: 'text',
-						text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}\n\n💡 Tip: Use 'fetch' with any ID above to see the full code.`,
+						text: `Found ${results.length} result(s) for "${queryStr}":\n\n${resultText}${tipText}`,
 					},
 				],
-				structuredContent: output,
+				structuredContent,
 			};
 		},
 	);

--- a/packages/tools/mcp/src/search.ts
+++ b/packages/tools/mcp/src/search.ts
@@ -15,7 +15,6 @@ const FUSE_OPTIONS: IFuseOptions<SampleEntry> = {
 		{ name: 'group', weight: 0.15 },
 		{ name: 'description', weight: 0.1 },
 		{ name: 'tags', weight: 0.05 },
-		{ name: 'code', weight: 0.3 }, // Added code content search
 	],
 };
 

--- a/packages/tools/mcp/test/fuzzy-search.test.js
+++ b/packages/tools/mcp/test/fuzzy-search.test.js
@@ -11,7 +11,6 @@ const SAMPLE_ENTRIES = [
 		description: 'Default button style for generic actions',
 		tags: ['button', 'action'],
 		kind: 'sample',
-		code: 'import { KolButton } from "@public-ui/react"; export const Basic = () => <KolButton _label="Click me" />;',
 	},
 	{
 		id: 'sample/button/primary',
@@ -20,7 +19,6 @@ const SAMPLE_ENTRIES = [
 		description: 'Primary call-to-action button variant',
 		tags: ['button', 'primary'],
 		kind: 'sample',
-		code: 'import { KolButton } from "@public-ui/react"; export const Primary = () => <KolButton _label="Primary" _variant="primary" />;',
 	},
 	{
 		id: 'sample/form/text-input',
@@ -29,7 +27,6 @@ const SAMPLE_ENTRIES = [
 		description: 'Form field for textual user input',
 		tags: ['form'],
 		kind: 'sample',
-		code: 'import { KolInputText } from "@public-ui/react"; export const TextInput = () => <KolInputText _label="Enter text" />;',
 	},
 	{
 		id: 'doc/guides/accessibility',
@@ -38,7 +35,6 @@ const SAMPLE_ENTRIES = [
 		description: 'Documentation on accessible components',
 		tags: ['guides'],
 		kind: 'doc',
-		code: '# Accessibility Guide\n\nThis guide explains how to make components accessible.',
 	},
 	{
 		id: 'scenario/forms/login',
@@ -47,10 +43,8 @@ const SAMPLE_ENTRIES = [
 		description: 'Scenario demonstrating a login flow across multiple components',
 		tags: ['scenario', 'form'],
 		kind: 'scenario',
-		code: 'import { KolFormLogin } from "@public-ui/react"; export const LoginScenario = () => <KolFormLogin />;',
 	},
 ];
-
 function ids(result) {
 	return result.map((entry) => entry.item.id);
 }


### PR DESCRIPTION
## Summary
Internal change — normalizes search result metadata in the MCP server and Vercel handler before returning structured content; improves text response formatting and score handling.

## Changes
- Normalize search result metadata before returning structured content
- Format textual responses with safer tag handling and defaulted scores
- Keep code previews out of metadata

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Änderung — normalisiert Such-Ergebnis-Metadaten im MCP-Server und Vercel-Handler vor der Rückgabe strukturierter Inhalte.

## Änderungen
- Such-Ergebnis-Metadaten vor Rückgabe normalisiert
- Textuelle Antworten mit sichererem Tag-Handling und Standard-Scores formatiert
- Code-Previews aus Metadaten herausgehalten
</details>