### PR TITLE
ci: skip netlify deployments for fork pull requests

### DIFF
--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   deploy:
     # Skip this job when the base clone URL may be different from the head clone URL.
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What changed?

The Netlify deployment workflow was updated to skip deployments for all pull requests originating from forks. This prevents unnecessary deployment attempts and potential permission errors when fork contributors open PRs against the repository. No component code or public API was changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Netlify-Deployment-Workflow wurde angepasst, um Deployments für PRs aus Forks zu überspringen. Keine Änderungen an Komponenten oder APIs.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/` — Fork-PR-Ausschluss für Netlify-Deployments hinzugefügt

</details>