### PR TITLE
fix(samples): enforce integer-only year formatter

### DIFF
--- a/packages/samples/react/src/components/input-number/routes.ts
+++ b/packages/samples/react/src/components/input-number/routes.ts
@@ -1,10 +1,10 @@
 import { Routes } from '../../shares/types';
 import { InputNumberBasic } from './basic';
-import { InputNumberYearFormatter } from './year-formatter';
+import { InputNumberWholeNumberFormatter } from './whole-number-formatter';
 
 export const INPUT_NUMBER_ROUTES: Routes = {
 	'input-number': {
 		basic: InputNumberBasic,
-		'year-formatter': InputNumberYearFormatter,
+		'whole-number-formatter': InputNumberWholeNumberFormatter,
 	},
 };

--- a/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
@@ -10,7 +10,7 @@ type WholeNumberFormValues = {
 	value?: number;
 };
 
-export function InputNumberYearFormatter() {
+export function InputNumberWholeNumberFormatter() {
 	const handleSubmit = async () => {};
 	const initialWholeNumberValues: WholeNumberFormValues = {
 		value: undefined,

--- a/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { SampleDescription } from '../SampleDescription';
 
 const WHOLE_NUMBER_ERROR = 'Please enter a whole number.';
+const LEADING_ZERO_ERROR = 'Numbers with multiple digits cannot start with 0.';
 
 type WholeNumberFormValues = {
 	value?: number;
@@ -19,7 +20,7 @@ export function InputNumberWholeNumberFormatter() {
 	return (
 		<>
 			<SampleDescription>
-				<p>This example limits the KolInputNumber to whole numbers only. Empty input remains valid.</p>
+				<p>This example allows only whole numbers or an empty field. Multi-digit numbers may not start with 0.</p>
 			</SampleDescription>
 			<section className="w-full flex flex-col">
 				<Formik<WholeNumberFormValues>
@@ -55,7 +56,27 @@ export function InputNumberWholeNumberFormatter() {
 															void form.setFieldTouched('value', true);
 														},
 														onInput: (_, value: unknown) => {
-															const parsedValue = typeof value === 'number' ? value : Number(value);
+															const rawValue =
+																typeof value === 'string'
+																	? value
+																	: value === undefined || value === null
+																		? ''
+																		: String(value);
+															const normalizedValue = rawValue.trim();
+
+															if (normalizedValue === '') {
+																form.setFieldError('value', undefined);
+																void form.setFieldValue('value', undefined, true);
+																return;
+															}
+
+															if (/^[+-]?0\d+/.test(normalizedValue)) {
+																void form.setFieldTouched('value', true, false);
+																form.setFieldError('value', LEADING_ZERO_ERROR);
+																return;
+															}
+
+															const parsedValue = typeof value === 'number' ? value : Number(rawValue);
 															if (Number.isNaN(parsedValue)) {
 																form.setFieldError('value', undefined);
 																void form.setFieldValue('value', undefined, true);
@@ -70,21 +91,22 @@ export function InputNumberWholeNumberFormatter() {
 
 															form.setFieldError('value', undefined);
 															void form.setFieldValue('value', parsedValue, true);
-														},
+													},
 													}}
-												/>
-										)}
-									</Field>
-								</KolForm>
-							</div>
-							<div className="p-2">
-								<KolHeading _label="Model" _level={2} />
-								<pre className="text-base">{JSON.stringify(form.values, null, 2)}</pre>
-							</div>
-						</>
-					)}
-				</Formik>
-			</section>
+											/>
+									</div>
+								)}
+							</Field>
+						</KolForm>
+					</div>
+					<div className="p-2">
+						<KolHeading _label="Model" _level={2} />
+						<pre className="text-base">{JSON.stringify(form.values, null, 2)}</pre>
+					</div>
+				</>
+				)}
+			</Formik>
+		</section>
 		</>
 	);
 }

--- a/packages/samples/react/src/components/input-number/year-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/year-formatter.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 
 import { SampleDescription } from '../SampleDescription';
 
+const WHOLE_YEAR_ERROR = 'Please enter a whole number.';
+
 type YearExampleFormValues = {
 	year?: number;
 };
@@ -27,6 +29,8 @@ export function InputNumberYearFormatter() {
 						const errors: Record<string, string> = {};
 						if (typeof values.year !== 'number') {
 							errors.year = 'Please enter a year.';
+							} else if (!Number.isInteger(values.year)) {
+								errors.year = WHOLE_YEAR_ERROR;
 						} else if (values.year > currentYear) {
 							errors.year = `The value must not exceed ${currentYear}.`;
 						}
@@ -62,12 +66,20 @@ export function InputNumberYearFormatter() {
 															const parsedValue = typeof value === 'number' ? value : Number(value);
 															if (Number.isNaN(parsedValue)) {
 																void form.setFieldValue('year', undefined, true);
-															} else {
-																const normalizedValue = Math.min(currentYear, Math.max(0, Math.trunc(parsedValue)));
-																void form.setFieldValue('year', normalizedValue, true);
+																return;
 															}
+
+															if (!Number.isInteger(parsedValue)) {
+																void form.setFieldTouched('year', true, false);
+																form.setFieldError('year', WHOLE_YEAR_ERROR);
+																return;
+															}
+
+															form.setFieldError('year', undefined);
+															const normalizedValue = Math.min(currentYear, Math.max(0, parsedValue));
+															void form.setFieldValue('year', normalizedValue, true);
 														},
-													}}
+												}}
 												/>
 											</div>
 										)}

--- a/packages/samples/react/src/components/input-number/year-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/year-formatter.tsx
@@ -4,35 +4,30 @@ import * as React from 'react';
 
 import { SampleDescription } from '../SampleDescription';
 
-const WHOLE_YEAR_ERROR = 'Please enter a whole number.';
+const WHOLE_NUMBER_ERROR = 'Please enter a whole number.';
 
-type YearExampleFormValues = {
-	year?: number;
+type WholeNumberFormValues = {
+	value?: number;
 };
 
 export function InputNumberYearFormatter() {
 	const handleSubmit = async () => {};
-	const currentYear = React.useMemo(() => new Date().getFullYear(), []);
-	const initialYearExampleValues: YearExampleFormValues = {
-		year: currentYear,
+	const initialWholeNumberValues: WholeNumberFormValues = {
+		value: undefined,
 	};
 
 	return (
 		<>
 			<SampleDescription>
-				<p>This example limits the KolInputNumber to whole years that cannot exceed the current year.</p>
+				<p>This example limits the KolInputNumber to whole numbers only. Empty input remains valid.</p>
 			</SampleDescription>
 			<section className="w-full flex flex-col">
-				<Formik<YearExampleFormValues>
-					initialValues={initialYearExampleValues}
+				<Formik<WholeNumberFormValues>
+					initialValues={initialWholeNumberValues}
 					validate={(values) => {
 						const errors: Record<string, string> = {};
-						if (typeof values.year !== 'number') {
-							errors.year = 'Please enter a year.';
-							} else if (!Number.isInteger(values.year)) {
-								errors.year = WHOLE_YEAR_ERROR;
-						} else if (values.year > currentYear) {
-							errors.year = `The value must not exceed ${currentYear}.`;
+						if (typeof values.value === 'number' && !Number.isInteger(values.value)) {
+							errors.value = WHOLE_NUMBER_ERROR;
 						}
 						return errors;
 					}}
@@ -41,47 +36,43 @@ export function InputNumberYearFormatter() {
 					{(form) => (
 						<>
 							<div className="p-2">
-								<KolHeading _label="Year input (whole numbers only)" _level={2} />
+								<KolHeading _label="Whole number input" _level={2} />
 								<KolForm>
-									<Field name="year">
-										{({ field }: FieldProps<YearExampleFormValues['year']>) => (
+									<Field name="value">
+										{({ field }: FieldProps<WholeNumberFormValues['value']>) => (
 											<div className="block mt-2">
 												<KolInputNumber
-													_label="Year"
-													_required
-													_min={0}
-													_max={currentYear}
+													_label="Whole number"
 													_step={1}
 													_value={field.value ?? undefined}
 													_msg={{
 														_type: 'error',
-														_description: form.errors.year || '',
+														_description: form.errors.value || '',
 													}}
-													_touched={form.touched.year}
+													_touched={form.touched.value}
 													_on={{
 														onBlur: () => {
-															void form.setFieldTouched('year', true);
+															void form.setFieldTouched('value', true);
 														},
 														onInput: (_, value: unknown) => {
 															const parsedValue = typeof value === 'number' ? value : Number(value);
 															if (Number.isNaN(parsedValue)) {
-																void form.setFieldValue('year', undefined, true);
+																form.setFieldError('value', undefined);
+																void form.setFieldValue('value', undefined, true);
 																return;
 															}
 
 															if (!Number.isInteger(parsedValue)) {
-																void form.setFieldTouched('year', true, false);
-																form.setFieldError('year', WHOLE_YEAR_ERROR);
+																void form.setFieldTouched('value', true, false);
+																form.setFieldError('value', WHOLE_NUMBER_ERROR);
 																return;
 															}
 
-															form.setFieldError('year', undefined);
-															const normalizedValue = Math.min(currentYear, Math.max(0, parsedValue));
-															void form.setFieldValue('year', normalizedValue, true);
+															form.setFieldError('value', undefined);
+															void form.setFieldValue('value', parsedValue, true);
 														},
-												}}
+													}}
 												/>
-											</div>
 										)}
 									</Field>
 								</KolForm>


### PR DESCRIPTION
## Summary

Internal sample fix — enforced integer-only input in the year formatter sample by preventing non-integer values.

## Changes

- `samples/input-number/year-formatter.tsx`: Added integer-only validation to prevent non-integer year values

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Interne Sample-Korrektur — Nur-Ganzzahl-Eingabe im Jahresformatierer-Sample erzwungen.

## Änderungen

- `samples/input-number/year-formatter.tsx`: Nur-Ganzzahl-Validierung hinzugefügt

</details>