### PR TITLE
fix(badge): forward _ariaDescription to smart button and simplify label

### DIFF
--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -25,6 +25,7 @@ export class KolBadge implements BadgeAPI {
 		return (
 			<KolButtonWcTag
 				_ariaControls={this.id}
+				_ariaDescription={props._ariaDescription}
 				_customClass={props._customClass}
 				_disabled={props._disabled}
 				_hideLabel={true}
@@ -34,7 +35,7 @@ export class KolBadge implements BadgeAPI {
 				_on={props._on}
 				_tooltipAlign={props._tooltipAlign}
 				_variant={props._variant}
-			></KolButtonWcTag>
+			/>
 		);
 	}
 

--- a/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
@@ -10,6 +10,17 @@ exports[`kol-badge should render with _label="**Te**xt" 1`] = `
 </kol-badge>
 `;
 
+exports[`kol-badge should render with _label="Badge fallback" _smartButton={"_ariaDescription":"Badge label","_label":"Remove"} 1`] = `
+<kol-badge class="kol-badge">
+  <template shadowrootmode="open">
+    <span class="smart-button" style="background-color: #000; color: #959595;">
+      <kol-span-wc _allowmarkdown="" _label="Badge fallback" id="nonce"></kol-span-wc>
+      <kol-button-wc _ariacontrols="nonce" _ariadescription="Badge label" _hidelabel="" _label="Remove"></kol-button-wc>
+    </span>
+  </template>
+</kol-badge>
+`;
+
 exports[`kol-badge should render with _label="Text" _color="#000000" 1`] = `
 <kol-badge class="kol-badge">
   <template shadowrootmode="open">

--- a/packages/components/src/components/badge/test/snapshot.spec.tsx
+++ b/packages/components/src/components/badge/test/snapshot.spec.tsx
@@ -13,5 +13,6 @@ executeSnapshotTests<BadgeProps>(
 		{ _label: 'Text', _color: '#000000' },
 		{ _label: 'Text', _icons: 'codicon codicon-home' },
 		{ _label: 'Text', _icons: 'codicon codicon-home', _color: '#000000' },
+		{ _label: 'Badge fallback', _smartButton: { _ariaDescription: 'Badge label', _label: 'Remove' } },
 	],
 );

--- a/packages/samples/react/src/components/badge/button.tsx
+++ b/packages/samples/react/src/components/badge/button.tsx
@@ -7,8 +7,9 @@ import { SampleDescription } from '../SampleDescription';
 const createBadgeProps = (label: string) => ({
 	_label: label,
 	_smartButton: {
+		_ariaDescription: label,
 		_icons: 'codicon codicon-close',
-		_label: `Remove ${label}`,
+		_label: `Remove`,
 		_on: {
 			onClick: () => alert('clicked'),
 		},


### PR DESCRIPTION
## Summary

Forwards the `_ariaDescription` property from `KolBadge` to the embedded `KolButtonWc` smart button, enabling screen readers to announce an accessible description independently from the button label.

Updates the React sample to pass `_ariaDescription: label` and simplify the smart button label from `` 'Remove ${label}' `` to `'Remove'`, avoiding redundant label concatenation.

**Affected component:** `@public-ui/components` – `kol-badge`

## Changes

- `packages/components/src/components/badge/shadow.tsx`: Added `_ariaDescription={props._ariaDescription}` prop forwarding to `KolButtonWcTag`
- `packages/components/src/components/badge/test/snapshot.spec.tsx`: Added snapshot test for badge with smart button and aria description
- `packages/samples/react/src/components/badge/button.tsx`: Updated sample to use `_ariaDescription: label` and simplified `_label: 'Remove'`

<details>
<summary>Deutsche Zusammenfassung</summary>

Die `_ariaDescription`-Eigenschaft wird nun vom `KolBadge` an den eingebetteten `KolButtonWc` Smart-Button weitergeleitet. Damit können Screenreader eine zugängliche Beschreibung unabhängig vom Button-Label ankündigen.

Das React-Beispiel wurde aktualisiert: `_ariaDescription: label` wird übergeben und das Smart-Button-Label wurde von `` 'Remove ${label}' `` zu `'Remove'` vereinfacht.

</details>