### PR TITLE
revert(deps): revert express bump from 5.1.0 to 5.2.0 in mcp

### DIFF
--- a/packages/tools/mcp/package.json
+++ b/packages/tools/mcp/package.json
@@ -68,7 +68,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "1.23.0",
 		"@public-ui/components": "workspace:*",
-		"express": "5.2.0",
+		"express": "5.1.0",
 		"fuse.js": "7.1.0",
 		"zod": "3.25.76"
 	},


### PR DESCRIPTION
## Summary

Internal maintenance — reverted the Dependabot bump of `express` from 5.1.0 to 5.2.0 in the MCP package due to issues introduced by the newer version.

## Changes

- Reverted `express` version in `/packages/tools/mcp` back to 5.1.0

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Interne Wartungsarbeit — Dependabot-Bump von `express` von 5.1.0 auf 5.2.0 im MCP-Paket wegen aufgetretener Probleme zurückgerollt.

## Änderungen

- `express`-Version in `/packages/tools/mcp` zurück auf 5.1.0 gesetzt

</details>