### PR TITLE
fix(input-password): add smart-button class to password toggle button

### DIFF
--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -135,7 +135,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 		return (
 			<KolIconButtonFc
 				componentName="button"
-				class="kol-input-password__password-toggle-button"
+				class="kol-input-password__password-toggle-button kol-input-container__smart-button"
 				data-testid="kol-input-password-toggle-button"
 				label={this._passwordVisible ? this.translateHidePassword : this.translateShowPassword}
 				buttonVariant="ghost"


### PR DESCRIPTION
## Summary

Fixed styling of the password visibility toggle button in `kol-input-password` by adding the `kol-input-container__smart-button` CSS class, ensuring consistent rendering with other smart buttons inside input containers.

## Changes

- `input-password/shadow.tsx`: Added `kol-input-container__smart-button` class to the password toggle `KolIconButtonFc`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Stilkorrektur des Passwort-Sichtbarkeits-Toggle-Buttons in `kol-input-password` durch Hinzufügen der CSS-Klasse `kol-input-container__smart-button`, um einheitliches Rendering mit anderen Smart-Buttons in Input-Containern sicherzustellen.

## Änderungen

- `input-password/shadow.tsx`: Klasse `kol-input-container__smart-button` zum Passwort-Toggle `KolIconButtonFc` hinzugefügt

</details>