### PR TITLE
chore: update minimist override to address audit concerns

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,15 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"axios": "^1.12.0",
-			"braces": "^3.0.3",
-			"form-data": "^4.0.4",
-			"glob": "^11.1.0",
-			"lodash.pick": "npm:lodash@^4.17.21",
-			"loupe": "^2.3.7",
-			"semver": "^7.5.2",
-			"tar-fs": "^3.1.1"
+                "axios": "^1.12.0",
+                "braces": "^3.0.3",
+                "form-data": "^4.0.4",
+                "glob": "^11.1.0",
+                "lodash.pick": "npm:lodash@^4.17.21",
+                "loupe": "^2.3.7",
+                "minimist": "1.2.8",
+                "semver": "^7.5.2",
+                "tar-fs": "^3.1.1"
 		}
 	},
 	"private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   glob: ^11.1.0
   lodash.pick: npm:lodash@^4.17.21
   loupe: ^2.3.7
+  minimist: 1.2.8
   semver: ^7.5.2
   tar-fs: ^3.1.1
 
@@ -609,7 +610,7 @@ importers:
         version: 1.3.54(chromedriver@140.0.4)(esbuild@0.25.9)(geckodriver@5.0.0)(typescript@5.9.3)
       '@leanup/stack-solid':
         specifier: 1.3.54
-        version: 1.3.54(@babel/core@7.28.3)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)
+        version: 1.3.54(@babel/core@7.24.7)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)
       '@leanup/stack-webpack':
         specifier: 1.3.54
         version: 1.3.54(@leanup/stack@1.3.54(chromedriver@140.0.4)(esbuild@0.25.9)(geckodriver@5.0.0)(typescript@5.9.3))(esbuild@0.25.9)(less@4.4.0)(postcss@8.5.6)(sass-embedded@1.93.3)(sass@1.93.3)
@@ -781,10 +782,10 @@ importers:
         version: 6.0.0
       eslint-plugin-jsx-a11y:
         specifier: 6.10.2
-        version: 6.10.2(eslint@8.57.1)
+        version: 6.10.2(eslint@8.57.0)
       eslint-plugin-react:
         specifier: 7.37.5
-        version: 7.37.5(eslint@8.57.1)
+        version: 7.37.5(eslint@8.57.0)
       formik:
         specifier: 2.4.9
         version: 2.4.9(react@19.2.0)
@@ -10390,9 +10391,6 @@ packages:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
 
-  minimist@1.2.6:
-    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -17815,11 +17813,11 @@ snapshots:
       - supports-color
       - webpack
 
-  '@leanup/stack-solid@1.3.54(@babel/core@7.28.3)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)':
+  '@leanup/stack-solid@1.3.54(@babel/core@7.24.7)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)':
     dependencies:
       '@leanup/cli-core-babel': 1.3.54(webpack@5.103.0)
       '@snowpack/plugin-babel': 2.1.7
-      babel-preset-solid: 1.8.17(@babel/core@7.28.3)
+      babel-preset-solid: 1.8.17(@babel/core@7.24.7)
       solid-js: 1.9.10
       vite-plugin-solid: 2.10.2(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -17873,7 +17871,7 @@ snapshots:
       '@types/nightwatch': 1.3.4
       '@types/sinon': 10.0.20
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
       chai: 4.4.1
       chromedriver: 140.0.4
       cross-env: 7.0.3
@@ -19865,7 +19863,7 @@ snapshots:
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
@@ -19900,14 +19898,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.0
-      eslint: 8.57.1
+      eslint: 8.57.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -20929,6 +20927,15 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
 
+  babel-plugin-jsx-dom-expressions@0.37.23(@babel/core@7.24.7):
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.24.7)
+      '@babel/types': 7.28.5
+      html-entities: 2.3.3
+      validate-html-nesting: 1.2.2
+
   babel-plugin-jsx-dom-expressions@0.37.23(@babel/core@7.28.3):
     dependencies:
       '@babel/core': 7.28.3
@@ -21010,6 +21017,11 @@ snapshots:
       '@babel/core': 7.28.3
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.3)
+
+  babel-preset-solid@1.8.17(@babel/core@7.24.7):
+    dependencies:
+      '@babel/core': 7.24.7
+      babel-plugin-jsx-dom-expressions: 0.37.23(@babel/core@7.24.7)
 
   babel-preset-solid@1.8.17(@babel/core@7.28.3):
     dependencies:
@@ -22901,6 +22913,25 @@ snapshots:
       lodash: 4.17.21
       vscode-json-languageservice: 4.2.1
 
+  eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.8
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.57.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
     dependencies:
       aria-query: 5.3.2
@@ -22919,6 +22950,28 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-react@7.37.5(eslint@8.57.0):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.1
+      eslint: 8.57.0
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 7.5.2
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
@@ -26241,8 +26294,6 @@ snapshots:
       is-plain-obj: 1.1.0
       kind-of: 6.0.3
 
-  minimist@1.2.6: {}
-
   minimist@1.2.8: {}
 
   minipass-collect@2.0.1:
@@ -26549,7 +26600,7 @@ snapshots:
       lodash.merge: 4.6.2
       lodash.pick: lodash@4.17.21
       minimatch: 3.1.2
-      minimist: 1.2.6
+      minimist: 1.2.8
       mocha: 9.2.2
       nightwatch-axe-verbose: 2.4.0
       open: 8.4.0


### PR DESCRIPTION
## Summary
Internal change — enforces `minimist` 1.2.8 through `pnpm` overrides to replace older vulnerable instances; regenerates lockfile.

## Changes
- Add `minimist` 1.2.8 override in `pnpm` workspace
- Regenerate `pnpm-lock.yaml`

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung
Interne Änderung — erzwingt `minimist` 1.2.8 via `pnpm`-Override, um ältere verwundbare Instanzen zu ersetzen, und aktualisiert den Lockfile.

## Änderungen
- `minimist` 1.2.8 Override im `pnpm`-Workspace hinzugefügt
- `pnpm-lock.yaml` neu generiert
</details>