### PR TITLE
fix(nav): add runtime deprecation warning for non-vertical _orientation

### DIFF
--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -315,7 +315,7 @@ export class KolNav implements NavAPI {
 
 	/**
 	 * Defines whether the orientation of the component is horizontal or vertical.
-	 * @deprecated Will be removed in the next major version.
+	 * @deprecated Will be removed in the next major version. The navigation defaults to vertical orientation.
 	 */
 	@Prop() public _orientation?: OrientationPropType = 'vertical';
 
@@ -372,6 +372,12 @@ export class KolNav implements NavAPI {
 
 	@Watch('_orientation')
 	public validateOrientation(value?: OrientationPropType): void {
+		if (value !== 'vertical') {
+			devWarning(
+				'[KolNav] Die Eigenschaft _orientation ist veraltet, wird im nächsten Major Release entfernt und ' +
+					'sollte nicht mehr auf horizontale Navigation gesetzt werden. Die Navigation ist standardmäßig vertikal.',
+			);
+		}
 		watchValidator(
 			this,
 			'_orientation',


### PR DESCRIPTION
## Summary

Adds a runtime `devWarning` to `KolNav` when `_orientation` is set to a non-vertical value, making the existing deprecation actionable. Previously the prop was marked deprecated in JSDoc only; now developers receive a console warning when the component is used with a non-default orientation value.

The JSDoc was also updated to clarify that the navigation defaults to vertical orientation.

**Affected component:** `@public-ui/components` – `kol-nav`

## Changes

- `packages/components/src/components/nav/shadow.tsx`: Added `devWarning` call in `validateOrientation` when value is not `'vertical'`; updated JSDoc deprecation message

<details>
<summary>Deutsche Zusammenfassung</summary>

In `KolNav` wird nun eine `devWarning` ausgegeben, wenn `_orientation` auf einen nicht-vertikalen Wert gesetzt wird, um die bestehende Deprecation-Warnung umsetzbar zu machen. Bisher war die Veraltungswarnung nur im JSDoc vermerkt; jetzt erhalten Entwickler eine Konsolenwarnung, wenn die Komponente mit nicht-standardmäßiger Orientierung verwendet wird.

Der JSDoc-Text wurde ebenfalls aktualisiert: Er weist nun darauf hin, dass die Navigation standardmäßig vertikal ausgerichtet ist.

</details>