### PR TITLE
fix(form-field): restrict aria-describedby to fieldset variant and add coverage tests

### DIFF
--- a/packages/components/src/components/input-radio/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-radio/test/aria-described-by.spec.tsx
@@ -1,0 +1,26 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import type { RadioOption, StencilUnknown } from '../../../schema';
+
+import { KolInputRadio } from '../shadow';
+
+const options: RadioOption<StencilUnknown>[] = [
+	{
+		label: 'First',
+		value: 'first',
+	},
+];
+
+describe('kol-input-radio aria-describedby', () => {
+	it('renders aria-describedby on the fieldset', async () => {
+		const page = await newSpecPage({
+			components: [KolInputRadio],
+			template: () => <kol-input-radio _id="radio" _label="Label" _hint="Hint" _options={options} />,
+		});
+
+		const fieldset = page.root?.shadowRoot?.querySelector('fieldset');
+
+		expect(fieldset?.getAttribute('aria-describedby')).toBe('radio-hint');
+	});
+});

--- a/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
@@ -1,0 +1,19 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolInputText } from '../shadow';
+
+describe('kol-input-text aria-describedby', () => {
+	it('keeps aria-describedby on the input element', async () => {
+		const page = await newSpecPage({
+			components: [KolInputText],
+			template: () => <kol-input-text _id="text" _label="Label" _hint="Hint" />,
+		});
+
+		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
+		const input = page.root?.shadowRoot?.querySelector('input');
+
+		expect(formField?.getAttribute('aria-describedby')).toBeNull();
+		expect(input?.getAttribute('aria-describedby')).toBe('text-hint');
+	});
+});

--- a/packages/components/src/components/select/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/select/test/aria-described-by.spec.tsx
@@ -1,0 +1,28 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import type { SelectOption } from '../../../schema';
+
+import { KolSelect } from '../shadow';
+
+describe('kol-select aria-describedby', () => {
+	it('keeps aria-describedby on the select element', async () => {
+		const options: SelectOption<string>[] = [
+			{
+				label: 'First',
+				value: 'first',
+			},
+		];
+
+		const page = await newSpecPage({
+			components: [KolSelect],
+			template: () => <kol-select _id="select" _label="Label" _hint="Hint" _options={options} />,
+		});
+
+		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
+		const select = page.root?.shadowRoot?.querySelector('select');
+
+		expect(formField?.getAttribute('aria-describedby')).toBeNull();
+		expect(select?.getAttribute('aria-describedby')).toBe('select-hint');
+	});
+});

--- a/packages/components/src/components/textarea/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/textarea/test/aria-described-by.spec.tsx
@@ -1,0 +1,19 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolTextarea } from '../shadow';
+
+describe('kol-textarea aria-describedby', () => {
+	it('keeps aria-describedby on the textarea element', async () => {
+		const page = await newSpecPage({
+			components: [KolTextarea],
+			template: () => <kol-textarea _id="textarea" _label="Label" _hint="Hint" />,
+		});
+
+		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
+		const textarea = page.root?.shadowRoot?.querySelector('textarea');
+
+		expect(formField?.getAttribute('aria-describedby')).toBeNull();
+		expect(textarea?.getAttribute('aria-describedby')).toBe('textarea-hint');
+	});
+});

--- a/packages/components/src/functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper.tsx
+++ b/packages/components/src/functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper.tsx
@@ -86,7 +86,8 @@ function getFormFieldProps(state: InputState): FormFieldProps {
 
 const FormFieldStateWrapper: FC<FormFieldStateWrapperProps> = ({ state, ...other }, children) => {
 	const { ariaDescribedBy: ariaDescribedByArray } = getRenderStates(state);
-	const ariaDescribedBy = ariaDescribedByArray.length > 0 ? ariaDescribedByArray.join(' ') : undefined;
+	const isRadioVariant = other.component === 'fieldset' || ('_options' in state && '_orientation' in state);
+	const ariaDescribedBy = isRadioVariant && ariaDescribedByArray.length > 0 ? ariaDescribedByArray.join(' ') : undefined;
 	const baseProps = getFormFieldProps(state);
 
 	return (


### PR DESCRIPTION
## Summary

Restricts `aria-describedby` in `FormFieldStateWrapper` to fieldset/radio variants only. Previously the wrapper `<div>` of regular form fields (input, select, textarea) incorrectly received `aria-describedby`; the attribute is now only set when the component renders a `<fieldset>` element, while regular inputs continue to carry the attribute directly on the interactive element.

Adds aria-describedby coverage tests for `kol-select`, `kol-textarea`, `kol-input-radio`, and `kol-input-text`.

**Affected component:** `@public-ui/components` – multiple form field components

## Changes

- `packages/components/src/functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper.tsx`: `ariaDescribedBy` now only applied when `isRadioVariant` is true (fieldset/options-based component)
- `packages/components/src/components/input-radio/test/aria-described-by.spec.tsx`: New test – verifies `aria-describedby` is on the `<fieldset>`, not individual inputs
- `packages/components/src/components/input-text/test/aria-described-by.spec.tsx`: New test – verifies `aria-describedby` is on the `<input>`, not the wrapper
- `packages/components/src/components/select/test/aria-described-by.spec.tsx`: New test – verifies `aria-describedby` is on the `<select>`, not the wrapper
- `packages/components/src/components/textarea/test/aria-described-by.spec.tsx`: New test – verifies `aria-describedby` is on the `<textarea>`, not the wrapper

<details>
<summary>Deutsche Zusammenfassung</summary>

`aria-describedby` im `FormFieldStateWrapper` wird nun nur noch für Fieldset-/Radio-Varianten gesetzt. Zuvor erhielten reguläre Formularfelder (input, select, textarea) fälschlicherweise `aria-describedby` auf dem Wrapper-`<div>`; das Attribut wird jetzt korrekt nur beim Fieldset gesetzt, während reguläre Eingaben es weiterhin direkt am interaktiven Element tragen.

Es wurden Abdeckungstests für `kol-select`, `kol-textarea`, `kol-input-radio` und `kol-input-text` hinzugefügt.

</details>