### PR TITLE
Add year limited number input sample to text formatter demo

### DIFF
--- a/packages/samples/react/src/components/input-text/text-formatter.tsx
+++ b/packages/samples/react/src/components/input-text/text-formatter.tsx
@@ -1,4 +1,4 @@
-import { KolForm, KolHeading, KolInputText } from '@public-ui/react-v19';
+import { KolForm, KolHeading, KolInputNumber, KolInputText } from '@public-ui/react-v19';
 import { Field, Formik, type FieldProps } from 'formik';
 import * as React from 'react';
 import { SampleDescription } from '../SampleDescription';
@@ -34,32 +34,45 @@ type IbanExampleFormValues = {
 };
 
 type CurrencyExampleFormValues = {
-	currency: number;
+        currency: number;
+};
+
+type YearExampleFormValues = {
+        year?: number;
 };
 
 export function InputTextFormatterDemo() {
-	const handleSubmit = async () => {};
-	const formatter = new IbanFormatter();
+        const handleSubmit = async () => {};
+        const formatter = new IbanFormatter();
 
 	const textInput1 = React.useRef<HTMLKolInputTextElement>(null);
 	let textInput1SelectionStart: number | null | undefined;
 
-	const initialIbanExampleValues: IbanExampleFormValues = {
-		iban: 'DE89370400440532013000',
-	};
+        const initialIbanExampleValues: IbanExampleFormValues = {
+                iban: 'DE89370400440532013000',
+        };
 
-	const initialCurrencyExampleValues: CurrencyExampleFormValues = {
-		currency: 1000000,
-	};
+        const initialCurrencyExampleValues: CurrencyExampleFormValues = {
+                currency: 1000000,
+        };
 
-	return (
-		<>
-			<SampleDescription>
+        const currentYear = React.useMemo(() => new Date().getFullYear(), []);
+        const initialYearExampleValues: YearExampleFormValues = {
+                year: currentYear,
+        };
+
+        return (
+                <>
+                        <SampleDescription>
 				<p>
 					This example demonstrates formatting a data value in an input field (example IBAN). The data value is formatted to the input field (print format) and
 					vice versa the formatting is removed again (machine format)
 				</p>
-			</SampleDescription>
+                                <p>
+                                        In addition, a KoliBri number input showcases how to restrict the value to whole years
+                                        up to the current one.
+                                </p>
+                        </SampleDescription>
 			<section className="w-full flex flex-col">
 				<Formik<IbanExampleFormValues> initialValues={initialIbanExampleValues} onSubmit={handleSubmit}>
 					{(form) => (
@@ -110,8 +123,8 @@ export function InputTextFormatterDemo() {
 				</Formik>
 			</section>
 
-			<section className="w-full flex flex-col">
-				<Formik<CurrencyExampleFormValues> initialValues={initialCurrencyExampleValues} onSubmit={handleSubmit}>
+                        <section className="w-full flex flex-col">
+                                <Formik<CurrencyExampleFormValues> initialValues={initialCurrencyExampleValues} onSubmit={handleSubmit}>
 					{(form) => (
 						<>
 							<div className="p-2">
@@ -146,8 +159,75 @@ export function InputTextFormatterDemo() {
 							</div>
 						</>
 					)}
-				</Formik>
-			</section>
-		</>
-	);
+                                </Formik>
+                        </section>
+
+                        <section className="w-full flex flex-col">
+                                <Formik<YearExampleFormValues>
+                                        initialValues={initialYearExampleValues}
+                                        validate={(values) => {
+                                                const errors: Record<string, string> = {};
+                                                if (typeof values.year !== 'number') {
+                                                        errors.year = 'Please enter a year.';
+                                                } else if (values.year > currentYear) {
+                                                        errors.year = `The value must not exceed ${currentYear}.`;
+                                                }
+                                                return errors;
+                                        }}
+                                        onSubmit={handleSubmit}
+                                >
+                                        {(form) => (
+                                                <>
+                                                        <div className="p-2">
+                                                                <KolHeading _label="Year input (whole numbers only)" _level={2} />
+                                                                <KolForm>
+                                                                        <Field name="year">
+                                                                                {({ field }: FieldProps<YearExampleFormValues['year']>) => (
+                                                                                        <div className="block mt-2">
+                                                                                                <KolInputNumber
+                                                                                                        _label="Year"
+                                                                                                        _required
+                                                                                                        _min={0}
+                                                                                                        _max={currentYear}
+                                                                                                        _step={1}
+                                                                                                        _value={field.value ?? undefined}
+                                                                                                        _msg={{
+                                                                                                                _type: 'error',
+                                                                                                                _description: form.errors.year || '',
+                                                                                                        }}
+                                                                                                        _touched={form.touched.year}
+                                                                                                        _on={{
+                                                                                                                onBlur: () => {
+                                                                                                                        void form.setFieldTouched('year', true);
+                                                                                                                },
+                                                                                                                onInput: (_, value: unknown) => {
+                                                                                                                        const parsedValue =
+                                                                                                                                typeof value === 'number' ? value : Number(value);
+                                                                                                                        if (Number.isNaN(parsedValue)) {
+                                                                                                                                void form.setFieldValue('year', undefined, true);
+                                                                                                                        } else {
+                                                                                                                                const normalizedValue = Math.min(
+                                                                                                                                        currentYear,
+                                                                                                                                        Math.max(0, Math.trunc(parsedValue)),
+                                                                                                                                );
+                                                                                                                                void form.setFieldValue('year', normalizedValue, true);
+                                                                                                                        }
+                                                                                                                },
+                                                                                                        }}
+                                                                                                />
+                                                                                        </div>
+                                                                                )}
+                                                                        </Field>
+                                                                </KolForm>
+                                                        </div>
+                                                        <div className="p-2">
+                                                                <KolHeading _label="Model" _level={2} />
+                                                                <pre className="text-base">{JSON.stringify(form.values, null, 2)}</pre>
+                                                        </div>
+                                                </>
+                                        )}
+                                </Formik>
+                        </section>
+                </>
+        );
 }

--- a/packages/samples/react/src/components/input-text/text-formatter.tsx
+++ b/packages/samples/react/src/components/input-text/text-formatter.tsx
@@ -34,45 +34,42 @@ type IbanExampleFormValues = {
 };
 
 type CurrencyExampleFormValues = {
-        currency: number;
+	currency: number;
 };
 
 type YearExampleFormValues = {
-        year?: number;
+	year?: number;
 };
 
 export function InputTextFormatterDemo() {
-        const handleSubmit = async () => {};
-        const formatter = new IbanFormatter();
+	const handleSubmit = async () => {};
+	const formatter = new IbanFormatter();
 
 	const textInput1 = React.useRef<HTMLKolInputTextElement>(null);
 	let textInput1SelectionStart: number | null | undefined;
 
-        const initialIbanExampleValues: IbanExampleFormValues = {
-                iban: 'DE89370400440532013000',
-        };
+	const initialIbanExampleValues: IbanExampleFormValues = {
+		iban: 'DE89370400440532013000',
+	};
 
-        const initialCurrencyExampleValues: CurrencyExampleFormValues = {
-                currency: 1000000,
-        };
+	const initialCurrencyExampleValues: CurrencyExampleFormValues = {
+		currency: 1000000,
+	};
 
-        const currentYear = React.useMemo(() => new Date().getFullYear(), []);
-        const initialYearExampleValues: YearExampleFormValues = {
-                year: currentYear,
-        };
+	const currentYear = React.useMemo(() => new Date().getFullYear(), []);
+	const initialYearExampleValues: YearExampleFormValues = {
+		year: currentYear,
+	};
 
-        return (
-                <>
-                        <SampleDescription>
+	return (
+		<>
+			<SampleDescription>
 				<p>
 					This example demonstrates formatting a data value in an input field (example IBAN). The data value is formatted to the input field (print format) and
 					vice versa the formatting is removed again (machine format)
 				</p>
-                                <p>
-                                        In addition, a KoliBri number input showcases how to restrict the value to whole years
-                                        up to the current one.
-                                </p>
-                        </SampleDescription>
+				<p>In addition, a KoliBri number input showcases how to restrict the value to whole years up to the current one.</p>
+			</SampleDescription>
 			<section className="w-full flex flex-col">
 				<Formik<IbanExampleFormValues> initialValues={initialIbanExampleValues} onSubmit={handleSubmit}>
 					{(form) => (
@@ -123,8 +120,8 @@ export function InputTextFormatterDemo() {
 				</Formik>
 			</section>
 
-                        <section className="w-full flex flex-col">
-                                <Formik<CurrencyExampleFormValues> initialValues={initialCurrencyExampleValues} onSubmit={handleSubmit}>
+			<section className="w-full flex flex-col">
+				<Formik<CurrencyExampleFormValues> initialValues={initialCurrencyExampleValues} onSubmit={handleSubmit}>
 					{(form) => (
 						<>
 							<div className="p-2">
@@ -159,75 +156,71 @@ export function InputTextFormatterDemo() {
 							</div>
 						</>
 					)}
-                                </Formik>
-                        </section>
+				</Formik>
+			</section>
 
-                        <section className="w-full flex flex-col">
-                                <Formik<YearExampleFormValues>
-                                        initialValues={initialYearExampleValues}
-                                        validate={(values) => {
-                                                const errors: Record<string, string> = {};
-                                                if (typeof values.year !== 'number') {
-                                                        errors.year = 'Please enter a year.';
-                                                } else if (values.year > currentYear) {
-                                                        errors.year = `The value must not exceed ${currentYear}.`;
-                                                }
-                                                return errors;
-                                        }}
-                                        onSubmit={handleSubmit}
-                                >
-                                        {(form) => (
-                                                <>
-                                                        <div className="p-2">
-                                                                <KolHeading _label="Year input (whole numbers only)" _level={2} />
-                                                                <KolForm>
-                                                                        <Field name="year">
-                                                                                {({ field }: FieldProps<YearExampleFormValues['year']>) => (
-                                                                                        <div className="block mt-2">
-                                                                                                <KolInputNumber
-                                                                                                        _label="Year"
-                                                                                                        _required
-                                                                                                        _min={0}
-                                                                                                        _max={currentYear}
-                                                                                                        _step={1}
-                                                                                                        _value={field.value ?? undefined}
-                                                                                                        _msg={{
-                                                                                                                _type: 'error',
-                                                                                                                _description: form.errors.year || '',
-                                                                                                        }}
-                                                                                                        _touched={form.touched.year}
-                                                                                                        _on={{
-                                                                                                                onBlur: () => {
-                                                                                                                        void form.setFieldTouched('year', true);
-                                                                                                                },
-                                                                                                                onInput: (_, value: unknown) => {
-                                                                                                                        const parsedValue =
-                                                                                                                                typeof value === 'number' ? value : Number(value);
-                                                                                                                        if (Number.isNaN(parsedValue)) {
-                                                                                                                                void form.setFieldValue('year', undefined, true);
-                                                                                                                        } else {
-                                                                                                                                const normalizedValue = Math.min(
-                                                                                                                                        currentYear,
-                                                                                                                                        Math.max(0, Math.trunc(parsedValue)),
-                                                                                                                                );
-                                                                                                                                void form.setFieldValue('year', normalizedValue, true);
-                                                                                                                        }
-                                                                                                                },
-                                                                                                        }}
-                                                                                                />
-                                                                                        </div>
-                                                                                )}
-                                                                        </Field>
-                                                                </KolForm>
-                                                        </div>
-                                                        <div className="p-2">
-                                                                <KolHeading _label="Model" _level={2} />
-                                                                <pre className="text-base">{JSON.stringify(form.values, null, 2)}</pre>
-                                                        </div>
-                                                </>
-                                        )}
-                                </Formik>
-                        </section>
-                </>
-        );
+			<section className="w-full flex flex-col">
+				<Formik<YearExampleFormValues>
+					initialValues={initialYearExampleValues}
+					validate={(values) => {
+						const errors: Record<string, string> = {};
+						if (typeof values.year !== 'number') {
+							errors.year = 'Please enter a year.';
+						} else if (values.year > currentYear) {
+							errors.year = `The value must not exceed ${currentYear}.`;
+						}
+						return errors;
+					}}
+					onSubmit={handleSubmit}
+				>
+					{(form) => (
+						<>
+							<div className="p-2">
+								<KolHeading _label="Year input (whole numbers only)" _level={2} />
+								<KolForm>
+									<Field name="year">
+										{({ field }: FieldProps<YearExampleFormValues['year']>) => (
+											<div className="block mt-2">
+												<KolInputNumber
+													_label="Year"
+													_required
+													_min={0}
+													_max={currentYear}
+													_step={1}
+													_value={field.value ?? undefined}
+													_msg={{
+														_type: 'error',
+														_description: form.errors.year || '',
+													}}
+													_touched={form.touched.year}
+													_on={{
+														onBlur: () => {
+															void form.setFieldTouched('year', true);
+														},
+														onInput: (_, value: unknown) => {
+															const parsedValue = typeof value === 'number' ? value : Number(value);
+															if (Number.isNaN(parsedValue)) {
+																void form.setFieldValue('year', undefined, true);
+															} else {
+																const normalizedValue = Math.min(currentYear, Math.max(0, Math.trunc(parsedValue)));
+																void form.setFieldValue('year', normalizedValue, true);
+															}
+														},
+													}}
+												/>
+											</div>
+										)}
+									</Field>
+								</KolForm>
+							</div>
+							<div className="p-2">
+								<KolHeading _label="Model" _level={2} />
+								<pre className="text-base">{JSON.stringify(form.values, null, 2)}</pre>
+							</div>
+						</>
+					)}
+				</Formik>
+			</section>
+		</>
+	);
 }


### PR DESCRIPTION
## Summary
- extend the InputText formatter sample with a description of the new number-input showcase
- add a Formik-driven KolInputNumber example that only accepts whole years up to the current year

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915dc2dfb74832b8ef703a5383c5b18)