### PR TITLE
fix: align badge label with smart button description

### DIFF
--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -33,6 +33,8 @@ export class KolBadge implements BadgeAPI, FocusableElement {
 				ref={this.catchSmartButtonRef}
 				class="kol-badge__smart-button"
 				_ariaControls={this.id}
+				_ariaDescription={props._ariaDescription}
+				_buttonVariant={props._variant}
 				_customClass={props._customClass}
 				_disabled={props._disabled}
 				_hideLabel={true}
@@ -41,8 +43,7 @@ export class KolBadge implements BadgeAPI, FocusableElement {
 				_label={props._label}
 				_on={props._on}
 				_tooltipAlign={props._tooltipAlign}
-				_buttonVariant={props._variant}
-			></KolButtonWcTag>
+			/>
 		);
 	}
 

--- a/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
@@ -20,6 +20,24 @@ exports[`kol-badge should render with _label="**Te**xt" 1`] = `
 </kol-badge>
 `;
 
+exports[`kol-badge should render with _label="Badge fallback" _smartButton={"_ariaDescription":"Badge label","_label":"Remove"} 1`] = `
+<kol-badge>
+  <template shadowrootmode="open">
+    <span class="kol-badge kol-badge--has-smart-button" style="background-color: #000; color: #959595;">
+      <span class="kol-badge__label kol-span" id="nonce">
+        <span class="kol-span__container">
+          <span class="kol-span__label md">
+            Badge fallback
+          </span>
+          <span aria-hidden="true" class="kol-span__label" hidden=""></span>
+        </span>
+      </span>
+      <kol-button-wc _ariacontrols="nonce" _ariadescription="Badge label" _hidelabel="" _label="Remove" class="kol-badge__smart-button"></kol-button-wc>
+    </span>
+  </template>
+</kol-badge>
+`;
+
 exports[`kol-badge should render with _label="Text" _color="#000000" 1`] = `
 <kol-badge>
   <template shadowrootmode="open">

--- a/packages/components/src/components/badge/test/snapshot.spec.tsx
+++ b/packages/components/src/components/badge/test/snapshot.spec.tsx
@@ -13,5 +13,6 @@ executeSnapshotTests<BadgeProps>(
 		{ _label: 'Text', _color: '#000000' },
 		{ _label: 'Text', _icons: 'codicon codicon-home' },
 		{ _label: 'Text', _icons: 'codicon codicon-home', _color: '#000000' },
+		{ _label: 'Badge fallback', _smartButton: { _ariaDescription: 'Badge label', _label: 'Remove' } },
 	],
 );

--- a/packages/samples/react/src/components/badge/button.tsx
+++ b/packages/samples/react/src/components/badge/button.tsx
@@ -7,8 +7,9 @@ import { SampleDescription } from '../SampleDescription';
 const createBadgeProps = (label: string) => ({
 	_label: label,
 	_smartButton: {
+		_ariaDescription: label,
 		_icons: 'codicon codicon-close',
-		_label: `Remove ${label}`,
+		_label: `Remove`,
 		_on: {
 			onClick: () => alert('clicked'),
 		},


### PR DESCRIPTION
## What changed?

The `KolBadge` component's internal `KolButtonWc` smart button now correctly receives `_ariaDescription` forwarded from the badge's own `_ariaDescription` prop. Previously this prop was not forwarded, leaving screen readers without a description for the smart button. The sample component (`badge/button.tsx`) was updated to pass `_ariaDescription: label` to `_smartButton` and to simplify the button label from `Remove ${label}` to `Remove` (since the description is now provided separately). A corresponding snapshot test case was added.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der interne `KolButtonWc`-Smart-Button der `KolBadge`-Komponente erhält nun korrekt `_ariaDescription` aus der Badge-Prop weitergeleitet. Screenreader erhalten damit eine aussagekräftige Beschreibung des Smart-Buttons. Die Beispielkomponente wurde entsprechend aktualisiert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/badge/shadow.tsx` — `_ariaDescription` und `_buttonVariant` korrekt an `KolButtonWc` weitergeleitet
- `packages/samples/react/src/components/badge/button.tsx` — `_ariaDescription` in `_smartButton`-Konfiguration hinzugefügt
- `packages/components/src/components/badge/test/snapshot.spec.tsx` — Neuer Testfall für Smart-Button mit `_ariaDescription`

</details>