### PR TITLE
fix(pagination): add missing bem class to numbered pagination buttons

### DIFF
--- a/packages/components/src/components/pagination/component.tsx
+++ b/packages/components/src/components/pagination/component.tsx
@@ -327,6 +327,7 @@ export class KolPaginationWc implements PaginationAPI {
 		return (
 			<li key={nonce()}>
 				<KolButtonWcTag
+					class="kol-pagination__button"
 					_ariaDescription={ariaDescription}
 					_customClass={this.state._customClass}
 					_label={pageText}

--- a/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/pagination/test/__snapshots__/snapshot.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`kol-pagination should render with _label="Label" _on={} _max=2 _page=1 
             <kol-button-wc _ariadescription="kol-page 1" _disabled="" _label="1" aria-current="page" class="kol-pagination__button kol-pagination__button--selected selected"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 2" _label="2"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 2" _label="2" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
             <kol-button-wc _hidelabel="" _label="kol-page-next" _tooltipalign="top" class="kol-pagination__button kol-pagination__button--next" exportparts="icon"></kol-button-wc>
@@ -56,19 +56,19 @@ exports[`kol-pagination should render with _label="Label" _on={} _max=10 _page=1
             <kol-button-wc _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="kol-pagination__button kol-pagination__button--previous" exportparts="icon"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 1" _label="1"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 1" _label="1" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 2" _label="2"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 2" _label="2" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
             <span aria-hidden="true" class="kol-pagination__separator"></span>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 8" _label="8"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 8" _label="8" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 9" _label="9"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 9" _label="9" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
             <kol-button-wc _ariadescription="kol-page 10" _disabled="" _label="10" aria-current="page" class="kol-pagination__button kol-pagination__button--selected selected"></kol-button-wc>
@@ -96,13 +96,13 @@ exports[`kol-pagination should render with _label="Label" _on={} _max=12 _page=6
             <kol-button-wc _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="kol-pagination__button kol-pagination__button--previous" exportparts="icon"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 5" _label="5"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 5" _label="5" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
             <kol-button-wc _ariadescription="kol-page 6" _disabled="" _label="6" aria-current="page" class="kol-pagination__button kol-pagination__button--selected selected"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 7" _label="7"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 7" _label="7" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
             <span aria-hidden="true" class="kol-pagination__separator"></span>
@@ -130,19 +130,19 @@ exports[`kol-pagination should render with _label="Label" _on={} _max=25 _page=3
             <kol-button-wc _hidelabel="" _label="kol-page-back" _tooltipalign="top" class="kol-pagination__button kol-pagination__button--previous" exportparts="icon"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 1" _label="1"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 1" _label="1" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 2" _label="2"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 2" _label="2" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
             <kol-button-wc _ariadescription="kol-page 3" _disabled="" _label="3" aria-current="page" class="kol-pagination__button kol-pagination__button--selected selected"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 4" _label="4"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 4" _label="4" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
-            <kol-button-wc _ariadescription="kol-page 5" _label="5"></kol-button-wc>
+            <kol-button-wc _ariadescription="kol-page 5" _label="5" class="kol-pagination__button"></kol-button-wc>
           </li>
           <li>
             <kol-button-wc _hidelabel="" _label="kol-page-next" _tooltipalign="top" class="kol-pagination__button kol-pagination__button--next" exportparts="icon"></kol-button-wc>


### PR DESCRIPTION
## Summary
Adds the missing `kol-pagination__button` BEM class to numbered pagination buttons for consistent styling.

## Changes
- Add `kol-pagination__button` class to numbered page buttons in `kol-pagination`
- Update pagination snapshots to assert the new class

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Fügt die fehlende BEM-Klasse `kol-pagination__button` zu den nummerierten Paginierungs-Buttons hinzu.

## Änderungen
- `kol-pagination__button`-Klasse zu nummerierten Seiten-Buttons hinzugefügt
- Paginierungs-Snapshots aktualisiert
</details>