### PR TITLE
Split formatter samples across input components

### DIFF
--- a/packages/samples/react/src/components/input-number/routes.ts
+++ b/packages/samples/react/src/components/input-number/routes.ts
@@ -1,8 +1,10 @@
 import { Routes } from '../../shares/types';
 import { InputNumberBasic } from './basic';
+import { InputNumberYearFormatter } from './year-formatter';
 
 export const INPUT_NUMBER_ROUTES: Routes = {
 	'input-number': {
 		basic: InputNumberBasic,
+		'year-formatter': InputNumberYearFormatter,
 	},
 };

--- a/packages/samples/react/src/components/input-number/year-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/year-formatter.tsx
@@ -1,0 +1,87 @@
+import { KolForm, KolHeading, KolInputNumber } from '@public-ui/react-v19';
+import { Field, Formik, type FieldProps } from 'formik';
+import * as React from 'react';
+
+import { SampleDescription } from '../SampleDescription';
+
+type YearExampleFormValues = {
+	year?: number;
+};
+
+export function InputNumberYearFormatter() {
+	const handleSubmit = async () => {};
+	const currentYear = React.useMemo(() => new Date().getFullYear(), []);
+	const initialYearExampleValues: YearExampleFormValues = {
+		year: currentYear,
+	};
+
+	return (
+		<>
+			<SampleDescription>
+				<p>This example limits the KolInputNumber to whole years that cannot exceed the current year.</p>
+			</SampleDescription>
+			<section className="w-full flex flex-col">
+				<Formik<YearExampleFormValues>
+					initialValues={initialYearExampleValues}
+					validate={(values) => {
+						const errors: Record<string, string> = {};
+						if (typeof values.year !== 'number') {
+							errors.year = 'Please enter a year.';
+						} else if (values.year > currentYear) {
+							errors.year = `The value must not exceed ${currentYear}.`;
+						}
+						return errors;
+					}}
+					onSubmit={handleSubmit}
+				>
+					{(form) => (
+						<>
+							<div className="p-2">
+								<KolHeading _label="Year input (whole numbers only)" _level={2} />
+								<KolForm>
+									<Field name="year">
+										{({ field }: FieldProps<YearExampleFormValues['year']>) => (
+											<div className="block mt-2">
+												<KolInputNumber
+													_label="Year"
+													_required
+													_min={0}
+													_max={currentYear}
+													_step={1}
+													_value={field.value ?? undefined}
+													_msg={{
+														_type: 'error',
+														_description: form.errors.year || '',
+													}}
+													_touched={form.touched.year}
+													_on={{
+														onBlur: () => {
+															void form.setFieldTouched('year', true);
+														},
+														onInput: (_, value: unknown) => {
+															const parsedValue = typeof value === 'number' ? value : Number(value);
+															if (Number.isNaN(parsedValue)) {
+																void form.setFieldValue('year', undefined, true);
+															} else {
+																const normalizedValue = Math.min(currentYear, Math.max(0, Math.trunc(parsedValue)));
+																void form.setFieldValue('year', normalizedValue, true);
+															}
+														},
+													}}
+												/>
+											</div>
+										)}
+									</Field>
+								</KolForm>
+							</div>
+							<div className="p-2">
+								<KolHeading _label="Model" _level={2} />
+								<pre className="text-base">{JSON.stringify(form.values, null, 2)}</pre>
+							</div>
+						</>
+					)}
+				</Formik>
+			</section>
+		</>
+	);
+}

--- a/packages/samples/react/src/components/input-text/text-formatter.tsx
+++ b/packages/samples/react/src/components/input-text/text-formatter.tsx
@@ -1,9 +1,9 @@
 import { KolForm, KolHeading, KolInputText } from '@public-ui/react-v19';
 import { Field, Formik, type FieldProps } from 'formik';
 import * as React from 'react';
-import { SampleDescription } from '../SampleDescription';
-
 import { NumericFormat, type NumberFormatValues } from 'react-number-format';
+
+import { SampleDescription } from '../SampleDescription';
 
 const NON_ALPHANUM = /[^a-zA-Z0-9]/g;
 const EVERY_FOUR_CHARS = /(.{4})(?!$)/g;
@@ -20,11 +20,13 @@ class IbanFormatter {
 	public parse(value: string): string {
 		return this.electronicFormat(value);
 	}
+
 	public format(value: string, ref?: HTMLKolInputTextElement | null, selectionStart?: number | null): string {
 		if (ref && selectionStart) {
 			if (selectionStart % 5 === 0) selectionStart++;
 			ref?.setSelectionStart(selectionStart);
 		}
+
 		return this.printFormat(value);
 	}
 }
@@ -56,9 +58,10 @@ export function InputTextFormatterDemo() {
 		<>
 			<SampleDescription>
 				<p>
-					This example demonstrates formatting a data value in an input field (example IBAN). The data value is formatted to the input field (print format) and
-					vice versa the formatting is removed again (machine format)
+					This example demonstrates formatting a data value in an input field (example IBAN). The data value is formatted to the input field (print
+					format) and vice versa the formatting is removed again (machine format).
 				</p>
+				<p>It also illustrates how to format a number input using react-number-format.</p>
 			</SampleDescription>
 			<section className="w-full flex flex-col">
 				<Formik<IbanExampleFormValues> initialValues={initialIbanExampleValues} onSubmit={handleSubmit}>
@@ -90,8 +93,8 @@ export function InputTextFormatterDemo() {
 																textInput1.current?.selectionStart().then((start) => {
 																	textInput1SelectionStart = start;
 																});
-																const parsed_value = formatter.parse((value as string) ?? '');
-																void form.setFieldValue('iban', parsed_value, true);
+																const parsedValue = formatter.parse((value as string) ?? '');
+																void form.setFieldValue('iban', parsedValue, true);
 															}
 														},
 													}}

--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -416,6 +416,17 @@ ROUTES.set('input-number/basic?noColumns', {
 		},
 	},
 });
+ROUTES.set('input-number/year-formatter', {
+	snapshot: {
+		viewportSize: {
+			width: 500,
+			height: 300,
+		},
+		zoom: {
+			skip: true,
+		},
+	},
+});
 ROUTES.set('input-password/basic?noColumns', {
 	snapshot: {
 		viewportSize: {
@@ -491,6 +502,13 @@ ROUTES.set('input-text/basic?noColumns', {
 			width: 500,
 			height: 100,
 		},
+		zoom: {
+			skip: true,
+		},
+	},
+});
+ROUTES.set('input-text/text-formatter', {
+	snapshot: {
 		zoom: {
 			skip: true,
 		},


### PR DESCRIPTION
## Summary
- move the year-restricted formatter example from the input-text story into its own KolInputNumber demo
- expose the new story via the input-number routes and add both formatter stories to the visual test route map

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915dc2dfb74832b8ef703a5383c5b18)