### PR TITLE
fix(input): broaden message validity check to all message types

### DIFF
--- a/packages/components/src/components/input/controller.ts
+++ b/packages/components/src/components/input/controller.ts
@@ -18,7 +18,7 @@ export const getRenderStates = (state: {
 	hasHint: boolean;
 	ariaDescribedBy: string[];
 } => {
-	const isMessageValidError = Boolean(state._msg?._type === 'error' && state._msg._description && state._msg._description?.length > 0);
+	const isMessageValidError = Boolean(state._msg && state._msg._description && state._msg._description?.length > 0);
 	const hasError = isMessageValidError && state._touched === true;
 	const hasHint = typeof state._hint === 'string' && state._hint.length > 0;
 


### PR DESCRIPTION
## Summary

Broadens the `isMessageValidError` check in `getRenderStates` to be true for any message with a non-empty description, regardless of its `_type`. Previously, `hasError` (and thus the `aria-describedby` wiring via `_touched` state) was only active when `_type === 'error'`; now all message types trigger the touched-state check, ensuring consistent `aria-describedby` behavior across all message variants.

**Affected component:** `@public-ui/components` – form input controller

## Changes

- `packages/components/src/components/input/controller.ts`: `isMessageValidError` condition changed from `state._msg?._type === 'error' && state._msg._description && ...` to `state._msg && state._msg._description && ...`

<details>
<summary>Deutsche Zusammenfassung</summary>

Die `isMessageValidError`-Prüfung in `getRenderStates` wurde verallgemeinert: Sie ist nun für jede Nachricht mit einer nicht-leeren Beschreibung `true`, unabhängig vom `_type`. Zuvor war `hasError` (und damit die `aria-describedby`-Verdrahtung über den `_touched`-Zustand) nur für `_type === 'error'`-Nachrichten aktiv; jetzt lösen alle Nachrichtentypen die `_touched`-Prüfung aus.

</details>