### PR TITLE
Add v4 migration for `_error` removal

### DIFF
--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/error.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/error.ts
@@ -1,0 +1,21 @@
+import { AbstractTask } from '../../abstract-task';
+import { RefactorPropertyErrorToMsg } from '../common/RefactorPropertyErrorToMsg';
+
+const INPUT_COMPONENTS = [
+	'kol-combobox',
+	'kol-input-checkbox',
+	'kol-input-color',
+	'kol-input-date',
+	'kol-input-email',
+	'kol-input-file',
+	'kol-input-number',
+	'kol-input-password',
+	'kol-input-radio',
+	'kol-input-range',
+	'kol-input-text',
+	'kol-select',
+	'kol-single-select',
+	'kol-textarea',
+];
+
+export const RefactorErrorToMsgTasks: AbstractTask[] = INPUT_COMPONENTS.map((componentName) => RefactorPropertyErrorToMsg.getInstance(componentName, '^4'));

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,4 +1,5 @@
 import { AbstractTask } from '../../abstract-task';
+import { RefactorErrorToMsgTasks } from './error';
 import { RemoveIdPropTasks } from './id';
 import { MapVariantStandaloneToInlineTasks } from './link';
 import { UpdateLoaderImportPathTask } from './loader';
@@ -8,6 +9,7 @@ import { RemoveToasterGetInstanceOptionsTask } from './toaster';
 
 export const v4Tasks: AbstractTask[] = [];
 
+v4Tasks.push(...RefactorErrorToMsgTasks);
 v4Tasks.push(...MapVariantStandaloneToInlineTasks);
 v4Tasks.push(...RemoveIdPropTasks);
 v4Tasks.push(...RemoveMsgPropsTasks);


### PR DESCRIPTION
## Summary
- add a v4 migration task to refactor the deprecated `_error` attribute to `_msg` for form inputs
- register the new migration tasks with the v4 task collection

## Testing
- pnpm format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937597dd804832bb9f4373fe0bcf51a)