### PR TITLE
fix(input-radio): move aria-describedby to fieldset and add id to hint element

### DIFF
--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -76,12 +76,12 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	}
 
 	public render(): JSX.Element {
-		const { ariaDescribedBy, hasError } = getRenderStates(this.state);
+		const { ariaDescribedBy, hasError, hasHint } = getRenderStates(this.state);
 		const hasExpertSlot = showExpertSlot(this.state._label);
-		const hasHint = typeof this._hint === 'string' && this._hint.length > 0;
 		return (
 			<Host class="kol-input-radio">
 				<fieldset
+					aria-describedby={ariaDescribedBy.length > 0 ? ariaDescribedBy.join(' ') : undefined}
 					class={{
 						fieldset: true,
 						disabled: this.state._disabled === true,
@@ -130,7 +130,6 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 									<input
 										ref={this.state._value === option.value ? this.catchRef : undefined}
 										title=""
-										aria-describedby={ariaDescribedBy.length > 0 ? ariaDescribedBy.join(' ') : undefined}
 										aria-label={this.state._hideLabel && typeof option.label === 'string' ? option.label : undefined}
 										type="radio"
 										id={customId}
@@ -173,7 +172,11 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 						);
 					})}
 					{hasError && <KolFormFieldMsgFc _alert={this.showAsAlert()} _hideError={this.state._hideError} _msg={this.state._msg} _id={this.state._id} />}
-					{hasHint && <span class="hint">{this.state._hint}</span>}
+					{hasHint && (
+						<span class="hint" id={`${this.state._id}-hint`}>
+							{this.state._hint}
+						</span>
+					)}
 				</fieldset>
 			</Host>
 		);

--- a/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
@@ -159,7 +159,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hint="Hint" 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" class="kol-input-radio">
   <template shadowrootmode="open">
-    <fieldset class="fieldset vertical">
+    <fieldset aria-describedby="id-nonce-hint" class="fieldset vertical">
       <legend class="block leading-normal mb-1 w-full">
         <span>
           <span slot="label">
@@ -169,7 +169,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input aria-describedby="id-nonce-hint" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
           <label class="radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
@@ -181,7 +181,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _id="id-nonce-1" _label="Herr" _rendernolabel="" _slotname="radio-1" _tooltipalign="top" class="radio">
         <div class="radio-input-wrapper" slot="radio-1">
-          <input aria-describedby="id-nonce-hint" id="id-nonce-1" name="field" type="radio" value="-1">
+          <input id="id-nonce-1" name="field" type="radio" value="-1">
           <label class="radio-label" htmlfor="id-nonce-1">
             <span>
               <span class="radio-label-span-inner">
@@ -193,7 +193,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _id="id-nonce-2" _label="Divers" _rendernolabel="" _slotname="radio-2" _tooltipalign="top" class="radio">
         <div class="radio-input-wrapper" slot="radio-2">
-          <input aria-describedby="id-nonce-hint" id="id-nonce-2" name="field" type="radio" value="-2">
+          <input id="id-nonce-2" name="field" type="radio" value="-2">
           <label class="radio-label" htmlfor="id-nonce-2">
             <span>
               <span class="radio-label-span-inner">
@@ -203,7 +203,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
           </label>
         </div>
       </kol-input>
-      <span class="hint">
+      <span class="hint" id="id-nonce-hint">
         Hint
       </span>
     </fieldset>
@@ -630,7 +630,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _orientation="horizontal" _hint="Hint" 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" class="kol-input-radio">
   <template shadowrootmode="open">
-    <fieldset class="fieldset horizontal">
+    <fieldset aria-describedby="id-nonce-hint" class="fieldset horizontal">
       <legend class="block leading-normal mb-1 w-full">
         <span>
           <span slot="label">
@@ -640,7 +640,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </legend>
       <kol-input _disabled="" _id="id-nonce-0" _label="Frau" _rendernolabel="" _slotname="radio-0" _tooltipalign="top" class="disabled radio">
         <div class="radio-input-wrapper" slot="radio-0">
-          <input aria-describedby="id-nonce-hint" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+          <input disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
           <label class="radio-label" htmlfor="id-nonce-0">
             <span>
               <span class="radio-label-span-inner">
@@ -652,7 +652,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _id="id-nonce-1" _label="Herr" _rendernolabel="" _slotname="radio-1" _tooltipalign="top" class="radio">
         <div class="radio-input-wrapper" slot="radio-1">
-          <input aria-describedby="id-nonce-hint" id="id-nonce-1" name="field" type="radio" value="-1">
+          <input id="id-nonce-1" name="field" type="radio" value="-1">
           <label class="radio-label" htmlfor="id-nonce-1">
             <span>
               <span class="radio-label-span-inner">
@@ -664,7 +664,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
       </kol-input>
       <kol-input _id="id-nonce-2" _label="Divers" _rendernolabel="" _slotname="radio-2" _tooltipalign="top" class="radio">
         <div class="radio-input-wrapper" slot="radio-2">
-          <input aria-describedby="id-nonce-hint" id="id-nonce-2" name="field" type="radio" value="-2">
+          <input id="id-nonce-2" name="field" type="radio" value="-2">
           <label class="radio-label" htmlfor="id-nonce-2">
             <span>
               <span class="radio-label-span-inner">
@@ -674,7 +674,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
           </label>
         </div>
       </kol-input>
-      <span class="hint">
+      <span class="hint" id="id-nonce-hint">
         Hint
       </span>
     </fieldset>


### PR DESCRIPTION
## Summary

Refactors `aria-describedby` handling in `KolInputRadio`. The hint `<span>` element now receives an explicit `id` attribute so it can be referenced by `aria-describedby`. The `aria-describedby` attribute is moved from individual `<input type="radio">` elements to the enclosing `<fieldset>`, following correct ARIA semantics for group descriptions. Additionally, `hasHint` is now derived from `getRenderStates` instead of being calculated inline.

**Affected component:** `@public-ui/components` – `kol-input-radio`

## Changes

- `packages/components/src/components/input-radio/shadow.tsx`: Added `id` to hint `<span>`; moved `aria-describedby` from individual inputs to `<fieldset>`; `hasHint` now sourced from `getRenderStates`
- `packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap`: Updated snapshots

<details>
<summary>Deutsche Zusammenfassung</summary>

Das Hint-`<span>`-Element in `KolInputRadio` erhält nun ein explizites `id`-Attribut, damit es per `aria-describedby` referenziert werden kann. Das `aria-describedby`-Attribut wird vom einzelnen `<input type="radio">` auf das umschließende `<fieldset>` verschoben – entsprechend der korrekten ARIA-Semantik für Gruppen-Beschreibungen. `hasHint` wird jetzt von `getRenderStates` bezogen statt inline berechnet.

</details>