### PR TITLE
fix(components): move aria-describedby to fieldset for radio and remove data-role from checkbox button

### DIFF
--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -89,7 +89,6 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 				[`kol-input-checkbox--label-align-${this.state._labelAlign || 'right'}`]: true,
 			}),
 			tooltipAlign: this._tooltipAlign,
-			'data-role': this.state._variant === 'button' ? 'button' : undefined,
 			alert: this.showAsAlert(),
 			renderNoTooltip: true,
 		};

--- a/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -346,7 +346,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _accessKey="V" 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -373,7 +373,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _alert=true 1`] = `
 <kol-input-checkbox _alert="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -399,7 +399,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _disabled=true 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-form-field--disabled kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-form-field--disabled kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -425,7 +425,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _hint="Hint" 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -454,7 +454,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -480,7 +480,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -506,7 +506,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -532,7 +532,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -558,7 +558,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -584,7 +584,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _readOnly=true 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext" _readonly="">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -610,7 +610,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _shortKey="S" 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -637,7 +637,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" _touched=true 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-form-field--touched kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-form-field--touched kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -663,7 +663,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=false _variant="button" 1`] = `
 <kol-input-checkbox _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1718,7 +1718,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _accessKey="V" 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1745,7 +1745,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _alert=true 1`] = `
 <kol-input-checkbox _alert="" _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1771,7 +1771,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _disabled=true 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-form-field--disabled kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-form-field--disabled kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1797,7 +1797,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _hint="Hint" 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1826,7 +1826,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1852,7 +1852,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1878,7 +1878,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1904,7 +1904,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1930,7 +1930,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1956,7 +1956,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _readOnly=true 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext" _readonly="">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -1982,7 +1982,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _shortKey="S" 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -2009,7 +2009,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" _touched=true 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext" _touched="">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-form-field--touched kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
@@ -2035,7 +2035,7 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
 exports[`kol-input-checkbox should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _checked=true _variant="button" 1`] = `
 <kol-input-checkbox _checked="" _placeholder="Hier steht ein Platzhaltertext">
   <template shadowrootmode="open">
-    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button" data-role="button">
+    <div class="kol-form-field kol-input-checkbox kol-input-checkbox--checked kol-input-checkbox--label-align-right kol-input-checkbox--variant-button">
       <div class="kol-form-field__input">
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">

--- a/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-radio/test/__snapshots__/snapshot.spec.tsx.snap
@@ -183,7 +183,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hint="Hint" 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _value="Value">
   <template shadowrootmode="open">
-    <fieldset class="kol-form-field kol-form-field--radio">
+    <fieldset aria-describedby="id-nonce-hint" class="kol-form-field kol-form-field--radio">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           <span>
@@ -195,7 +195,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--disabled">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-0" id="id-nonce-0-label">
@@ -209,7 +209,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -223,7 +223,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">
@@ -426,7 +426,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Value">
   <template shadowrootmode="open">
-    <fieldset class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--radio kol-form-field--touched">
+    <fieldset aria-describedby="id-nonce-error" class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--radio kol-form-field--touched">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           <span>
@@ -438,7 +438,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--disabled kol-field-control--error kol-field-control--touched">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--disabled kol-input-radio--error kol-input-radio--touched">
-              <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input--error kol-input--touched kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input--error kol-input--touched kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-0" id="id-nonce-0-label">
@@ -452,7 +452,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--error kol-field-control--touched">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--error kol-input-radio--touched">
-              <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -466,7 +466,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--error kol-field-control--touched">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--error kol-input-radio--touched">
-              <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">
@@ -486,7 +486,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _value="Value">
   <template shadowrootmode="open">
-    <fieldset class="kol-form-field kol-form-field--radio">
+    <fieldset aria-describedby="id-nonce-msg" class="kol-form-field kol-form-field--radio">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           <span>
@@ -498,7 +498,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--disabled">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-0" id="id-nonce-0-label">
@@ -512,7 +512,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -526,7 +526,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">
@@ -726,7 +726,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _orientation="horizontal" _hint="Hint" 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _value="Value">
   <template shadowrootmode="open">
-    <fieldset class="kol-form-field kol-form-field--radio">
+    <fieldset aria-describedby="id-nonce-hint" class="kol-form-field kol-form-field--radio">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           <span>
@@ -738,7 +738,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--disabled">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-0" id="id-nonce-0-label">
@@ -752,7 +752,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -766,7 +766,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">
@@ -969,7 +969,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _orientation="horizontal" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Value">
   <template shadowrootmode="open">
-    <fieldset class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--radio kol-form-field--touched">
+    <fieldset aria-describedby="id-nonce-error" class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--radio kol-form-field--touched">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           <span>
@@ -981,7 +981,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--disabled kol-field-control--error kol-field-control--touched">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--disabled kol-input-radio--error kol-input-radio--touched">
-              <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input--error kol-input--touched kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input--error kol-input--touched kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-0" id="id-nonce-0-label">
@@ -995,7 +995,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--error kol-field-control--touched">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--error kol-input-radio--touched">
-              <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -1009,7 +1009,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--error kol-field-control--touched">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--error kol-input-radio--touched">
-              <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">
@@ -1029,7 +1029,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
 exports[`kol-input-radio should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _value="Value" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _orientation="horizontal" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
 <kol-input-radio _placeholder="Hier steht ein Platzhaltertext" _value="Value">
   <template shadowrootmode="open">
-    <fieldset class="kol-form-field kol-form-field--radio">
+    <fieldset aria-describedby="id-nonce-msg" class="kol-form-field kol-form-field--radio">
       <legend class="kol-form-field__label kol-form-field__label--legend" htmlfor="id-nonce" id="id-nonce-label">
         <span class="kol-form-field__label-text">
           <span>
@@ -1041,7 +1041,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control kol-field-control--disabled">
           <div class="kol-field-control__input">
             <label class="kol-input-radio kol-input-radio--disabled">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-input-radio__input" disabled="" id="id-nonce-0" name="field" type="radio" value="-0">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-0" id="id-nonce-0-label">
@@ -1055,7 +1055,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-1" name="field" type="radio" value="-1">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-1" id="id-nonce-1-label">
@@ -1069,7 +1069,7 @@ exports[`kol-input-radio should render with _label="Label" _name="field" _placeh
         <div class="kol-field-control">
           <div class="kol-field-control__input">
             <label class="kol-input-radio">
-              <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
+              <input autocapitalize="off" autocorrect="off" class="kol-input kol-input-radio__input" id="id-nonce-2" name="field" type="radio" value="-2">
             </label>
           </div>
           <label class="kol-field-control__label" htmlfor="id-nonce-2" id="id-nonce-2-label">

--- a/packages/components/src/components/input-radio/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-radio/test/aria-described-by.spec.tsx
@@ -1,0 +1,26 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import type { RadioOption, StencilUnknown } from '../../../schema';
+
+import { KolInputRadio } from '../shadow';
+
+const options: RadioOption<StencilUnknown>[] = [
+	{
+		label: 'First',
+		value: 'first',
+	},
+];
+
+describe('kol-input-radio aria-describedby', () => {
+	it('renders aria-describedby on the fieldset', async () => {
+		const page = await newSpecPage({
+			components: [KolInputRadio],
+			template: () => <kol-input-radio _id="radio" _label="Label" _hint="Hint" _options={options} />,
+		});
+
+		const fieldset = page.root?.shadowRoot?.querySelector('fieldset');
+
+		expect(fieldset?.getAttribute('aria-describedby')).toBe('radio-hint');
+	});
+});

--- a/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
@@ -1,0 +1,19 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolInputText } from '../shadow';
+
+describe('kol-input-text aria-describedby', () => {
+	it('keeps aria-describedby on the input element', async () => {
+		const page = await newSpecPage({
+			components: [KolInputText],
+			template: () => <kol-input-text _id="text" _label="Label" _hint="Hint" />,
+		});
+
+		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
+		const input = page.root?.shadowRoot?.querySelector('input');
+
+		expect(formField?.getAttribute('aria-describedby')).toBeNull();
+		expect(input?.getAttribute('aria-describedby')).toBe('text-hint');
+	});
+});

--- a/packages/components/src/components/select/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/select/test/aria-described-by.spec.tsx
@@ -1,0 +1,28 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import type { SelectOption } from '../../../schema';
+
+import { KolSelect } from '../shadow';
+
+describe('kol-select aria-describedby', () => {
+	it('keeps aria-describedby on the select element', async () => {
+		const options: SelectOption<string>[] = [
+			{
+				label: 'First',
+				value: 'first',
+			},
+		];
+
+		const page = await newSpecPage({
+			components: [KolSelect],
+			template: () => <kol-select _id="select" _label="Label" _hint="Hint" _options={options} />,
+		});
+
+		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
+		const select = page.root?.shadowRoot?.querySelector('select');
+
+		expect(formField?.getAttribute('aria-describedby')).toBeNull();
+		expect(select?.getAttribute('aria-describedby')).toBe('select-hint');
+	});
+});

--- a/packages/components/src/components/textarea/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/textarea/test/aria-described-by.spec.tsx
@@ -1,0 +1,19 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolTextarea } from '../shadow';
+
+describe('kol-textarea aria-describedby', () => {
+	it('keeps aria-describedby on the textarea element', async () => {
+		const page = await newSpecPage({
+			components: [KolTextarea],
+			template: () => <kol-textarea _id="textarea" _label="Label" _hint="Hint" />,
+		});
+
+		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
+		const textarea = page.root?.shadowRoot?.querySelector('textarea');
+
+		expect(formField?.getAttribute('aria-describedby')).toBeNull();
+		expect(textarea?.getAttribute('aria-describedby')).toBe('textarea-hint');
+	});
+});

--- a/packages/components/src/functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper.tsx
+++ b/packages/components/src/functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper.tsx
@@ -14,6 +14,7 @@ import {
 	type MsgPropType,
 	type SelectStates,
 } from '../../schema';
+import { getRenderStates } from '../_helpers/getRenderStates';
 
 type InputState =
 	| InputTextStates
@@ -84,8 +85,13 @@ function getFormFieldProps(state: InputState): FormFieldProps {
 }
 
 const FormFieldStateWrapper: FC<FormFieldStateWrapperProps> = ({ state, ...other }, children) => {
+	const { ariaDescribedBy: ariaDescribedByArray } = getRenderStates(state);
+	const isRadioVariant = other.component === 'fieldset' || ('_options' in state && '_orientation' in state);
+	const ariaDescribedBy = isRadioVariant && ariaDescribedByArray.length > 0 ? ariaDescribedByArray.join(' ') : undefined;
+	const baseProps = getFormFieldProps(state);
+
 	return (
-		<KolFormFieldFc {...getFormFieldProps(state)} {...other}>
+		<KolFormFieldFc {...baseProps} {...other} ariaDescribedBy={ariaDescribedBy}>
 			{children}
 		</KolFormFieldFc>
 	);

--- a/packages/components/src/functional-component-wrappers/RadioStateWrapper/RadioStateWrapper.tsx
+++ b/packages/components/src/functional-component-wrappers/RadioStateWrapper/RadioStateWrapper.tsx
@@ -3,7 +3,6 @@ import { type InputProps } from '../../functional-components/inputs/Input';
 import KolRadioFc, { type RadioProps } from '../../functional-components/inputs/Radio';
 
 import { type InputRadioStates, type MsgPropType } from '../../schema';
-import { getRenderStates } from '../_helpers/getRenderStates';
 
 export type RadioStateWrapperProps = Omit<RadioProps, 'inputProps'> & {
 	state: InputRadioStates;
@@ -11,8 +10,6 @@ export type RadioStateWrapperProps = Omit<RadioProps, 'inputProps'> & {
 };
 
 function getRadioProps(state: InputRadioStates, inputProps: Partial<InputProps> = {}): InputProps {
-	const { ariaDescribedBy } = getRenderStates(state);
-
 	const props: InputProps = {
 		id: state._id,
 		hideLabel: state._hideLabel,
@@ -20,7 +17,6 @@ function getRadioProps(state: InputRadioStates, inputProps: Partial<InputProps> 
 		value: state._value as string | number | string[] | undefined,
 		disabled: state._disabled,
 		name: state._name,
-		ariaDescribedBy,
 	};
 
 	if ('_required' in state) props.required = state._required;

--- a/packages/components/src/functional-components/FormField/FormField.tsx
+++ b/packages/components/src/functional-components/FormField/FormField.tsx
@@ -27,7 +27,7 @@ function getModifierClassNameByMsgType(msg?: { type?: string }): string {
 	return '';
 }
 
-export type FormFieldProps = Omit<JSXBase.HTMLAttributes<HTMLElement>, 'id'> & {
+export type FormFieldProps = JSXBase.HTMLAttributes<HTMLElement> & {
 	component?: 'div' | 'fieldset';
 	id: string;
 	alert?: boolean;
@@ -55,8 +55,6 @@ export type FormFieldProps = Omit<JSXBase.HTMLAttributes<HTMLElement>, 'id'> & {
 	formFieldTooltipProps?: Pick<JSXBase.HTMLAttributes<HTMLElement>, 'class'>;
 	formFieldMsgProps?: JSXBase.HTMLAttributes<HTMLDivElement>;
 	formFieldInputProps?: JSXBase.HTMLAttributes<HTMLDivElement>;
-} & {
-	[key: `data-${string}`]: unknown;
 };
 
 const InputContainer: FC<JSXBase.HTMLAttributes<HTMLDivElement>> = ({ class: classNames, ...other }, children) => {
@@ -91,6 +89,7 @@ const KolFormFieldFc: FC<FormFieldProps> = (props, children) => {
 		readOnly,
 		touched,
 		maxLength,
+		ariaDescribedBy,
 		formFieldLabelProps,
 		formFieldHintProps,
 		formFieldTooltipProps,
@@ -127,7 +126,7 @@ const KolFormFieldFc: FC<FormFieldProps> = (props, children) => {
 	}
 
 	return (
-		<Component class={clsx('kol-form-field', stateCssClasses, classNames)} {...other}>
+		<Component class={clsx('kol-form-field', stateCssClasses, classNames)} aria-describedby={ariaDescribedBy} {...other}>
 			{showLabel && (
 				<KolFormFieldLabelFc
 					{...(formFieldLabelProps || {})}

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -24,7 +24,7 @@
 		"unused": "knip"
 	},
 	"dependencies": {
-		"@hookform/resolvers": "5.2.2",
+		"@hookform/resolvers": "3.4.2",
 		"@leanup/stack": "1.3.54",
 		"@playwright/test": "1.57.0",
 		"@public-ui/components": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,8 +706,8 @@ importers:
   packages/samples/react:
     dependencies:
       '@hookform/resolvers':
-        specifier: 5.2.2
-        version: 5.2.2(react-hook-form@7.68.0(react@19.2.1))
+        specifier: 3.4.2
+        version: 3.4.2(react-hook-form@7.68.0(react@19.2.1))
       '@leanup/stack':
         specifier: 1.3.54
         version: 1.3.54(chromedriver@139.0.3)(esbuild@0.27.0)(geckodriver@6.1.0)(typescript@5.9.3)
@@ -2995,10 +2995,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hookform/resolvers@5.2.2':
-    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+  '@hookform/resolvers@3.4.2':
+    resolution: {integrity: sha512-1m9uAVIO8wVf7VCDAGsuGA0t6Z3m6jVGAN50HkV9vYLl0yixKK/Z1lr01vaRvYCkIKGoy1noVRxMzQYb4y/j1Q==}
     peerDependencies:
-      react-hook-form: ^7.55.0
+      react-hook-form: ^7.0.0
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -5220,9 +5220,6 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
-
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@stencil-community/eslint-plugin@0.10.0':
     resolution: {integrity: sha512-KLx/NrZN80zNcNyWa6wGgUTL7ucD+57vGYqcmzSpVudoWNmhG8zYi+HteF1s+RZ5bJRZe4b/k81UFDEP24PGkg==}
@@ -16660,9 +16657,8 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hookform/resolvers@5.2.2(react-hook-form@7.68.0(react@19.2.1))':
+  '@hookform/resolvers@3.4.2(react-hook-form@7.68.0(react@19.2.1))':
     dependencies:
-      '@standard-schema/utils': 0.3.0
       react-hook-form: 7.68.0(react@19.2.1)
 
   '@humanwhocodes/config-array@0.11.14':
@@ -19129,8 +19125,6 @@ snapshots:
   '@sinonjs/text-encoding@0.7.3': {}
 
   '@socket.io/component-emitter@3.1.2': {}
-
-  '@standard-schema/utils@0.3.0': {}
 
   '@stencil-community/eslint-plugin@0.10.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -24349,7 +24343,7 @@ snapshots:
       jest-environment-jsdom: 26.6.2
       jest-environment-node: 26.6.2
       jest-get-type: 26.3.0
-      jest-jasmine2: 26.6.3(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.10.1)(typescript@5.9.3))
+      jest-jasmine2: 26.6.3
       jest-regex-util: 26.0.0
       jest-resolve: 26.6.2
       jest-util: 26.6.2
@@ -24443,7 +24437,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-jasmine2@26.6.3(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.10.1)(typescript@5.9.3)):
+  jest-jasmine2@26.6.3:
     dependencies:
       '@babel/traverse': 7.28.5
       '@jest/environment': 26.6.2
@@ -24464,11 +24458,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-leak-detector@26.6.2:
     dependencies:


### PR DESCRIPTION
## Summary

Comprehensive accessibility refactor across form field components:

1. **`kol-input-radio`**: `aria-describedby` moved from individual radio `<input>` elements to the enclosing `<fieldset>`, following correct ARIA group description semantics
2. **`kol-input-checkbox`**: Removed the non-standard `data-role="button"` attribute from the checkbox button variant
3. **`FormField` / `FormFieldStateWrapper` / `RadioStateWrapper`**: Refactored to properly support `aria-describedby` on fieldset elements through the wrapper hierarchy
4. **Test coverage**: Added aria-describedby unit tests for `kol-input-radio`, `kol-input-text`, `kol-select`, `kol-textarea`

**Affected component:** `@public-ui/components` – `kol-input-radio`, `kol-input-checkbox`, form field wrappers

## Changes

- `packages/components/src/components/input-checkbox/shadow.tsx`: Removed `data-role: 'button'` assignment from checkbox button variant render props
- `packages/components/src/functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper.tsx`: `ariaDescribedBy` now only forwarded for fieldset/radio variants
- `packages/components/src/functional-component-wrappers/RadioStateWrapper/RadioStateWrapper.tsx`: Cleaned up redundant aria-describedby logic
- `packages/components/src/functional-components/FormField/FormField.tsx`: Accepts and applies `aria-describedby` prop for fieldset rendering
- New aria-describedby spec files for radio, text, select, textarea
- Snapshot updates

<details>
<summary>Deutsche Zusammenfassung</summary>

Umfassendes Barrierefreiheits-Refactoring über mehrere Formularfeld-Komponenten:

1. **`kol-input-radio`**: `aria-describedby` von einzelnen Radio-`<input>`-Elementen auf das umschließende `<fieldset>` verlagert
2. **`kol-input-checkbox`**: Nicht-standardmäßiges `data-role="button"`-Attribut aus der Checkbox-Button-Variante entfernt
3. **Wrapper-Komponenten**: Refactoring zur korrekten Unterstützung von `aria-describedby` auf Fieldset-Ebene
4. **Testabdeckung**: Unit-Tests für `aria-describedby`-Verhalten für alle betroffenen Komponenten hinzugefügt

</details>