### PR TITLE
Add Shai-Hulud 2.0 dependency audit

### DIFF
--- a/docs/security/shai-hulud-2.0-audit.md
+++ b/docs/security/shai-hulud-2.0-audit.md
@@ -1,0 +1,40 @@
+# Shai-Hulud 2.0 dependency audit
+
+## Context
+The GitHub issue [#8906](https://github.com/public-ui/kolibri/issues/8906) warns about a large set of compromised NPM packages distributed via the "Shai-Hulud 2.0" worm. The project needs confirmation that none of the published malicious packages are present in this branch.
+
+## Method
+- Pulled the complete indicator list from the issue body via the GitHub API (425 package names).
+- Scanned the current `pnpm-lock.yaml` for any occurrences of those package names to cover both direct and transitive dependencies.
+- Checked all workspace `package.json` files as part of the lockfile scan, since `pnpm-lock.yaml` reflects every dependency resolved in the branch.
+
+To repeat the scan:
+
+```bash
+python - <<'PY'
+import json, subprocess, re, pathlib
+raw = subprocess.check_output(
+    ['curl', '-s', 'https://api.github.com/repos/public-ui/kolibri/issues/8906']
+)
+body = json.loads(raw)['body']
+blocks = re.findall(r"```bash\n([\s\S]*?)```", body)
+items = set()
+for block in blocks:
+    for line in block.splitlines():
+        line = line.strip()
+        if not line or line.startswith('...'):
+            continue
+        for token in re.split(r"\s+", line):
+            token = token.strip(',')
+            if token:
+                items.add(token)
+text = pathlib.Path('pnpm-lock.yaml').read_text()
+found = sorted([name for name in items if name in text])
+print('Flagged packages found:', len(found))
+for name in found:
+    print(name)
+PY
+```
+
+## Result
+No packages from the Shai-Hulud 2.0 list are present in the current lockfile. The scan returned **0** matches.


### PR DESCRIPTION
## Summary
- document the Shai-Hulud 2.0 dependency audit and how to repeat it
- confirm the current lockfile contains no packages from the compromised list

## Testing
- pnpm format *(fails: missing prettier-plugin-organize-imports because node_modules are not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925aaf80e0c832b94f96e5f112ef284)