### PR TITLE
feat(input): add onBeforeInput and onKeyDown callbacks to InputTypeOnDefault

### DIFF
--- a/packages/components/src/components/@deprecated/input/controller.ts
+++ b/packages/components/src/components/@deprecated/input/controller.ts
@@ -264,6 +264,12 @@ export class InputController extends ControlledInputController implements Watche
 		}
 	}
 
+	protected onKeyDown(event: KeyboardEvent): void {
+		if (typeof this.component._on?.onKeyDown === 'function') {
+			this.component._on.onKeyDown(event);
+		}
+	}
+
 	/**
 	 * Hinweis: In der Subklasse 'InputPasswordController'
 	 *          werden die Methoden onBlur und onFocus
@@ -279,6 +285,7 @@ export class InputController extends ControlledInputController implements Watche
 		onClick: this.onClick.bind(this),
 		onFocus: this.onFocus.bind(this),
 		onInput: this.onInput.bind(this),
+		onKeyDown: this.onKeyDown.bind(this),
 	};
 
 	public readonly updateCurrentLengthDebounced = debounce((length: number) => {

--- a/packages/components/src/components/@deprecated/input/controller.ts
+++ b/packages/components/src/components/@deprecated/input/controller.ts
@@ -100,6 +100,12 @@ export class InputController extends ControlledInputController implements Watche
 		validateHint(this.component, value);
 	}
 
+	public validateOn(value?: InputTypeOnDefault): void {
+		if (typeof value === 'object') {
+			setState(this.component, '_on', value);
+		}
+	}
+
 	public validateId(value?: string): void {
 		watchString(this.component, '_id', value, { minLength: 1 });
 		if (value === '' || typeof value === 'undefined') {
@@ -115,12 +121,6 @@ export class InputController extends ControlledInputController implements Watche
 
 	public validateMsg(value?: Stringified<MsgPropType>): void {
 		validateMsg(this.component, value);
-	}
-
-	public validateOn(value?: InputTypeOnDefault): void {
-		if (typeof value === 'object') {
-			setState(this.component, '_on', value);
-		}
 	}
 
 	public validateShortKey(value?: ShortKeyPropType): void {
@@ -258,6 +258,12 @@ export class InputController extends ControlledInputController implements Watche
 		this.valueChangeListeners.push(listener);
 	}
 
+	protected onBeforeInput(event: InputEvent): void {
+		if (typeof this.component._on?.onBeforeInput === 'function') {
+			this.component._on.onBeforeInput(event);
+		}
+	}
+
 	/**
 	 * Hinweis: In der Subklasse 'InputPasswordController'
 	 *          werden die Methoden onBlur und onFocus
@@ -267,6 +273,7 @@ export class InputController extends ControlledInputController implements Watche
 	 *          Oberklassen.
 	 */
 	public readonly onFacade = {
+		onBeforeInput: this.onBeforeInput.bind(this),
 		onBlur: this.onBlur.bind(this),
 		onChange: this.onChange.bind(this),
 		onClick: this.onClick.bind(this),

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -284,7 +284,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputCheckboxController(this, 'checkbox', this.host);
+		this.controller = new InputCheckboxController(this, 'checkbox', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {
@@ -410,9 +410,11 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	};
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.inputRef,
 			});
 		}

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -143,9 +143,11 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	};
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if ((event.code === 'Enter' || event.code === 'NumpadEnter') && !this.isNativeCalendarIconFocused()) {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.inputRef,
 			});
 		}
@@ -336,7 +338,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputDateController(this, 'date', this.host);
+		this.controller = new InputDateController(this, 'date', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -75,9 +75,11 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.inputRef,
 			});
 		}
@@ -291,7 +293,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputEmailController(this, 'email', this.host);
+		this.controller = new InputEmailController(this, 'email', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -109,9 +109,11 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	};
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.inputRef,
 			});
 		}
@@ -305,7 +307,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputNumberController(this, 'number', this.host);
+		this.controller = new InputNumberController(this, 'number', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -80,9 +80,11 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.inputRef,
 			});
 		}
@@ -313,7 +315,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputPasswordController(this, 'password', this.host);
+		this.controller = new InputPasswordController(this, 'password', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -259,7 +259,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputRadioController(this, 'radio', this.host);
+		this.controller = new InputRadioController(this, 'radio', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {
@@ -372,9 +372,11 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	};
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.inputRef,
 			});
 		}

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -121,9 +121,11 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	};
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.refInputNumber,
 			});
 		}
@@ -345,7 +347,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputRangeController(this, 'range', this.host);
+		this.controller = new InputRangeController(this, 'range', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -85,9 +85,11 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	};
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
+		this.controller.onFacade.onKeyDown(event);
+
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
-				form: this.host,
+				form: this.host as HTMLElement | undefined,
 				ref: this.inputRef,
 			});
 		}
@@ -361,7 +363,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@State() private inputHasFocus = false;
 
 	public constructor() {
-		this.controller = new InputTextController(this, 'text', this.host);
+		this.controller = new InputTextController(this, 'text', this.host as HTMLElement | undefined);
 	}
 
 	private showAsAlert(): boolean {

--- a/packages/components/src/schema/enums/callback.ts
+++ b/packages/components/src/schema/enums/callback.ts
@@ -1,4 +1,5 @@
 export enum Callback {
+	onBeforeInput = 'onBeforeInput',
 	onBlur = 'onBlur',
 	onChange = 'onChange',
 	onChangePage = 'onChangePage',

--- a/packages/components/src/schema/types/input/types.ts
+++ b/packages/components/src/schema/types/input/types.ts
@@ -5,6 +5,10 @@ type InputTypeOnBlur = {
 	[Callback.onBlur]?: EventCallback<Event>;
 };
 
+type InputTypeOnBeforeInput = {
+	[Callback.onBeforeInput]?: EventCallback<InputEvent>;
+};
+
 type InputTypeOnClick = {
 	[Callback.onClick]?: EventCallback<Event>;
 };
@@ -39,4 +43,4 @@ export type Optgroup<T> = {
 
 export type SelectOption<T> = Option<T> | Optgroup<T> | RadioOption<T>;
 
-export type InputTypeOnDefault = InputTypeOnBlur & InputTypeOnClick & InputTypeOnChange & InputTypeOnFocus & InputTypeOnInput;
+export type InputTypeOnDefault = InputTypeOnBeforeInput & InputTypeOnBlur & InputTypeOnClick & InputTypeOnChange & InputTypeOnFocus & InputTypeOnInput;

--- a/packages/components/src/schema/types/input/types.ts
+++ b/packages/components/src/schema/types/input/types.ts
@@ -25,6 +25,10 @@ type InputTypeOnInput = {
 	[Callback.onInput]?: EventValueOrEventCallback<Event, unknown>;
 };
 
+type InputTypeOnKeyDown = {
+	[Callback.onKeyDown]?: EventCallback<KeyboardEvent>;
+};
+
 // https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element
 export type Option<T> = {
 	disabled?: boolean;
@@ -43,4 +47,10 @@ export type Optgroup<T> = {
 
 export type SelectOption<T> = Option<T> | Optgroup<T> | RadioOption<T>;
 
-export type InputTypeOnDefault = InputTypeOnBeforeInput & InputTypeOnBlur & InputTypeOnClick & InputTypeOnChange & InputTypeOnFocus & InputTypeOnInput;
+export type InputTypeOnDefault = InputTypeOnBeforeInput &
+	InputTypeOnBlur &
+	InputTypeOnClick &
+	InputTypeOnChange &
+	InputTypeOnFocus &
+	InputTypeOnInput &
+	InputTypeOnKeyDown;

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -14,7 +14,7 @@
 		"lint": "pnpm lint:eslint && pnpm lint:stylelint && pnpm lint:tsc",
 		"lint:eslint": "eslint src",
 		"lint:stylelint": "stylelint \"src/**/*.{css,scss}\"",
-		"lint:tsc": "tsc --noemit",
+                "lint:tsc": "pnpm build:deps && tsc --noemit",
 		"prepare": "npm-run-all2 prepare:*",
 		"prepare:components": "cpy \"node_modules/@public-ui/components/assets/**/*\" public/assets --dot",
 		"prepare:themes": "cpy \"node_modules/@public-ui/themes/assets/**/*\" public/assets --dot",

--- a/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
@@ -18,12 +18,9 @@ class WholeNumberFormatter {
 
 const disallowedCharactersPattern = /[.,eE]/;
 
-const preventInvalidInput: React.FormEventHandler<HTMLInputElement> = (event) => {
-	const nativeEvent = event.nativeEvent as InputEvent;
-	const { data } = nativeEvent;
-
-	if (data !== null && data !== undefined && disallowedCharactersPattern.test(data)) {
-		nativeEvent.preventDefault();
+const preventInvalidKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+	if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && disallowedCharactersPattern.test(event.key)) {
+		event.preventDefault();
 	}
 };
 
@@ -63,7 +60,7 @@ export function InputNumberWholeNumberFormatter() {
 													_step={1}
 													_value={displayValue ?? field.value}
 													_on={{
-														onBeforeInput: preventInvalidInput,
+														onKeyDown: preventInvalidKeyDown,
 														onBlur: () => {
 															void form.setFieldTouched('value', true);
 														},

--- a/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
@@ -18,7 +18,7 @@ class WholeNumberFormatter {
 
 const disallowedCharactersPattern = /[.,eE]/;
 
-const preventInvalidKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+const preventInvalidKeyDown = (event: KeyboardEvent) => {
 	if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && disallowedCharactersPattern.test(event.key)) {
 		event.preventDefault();
 	}
@@ -64,7 +64,7 @@ export function InputNumberWholeNumberFormatter() {
 														onBlur: () => {
 															void form.setFieldTouched('value', true);
 														},
-														onInput: (_, value: unknown) => {
+														onInput: (_event: Event, value: unknown) => {
 															const cleaned = formatter.parse(value);
 															const numValue = cleaned === '' ? undefined : Number(cleaned);
 

--- a/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
+++ b/packages/samples/react/src/components/input-number/whole-number-formatter.tsx
@@ -16,6 +16,17 @@ class WholeNumberFormatter {
 	}
 }
 
+const disallowedCharactersPattern = /[.,eE]/;
+
+const preventInvalidInput: React.FormEventHandler<HTMLInputElement> = (event) => {
+	const nativeEvent = event.nativeEvent as InputEvent;
+	const { data } = nativeEvent;
+
+	if (data !== null && data !== undefined && disallowedCharactersPattern.test(data)) {
+		nativeEvent.preventDefault();
+	}
+};
+
 type WholeNumberFormValues = {
 	value?: number;
 };
@@ -52,6 +63,7 @@ export function InputNumberWholeNumberFormatter() {
 													_step={1}
 													_value={displayValue ?? field.value}
 													_on={{
+														onBeforeInput: preventInvalidInput,
 														onBlur: () => {
 															void form.setFieldTouched('value', true);
 														},


### PR DESCRIPTION
## Summary

Extended `InputTypeOnDefault` with two new optional callback types — `onBeforeInput` and `onKeyDown` — and implemented them across all KoliBri input components. This enables consumers to intercept and control keyboard input behavior at the component level.

## Changes

- `schema/types/input/types.ts`: Added `InputTypeOnBeforeInput` and `InputTypeOnKeyDown` to `InputTypeOnDefault`
- `schema/enums/callback.ts`: Added `Callback.onBeforeInput` and `Callback.onKeyDown`
- `@deprecated/input/controller.ts`: Added `onBeforeInput` and `onKeyDown` to `InputController.onFacade`; reordered `validateOn`
- All input shadow components (`input-checkbox`, `input-date`, `input-email`, `input-number`, `input-password`, `input-radio`, `input-range`, `input-text`): Wired `onKeyDown` via facade in `onKeyDown` handlers
- `samples/input-number/whole-number-formatter.tsx`: Uses `onKeyDown` to block decimal/exponent characters

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

`InputTypeOnDefault` wurde um zwei neue optionale Callback-Typen erweitert — `onBeforeInput` und `onKeyDown` — und in allen KoliBri-Input-Komponenten implementiert. Dies ermöglicht es Verbrauchern, Tastatureingaben auf Komponentenebene abzufangen und zu steuern.

## Änderungen

- `schema/types/input/types.ts`: `InputTypeOnBeforeInput` und `InputTypeOnKeyDown` zu `InputTypeOnDefault` hinzugefügt
- `schema/enums/callback.ts`: `Callback.onBeforeInput` und `Callback.onKeyDown` hinzugefügt
- `InputController`: `onBeforeInput` und `onKeyDown` zu `onFacade` hinzugefügt
- Alle Input-Shadow-Komponenten: `onKeyDown` via Facade in `onKeyDown`-Handlern verdrahtet
- `whole-number-formatter.tsx`-Sample: `onKeyDown` zum Blockieren von Dezimal-/Exponenten-Zeichen verwendet

</details>