### PR TITLE
feat(kolibri-cli): add v4 migration tasks for nav orientation and link variant

### DIFF
--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,12 +1,16 @@
 import { AbstractTask } from '../../abstract-task';
+import { MapVariantStandaloneToInlineTasks } from './link';
+import { NavRemovePropertyOrientationTask } from './nav';
 import { RemoveIdPropTasks } from './id';
-import { UpdateLoaderImportPathTask } from './loader';
 import { RemoveMsgPropsTasks } from './msg';
 import { RemoveToastVariantTask } from './toast';
 import { RemoveToasterGetInstanceOptionsTask } from './toaster';
+import { UpdateLoaderImportPathTask } from './loader';
 
 export const v4Tasks: AbstractTask[] = [];
 
+v4Tasks.push(...MapVariantStandaloneToInlineTasks);
+v4Tasks.push(NavRemovePropertyOrientationTask);
 v4Tasks.push(...RemoveIdPropTasks);
 v4Tasks.push(...RemoveMsgPropsTasks);
 v4Tasks.push(RemoveToastVariantTask.getInstance('^4'));

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,11 +1,11 @@
 import { AbstractTask } from '../../abstract-task';
-import { MapVariantStandaloneToInlineTasks } from './link';
-import { NavRemovePropertyOrientationTask } from './nav';
 import { RemoveIdPropTasks } from './id';
+import { MapVariantStandaloneToInlineTasks } from './link';
+import { UpdateLoaderImportPathTask } from './loader';
 import { RemoveMsgPropsTasks } from './msg';
+import { NavRemovePropertyOrientationTask } from './nav';
 import { RemoveToastVariantTask } from './toast';
 import { RemoveToasterGetInstanceOptionsTask } from './toaster';
-import { UpdateLoaderImportPathTask } from './loader';
 
 export const v4Tasks: AbstractTask[] = [];
 

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+
+import { COMPONENT_FILE_EXTENSIONS, CUSTOM_ELEMENT_FILE_EXTENSIONS, MARKUP_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, kebabToCapitalCase, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+class MapVariantStandaloneToInlineTask extends AbstractTask {
+        private readonly tagCapitalCase: string;
+        private readonly variantStandaloneRegExp = /\s_variant\s*=\s*(\{["'`]standalone["'`]\}|["'`]standalone["'`])/;
+
+        private constructor(identifier: string, private readonly tag: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions) {
+                super(identifier, `Map "_variant=standalone" to "_inline" for "${tag}"`, MARKUP_EXTENSIONS, versionRange, dependentTasks, options);
+                this.tagCapitalCase = kebabToCapitalCase(tag);
+        }
+
+        public static getInstance(tag: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions): MapVariantStandaloneToInlineTask {
+                const identifier = `${tag}-map-variant-standalone-to-inline`;
+                if (!this.instances.has(identifier)) {
+                        this.instances.set(identifier, new MapVariantStandaloneToInlineTask(identifier, tag, versionRange, dependentTasks, options));
+                }
+                return this.instances.get(identifier) as MapVariantStandaloneToInlineTask;
+        }
+
+        public run(baseDir: string): void {
+                this.transpileComponentFiles(baseDir);
+                this.transpileCustomElementFiles(baseDir);
+        }
+
+        private transpileComponentFiles(baseDir: string): void {
+                const tagRegExp = new RegExp(`<${this.tagCapitalCase}[^>]*_variant[^>]*>`, 'g');
+
+                filterFilesByExt(baseDir, COMPONENT_FILE_EXTENSIONS).forEach((file) => {
+                        const content = fs.readFileSync(file, 'utf8');
+                        const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, true));
+                        if (content !== newContent) {
+                                MODIFIED_FILES.add(file);
+                                fs.writeFileSync(file, newContent);
+                        }
+                });
+        }
+
+        private transpileCustomElementFiles(baseDir: string): void {
+                const tagRegExp = new RegExp(`<${this.tag}[^>]*_variant[^>]*>`, 'g');
+
+                filterFilesByExt(baseDir, CUSTOM_ELEMENT_FILE_EXTENSIONS).forEach((file) => {
+                        const content = fs.readFileSync(file, 'utf8');
+                        const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, false));
+                        if (content !== newContent) {
+                                MODIFIED_FILES.add(file);
+                                fs.writeFileSync(file, newContent);
+                        }
+                });
+        }
+
+        private rewriteTag(componentTag: string, isComponent: boolean): string {
+                if (!this.variantStandaloneRegExp.test(componentTag)) {
+                        return componentTag;
+                }
+
+                const inlineReplacement = isComponent ? ' _inline={false}' : ' _inline="false"';
+                if (/\s_inline\s*=/.test(componentTag)) {
+                        return componentTag.replace(this.variantStandaloneRegExp, '');
+                }
+
+                return componentTag.replace(this.variantStandaloneRegExp, inlineReplacement);
+        }
+}
+
+export const MapLinkVariantStandaloneToInlineTask: AbstractTask = MapVariantStandaloneToInlineTask.getInstance('kol-link', '^4');
+export const MapButtonLinkVariantStandaloneToInlineTask: AbstractTask = MapVariantStandaloneToInlineTask.getInstance('kol-button-link', '^4');
+export const MapVariantStandaloneToInlineTasks: AbstractTask[] = [MapLinkVariantStandaloneToInlineTask, MapButtonLinkVariantStandaloneToInlineTask];

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
@@ -1,74 +1,77 @@
 import fs from 'fs';
 
-import { AbstractTask, TaskOptions } from '../../abstract-task';
-import { filterFilesByExt, kebabToCapitalCase, MODIFIED_FILES } from '../../../shares/reuse';
 import { COMPONENT_FILE_EXTENSIONS, CUSTOM_ELEMENT_FILE_EXTENSIONS, MARKUP_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, kebabToCapitalCase, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
 
 class MapVariantStandaloneToInlineTask extends AbstractTask {
-        private readonly tagCapitalCase: string;
-        private readonly variantStandaloneRegExp = /\s_variant\s*=\s*(\{["'`]standalone["'`]\}|["'`]standalone["'`])/;
+	private readonly tagCapitalCase: string;
+	private readonly variantStandaloneRegExp = /\s_variant\s*=\s*(\{["'`]standalone["'`]\}|["'`]standalone["'`])/;
 
-        private constructor(identifier: string, private readonly tag: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions) {
-                super(identifier, `Map "_variant=standalone" to "_inline" for "${tag}"`, MARKUP_EXTENSIONS, versionRange, dependentTasks, options);
-                this.tagCapitalCase = kebabToCapitalCase(tag);
-        }
+	private constructor(
+		identifier: string,
+		private readonly tag: string,
+		versionRange: string,
+		dependentTasks?: AbstractTask[],
+		options?: TaskOptions,
+	) {
+		super(identifier, `Map "_variant=standalone" to "_inline" for "${tag}"`, MARKUP_EXTENSIONS, versionRange, dependentTasks, options);
+		this.tagCapitalCase = kebabToCapitalCase(tag);
+	}
 
-        public static getInstance(tag: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions): MapVariantStandaloneToInlineTask {
-                const identifier = `${tag}-map-variant-standalone-to-inline`;
-                if (!this.instances.has(identifier)) {
-                        this.instances.set(identifier, new MapVariantStandaloneToInlineTask(identifier, tag, versionRange, dependentTasks, options));
-                }
-                return this.instances.get(identifier) as MapVariantStandaloneToInlineTask;
-        }
+	public static getInstance(tag: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions): MapVariantStandaloneToInlineTask {
+		const identifier = `${tag}-map-variant-standalone-to-inline`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new MapVariantStandaloneToInlineTask(identifier, tag, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as MapVariantStandaloneToInlineTask;
+	}
 
-        public run(baseDir: string): void {
-                this.transpileComponentFiles(baseDir);
-                this.transpileCustomElementFiles(baseDir);
-        }
+	public run(baseDir: string): void {
+		this.transpileComponentFiles(baseDir);
+		this.transpileCustomElementFiles(baseDir);
+	}
 
-        private transpileComponentFiles(baseDir: string): void {
-                const tagRegExp = new RegExp(`<${this.tagCapitalCase}[^>]*_variant[^>]*>`, 'g');
+	private transpileComponentFiles(baseDir: string): void {
+		const tagRegExp = new RegExp(`<${this.tagCapitalCase}[^>]*_variant[^>]*>`, 'g');
 
-                filterFilesByExt(baseDir, COMPONENT_FILE_EXTENSIONS).forEach((file) => {
-                        const content = fs.readFileSync(file, 'utf8');
-                        const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, true));
-                        if (content !== newContent) {
-                                MODIFIED_FILES.add(file);
-                                fs.writeFileSync(file, newContent);
-                        }
-                });
-        }
+		filterFilesByExt(baseDir, COMPONENT_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, true));
+			if (content !== newContent) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
 
-        private transpileCustomElementFiles(baseDir: string): void {
-                const tagRegExp = new RegExp(`<${this.tag}[^>]*_variant[^>]*>`, 'g');
+	private transpileCustomElementFiles(baseDir: string): void {
+		const tagRegExp = new RegExp(`<${this.tag}[^>]*_variant[^>]*>`, 'g');
 
-                filterFilesByExt(baseDir, CUSTOM_ELEMENT_FILE_EXTENSIONS).forEach((file) => {
-                        const content = fs.readFileSync(file, 'utf8');
-                        const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, false));
-                        if (content !== newContent) {
-                                MODIFIED_FILES.add(file);
-                                fs.writeFileSync(file, newContent);
-                        }
-                });
-        }
+		filterFilesByExt(baseDir, CUSTOM_ELEMENT_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, false));
+			if (content !== newContent) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
 
-        private rewriteTag(componentTag: string, isComponent: boolean): string {
-                if (!this.variantStandaloneRegExp.test(componentTag)) {
-                        return componentTag;
-                }
+	private rewriteTag(componentTag: string, isComponent: boolean): string {
+		if (!this.variantStandaloneRegExp.test(componentTag)) {
+			return componentTag;
+		}
 
-                const inlineReplacement = isComponent ? ' _inline={false}' : ' _inline="false"';
-                if (/\s_inline\s*=/.test(componentTag)) {
-                        return componentTag.replace(this.variantStandaloneRegExp, '');
-                }
+		const inlineReplacement = isComponent ? ' _inline={false}' : ' _inline="false"';
+		if (/\s_inline\s*=/.test(componentTag)) {
+			return componentTag.replace(this.variantStandaloneRegExp, '');
+		}
 
-                return componentTag.replace(this.variantStandaloneRegExp, inlineReplacement);
-        }
+		return componentTag.replace(this.variantStandaloneRegExp, inlineReplacement);
+	}
 }
 
 export const MapButtonLinkVariantStandaloneToInlineTask: AbstractTask = MapVariantStandaloneToInlineTask.getInstance('kol-button-link', '^4');
 export const MapLinkVariantStandaloneToInlineTask: AbstractTask = MapVariantStandaloneToInlineTask.getInstance('kol-link', '^4');
-export const MapVariantStandaloneToInlineTasks: AbstractTask[] = [
-	MapButtonLinkVariantStandaloneToInlineTask,
-	MapLinkVariantStandaloneToInlineTask,
-];
+export const MapVariantStandaloneToInlineTasks: AbstractTask[] = [MapButtonLinkVariantStandaloneToInlineTask, MapLinkVariantStandaloneToInlineTask];

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 
-import { COMPONENT_FILE_EXTENSIONS, CUSTOM_ELEMENT_FILE_EXTENSIONS, MARKUP_EXTENSIONS } from '../../../../types';
-import { filterFilesByExt, kebabToCapitalCase, MODIFIED_FILES } from '../../../shares/reuse';
 import { AbstractTask, TaskOptions } from '../../abstract-task';
+import { filterFilesByExt, kebabToCapitalCase, MODIFIED_FILES } from '../../../shares/reuse';
+import { COMPONENT_FILE_EXTENSIONS, CUSTOM_ELEMENT_FILE_EXTENSIONS, MARKUP_EXTENSIONS } from '../../../../types';
 
 class MapVariantStandaloneToInlineTask extends AbstractTask {
         private readonly tagCapitalCase: string;

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
@@ -66,6 +66,9 @@ class MapVariantStandaloneToInlineTask extends AbstractTask {
         }
 }
 
-export const MapLinkVariantStandaloneToInlineTask: AbstractTask = MapVariantStandaloneToInlineTask.getInstance('kol-link', '^4');
 export const MapButtonLinkVariantStandaloneToInlineTask: AbstractTask = MapVariantStandaloneToInlineTask.getInstance('kol-button-link', '^4');
-export const MapVariantStandaloneToInlineTasks: AbstractTask[] = [MapLinkVariantStandaloneToInlineTask, MapButtonLinkVariantStandaloneToInlineTask];
+export const MapLinkVariantStandaloneToInlineTask: AbstractTask = MapVariantStandaloneToInlineTask.getInstance('kol-link', '^4');
+export const MapVariantStandaloneToInlineTasks: AbstractTask[] = [
+	MapButtonLinkVariantStandaloneToInlineTask,
+	MapLinkVariantStandaloneToInlineTask,
+];

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/nav.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/nav.ts
@@ -1,0 +1,4 @@
+import { AbstractTask } from '../../abstract-task';
+import { RemovePropertyNameTask } from '../common/RemovePropertyNameTask';
+
+export const NavRemovePropertyOrientationTask: AbstractTask = RemovePropertyNameTask.getInstance('kol-nav', '_orientation', '^4');

--- a/packages/tools/kolibri-cli/test/map-variant-standalone-to-inline.spec.ts
+++ b/packages/tools/kolibri-cli/test/map-variant-standalone-to-inline.spec.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import assert from 'node:assert';
+import os from 'os';
+import path from 'path';
+import { MapButtonLinkVariantStandaloneToInlineTask, MapLinkVariantStandaloneToInlineTask } from '../src/migrate/runner/tasks/v4/link';
+
+describe('MapVariantStandaloneToInlineTask', () => {
+        it('maps kol-link standalone variant to inline flag in component files', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const tsxPath = path.join(tmpDir, 'component.tsx');
+                fs.writeFileSync(tsxPath, '<KolLink _variant="standalone" />');
+
+                MapLinkVariantStandaloneToInlineTask.run(tmpDir);
+
+                const content = fs.readFileSync(tsxPath, 'utf8');
+                assert.ok(!content.includes('_variant'));
+                assert.ok(content.includes('_inline={false}'));
+        });
+
+        it('maps kol-button-link standalone variant to inline flag in custom element files', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const htmlPath = path.join(tmpDir, 'sample.html');
+                fs.writeFileSync(htmlPath, '<kol-button-link _variant="standalone">Link</kol-button-link>');
+
+                MapButtonLinkVariantStandaloneToInlineTask.run(tmpDir);
+
+                const content = fs.readFileSync(htmlPath, 'utf8');
+                assert.ok(!content.includes('_variant'));
+                assert.ok(content.includes('_inline="false"'));
+        });
+
+        it('removes standalone variant when inline already exists', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const htmlPath = path.join(tmpDir, 'sample.html');
+                fs.writeFileSync(htmlPath, '<kol-link _variant="standalone" _inline="true"></kol-link>');
+
+                MapLinkVariantStandaloneToInlineTask.run(tmpDir);
+
+                const content = fs.readFileSync(htmlPath, 'utf8');
+                assert.ok(!content.includes('_variant'));
+                assert.ok(content.includes('_inline="true"'));
+        });
+
+        it('ignores other variant values', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const tsxPath = path.join(tmpDir, 'component.tsx');
+                fs.writeFileSync(tsxPath, '<KolLink _variant="primary" />');
+
+                MapLinkVariantStandaloneToInlineTask.run(tmpDir);
+
+                const content = fs.readFileSync(tsxPath, 'utf8');
+                assert.ok(content.includes('_variant="primary"'));
+                assert.ok(!content.includes('_inline'));
+        });
+});

--- a/packages/tools/kolibri-cli/test/map-variant-standalone-to-inline.spec.ts
+++ b/packages/tools/kolibri-cli/test/map-variant-standalone-to-inline.spec.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import assert from 'node:assert';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { MapButtonLinkVariantStandaloneToInlineTask, MapLinkVariantStandaloneToInlineTask } from '../src/migrate/runner/tasks/v4/link';

--- a/packages/tools/kolibri-cli/test/nav-remove-orientation.spec.ts
+++ b/packages/tools/kolibri-cli/test/nav-remove-orientation.spec.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import assert from 'node:assert';
+import os from 'os';
+import path from 'path';
+import { NavRemovePropertyOrientationTask } from '../src/migrate/runner/tasks/v4/nav';
+import { setRemoveMode } from '../src/migrate/shares/reuse';
+
+describe('NavRemovePropertyOrientationTask', () => {
+        beforeEach(() => {
+                setRemoveMode('delete');
+        });
+
+        afterEach(() => {
+                setRemoveMode('prefix');
+        });
+
+        it('removes _orientation from component and custom element markup', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const tsxPath = path.join(tmpDir, 'component.tsx');
+                const htmlPath = path.join(tmpDir, 'sample.html');
+                fs.writeFileSync(tsxPath, '<KolNav _orientation="horizontal"></KolNav>');
+                fs.writeFileSync(htmlPath, '<kol-nav _orientation="horizontal"></kol-nav>');
+
+                NavRemovePropertyOrientationTask.run(tmpDir);
+
+                const tsxContent = fs.readFileSync(tsxPath, 'utf8');
+                const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+                assert.ok(!tsxContent.includes('_orientation'));
+                assert.ok(!htmlContent.includes('_orientation'));
+        });
+});

--- a/packages/tools/kolibri-cli/test/nav-remove-orientation.spec.ts
+++ b/packages/tools/kolibri-cli/test/nav-remove-orientation.spec.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
 import assert from 'node:assert';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { NavRemovePropertyOrientationTask } from '../src/migrate/runner/tasks/v4/nav';


### PR DESCRIPTION
## Summary

Adds two new v4 migration tasks to `@public-ui/kolibri-cli`:

1. **`MapVariantStandaloneToInlineTask`** – Migrates `_variant="standalone"` to `_inline={false}` for `kol-link` and `kol-button-link` in both component (TSX/JSX) and custom-element (HTML) files. If `_inline` already exists, the redundant `_variant` attribute is simply removed.
2. **`NavRemovePropertyOrientationTask`** – Removes the deprecated `_orientation` prop from `kol-nav` elements.

Both tasks are registered in the v4 task runner and include unit tests.

**Affected package:** `@public-ui/kolibri-cli`

## Changes

- `packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts`: New `MapVariantStandaloneToInlineTask` class (supports `kol-link` and `kol-button-link`)
- `packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/nav.ts`: New `NavRemovePropertyOrientationTask`
- `packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts`: Registered both new tasks in the task list
- `packages/tools/kolibri-cli/test/map-variant-standalone-to-inline.spec.ts`: Unit tests for link migration task
- `packages/tools/kolibri-cli/test/nav-remove-orientation.spec.ts`: Unit tests for nav orientation removal task

<details>
<summary>Deutsche Zusammenfassung</summary>

Fügt zwei neue v4-Migrationsaufgaben zu `@public-ui/kolibri-cli` hinzu:

1. **`MapVariantStandaloneToInlineTask`** – Migriert `_variant="standalone"` zu `_inline={false}` für `kol-link` und `kol-button-link` in Komponenten- (TSX/JSX) und Custom-Element-Dateien (HTML)
2. **`NavRemovePropertyOrientationTask`** – Entfernt die veraltete `_orientation`-Eigenschaft von `kol-nav`-Elementen

Beide Aufgaben sind im v4-Task-Runner registriert und mit Unit-Tests abgedeckt.

</details>