### PR TITLE
fix(toast): expand close-all button label text for clarity

### DIFF
--- a/packages/components/src/locales/de.ts
+++ b/packages/components/src/locales/de.ts
@@ -32,7 +32,7 @@ export default {
 	'avatar-alt': 'Avatar von {{name}}',
 	'split-button-dropdown-label-open': 'Optionen anzeigen',
 	'split-button-dropdown-label-close': 'Optionen schließen',
-	'toast-close-all': 'Alle schließen',
+        'toast-close-all': 'Alle Benachrichtigungen schließen',
 	'error-list': 'Fehlerliste',
 	'error-list-message': 'Bitte korrigieren Sie folgende Fehler:',
 	version: 'Versionsnummer',

--- a/packages/components/src/locales/en.ts
+++ b/packages/components/src/locales/en.ts
@@ -32,7 +32,7 @@ export default {
 	'avatar-alt': 'Avatar of {{name}}',
 	'split-button-dropdown-label-open': 'Show options',
 	'split-button-dropdown-label-close': 'Hide options',
-	'toast-close-all': 'Close all',
+        'toast-close-all': 'Close all notifications',
 	'error-list': 'Error list',
 	'error-list-message': 'Please correct the following errors',
 	version: 'Version number',


### PR DESCRIPTION
## Summary

Expands the `toast-close-all` locale string from `'Close all'`/`'Alle schließen'` to `'Close all notifications'`/`'Alle Benachrichtigungen schließen'`. The more descriptive label improves accessibility by making the button's purpose explicit for screen reader users who may not have the visual context of a toast container.

**Affected component:** `@public-ui/components` – `kol-toast`

## Changes

- `packages/components/src/locales/en.ts`: `toast-close-all` changed from `'Close all'` to `'Close all notifications'`
- `packages/components/src/locales/de.ts`: `toast-close-all` changed from `'Alle schließen'` to `'Alle Benachrichtigungen schließen'`
- Screenshot snapshots updated to reflect the label change

<details>
<summary>Deutsche Zusammenfassung</summary>

Die Lokalisierungs-Zeichenkette `toast-close-all` wurde von `'Close all'`/`'Alle schließen'` zu `'Close all notifications'`/`'Alle Benachrichtigungen schließen'` erweitert. Der beschreibendere Text verbessert die Barrierefreiheit, indem der Zweck des Buttons für Screenreader-Nutzer explizit gemacht wird, die möglicherweise keinen visuellen Kontext des Toast-Containers haben.

</details>