### PR TITLE
refactor(visual-tests): migrate to `@axe-core/playwright`

### DIFF
--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -32,6 +32,7 @@
 	},
 	"dependencies": {
 		"@axe-core/playwright": "4.11.0",
+		"axe-html-reporter": "2.2.11",
 		"@public-ui/sample-react": "workspace:*",
 		"portfinder": "1.0.38",
 		"serve": "14.2.5"

--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -31,8 +31,8 @@
 		"kolibri-visual-test": "src/index.js"
 	},
 	"dependencies": {
+		"@axe-core/playwright": "4.11.0",
 		"@public-ui/sample-react": "workspace:*",
-		"axe-playwright": "2.2.2",
 		"portfinder": "1.0.38",
 		"serve": "14.2.5"
 	},

--- a/packages/tools/visual-tests/tests/axe-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/axe-snapshots.spec.js
@@ -1,7 +1,12 @@
 import { test } from '@playwright/test';
-import { checkA11y, injectAxe } from '@axe-core/playwright';
+import AxeBuilder from '@axe-core/playwright';
+import axeHtmlReporter from 'axe-html-reporter';
 import process from 'process';
 import { ROUTES } from './sample-app.routes.js';
+
+const { createHtmlReport } = axeHtmlReporter;
+
+const AXE_TAGS = ['best-practices', 'wcag2a', 'wcag2aa', 'wcag21aa'];
 
 const themeName = (process.env.THEME_EXPORT || 'default').toLocaleLowerCase();
 const rename = (snapshotName) => {
@@ -25,6 +30,25 @@ const rename = (snapshotName) => {
 	return result;
 };
 
+const sanitizeRouteForReport = (route) => route.replace(/[/?]/g, '-').replace(/^-+/, '') || 'root';
+
+const buildReportOptions = (testInfo, route) => ({
+	projectKey: `axe-${themeName}`,
+	reportFileName: `${sanitizeRouteForReport(route)}.html`,
+	outputDirPath: rename(testInfo.outputDir),
+	outputDir: `axe-${themeName}`,
+});
+
+const logViolations = (route, violations) => {
+	if (!violations?.length) {
+		return;
+	}
+	console.warn(`Axe found ${violations.length} violation(s) on ${route}`);
+	for (const violation of violations) {
+		console.warn(`- ${violation.id}: ${violation.help} (${violation.nodes.length} nodes)`);
+	}
+};
+
 // https://playwright.dev/docs/emulation
 test.use({
 	colorScheme: 'light',
@@ -42,13 +66,12 @@ ROUTES.forEach((options, route) => {
 	if (options?.axe?.skip === true || process.argv.includes('--update-snapshots')) {
 		return;
 	}
-	test(`snapshot for ${route}`, async ({ page }, testInfo) => {
-		const outputPath = rename(testInfo.outputDir);
-		const hideMenusParam = `${route.includes('?') ? '&' : '?'}hideMenus`;
-		await page.goto(`/#${route}${hideMenusParam}`);
-		await page.waitForLoadState('networkidle');
-		await page.addStyleTag({
-			content: `
+        test(`snapshot for ${route}`, async ({ page }, testInfo) => {
+                const hideMenusParam = `${route.includes('?') ? '&' : '?'}hideMenus`;
+                await page.goto(`/#${route}${hideMenusParam}`);
+                await page.waitForLoadState('networkidle');
+                await page.addStyleTag({
+                        content: `
 				* {
 					transition: none !important;
 					animation: none !important;
@@ -58,33 +81,20 @@ ROUTES.forEach((options, route) => {
 		if (options?.snapshot?.viewportSize) {
 			await page.setViewportSize(options?.snapshot?.viewportSize);
 		}
-		if (options?.snapshot?.waitForTimeout) {
-			await page.waitForTimeout(options?.snapshot?.waitForTimeout);
-		}
+                if (options?.snapshot?.waitForTimeout) {
+                        await page.waitForTimeout(options?.snapshot?.waitForTimeout);
+                }
 
-		await injectAxe(page);
-		await checkA11y(
-			page,
-			undefined,
-			{
-				axeOptions: {
-					runOnly: {
-						type: 'tag',
-						values: ['best-practices', 'wcag2a', 'wcag2aa', 'wcag21aa'],
-					},
-				},
-				detailedReport: true,
-				detailedReportOptions: {
-					html: true,
-				},
-			},
-			true, // options?.axe?.skipFailures ?? false,
-			'html',
-			{
-				outputDirPath: outputPath.replace(/\/[^/]+$/, ''),
-				outputDir: `axe-${themeName}`,
-				reportFileName: `${route.replace(/[/?]/g, '-')}.html`,
-			},
-		);
-	});
+		const builder = new AxeBuilder({ page }).withTags(AXE_TAGS);
+		const results = await builder.analyze();
+		await testInfo.attach('axe-results', {
+			body: JSON.stringify(results, null, 2),
+			contentType: 'application/json',
+		});
+		createHtmlReport({
+			results,
+			options: buildReportOptions(testInfo, route),
+		});
+		logViolations(route, results.violations);
+        });
 });

--- a/packages/tools/visual-tests/tests/axe-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/axe-snapshots.spec.js
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { checkA11y, injectAxe } from 'axe-playwright';
+import { checkA11y, injectAxe } from '@axe-core/playwright';
 import process from 'process';
 import { ROUTES } from './sample-app.routes.js';
 

--- a/packages/tools/visual-tests/tests/axe-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/axe-snapshots.spec.js
@@ -1,5 +1,5 @@
-import { test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { test } from '@playwright/test';
 import axeHtmlReporter from 'axe-html-reporter';
 import process from 'process';
 import { ROUTES } from './sample-app.routes.js';
@@ -66,12 +66,12 @@ ROUTES.forEach((options, route) => {
 	if (options?.axe?.skip === true || process.argv.includes('--update-snapshots')) {
 		return;
 	}
-        test(`snapshot for ${route}`, async ({ page }, testInfo) => {
-                const hideMenusParam = `${route.includes('?') ? '&' : '?'}hideMenus`;
-                await page.goto(`/#${route}${hideMenusParam}`);
-                await page.waitForLoadState('networkidle');
-                await page.addStyleTag({
-                        content: `
+	test(`snapshot for ${route}`, async ({ page }, testInfo) => {
+		const hideMenusParam = `${route.includes('?') ? '&' : '?'}hideMenus`;
+		await page.goto(`/#${route}${hideMenusParam}`);
+		await page.waitForLoadState('networkidle');
+		await page.addStyleTag({
+			content: `
 				* {
 					transition: none !important;
 					animation: none !important;
@@ -81,9 +81,9 @@ ROUTES.forEach((options, route) => {
 		if (options?.snapshot?.viewportSize) {
 			await page.setViewportSize(options?.snapshot?.viewportSize);
 		}
-                if (options?.snapshot?.waitForTimeout) {
-                        await page.waitForTimeout(options?.snapshot?.waitForTimeout);
-                }
+		if (options?.snapshot?.waitForTimeout) {
+			await page.waitForTimeout(options?.snapshot?.waitForTimeout);
+		}
 
 		const builder = new AxeBuilder({ page }).withTags(AXE_TAGS);
 		const results = await builder.analyze();
@@ -96,5 +96,5 @@ ROUTES.forEach((options, route) => {
 			options: buildReportOptions(testInfo, route),
 		});
 		logViolations(route, results.violations);
-        });
+	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1238,12 +1238,12 @@ importers:
 
   packages/tools/visual-tests:
     dependencies:
+      '@axe-core/playwright':
+        specifier: 4.11.0
+        version: 4.11.0(playwright-core@1.56.0)
       '@public-ui/sample-react':
         specifier: workspace:*
         version: link:../../samples/react
-      axe-playwright:
-        specifier: 2.2.2
-        version: 2.2.2(playwright@1.56.0)
       portfinder:
         specifier: 1.0.38
         version: 1.0.38
@@ -1631,6 +1631,11 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@axe-core/playwright@4.11.0':
+    resolution: {integrity: sha512-70vBT/Ylqpm65RQz2iCG2o0JJCEG/WCNyefTr2xcOcr1CoSee60gNQYUMZZ7YukoKkFLv26I/jjlsvwwp532oQ==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -5239,9 +5244,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/junit-report-builder@3.0.2':
-    resolution: {integrity: sha512-R5M+SYhMbwBeQcNXYWNCZkl09vkVfAtcPIaCGdzIkkbeaTrVbGQ7HVgi4s+EmM/M1K4ZuWQH0jGcvMvNePfxYA==}
-
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
@@ -6171,16 +6173,9 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axe-html-reporter@2.2.11:
-    resolution: {integrity: sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==}
-    engines: {node: '>=8.9.0'}
-    peerDependencies:
-      axe-core: '>=3'
-
-  axe-playwright@2.2.2:
-    resolution: {integrity: sha512-h350/grzDCPgpuWV7eEOqr/f61Xn07Gi9f9B3Ew4rW6/nFtpdEJYW6jgRATorgAGXjEAYFTnaY3sEys39wDw4A==}
-    peerDependencies:
-      playwright: '>1.0.0'
+  axe-core@4.11.0:
+    resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
+    engines: {node: '>=4'}
 
   axios@1.12.0:
     resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
@@ -9617,10 +9612,6 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
-
-  junit-report-builder@5.1.1:
-    resolution: {integrity: sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==}
-    engines: {node: '>=16'}
 
   junk@4.0.1:
     resolution: {integrity: sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==}
@@ -14563,10 +14554,6 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
-  xmlbuilder@15.1.1:
-    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
-    engines: {node: '>=8.0'}
-
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -15155,6 +15142,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@axe-core/playwright@4.11.0(playwright-core@1.56.0)':
+    dependencies:
+      axe-core: 4.11.0
+      playwright-core: 1.56.0
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -19325,8 +19317,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/junit-report-builder@3.0.2': {}
-
   '@types/linkify-it@5.0.0': {}
 
   '@types/lodash-es@4.17.12':
@@ -20500,19 +20490,7 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axe-html-reporter@2.2.11(axe-core@4.10.3):
-    dependencies:
-      axe-core: 4.10.3
-      mustache: 4.2.0
-
-  axe-playwright@2.2.2(playwright@1.56.0):
-    dependencies:
-      '@types/junit-report-builder': 3.0.2
-      axe-core: 4.10.3
-      axe-html-reporter: 2.2.11(axe-core@4.10.3)
-      junit-report-builder: 5.1.1
-      picocolors: 1.1.1
-      playwright: 1.56.0
+  axe-core@4.11.0: {}
 
   axios@1.12.0:
     dependencies:
@@ -24822,12 +24800,6 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
-
-  junit-report-builder@5.1.1:
-    dependencies:
-      lodash: 4.17.21
-      make-dir: 3.1.0
-      xmlbuilder: 15.1.1
 
   junk@4.0.1: {}
 
@@ -30586,8 +30558,6 @@ snapshots:
   xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
-
-  xmlbuilder@15.1.1: {}
 
   xmlchars@2.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1244,6 +1244,9 @@ importers:
       '@public-ui/sample-react':
         specifier: workspace:*
         version: link:../../samples/react
+      axe-html-reporter:
+        specifier: 2.2.11
+        version: 2.2.11(axe-core@4.11.0)
       portfinder:
         specifier: 1.0.38
         version: 1.0.38
@@ -6176,6 +6179,12 @@ packages:
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
     engines: {node: '>=4'}
+
+  axe-html-reporter@2.2.11:
+    resolution: {integrity: sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==}
+    engines: {node: '>=8.9.0'}
+    peerDependencies:
+      axe-core: '>=3'
 
   axios@1.12.0:
     resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
@@ -20491,6 +20500,11 @@ snapshots:
   axe-core@4.10.3: {}
 
   axe-core@4.11.0: {}
+
+  axe-html-reporter@2.2.11(axe-core@4.11.0):
+    dependencies:
+      axe-core: 4.11.0
+      mustache: 4.2.0
 
   axios@1.12.0:
     dependencies:


### PR DESCRIPTION
## Summary

Internal test tooling improvement — migrated visual tests from the previous testing approach to use `@axe-core/playwright` for integrated accessibility and visual testing.

## Changes

- Migrated visual tests to use `@axe-core/playwright`
- Updated test configuration and dependencies accordingly

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Interne Test-Tooling-Verbesserung — visuelle Tests auf `@axe-core/playwright` migriert für integriertes Barrierefreiheits- und visuelles Testen.

## Änderungen

- Visuelle Tests auf `@axe-core/playwright` migriert
- Test-Konfiguration und Abhängigkeiten entsprechend aktualisiert

</details>