### PR TITLE
fix: apply MCP search kind filter to empty queries

### DIFF
--- a/packages/tools/mcp/src/search.ts
+++ b/packages/tools/mcp/src/search.ts
@@ -31,12 +31,12 @@ export interface SearchResult {
 
 export function searchEntries(entries: SampleEntry[], query: string, options: SearchOptions = {}): SearchResult[] {
 	const normalizedQuery = query.trim();
-	if (!normalizedQuery) {
-		return entries.map((item) => ({ item, score: 1 }));
-	}
-
 	// Filter by kind if specified
 	const filteredEntries = options.kind ? entries.filter((e) => e.kind === options.kind) : entries;
+
+	if (!normalizedQuery) {
+		return filteredEntries.map((item) => ({ item, score: 1 }));
+	}
 
 	// Split query into words to determine search strategy
 	const words = normalizedQuery.split(/\s+/).filter((w) => w.length > 0);

--- a/packages/tools/mcp/test/fuzzy-search.test.js
+++ b/packages/tools/mcp/test/fuzzy-search.test.js
@@ -72,6 +72,18 @@ test('searchEntries handles whitespace-only queries', () => {
 	assert.strictEqual(result.length, SAMPLE_ENTRIES.length);
 });
 
+test('searchEntries returns only entries of requested kind for empty queries', () => {
+	const sampleEntries = SAMPLE_ENTRIES.filter((entry) => entry.kind === 'sample');
+	const results = searchEntries(SAMPLE_ENTRIES, '   ', { kind: 'sample' });
+
+	assert.strictEqual(results.length, sampleEntries.length);
+	assert.ok(results.every((r) => r.item.kind === 'sample'));
+	assert.deepStrictEqual(
+		ids(results),
+		sampleEntries.map((entry) => entry.id),
+	);
+});
+
 test('searchEntries finds button-related entries case-insensitively', () => {
 	const results = searchEntries(SAMPLE_ENTRIES, 'button');
 	const resultIds = ids(results);


### PR DESCRIPTION
## Summary
Fixes the MCP `searchEntries` function to correctly apply the `kind` filter even when the search query is empty.

## Changes
- Filter entries by `kind` before processing blank queries in `searchEntries`
- Add regression test: empty query respects kind constraint

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Behebt einen Fehler in der MCP-Funktion `searchEntries`, bei dem der `kind`-Filter bei leerem Suchbegriff ignoriert wurde.

## Änderungen
- Einträge werden jetzt nach `kind` gefiltert, bevor leere Suchanfragen verarbeitet werden
- Regressionstest hinzugefügt: leere Anfrage respektiert die `kind`-Einschränkung
</details>