### PR TITLE
docs: reinforce formatting reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,16 @@ We have a monorepo structure with multiple packages, each with its own `package.
 - If something does not work, check in the event of an error whether all dependent submodules have been built.
 - To build a single package faster, run commands with downstream dependents using `pnpm --filter ...<package>` (e.g., `pnpm --filter ...@public-ui/sample-react build`).
 
+## 🚨 Format-first rule
+
+> **Stop before you commit:** run the formatter so CI never rejects your patch for style drift.
+
+1. Run `pnpm format` from the repo root whenever you change code, docs or configs.
+2. If you only touched one package, you may instead run `pnpm --filter <package> format` for a quicker pass.
+3. Re-stage the affected files (`git add -u`) so the formatted result is what lands in the commit.
+
+No package scripts in this repo need extra flags such as `-- --write`; the scripts already know when to write changes versus just check.
+
 ## Semantic Versioning
 
 This repository follows **Semantic Versioning** (SemVer) for all packages. Each package version is defined in its own `package.json` file. The versioning scheme is as follows:
@@ -258,7 +268,7 @@ The samples are located in `packages/samples/react` and demonstrate how to use t
 
 ### Pre-commit checklist
 
-- **Always run `pnpm format` (or the relevant `pnpm --filter <package> format -- --write` command) right before committing.** Formatting failures are one of the most common reasons for blocked quality gates, so make this the last step before `git commit` even for documentation-only changes.
+- **Always run `pnpm format` (or `pnpm --filter <package> format` for a single workspace) right before committing.** Formatting failures are one of the most common reasons for blocked quality gates, so make this the last step before `git commit` even for documentation-only changes.
 - After formatting, re-stage affected files with `git add -u` so the formatted content is what gets committed.
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,11 @@ The samples are located in `packages/samples/react` and demonstrate how to use t
 - Run `pnpm format` to format all code files using Prettier. You can try to automatically fix linting issues with `pnpm format -w`, but this may not resolve all issues.
 - If your pull request only modifies Markdown files, skip `pnpm build`, `pnpm lint` and `pnpm test`. Just format the Markdown using `pnpm format` or Prettier.
 
+### Pre-commit checklist
+
+- **Always run `pnpm format` (or the relevant `pnpm --filter <package> format -- --write` command) right before committing.** Formatting failures are one of the most common reasons for blocked quality gates, so make this the last step before `git commit` even for documentation-only changes.
+- After formatting, re-stage affected files with `git add -u` so the formatted content is what gets committed.
+
 ## Testing
 
 - Run `pnpm test` from the repository root to execute all unit and integration tests.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -5,10 +5,7 @@ This package contains the Stencil based web component library for KoliBri.
 Use `pnpm --filter @public-ui/components build` to build the library or `pnpm start` for development.
 Always run a build before linting so the generated component typings exist for the check.
 
-## Formatting discipline
-
-- Run `pnpm --filter @public-ui/components format -- --write` (or `pnpm format` from the repository root) right before every commit. The local format script only checks by default, so pass `-- --write` to auto-apply fixes.
-- After formatting, re-stage the touched files so the commit contains the prettified output that satisfies the quality gates.
+> 🧹 **Formatting**: Follow the repo-wide “Format-first rule” in `/AGENTS.md`. Run `pnpm format` or `pnpm --filter @public-ui/components format` before committing—no extra flags are needed.
 
 ## Structure
 

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -5,6 +5,11 @@ This package contains the Stencil based web component library for KoliBri.
 Use `pnpm --filter @public-ui/components build` to build the library or `pnpm start` for development.
 Always run a build before linting so the generated component typings exist for the check.
 
+## Formatting discipline
+
+- Run `pnpm --filter @public-ui/components format -- --write` (or `pnpm format` from the repository root) right before every commit. The local format script only checks by default, so pass `-- --write` to auto-apply fixes.
+- After formatting, re-stage the touched files so the commit contains the prettified output that satisfies the quality gates.
+
 ## Structure
 
 - `src/components` – Each component lives in its own folder. The usual files are:

--- a/packages/samples/react/AGENTS.md
+++ b/packages/samples/react/AGENTS.md
@@ -17,7 +17,4 @@ This package contains the React based sample application showcasing the KoliBri 
 
 Run `pnpm start` in this directory to launch the development server.
 
-## Formatting discipline
-
-- Run `pnpm --filter @public-ui/sample-react format -- --write` (or `pnpm format` at the root) before every commit so prettierized React/Vite files match the enforced style.
-- Once formatted, re-stage the touched files; this prevents CI from reformatting them and blocking the quality gates.
+> 🧹 **Formatting**: Follow the repo-wide “Format-first rule” in `/AGENTS.md`. Use `pnpm format` or `pnpm --filter @public-ui/sample-react format` before committing—no additional `--write` flags are required.

--- a/packages/samples/react/AGENTS.md
+++ b/packages/samples/react/AGENTS.md
@@ -16,3 +16,8 @@ This package contains the React based sample application showcasing the KoliBri 
 - `e2e` – end to end tests for the sample app.
 
 Run `pnpm start` in this directory to launch the development server.
+
+## Formatting discipline
+
+- Run `pnpm --filter @public-ui/sample-react format -- --write` (or `pnpm format` at the root) before every commit so prettierized React/Vite files match the enforced style.
+- Once formatted, re-stage the touched files; this prevents CI from reformatting them and blocking the quality gates.

--- a/packages/themes/AGENTS.md
+++ b/packages/themes/AGENTS.md
@@ -14,10 +14,7 @@ This folder collects all official KoliBri themes. Each theme package under this 
 - The build stack is based on **Rollup**, **TypeScript** and **PostCSS**. Keep `rollup.config.js`, `tsconfig.json` and dependency versions identical across all theme packages.
 - Do not edit the generated `assets` folders. Modify the source files instead and rebuild.
 
-### Formatting discipline
-
-- Before committing, run `pnpm --filter <theme> format -- --write` (or `pnpm format` at the repo root) so that SCSS/TS edits pass the shared Prettier rules.
-- Each theme package reuses the same Prettier configuration; formatting all touched files immediately before `git commit` prevents follow-up runs when CI enforces the checks.
+> 🧹 **Formatting**: Follow the repo-wide “Format-first rule” in `/AGENTS.md`. Run `pnpm format` or `pnpm --filter <theme> format` before committing so the shared Prettier config stays satisfied—no manual `--write` flag is needed.
 
 ## Coding Guidelines
 

--- a/packages/themes/AGENTS.md
+++ b/packages/themes/AGENTS.md
@@ -14,6 +14,11 @@ This folder collects all official KoliBri themes. Each theme package under this 
 - The build stack is based on **Rollup**, **TypeScript** and **PostCSS**. Keep `rollup.config.js`, `tsconfig.json` and dependency versions identical across all theme packages.
 - Do not edit the generated `assets` folders. Modify the source files instead and rebuild.
 
+### Formatting discipline
+
+- Before committing, run `pnpm --filter <theme> format -- --write` (or `pnpm format` at the repo root) so that SCSS/TS edits pass the shared Prettier rules.
+- Each theme package reuses the same Prettier configuration; formatting all touched files immediately before `git commit` prevents follow-up runs when CI enforces the checks.
+
 ## Coding Guidelines
 
 - Organise SCSS using `@layer kol-theme-global` and `@layer kol-theme-component`.

--- a/packages/tools/AGENTS.md
+++ b/packages/tools/AGENTS.md
@@ -2,10 +2,7 @@
 
 This folder hosts all developer tooling packages (CLI, MCP server, shared scripts). Each tool is published as its own workspace package.
 
-## Formatting discipline
-
-- Run `pnpm --filter <tool-package> format -- --write` (or `pnpm format` at the root) right before committing so Prettier-stable files reach CI.
-- Restage the files after formatting to ensure the final commit contains the auto-formatted output.
+> 🧹 **Formatting**: Follow the repo-wide “Format-first rule” in `/AGENTS.md`. Use `pnpm format` or `pnpm --filter <tool-package> format` before committing—no extra flags or manual write arguments are needed.
 
 ## Build & test expectations
 

--- a/packages/tools/AGENTS.md
+++ b/packages/tools/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions
+
+This folder hosts all developer tooling packages (CLI, MCP server, shared scripts). Each tool is published as its own workspace package.
+
+## Formatting discipline
+
+- Run `pnpm --filter <tool-package> format -- --write` (or `pnpm format` at the root) right before committing so Prettier-stable files reach CI.
+- Restage the files after formatting to ensure the final commit contains the auto-formatted output.
+
+## Build & test expectations
+
+- Use `pnpm --filter <tool-package> build` to create distributable artifacts.
+- When touching shared helpers, run the affected tool's unit tests with `pnpm --filter <tool-package> test` before opening a PR.

--- a/packages/tools/mcp/AGENTS.md
+++ b/packages/tools/mcp/AGENTS.md
@@ -4,6 +4,11 @@
 
 This package provides a Model Context Protocol (MCP) server implementation using the official `@modelcontextprotocol/sdk`. It offers AI agents structured access to KoliBri component samples and documentation with fuzzy search capabilities.
 
+### Formatting discipline
+
+- Run `pnpm --filter @public-ui/mcp format -- --write` (or `pnpm format` from the repo root) immediately before committing so that CI's Prettier check passes the first time.
+- Re-stage the formatted files to avoid "changes not staged" surprises.
+
 The server supports **three deployment modes**:
 
 - **stdio**: For local MCP clients (Claude Desktop, VS Code MCP extension)

--- a/packages/tools/mcp/AGENTS.md
+++ b/packages/tools/mcp/AGENTS.md
@@ -4,10 +4,7 @@
 
 This package provides a Model Context Protocol (MCP) server implementation using the official `@modelcontextprotocol/sdk`. It offers AI agents structured access to KoliBri component samples and documentation with fuzzy search capabilities.
 
-### Formatting discipline
-
-- Run `pnpm --filter @public-ui/mcp format -- --write` (or `pnpm format` from the repo root) immediately before committing so that CI's Prettier check passes the first time.
-- Re-stage the formatted files to avoid "changes not staged" surprises.
+> 🧹 **Formatting**: Follow the repo-wide “Format-first rule” in `/AGENTS.md`. Run `pnpm format` or `pnpm --filter @public-ui/mcp format` before committing—no extra arguments like `--write` are necessary.
 
 The server supports **three deployment modes**:
 


### PR DESCRIPTION
## Summary

Internal documentation update — reinforced code formatting reminders in contributing guidelines.

## Changes

- Added or updated formatting reminders in documentation

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Interne Dokumentationsaktualisierung — Hinweise zur Code-Formatierung in den Beitragsrichtlinien verstärkt.

## Änderungen

- Formatierungshinweise in der Dokumentation hinzugefügt oder aktualisiert

</details>