### PR TITLE
ci: use pnpm exec for ncu in dependency updater workflow

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -58,7 +58,11 @@ jobs:
       - name: Install
         run: pnpm i --no-frozen-lockfile
       - name: Update dependencies (minor)
-        run: pnpm ncu:minor
+        run: |
+          pnpm exec ncu -t minor -u
+          pnpm -r exec ncu -t minor -u
+          # Run the recursive update twice so peer and dev dependency bumps align after the first pass adjusts peer ranges.
+          pnpm -r exec ncu -t minor -u
       - name: Reinstall dependencies
         run: pnpm i --no-frozen-lockfile
       - name: Fix format
@@ -96,4 +100,6 @@ jobs:
           pnpm test:e2e
           pnpm unused
       - name: Update dependencies (major)
-        run: pnpm ncu:major
+        run: |
+          pnpm exec ncu
+          pnpm -r exec ncu

--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
 		"lint:stylelint": "pnpm -r --no-bail lint:stylelint",
 		"lint:tsc": "pnpm -r --no-bail lint:tsc",
 		"unused": "pnpm -r unused",
-		"ncu:major": "ncu && pnpm -r exec ncu",
-		"ncu:minor": "ncu -t minor -u && pnpm -r exec ncu -t minor -u",
-		"ncu:patch": "ncu -t patch -u && pnpm -r exec ncu -t patch -u",
 		"pack": "pnpm -r exec pnpm pack",
 		"prepare": "husky",
 		"reinstall": "pnpm clean:pnpm && pnpm i",
@@ -68,7 +65,6 @@
 		"test:update": "pnpm test:update:e2e && pnpm test:update:unit",
 		"test:update:e2e": "pnpm -r --workspace-concurrency=1 test:update:e2e",
 		"test:update:unit": "pnpm -r --workspace-concurrency=1 test:update:unit",
-		"update": "pnpm ncu:minor && pnpm ncu:major",
 		"version": "node scripts/update-publiccode.mjs && git add publiccode.yml"
 	}
 }


### PR DESCRIPTION
## What changed?

The dependency updater CI workflow was updated to invoke `ncu` (npm-check-updates) via `pnpm exec` instead of a direct command, ensuring the correct locally-installed version is used rather than a globally available one. No component code or public API was changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Dependency-Updater-Workflow ruft `ncu` jetzt über `pnpm exec` auf, um die lokal installierte Version zu verwenden. Keine Änderungen an Komponenten oder APIs.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/` — `ncu`-Aufruf auf `pnpm exec ncu` umgestellt

</details>