### PR TITLE
test(mcp): add search fetch consistency test

### DIFF
--- a/packages/tools/mcp/test/search-fetch-consistency.test.js
+++ b/packages/tools/mcp/test/search-fetch-consistency.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getEntryById } from '../dist/data.mjs';
+import { createKolibriMcpServer } from '../dist/mcp.mjs';
+
+const DEFAULT_LIMIT = 5;
+
+async function runSearch(server, query = 'button', limit = DEFAULT_LIMIT) {
+	const searchTool = server._registeredTools?.search;
+	assert.ok(searchTool, 'expected search tool to be registered');
+
+	const response = await searchTool.callback({ query, limit });
+	assert.ok(response?.structuredContent, 'search tool should return structured content');
+	return response.structuredContent;
+}
+
+test('search tool results stay consistent with fetch results', async () => {
+	const server = createKolibriMcpServer();
+	const structuredContent = await runSearch(server);
+
+	assert.ok(structuredContent.results.length > 0, 'search should return at least one result');
+
+	const fetchTool = server._registeredTools?.fetch;
+	assert.ok(fetchTool, 'expected fetch tool to be registered');
+
+	for (const result of structuredContent.results) {
+		assert.strictEqual(Object.prototype.hasOwnProperty.call(result, 'code'), false, 'search results should not expose code');
+
+		const entry = getEntryById(result.id);
+		assert.ok(entry, `expected entry ${result.id} to be resolvable via getEntryById`);
+
+		assert.strictEqual(entry.id, result.id);
+		assert.strictEqual(entry.kind, result.kind);
+		assert.strictEqual(entry.name, result.name);
+		assert.strictEqual(result.group, entry.group ?? 'N/A');
+		assert.strictEqual(result.description, entry.description ?? 'N/A');
+		assert.deepStrictEqual(result.tags, Array.isArray(entry.tags) ? entry.tags : []);
+
+		const fetchResponse = await fetchTool.callback({ id: result.id });
+		assert.ok(fetchResponse?.structuredContent, 'fetch tool should return structured content');
+		assert.strictEqual(fetchResponse.structuredContent.id, result.id);
+		assert.strictEqual(typeof fetchResponse.structuredContent.code, 'string', 'fetch should include code content');
+	}
+});

--- a/packages/tools/mcp/test/search-fetch-consistency.test.js
+++ b/packages/tools/mcp/test/search-fetch-consistency.test.js
@@ -1,13 +1,33 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
 import { getEntryById } from '../dist/data.mjs';
 import { createKolibriMcpServer } from '../dist/mcp.mjs';
 
 const DEFAULT_LIMIT = 5;
 
-async function runSearch(server, query = 'button', limit = DEFAULT_LIMIT) {
-	const searchTool = server._registeredTools?.search;
+function createServerWithRegisteredTools() {
+	const registeredTools = new Map();
+	const originalRegisterTool = McpServer.prototype.registerTool;
+
+	try {
+		McpServer.prototype.registerTool = function patchedRegisterTool(name, config, callback) {
+			const tool = originalRegisterTool.call(this, name, config, callback);
+			registeredTools.set(name, tool);
+			return tool;
+		};
+
+		const server = createKolibriMcpServer();
+		return { server, registeredTools };
+	} finally {
+		McpServer.prototype.registerTool = originalRegisterTool;
+	}
+}
+
+async function runSearch(tools, query = 'button', limit = DEFAULT_LIMIT) {
+	const searchTool = tools.get('search');
 	assert.ok(searchTool, 'expected search tool to be registered');
 
 	const response = await searchTool.callback({ query, limit });
@@ -16,12 +36,12 @@ async function runSearch(server, query = 'button', limit = DEFAULT_LIMIT) {
 }
 
 test('search tool results stay consistent with fetch results', async () => {
-	const server = createKolibriMcpServer();
-	const structuredContent = await runSearch(server);
+	const { server, registeredTools } = createServerWithRegisteredTools();
+	const structuredContent = await runSearch(registeredTools);
 
 	assert.ok(structuredContent.results.length > 0, 'search should return at least one result');
 
-	const fetchTool = server._registeredTools?.fetch;
+	const fetchTool = registeredTools.get('fetch');
 	assert.ok(fetchTool, 'expected fetch tool to be registered');
 
 	for (const result of structuredContent.results) {


### PR DESCRIPTION
## Summary

Internal test improvement — added a consistency test for MCP search fetch behavior.

## Changes

- Added new test case verifying MCP search fetch consistency

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Interne Test-Verbesserung — Konsistenztest für das MCP-Such-Fetch-Verhalten hinzugefügt.

## Änderungen

- Neuen Testfall zur Überprüfung der MCP-Such-Fetch-Konsistenz hinzugefügt

</details>