### PR TITLE
chore: remove redundant unit snapshot update scripts

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Display git status (before test-update)
         run: git status
 
-      - name: Run test-update in all packages
-        run: pnpm -r --workspace-concurrency=1 test-update
+      - name: Run snapshot updates
+        run: pnpm test:update
 
       - name: Display git status (after test-update)
         run: git status
@@ -88,6 +88,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Update all snapshots
-          file_pattern: 'packages/themes/**/snapshots/* packages/test-tag-name-transformer/snapshots/*'
+          file_pattern: 'packages/**/__snapshots__/** packages/**/snapshots/**'
           commit_user_name: '${{ steps.app-token.outputs.app-slug }}[bot]'
           commit_user_email: '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ The samples are located in `packages/samples/react` and demonstrate how to use t
 ## Testing
 
 - Run `pnpm test` from the repository root to execute all unit and integration tests.
-- Visual and snapshot tests can be updated with `pnpm test-update` or via the `update-snapshots.yml` GitHub workflow (see `CONTRIBUTING.md`).
+- Visual and snapshot tests can be updated with `pnpm test:update` or via the `update-snapshots.yml` GitHub workflow (see `CONTRIBUTING.md`).
 - Individual packages provide their own test scripts (e.g. `pnpm --filter @public-ui/components test:unit`).
 
 ## Pull Request Guidelines

--- a/package.json
+++ b/package.json
@@ -64,9 +64,8 @@
 		"test": "pnpm -r test",
 		"test:e2e": "pnpm -r test:e2e",
 		"test:unit": "pnpm -r test:unit",
-		"test:unit:update": "pnpm -r test:unit:update",
-		"test-reset-and-update": "rimraf packages/themes/**/snapshots/** && pnpm test-update",
-		"test-update": "pnpm -r test-update",
+		"test:update": "pnpm -r --filter=!workspace:root --workspace-concurrency=1 test:update",
+		"test-reset-and-update": "rimraf packages/themes/**/snapshots/** && pnpm test:update",
 		"update": "pnpm ncu:minor && pnpm ncu:major",
 		"version": "node scripts/update-publiccode.mjs && git add publiccode.yml"
 	}

--- a/packages/adapters/hydrate/package.json
+++ b/packages/adapters/hydrate/package.json
@@ -50,7 +50,7 @@
 		"format": "prettier --check '**/*.{js,json,md}'",
 		"test": "pnpm run test:unit",
 		"test:unit": "cross-env NODE_ENV=test mocha",
-		"test:unit:update": "cross-env NODE_ENV=test UPDATE=1 mocha"
+		"test:update": "cross-env NODE_ENV=test UPDATE=1 mocha"
 	},
 	"devDependencies": {
 		"@public-ui/components": "workspace:*",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -84,7 +84,7 @@
 		"test": "pnpm test:unit && pnpm test:e2e",
 		"test:e2e": "playwright test",
 		"test:unit": "mkdir -p dist && cross-env NODE_ENV=test stencil test --spec --json --outputFile dist/jest-test-results.json",
-		"test:unit:update": "pnpm test:unit -u",
+		"test:update": "pnpm test:unit -u",
 		"test:watch": "cross-env NODE_ENV=test stencil test --spec --watchAll",
 		"postpack": "mv package.bak.json package.json",
 		"prepack": "npm run build && cp package.json package.bak.json && rimraf dist/collection dist/kolibri/assets/@leanup dist/types/assets/@leanup && node scripts/anonymous.js && node scripts/minify.js",

--- a/packages/test-tag-name-transformer/package.json
+++ b/packages/test-tag-name-transformer/package.json
@@ -6,7 +6,7 @@
 	"description": "Performs snapshot testing on the default theme with a tag name transformer enabled.",
 	"scripts": {
 		"test": "THEME_MODULE=theme ENABLE_TAG_NAME_TRANSFORMER=true kolibri-visual-test",
-		"test-update": "THEME_MODULE=theme ENABLE_TAG_NAME_TRANSFORMER=true kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js"
+		"test:update": "THEME_MODULE=theme ENABLE_TAG_NAME_TRANSFORMER=true kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js"
 	},
 	"devDependencies": {
 		"@public-ui/themes": "workspace:*",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -54,9 +54,9 @@
 		"start": "npm-run-all2 --parallel dev serve",
 		"serve": "sh serve.sh DEFAULT",
 		"test": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test",
-		"test-update": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js",
+		"test:update": "cross-env THEME_MODULE=dist THEME_EXPORT=DEFAULT kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js",
 		"pretest": "pnpm build",
-		"pretest-update": "pnpm build"
+		"pretest:update": "pnpm build"
 	},
 	"devDependencies": {
 		"@public-ui/components": "workspace:*",

--- a/packages/themes/ecl/package.json
+++ b/packages/themes/ecl/package.json
@@ -58,11 +58,11 @@
 		"xtest": "npm-run-all2 test:*",
 		"test:ecl-ec": "cross-env THEME_MODULE=dist THEME_EXPORT=ECL_EC kolibri-visual-test",
 		"test:ecl-eu": "cross-env THEME_MODULE=dist THEME_EXPORT=ECL_EU kolibri-visual-test",
-		"xtest-update": "npm-run-all2 test-update:*",
-		"test-update:ecl-ec": "cross-env THEME_MODULE=dist THEME_EXPORT=ECL_EC kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js",
-		"test-update:ecl-eu": "cross-env THEME_MODULE=dist THEME_EXPORT=ECL_EU kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js",
+		"xtest:update": "npm-run-all2 test:update:*",
+		"test:update:ecl-ec": "cross-env THEME_MODULE=dist THEME_EXPORT=ECL_EC kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js",
+		"test:update:ecl-eu": "cross-env THEME_MODULE=dist THEME_EXPORT=ECL_EU kolibri-visual-test --update-snapshots=changed theme-snapshots.spec.js",
 		"pretest": "pnpm build",
-		"pretest-update": "pnpm build"
+		"pretest:update": "pnpm build"
 	},
 	"devDependencies": {
 		"@public-ui/components": "workspace:*",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -54,7 +54,7 @@
 		"lint:tsc": "tsc --noemit",
 		"prepare": "cpy \"node_modules/@public-ui/components/assets/**/*\" assets --dot",
 		"test-all": "pnpm -r --workspace-concurrency=1 test",
-		"test-update-all": "pnpm -r --workspace-concurrency=1 test-update"
+		"test:update:all": "pnpm -r --workspace-concurrency=1 test:update"
 	},
 	"devDependencies": {
 		"@public-ui/components": "workspace:*",

--- a/packages/tools/visual-tests/README.md
+++ b/packages/tools/visual-tests/README.md
@@ -45,7 +45,7 @@ Add the following npm scripts to the theme's `package.json`:
 {
 	"scripts": {
 		"test": "THEME_MODULE=src/index THEME_EXPORT=THEME_NAME kolibri-visual-test",
-		"test-update": "THEME_MODULE=src/index THEME_EXPORT=THEME_NAME kolibri-visual-test --update-snapshots=changed"
+		"test:update": "THEME_MODULE=src/index THEME_EXPORT=THEME_NAME kolibri-visual-test --update-snapshots=changed"
 	}
 }
 ```
@@ -61,6 +61,6 @@ Add the following npm scripts to the theme's `package.json`:
 Run the tests with `npm test`. The first time, this will create a new folder `snapshots` which is supposed to be committed to the repository.
 In the following runs, new screenshots will be compared to this reference.
 
-To update the reference screenshots call `npm run test-update`.
+To update the reference screenshots call `npm run test:update`.
 
 For details on theming see the [default theme README](../../themes/default/README.md).


### PR DESCRIPTION
## What changed?

Redundant scripts for updating unit test snapshots were removed. This PR is closely related to #8999 and was part of the same cleanup effort to eliminate duplicate tooling scripts. No component code or public API was changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Redundante Skripte zum Aktualisieren von Unit-Test-Snapshots wurden entfernt (vgl. #8999). Keine Änderungen an Komponenten oder APIs.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- Repository-Root oder `package.json` — Redundante Snapshot-Update-Skripte entfernt

</details>