### PR TITLE
fix: pin minimatch for jsx-a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 			"glob": "^11.1.0",
 			"lodash.pick": "npm:lodash@^4.17.21",
 			"loupe": "^2.3.7",
+			"eslint-plugin-jsx-a11y>minimatch": "^3.1.2",
 			"minimatch": "^9.0.5",
 			"minimist": "1.2.8",
 			"semver": "^7.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   glob: ^11.1.0
   lodash.pick: npm:lodash@^4.17.21
   loupe: ^2.3.7
+  eslint-plugin-jsx-a11y>minimatch: ^3.1.2
   minimatch: ^9.0.5
   minimist: 1.2.8
   semver: ^7.5.2
@@ -627,7 +628,7 @@ importers:
         version: 1.3.54(chromedriver@140.0.4)(esbuild@0.25.9)(geckodriver@5.0.0)(typescript@5.9.3)
       '@leanup/stack-solid':
         specifier: 1.3.54
-        version: 1.3.54(@babel/core@7.28.3)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)
+        version: 1.3.54(@babel/core@7.24.7)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)
       '@leanup/stack-webpack':
         specifier: 1.3.54
         version: 1.3.54(@leanup/stack@1.3.54(chromedriver@140.0.4)(esbuild@0.25.9)(geckodriver@5.0.0)(typescript@5.9.3))(esbuild@0.25.9)(less@4.4.0)(postcss@8.5.6)(sass-embedded@1.93.3)(sass@1.93.3)
@@ -799,10 +800,10 @@ importers:
         version: 6.0.0
       eslint-plugin-jsx-a11y:
         specifier: 6.10.2
-        version: 6.10.2(eslint@8.57.1)
+        version: 6.10.2(eslint@8.57.0)
       eslint-plugin-react:
         specifier: 7.37.5
-        version: 7.37.5(eslint@8.57.1)
+        version: 7.37.5(eslint@8.57.0)
       formik:
         specifier: 2.4.9
         version: 2.4.9(react@19.2.0)
@@ -10021,6 +10022,9 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -17236,11 +17240,11 @@ snapshots:
       - supports-color
       - webpack
 
-  '@leanup/stack-solid@1.3.54(@babel/core@7.28.3)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)':
+  '@leanup/stack-solid@1.3.54(@babel/core@7.24.7)(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))(webpack@5.103.0)':
     dependencies:
       '@leanup/cli-core-babel': 1.3.54(webpack@5.103.0)
       '@snowpack/plugin-babel': 2.1.7
-      babel-preset-solid: 1.8.17(@babel/core@7.28.3)
+      babel-preset-solid: 1.8.17(@babel/core@7.24.7)
       solid-js: 1.9.10
       vite-plugin-solid: 2.10.2(solid-js@1.9.10)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.93.3)(sass@1.93.3)(terser@5.44.1)(tsx@4.19.4)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -17294,7 +17298,7 @@ snapshots:
       '@types/nightwatch': 1.3.4
       '@types/sinon': 10.0.20
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
       chai: 4.4.1
       chromedriver: 140.0.4
       cross-env: 7.0.3
@@ -19284,7 +19288,7 @@ snapshots:
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3))(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.9.3)
@@ -19319,14 +19323,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.0
-      eslint: 8.57.1
+      eslint: 8.57.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -20328,6 +20332,15 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
 
+  babel-plugin-jsx-dom-expressions@0.37.23(@babel/core@7.24.7):
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.24.7)
+      '@babel/types': 7.28.5
+      html-entities: 2.3.3
+      validate-html-nesting: 1.2.2
+
   babel-plugin-jsx-dom-expressions@0.37.23(@babel/core@7.28.3):
     dependencies:
       '@babel/core': 7.28.3
@@ -20409,6 +20422,11 @@ snapshots:
       '@babel/core': 7.28.3
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.3)
+
+  babel-preset-solid@1.8.17(@babel/core@7.24.7):
+    dependencies:
+      '@babel/core': 7.24.7
+      babel-plugin-jsx-dom-expressions: 0.37.23(@babel/core@7.24.7)
 
   babel-preset-solid@1.8.17(@babel/core@7.28.3):
     dependencies:
@@ -22195,6 +22213,25 @@ snapshots:
       lodash: 4.17.21
       vscode-json-languageservice: 4.2.1
 
+  eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.8
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.57.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
     dependencies:
       aria-query: 5.3.2
@@ -22209,10 +22246,32 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 9.0.5
+      minimatch: 3.1.2
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-react@7.37.5(eslint@8.57.0):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.1
+      eslint: 8.57.0
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 9.0.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 7.5.2
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
@@ -25360,6 +25419,10 @@ snapshots:
       webpack: 5.101.2(@swc/core@1.13.5)(esbuild@0.25.9)
 
   minimalistic-assert@1.0.1: {}
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 4.0.1
 
   minimatch@9.0.5:
     dependencies:


### PR DESCRIPTION
## What changed?

Adds a pnpm dependency override so that `eslint-plugin-jsx-a11y` resolves `minimatch` 3.x instead of 9.x, which was causing the ESLint run to crash. The override `eslint-plugin-jsx-a11y>minimatch: ^3.1.2` is added to the `overrides` block of the root `package.json`, and `pnpm-lock.yaml` is regenerated accordingly. This is a build/tooling-only change with no impact on the published components or their runtime behavior.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Fügt einen pnpm-Dependency-Override hinzu, damit `eslint-plugin-jsx-a11y` `minimatch` in Version 3.x statt 9.x auflöst, wodurch ein Absturz des ESLint-Laufs behoben wird. Der Override `eslint-plugin-jsx-a11y>minimatch: ^3.1.2` wird im `overrides`-Block der Root-`package.json` ergänzt und `pnpm-lock.yaml` entsprechend neu erzeugt. Reine Build-/Tooling-Änderung ohne Auswirkung auf die veröffentlichten Komponenten oder deren Laufzeitverhalten.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `package.json` — Neuer pnpm-Override `eslint-plugin-jsx-a11y>minimatch: ^3.1.2`.
- `pnpm-lock.yaml` — Aktualisierte Lockfile nach Anwendung des Overrides.

</details>