### PR TITLE
fix(input-date): prevent spacebar from opening datepicker in readonly mode

### DIFF
--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -149,6 +149,9 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 				ref: this.inputRef,
 			});
 		}
+		if (this.state._readOnly && event.code === 'Space') {
+			event.preventDefault();
+		}
 	};
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {


### PR DESCRIPTION
## Summary
Fixes `kol-input-date` so that pressing the spacebar no longer opens the date picker when the input is in readonly mode.

## Changes
- Add `event.preventDefault()` for `Space` key press when `_readOnly` is active in `input-date/shadow.tsx`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Behebt ein Problem bei `kol-input-date`, bei dem die Leertaste den Datepicker öffnete, obwohl das Eingabefeld im Readonly-Modus war.

## Änderungen
- `event.preventDefault()` für die Leertaste ergänzt, wenn `_readOnly` aktiv ist
</details>