### PR TITLE
feat: add Convert to KoliBri VS Code extension package

### DIFF
--- a/packages/tools/convert-to-kolibri-vscode/.eslintrc.cjs
+++ b/packages/tools/convert-to-kolibri-vscode/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+root: true,
+extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+parserOptions: {
+project: 'tsconfig.json',
+tsconfigRootDir: __dirname,
+sourceType: 'module',
+},
+plugins: ['@typescript-eslint'],
+rules: {
+eqeqeq: 'error',
+},
+};

--- a/packages/tools/convert-to-kolibri-vscode/README.md
+++ b/packages/tools/convert-to-kolibri-vscode/README.md
@@ -1,0 +1,31 @@
+# Convert to KoliBri VS Code Extension
+
+## Why this exists
+
+The "Convert to KoliBri" extension accelerates accessibility migrations by turning plain HTML or TSX snippets into KoliBri components that are BITV-ready by default. It focuses on the highest-impact elements first: buttons, inputs, links and selects.
+
+## Features (MVP)
+
+- **Convert selection**: Right-click or run the command palette action to replace the current selection (or the whole file) with KoliBri-aware markup.
+- **Document scan**: Get a quick summary of how many buttons, inputs, links and selects can be migrated before committing to a full conversion.
+- **Confidence scores**: Suggestions annotate whether a migration is safe to auto-apply or should be reviewed manually.
+
+## Commands
+
+- `KoliBri: Convert selection to KoliBri` (`kolibri.convertSelection`)
+- `KoliBri: Scan document for convertible components` (`kolibri.scanDocument`)
+
+## How conversion works
+
+- **HTML**: Lightweight pattern matching transforms common elements into their KoliBri equivalents (`<button>` → `<kol-button>`, `<input>` + `<label>` → `<kol-input-text>`, etc.).
+- **TSX/JSX**: Babel parses the file to rewrite JSX elements into their KoliBri counterparts while preserving event handlers, hints and validation flags when possible.
+- **Confidence**: Conversions with simple text labels and well-mapped props are marked `high`; ambiguous labels or unknown variants are `medium` and carry a warning.
+
+## Local development
+
+```bash
+pnpm install
+pnpm --filter @public-ui/convert-to-kolibri-vscode build
+```
+
+Open the `packages/tools/convert-to-kolibri-vscode` folder in VS Code and run the "Launch Extension" debug task to try it out.

--- a/packages/tools/convert-to-kolibri-vscode/package.json
+++ b/packages/tools/convert-to-kolibri-vscode/package.json
@@ -1,0 +1,68 @@
+{
+	"name": "@public-ui/convert-to-kolibri-vscode",
+	"displayName": "Convert to KoliBri",
+	"version": "0.1.0",
+	"description": "VS Code extension that migrates HTML or TSX snippets into accessible KoliBri components.",
+	"license": "EUPL-1.2",
+	"homepage": "https://public-ui.github.io",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/public-ui/kolibri"
+	},
+	"bugs": {
+		"url": "https://github.com/public-ui/kolibri/issues",
+		"email": "kolibri@itzbund.de"
+	},
+	"author": {
+		"name": "Informationstechnikzentrum Bund",
+		"email": "kolibri@itzbund.de"
+	},
+	"private": true,
+	"main": "./dist/extension.js",
+	"type": "commonjs",
+	"engines": {
+		"vscode": "^1.93.0",
+		"node": ">=18"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"onCommand:kolibri.convertSelection",
+		"onCommand:kolibri.scanDocument"
+	],
+	"contributes": {
+		"commands": [
+			{
+				"command": "kolibri.convertSelection",
+				"title": "KoliBri: Convert selection to KoliBri"
+			},
+			{
+				"command": "kolibri.scanDocument",
+				"title": "KoliBri: Scan document for convertible components"
+			}
+		]
+	},
+	"scripts": {
+		"build": "tsc -p .",
+		"format": "prettier -c src README.md package.json tsconfig.json",
+		"lint": "pnpm lint:tsc",
+		"lint:tsc": "tsc --noEmit"
+	},
+	"files": [
+		"dist"
+	],
+	"dependencies": {
+		"@babel/generator": "7.28.5",
+		"@babel/parser": "7.28.5",
+		"@babel/traverse": "7.28.5",
+		"@babel/types": "7.28.5"
+	},
+	"devDependencies": {
+		"@types/node": "24.10.1",
+		"@types/vscode": "1.93.0",
+		"prettier": "3.7.3",
+		"prettier-plugin-organize-imports": "4.3.0",
+		"typescript": "5.9.3"
+	}
+}

--- a/packages/tools/convert-to-kolibri-vscode/src/conversion/html-converter.ts
+++ b/packages/tools/convert-to-kolibri-vscode/src/conversion/html-converter.ts
@@ -1,0 +1,290 @@
+import { ConversionCandidate, ConversionOutput, ScanSummary } from './types';
+
+interface AttributeMap {
+	[key: string]: string | boolean;
+}
+
+const buttonPattern = /<button\b([^>]*)>([\s\S]*?)<\/button>/gi;
+const labelledInputPattern = /<label[^>]*>([^<]*)<\/label>\s*<input([^>]*)>/gi;
+const inputPattern = /<input([^>]*)>/gi;
+const anchorPattern = /<a\b([^>]*)>([\s\S]*?)<\/a>/gi;
+const selectPattern = /<select\b([^>]*)>([\s\S]*?)<\/select>/gi;
+
+const variantClasses: Record<string, string> = {
+	primary: 'primary',
+	secondary: 'secondary',
+	success: 'success',
+	danger: 'danger',
+	warning: 'warning',
+};
+
+const selectVariants = ['outline', 'ghost', 'solid'];
+
+function parseAttributes(text: string): AttributeMap {
+	const attributes: AttributeMap = {};
+	const regex = /(\w[\w-]*)(?:=("([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(text)) !== null) {
+		const [, key, , doubleQuoted, singleQuoted, bare] = match;
+		attributes[key] = doubleQuoted ?? singleQuoted ?? bare ?? true;
+	}
+
+	return attributes;
+}
+
+function extractLabel(content: string): string {
+	const withoutTags = content
+		.replace(/<[^>]*>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+	return withoutTags || 'Label';
+}
+
+function extractIcon(content: string): string | undefined {
+	const iconMatch = /<i[^>]*class=(?:"([^"]*)"|'([^']*)')/i.exec(content);
+	if (!iconMatch) {
+		return undefined;
+	}
+
+	const iconClass = iconMatch[1] ?? iconMatch[2];
+	if (!iconClass) {
+		return undefined;
+	}
+
+	const classes = iconClass.split(/\s+/);
+	return classes.find((item) => item.startsWith('fa-'));
+}
+
+function mapVariant(classValue?: string | boolean): string | undefined {
+	if (!classValue || typeof classValue !== 'string') {
+		return undefined;
+	}
+
+	const classes = classValue.split(/\s+/).filter(Boolean);
+	const match = classes.find((item) => variantClasses[item]);
+	return match ? variantClasses[match] : undefined;
+}
+
+function mapSelectVariant(classValue?: string | boolean): string | undefined {
+	if (!classValue || typeof classValue !== 'string') {
+		return undefined;
+	}
+
+	const classes = classValue.split(/\s+/).filter(Boolean);
+	return classes.find((item) => selectVariants.includes(item));
+}
+
+function normalizeBoolean(value: string | boolean | undefined): boolean {
+	if (value === undefined) {
+		return false;
+	}
+
+	if (typeof value === 'boolean') {
+		return value;
+	}
+
+	return value === '' || value.toLowerCase() === 'true';
+}
+
+function convertButtonMatch(_: string, attributeText: string, content: string): ConversionCandidate {
+	const attributes = parseAttributes(attributeText);
+	const label = extractLabel(content);
+	const variant = mapVariant(attributes.class ?? attributes.className);
+	const icon = extractIcon(content);
+	const disabled = normalizeBoolean(attributes.disabled);
+
+	let replacement = `<kol-button _label="${label}"`;
+	if (variant) {
+		replacement += ` _variant="${variant}"`;
+	}
+	if (icon) {
+		replacement += ` _icon="${icon}"`;
+	}
+	if (disabled) {
+		replacement += ' _disabled="true"';
+	}
+	replacement += '></kol-button>';
+
+	const warnings: string[] = [];
+	if (!icon && /<i/i.test(content)) {
+		warnings.push('Icon detected but could not be mapped');
+	}
+
+	return {
+		kind: 'button',
+		confidence: label ? 'high' : 'medium',
+		original: content,
+		replacement,
+		reason: variant ? 'Mapped button variant from class name' : 'Defaulted to standard kol-button',
+		warnings: warnings.length ? warnings : undefined,
+	};
+}
+
+function convertLabelledInputMatch(_: string, labelContent: string, attributeText: string): ConversionCandidate {
+	const attributes = parseAttributes(attributeText);
+	const label = extractLabel(labelContent);
+	const type = typeof attributes.type === 'string' ? attributes.type : 'text';
+	const hint = typeof attributes.placeholder === 'string' ? attributes.placeholder : undefined;
+	const required = normalizeBoolean(attributes.required);
+	const replacementParts = [`<kol-input-${type} _label="${label}"`];
+
+	if (type !== 'text') {
+		replacementParts.push(` _type="${type}"`);
+	}
+	if (hint) {
+		replacementParts.push(` _hint="${hint}"`);
+	}
+	if (required) {
+		replacementParts.push(' _required="true"');
+	}
+
+	replacementParts.push(' />');
+
+	return {
+		kind: 'input',
+		confidence: 'high',
+		original: `<label>${label}</label><input ... />`,
+		replacement: replacementParts.join(''),
+		reason: 'Mapped label and validation hints from HTML pair',
+	};
+}
+
+function convertInputMatch(_: string, attributeText: string): ConversionCandidate {
+	const attributes = parseAttributes(attributeText);
+	const type = typeof attributes.type === 'string' ? attributes.type : 'text';
+	const label =
+		(typeof attributes['aria-label'] === 'string' && attributes['aria-label']) ||
+		(typeof attributes.placeholder === 'string' && attributes.placeholder) ||
+		(type !== 'text' ? `${type} input` : 'Input');
+	const hint = typeof attributes.placeholder === 'string' ? attributes.placeholder : undefined;
+	const required = normalizeBoolean(attributes.required);
+	const replacementParts = [`<kol-input-${type} _label="${label}"`];
+
+	if (type !== 'text') {
+		replacementParts.push(` _type="${type}"`);
+	}
+	if (hint) {
+		replacementParts.push(` _hint="${hint}"`);
+	}
+	if (required) {
+		replacementParts.push(' _required="true"');
+	}
+
+	replacementParts.push(' />');
+
+	const warnings: string[] = [];
+	if (!attributes.placeholder && !attributes['aria-label']) {
+		warnings.push('No explicit label found; placeholder was used as label');
+	}
+
+	return {
+		kind: 'input',
+		confidence: warnings.length ? 'medium' : 'high',
+		original: `<input ${attributeText.trim()}/>`,
+		replacement: replacementParts.join(''),
+		reason: 'Mapped input attributes to kol-input props',
+		warnings: warnings.length ? warnings : undefined,
+	};
+}
+
+function convertAnchorMatch(_: string, attributeText: string, content: string): ConversionCandidate {
+	const attributes = parseAttributes(attributeText);
+	const href = typeof attributes.href === 'string' ? attributes.href : '#';
+	const label = extractLabel(content);
+	const replacement = `<kol-link _href="${href}" _label="${label}"></kol-link>`;
+
+	return {
+		kind: 'link',
+		confidence: 'high',
+		original: content,
+		replacement,
+		reason: 'Anchor converted to kol-link',
+	};
+}
+
+function convertSelectMatch(_: string, attributeText: string, content: string): ConversionCandidate {
+	const attributes = parseAttributes(attributeText);
+	const variant = mapSelectVariant(attributes.class ?? attributes.className);
+	let replacement = '<kol-select';
+
+	if (variant) {
+		replacement += ` _variant="${variant}"`;
+	}
+
+	replacement += `>${content}</kol-select>`;
+
+	return {
+		kind: 'select',
+		confidence: 'medium',
+		original: content,
+		replacement,
+		reason: 'Select converted to kol-select',
+		warnings: variant ? undefined : ['Select variant unknown; default styles applied'],
+	};
+}
+
+function applyPattern(source: string, pattern: RegExp, handler: (...args: string[]) => ConversionCandidate): ConversionOutput {
+	const candidates: ConversionCandidate[] = [];
+	pattern.lastIndex = 0;
+	const text = source.replace(pattern, (...args) => {
+		const candidate = handler(...args);
+		candidates.push(candidate);
+		return candidate.replacement;
+	});
+
+	return { text, candidates };
+}
+
+export function convertHtml(source: string): ConversionOutput {
+	const aggregatedCandidates: ConversionCandidate[] = [];
+	let output = source;
+
+	const buttonResult = applyPattern(output, buttonPattern, convertButtonMatch);
+	output = buttonResult.text;
+	aggregatedCandidates.push(...buttonResult.candidates);
+
+	const labelledInputResult = applyPattern(output, labelledInputPattern, convertLabelledInputMatch);
+	output = labelledInputResult.text;
+	aggregatedCandidates.push(...labelledInputResult.candidates);
+
+	const inputResult = applyPattern(output, inputPattern, convertInputMatch);
+	output = inputResult.text;
+	aggregatedCandidates.push(...inputResult.candidates);
+
+	const anchorResult = applyPattern(output, anchorPattern, convertAnchorMatch);
+	output = anchorResult.text;
+	aggregatedCandidates.push(...anchorResult.candidates);
+
+	const selectResult = applyPattern(output, selectPattern, convertSelectMatch);
+	output = selectResult.text;
+	aggregatedCandidates.push(...selectResult.candidates);
+
+	return { text: output, candidates: aggregatedCandidates };
+}
+
+export function scanHtml(source: string): ScanSummary {
+	const candidates: ConversionCandidate[] = [];
+
+	const apply = (pattern: RegExp, handler: (...args: string[]) => ConversionCandidate): void => {
+		pattern.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = pattern.exec(source)) !== null) {
+			const candidate = handler(...(match as unknown as string[]));
+			candidates.push(candidate);
+		}
+	};
+
+	apply(buttonPattern, convertButtonMatch);
+	apply(labelledInputPattern, convertLabelledInputMatch);
+	apply(inputPattern, convertInputMatch);
+	apply(anchorPattern, convertAnchorMatch);
+	apply(selectPattern, convertSelectMatch);
+
+	const counts = candidates.reduce<Record<string, number>>((accumulator, item) => {
+		accumulator[item.kind] = (accumulator[item.kind] ?? 0) + 1;
+		return accumulator;
+	}, {});
+
+	return { counts, candidates };
+}

--- a/packages/tools/convert-to-kolibri-vscode/src/conversion/tsx-converter.ts
+++ b/packages/tools/convert-to-kolibri-vscode/src/conversion/tsx-converter.ts
@@ -1,0 +1,389 @@
+import generate from '@babel/generator';
+import { parse } from '@babel/parser';
+import traverse, { NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
+import { ConversionCandidate, ConversionOutput, ScanSummary } from './types';
+
+function getName(node: t.JSXIdentifier | t.JSXNamespacedName | t.JSXMemberExpression): string | undefined {
+	if (t.isJSXIdentifier(node)) {
+		return node.name;
+	}
+
+	return undefined;
+}
+
+function stringLiteral(value: string): t.JSXExpressionContainer {
+	return t.jsxExpressionContainer(t.stringLiteral(value));
+}
+
+function booleanLiteral(value: boolean): t.JSXExpressionContainer {
+	return t.jsxExpressionContainer(t.booleanLiteral(value));
+}
+
+function normalizeText(children: t.JSXElement['children']): string | undefined {
+	const textNodes = children.filter((child) => t.isJSXText(child));
+	const label = textNodes
+		.map((node) => node.value)
+		.join(' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+
+	return label || undefined;
+}
+
+function extractClassName(attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>): string | undefined {
+	const attribute = attributes.find((item): item is t.JSXAttribute => t.isJSXAttribute(item) && t.isJSXIdentifier(item.name) && item.name.name === 'className');
+
+	if (!attribute || !attribute.value) {
+		return undefined;
+	}
+
+	if (t.isStringLiteral(attribute.value)) {
+		return attribute.value.value;
+	}
+
+	return undefined;
+}
+
+function mapVariantFromClassName(classes?: string): string | undefined {
+	if (!classes) {
+		return undefined;
+	}
+
+	const variants = ['primary', 'secondary', 'success', 'danger', 'warning'];
+	const classList = classes.split(/\s+/);
+	return classList.find((item) => variants.includes(item));
+}
+
+function extractIconFromChildren(children: t.JSXElement['children']): string | undefined {
+	const iconElement = children.find(
+		(child): child is t.JSXElement => t.isJSXElement(child) && t.isJSXIdentifier(child.openingElement.name) && child.openingElement.name.name === 'i',
+	);
+
+	if (!iconElement) {
+		return undefined;
+	}
+
+	const className = extractClassName(iconElement.openingElement.attributes);
+	if (!className) {
+		return undefined;
+	}
+
+	const classes = className.split(/\s+/);
+	return classes.find((item) => item.startsWith('fa-'));
+}
+
+function extractEventHandlers(attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>): {
+	eventAttribute: t.JSXAttribute | null;
+	remaining: Array<t.JSXAttribute | t.JSXSpreadAttribute>;
+	warning?: string;
+} {
+	const properties: t.ObjectProperty[] = [];
+	const remaining: Array<t.JSXAttribute | t.JSXSpreadAttribute> = [];
+	let warning: string | undefined;
+
+	for (const attribute of attributes) {
+		if (!t.isJSXAttribute(attribute) || !t.isJSXIdentifier(attribute.name)) {
+			remaining.push(attribute);
+			continue;
+		}
+
+		if (!attribute.name.name.startsWith('on')) {
+			remaining.push(attribute);
+			continue;
+		}
+
+		if (!attribute.value || !t.isJSXExpressionContainer(attribute.value)) {
+			warning = 'Event handler without expression could not be mapped';
+			continue;
+		}
+
+		properties.push(t.objectProperty(t.identifier(attribute.name.name), attribute.value.expression as t.Expression));
+	}
+
+	if (!properties.length) {
+		return { eventAttribute: null, remaining, warning };
+	}
+
+	return {
+		eventAttribute: t.jsxAttribute(t.jsxIdentifier('_on'), t.jsxExpressionContainer(t.objectExpression(properties))),
+		remaining,
+		warning,
+	};
+}
+
+function convertButton(path: NodePath<t.JSXElement>, candidates: ConversionCandidate[]): void {
+	const original = generate(path.node).code;
+	const attributes = path.node.openingElement.attributes;
+	const label = normalizeText(path.node.children);
+	const className = extractClassName(attributes);
+	const variant = mapVariantFromClassName(className);
+	const icon = extractIconFromChildren(path.node.children);
+	const disabled = attributes.some((attribute) => t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name) && attribute.name.name === 'disabled');
+	const { eventAttribute, remaining, warning } = extractEventHandlers(attributes);
+
+	path.node.openingElement.name = t.jsxIdentifier('KolButton');
+	if (path.node.closingElement) {
+		path.node.closingElement.name = t.jsxIdentifier('KolButton');
+	}
+
+	path.node.children = [];
+	const newAttributes: Array<t.JSXAttribute | t.JSXSpreadAttribute> = [];
+
+	if (label) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_label'), stringLiteral(label)));
+	}
+	if (variant) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_variant'), stringLiteral(variant)));
+	}
+	if (icon) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_icon'), stringLiteral(icon)));
+	}
+	if (disabled) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_disabled'), booleanLiteral(true)));
+	}
+	if (eventAttribute) {
+		newAttributes.push(eventAttribute);
+	}
+
+	for (const attribute of remaining) {
+		if (t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name) && attribute.name.name === 'className') {
+			continue;
+		}
+
+		newAttributes.push(attribute);
+	}
+
+	path.node.openingElement.attributes = newAttributes;
+
+	const replacement = generate(path.node).code;
+	const warnings = [];
+
+	if (!label) {
+		warnings.push('Button label was inferred from children; please verify the _label prop');
+	}
+	if (!variant && className) {
+		warnings.push('Button class could not be mapped to a variant');
+	}
+	if (warning) {
+		warnings.push(warning);
+	}
+
+	candidates.push({
+		kind: 'button',
+		confidence: warnings.length ? 'medium' : 'high',
+		original,
+		replacement,
+		reason: 'Converted JSX button into KolButton with mapped props',
+		warnings: warnings.length ? warnings : undefined,
+	});
+}
+
+function convertInput(path: NodePath<t.JSXElement>, candidates: ConversionCandidate[]): void {
+	const original = generate(path.node).code;
+	const attributes = path.node.openingElement.attributes;
+	const className = extractClassName(attributes);
+	const typeAttribute = attributes.find((item): item is t.JSXAttribute => t.isJSXAttribute(item) && t.isJSXIdentifier(item.name) && item.name.name === 'type');
+	const placeholderAttribute = attributes.find(
+		(item): item is t.JSXAttribute =>
+			t.isJSXAttribute(item) && t.isJSXIdentifier(item.name) && (item.name.name === 'placeholder' || item.name.name === 'aria-label'),
+	);
+	const requiredAttribute = attributes.find(
+		(item): item is t.JSXAttribute => t.isJSXAttribute(item) && t.isJSXIdentifier(item.name) && item.name.name === 'required',
+	);
+	const typeValue = typeAttribute && typeAttribute.value && t.isStringLiteral(typeAttribute.value) ? typeAttribute.value.value : 'text';
+	const label =
+		placeholderAttribute && placeholderAttribute.value && t.isStringLiteral(placeholderAttribute.value)
+			? placeholderAttribute.value.value
+			: typeValue !== 'text'
+				? `${typeValue} input`
+				: undefined;
+	const { eventAttribute, remaining, warning } = extractEventHandlers(attributes);
+
+	path.node.openingElement.name = t.jsxIdentifier('KolInputText');
+	path.node.closingElement = null;
+	path.node.openingElement.selfClosing = true;
+	path.node.children = [];
+
+	const newAttributes: Array<t.JSXAttribute | t.JSXSpreadAttribute> = [];
+	if (label) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_label'), stringLiteral(label)));
+	}
+	if (typeValue) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_type'), stringLiteral(typeValue)));
+	}
+	if (requiredAttribute) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_required'), booleanLiteral(true)));
+	}
+	if (placeholderAttribute && placeholderAttribute.value && t.isStringLiteral(placeholderAttribute.value)) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_hint'), stringLiteral(placeholderAttribute.value.value)));
+	}
+	if (eventAttribute) {
+		newAttributes.push(eventAttribute);
+	}
+
+	for (const attribute of remaining) {
+		if (t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name) && attribute.name.name === 'className') {
+			continue;
+		}
+		if (attribute === typeAttribute || attribute === placeholderAttribute || attribute === requiredAttribute) {
+			continue;
+		}
+		newAttributes.push(attribute);
+	}
+
+	path.node.openingElement.attributes = newAttributes;
+
+	const replacement = generate(path.node).code;
+	const warnings = [];
+
+	if (!label) {
+		warnings.push('Input had no label; placeholder was used to seed _label');
+	}
+	if (!className && !typeAttribute) {
+		warnings.push('Input styling and type should be verified after conversion');
+	}
+	if (warning) {
+		warnings.push(warning);
+	}
+
+	candidates.push({
+		kind: 'input',
+		confidence: warnings.length ? 'medium' : 'high',
+		original,
+		replacement,
+		reason: 'Converted JSX input into KolInputText',
+		warnings: warnings.length ? warnings : undefined,
+	});
+}
+
+function convertLink(path: NodePath<t.JSXElement>, candidates: ConversionCandidate[]): void {
+	const original = generate(path.node).code;
+	const attributes = path.node.openingElement.attributes;
+	const hrefAttribute = attributes.find((item): item is t.JSXAttribute => t.isJSXAttribute(item) && t.isJSXIdentifier(item.name) && item.name.name === 'href');
+	const label = normalizeText(path.node.children);
+
+	path.node.openingElement.name = t.jsxIdentifier('KolLink');
+	if (path.node.closingElement) {
+		path.node.closingElement.name = t.jsxIdentifier('KolLink');
+	}
+	path.node.children = [];
+
+	const newAttributes: Array<t.JSXAttribute | t.JSXSpreadAttribute> = [];
+	if (hrefAttribute && hrefAttribute.value && t.isStringLiteral(hrefAttribute.value)) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_href'), stringLiteral(hrefAttribute.value.value)));
+	}
+	if (label) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_label'), stringLiteral(label)));
+	}
+
+	path.node.openingElement.attributes = newAttributes;
+
+	const replacement = generate(path.node).code;
+	const warnings = [];
+
+	if (!hrefAttribute) {
+		warnings.push('Link without href converted to KolLink; please add _href');
+	}
+	if (!label) {
+		warnings.push('Link text missing; _label seeded from children if possible');
+	}
+
+	candidates.push({
+		kind: 'link',
+		confidence: warnings.length ? 'medium' : 'high',
+		original,
+		replacement,
+		reason: 'Converted anchor into KolLink',
+		warnings: warnings.length ? warnings : undefined,
+	});
+}
+
+function convertSelect(path: NodePath<t.JSXElement>, candidates: ConversionCandidate[]): void {
+	const original = generate(path.node).code;
+	const attributes = path.node.openingElement.attributes;
+	const className = extractClassName(attributes);
+	const variant = mapVariantFromClassName(className);
+
+	path.node.openingElement.name = t.jsxIdentifier('KolSelect');
+	if (path.node.closingElement) {
+		path.node.closingElement.name = t.jsxIdentifier('KolSelect');
+	}
+
+	const newAttributes: Array<t.JSXAttribute | t.JSXSpreadAttribute> = [];
+	if (variant) {
+		newAttributes.push(t.jsxAttribute(t.jsxIdentifier('_variant'), stringLiteral(variant)));
+	}
+
+	for (const attribute of attributes) {
+		if (t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name) && attribute.name.name === 'className') {
+			continue;
+		}
+		newAttributes.push(attribute);
+	}
+
+	path.node.openingElement.attributes = newAttributes;
+
+	const replacement = generate(path.node).code;
+	const warnings = [];
+
+	if (!variant && className) {
+		warnings.push('Select class could not be mapped to a variant');
+	}
+
+	candidates.push({
+		kind: 'select',
+		confidence: warnings.length ? 'medium' : 'high',
+		original,
+		replacement,
+		reason: 'Converted JSX select into KolSelect',
+		warnings: warnings.length ? warnings : undefined,
+	});
+}
+
+function convertElement(path: NodePath<t.JSXElement>, candidates: ConversionCandidate[]): void {
+	const name = getName(path.node.openingElement.name);
+
+	if (name === 'button' || name === 'Button') {
+		convertButton(path, candidates);
+		return;
+	}
+
+	if (name === 'input' || name === 'Input') {
+		convertInput(path, candidates);
+		return;
+	}
+
+	if (name === 'a') {
+		convertLink(path, candidates);
+		return;
+	}
+
+	if (name === 'select') {
+		convertSelect(path, candidates);
+	}
+}
+
+export function convertTsx(source: string): ConversionOutput {
+	const ast = parse(source, { sourceType: 'module', plugins: ['jsx', 'typescript'] });
+	const candidates: ConversionCandidate[] = [];
+
+	traverse(ast, {
+		JSXElement(path) {
+			convertElement(path, candidates);
+		},
+	});
+
+	const text = generate(ast, { retainLines: true }).code;
+	return { text, candidates };
+}
+
+export function scanTsx(source: string): ScanSummary {
+	const conversion = convertTsx(source);
+	const counts = conversion.candidates.reduce<Record<string, number>>((accumulator, item) => {
+		accumulator[item.kind] = (accumulator[item.kind] ?? 0) + 1;
+		return accumulator;
+	}, {});
+
+	return { counts, candidates: conversion.candidates };
+}

--- a/packages/tools/convert-to-kolibri-vscode/src/conversion/types.ts
+++ b/packages/tools/convert-to-kolibri-vscode/src/conversion/types.ts
@@ -1,0 +1,20 @@
+export type Confidence = 'high' | 'medium' | 'low';
+
+export interface ConversionCandidate {
+	kind: 'button' | 'input' | 'link' | 'select' | 'unknown';
+	confidence: Confidence;
+	original: string;
+	replacement: string;
+	reason?: string;
+	warnings?: string[];
+}
+
+export interface ConversionOutput {
+	text: string;
+	candidates: ConversionCandidate[];
+}
+
+export interface ScanSummary {
+	counts: Record<string, number>;
+	candidates: ConversionCandidate[];
+}

--- a/packages/tools/convert-to-kolibri-vscode/src/extension.ts
+++ b/packages/tools/convert-to-kolibri-vscode/src/extension.ts
@@ -1,0 +1,113 @@
+import * as vscode from 'vscode';
+import { convertHtml, scanHtml } from './conversion/html-converter';
+import { convertTsx, scanTsx } from './conversion/tsx-converter';
+import { ConversionOutput, ScanSummary } from './conversion/types';
+
+function getConverter(languageId: string): {
+	convert: (text: string) => ConversionOutput;
+	scan: (text: string) => ScanSummary;
+	label: string;
+} {
+	if (languageId === 'javascriptreact' || languageId === 'typescriptreact' || languageId === 'javascript' || languageId === 'typescript') {
+		return { convert: convertTsx, scan: scanTsx, label: 'TSX/JSX' };
+	}
+
+	return { convert: convertHtml, scan: scanHtml, label: 'HTML' };
+}
+
+function summarizeCandidates(summary: ScanSummary): string {
+	const parts = Object.entries(summary.counts)
+		.map(([kind, count]) => `${count}× ${kind}`)
+		.join(', ');
+
+	return parts || '0 candidates';
+}
+
+function logCandidates(channel: vscode.OutputChannel, output: ConversionOutput): void {
+	channel.appendLine('Convert to KoliBri results:');
+	output.candidates.forEach((candidate, index) => {
+		channel.appendLine(` ${index + 1}. ${candidate.kind} → ${candidate.replacement}`);
+		channel.appendLine(`    confidence: ${candidate.confidence}`);
+		if (candidate.reason) {
+			channel.appendLine(`    reason: ${candidate.reason}`);
+		}
+		if (candidate.warnings?.length) {
+			channel.appendLine(`    warnings: ${candidate.warnings.join('; ')}`);
+		}
+	});
+	channel.appendLine('');
+}
+
+async function convertSelection(editor: vscode.TextEditor, channel: vscode.OutputChannel): Promise<void> {
+	const { convert, label } = getConverter(editor.document.languageId);
+	const selection = editor.selection.isEmpty
+		? new vscode.Range(editor.document.positionAt(0), editor.document.positionAt(editor.document.getText().length))
+		: editor.selection;
+	const selectedText = editor.document.getText(selection);
+	const result = convert(selectedText);
+
+	await editor.edit((builder) => {
+		builder.replace(selection, result.text);
+	});
+
+	logCandidates(channel, result);
+	vscode.window.showInformationMessage(`Converted ${result.candidates.length} fragment(s) from ${label} to KoliBri.`);
+}
+
+async function scanDocument(editor: vscode.TextEditor, channel: vscode.OutputChannel): Promise<void> {
+	const { scan, label } = getConverter(editor.document.languageId);
+	const text = editor.document.getText();
+	const summary = scan(text);
+
+	channel.appendLine('Convert to KoliBri scan:');
+	summary.candidates.forEach((candidate, index) => {
+		channel.appendLine(` ${index + 1}. ${candidate.kind} (confidence: ${candidate.confidence})`);
+		if (candidate.warnings?.length) {
+			channel.appendLine(`    warnings: ${candidate.warnings.join('; ')}`);
+		}
+	});
+	channel.appendLine('');
+
+	const parts = summarizeCandidates(summary);
+	vscode.window.showInformationMessage(`KoliBri scan detected ${parts} in this ${label} file.`);
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+	const channel = vscode.window.createOutputChannel('KoliBri Convert');
+
+	const convertCommand = vscode.commands.registerCommand('kolibri.convertSelection', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showErrorMessage('No active editor to convert.');
+			return;
+		}
+
+		try {
+			await convertSelection(editor, channel);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			vscode.window.showErrorMessage(`Conversion failed: ${message}`);
+		}
+	});
+
+	const scanCommand = vscode.commands.registerCommand('kolibri.scanDocument', async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showErrorMessage('No active editor to scan.');
+			return;
+		}
+
+		try {
+			await scanDocument(editor, channel);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			vscode.window.showErrorMessage(`Scan failed: ${message}`);
+		}
+	});
+
+	context.subscriptions.push(convertCommand, scanCommand, channel);
+}
+
+export function deactivate(): void {
+	// no-op
+}

--- a/packages/tools/convert-to-kolibri-vscode/tsconfig.json
+++ b/packages/tools/convert-to-kolibri-vscode/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "commonjs",
+		"lib": ["ES2020"],
+		"moduleResolution": "node",
+		"outDir": "dist",
+		"rootDir": "src",
+		"sourceMap": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"types": ["node", "vscode"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1114,6 +1114,37 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/tools/convert-to-kolibri-vscode:
+    dependencies:
+      '@babel/generator':
+        specifier: 7.28.5
+        version: 7.28.5
+      '@babel/parser':
+        specifier: 7.28.5
+        version: 7.28.5
+      '@babel/traverse':
+        specifier: 7.28.5
+        version: 7.28.5
+      '@babel/types':
+        specifier: 7.28.5
+        version: 7.28.5
+    devDependencies:
+      '@types/node':
+        specifier: 24.10.1
+        version: 24.10.1
+      '@types/vscode':
+        specifier: 1.93.0
+        version: 1.93.0
+      prettier:
+        specifier: 3.7.3
+        version: 3.7.3
+      prettier-plugin-organize-imports:
+        specifier: 4.3.0
+        version: 4.3.0(prettier@3.7.3)(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   packages/tools/hydrate-server:
     dependencies:
       '@grpc/grpc-js':
@@ -1815,21 +1846,6 @@ packages:
     resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.0':
-    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.28.3':
-    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.28.4':
-    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
@@ -2361,10 +2377,6 @@ packages:
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.28.3':
-    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.28.5':
@@ -5805,6 +5817,9 @@ packages:
 
   '@types/twig@1.12.17':
     resolution: {integrity: sha512-Lxcjgzt4mlDrv1xp1EdoBLPTxpjLAt9vtN3/qoblC5D6hMCYgZJOQHfaT/0gwCcAZENnKQ7Sga28DSsckPWa0g==}
+
+  '@types/vscode@1.93.0':
+    resolution: {integrity: sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==}
 
   '@types/wcag-contrast@3.0.3':
     resolution: {integrity: sha512-oprevfwJSLfpQK4KaWsRKJuNoebV76+xhmbXiWJGy+FkS34LpCgCMNIwRXWTb8xmmSxUE2ycFOYE7uyRVRm3LA==}
@@ -15426,7 +15441,7 @@ snapshots:
 
   '@babel/generator@7.28.3':
     dependencies:
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
@@ -15494,7 +15509,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -15537,7 +15552,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15578,18 +15593,6 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-
-  '@babel/parser@7.28.0':
-    dependencies:
-      '@babel/types': 7.28.5
-
-  '@babel/parser@7.28.3':
-    dependencies:
-      '@babel/types': 7.28.5
-
-  '@babel/parser@7.28.4':
-    dependencies:
       '@babel/types': 7.28.5
 
   '@babel/parser@7.28.5':
@@ -15635,7 +15638,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15739,7 +15742,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.4)
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15887,7 +15890,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
@@ -16311,18 +16314,6 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
-
-  '@babel/traverse@7.28.3':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.3
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.4
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.28.5':
     dependencies:
@@ -19851,6 +19842,8 @@ snapshots:
 
   '@types/twig@1.12.17': {}
 
+  '@types/vscode@1.93.0': {}
+
   '@types/wcag-contrast@3.0.3': {}
 
   '@types/which@2.0.2': {}
@@ -21734,7 +21727,7 @@ snapshots:
 
   constantinople@4.0.1:
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
 
   content-disposition@0.5.2: {}
@@ -24505,7 +24498,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.3
@@ -24515,7 +24508,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/parser': 7.28.4
+      '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.3
@@ -30682,7 +30675,7 @@ snapshots:
 
   with@7.0.2:
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
       assert-never: 1.4.0
       babel-walk: 3.0.0-canary-5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ packages:
   - packages/themes/default
   - packages/themes/ecl
   - packages/themes
+  - packages/tools/convert-to-kolibri-vscode
   - packages/tools/benchmark-tests
   - packages/tools/kolibri-cli
   - packages/tools/mcp


### PR DESCRIPTION
## Summary
- add a new `@public-ui/convert-to-kolibri-vscode` workspace with VS Code commands and packaging metadata for the Convert to KoliBri accessibility migrator
- implement HTML and TSX conversion and scanning utilities to map common elements into KoliBri components with confidence notes and warnings
- register the workspace in the pnpm monorepo and add lint configuration for the extension code

## Testing
- pnpm --filter @public-ui/convert-to-kolibri-vscode build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930bfd7159c832b87aef9d9bda90222)