### PR TITLE
Rename _hideError to _hideMsg and add migration

### DIFF
--- a/packages/components/src/components/@deprecated/input/controller.ts
+++ b/packages/components/src/components/@deprecated/input/controller.ts
@@ -5,6 +5,7 @@ import type {
 	AdjustHeightPropType,
 	ButtonProps,
 	DisabledPropType,
+	HideErrorPropType,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -25,6 +26,7 @@ import {
 	validateAccessKey,
 	validateAdjustHeight,
 	validateDisabled,
+	validateHideError,
 	validateHideLabel,
 	validateHideMsg,
 	validateHint,
@@ -67,6 +69,9 @@ export class InputController extends ControlledInputController implements Watche
 
 	public validateDisabled(value?: DisabledPropType): void {
 		validateDisabled(this.component, value);
+	}
+	public validateHideError(value?: HideErrorPropType): void {
+		validateHideError(this.component, value);
 	}
 	public validateTooltipAlign(value?: TooltipAlignPropType): void {
 		validateTooltipAlign(this.component, value);
@@ -150,6 +155,7 @@ export class InputController extends ControlledInputController implements Watche
 		this.validateAdjustHeight(this.component._adjustHeight);
 		this.validateMsg(this.component._msg);
 		this.validateDisabled(this.component._disabled);
+		this.validateHideError(this.component._hideError);
 		this.validateHideMsg(this.component._hideMsg);
 		this.validateHideLabel(this.component._hideLabel);
 		this.validateHint(this.component._hint);

--- a/packages/components/src/components/@deprecated/input/types.ts
+++ b/packages/components/src/components/@deprecated/input/types.ts
@@ -6,6 +6,7 @@ type OptionalProps = PropLabelWithExpertSlot & {
 	accessKey: AccessKeyPropType;
 	adjustHeight: boolean;
 	disabled: boolean;
+	hideError: boolean;
 	hideMsg: boolean;
 	hideLabel: boolean;
 	hint: string;

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -14,8 +14,8 @@ import type {
 	ComboboxAPI,
 	ComboboxStates,
 	DisabledPropType,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -436,10 +436,15 @@ export class KolCombobox implements ComboboxAPI {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -562,10 +567,9 @@ export class KolCombobox implements ComboboxAPI {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -7,6 +7,7 @@ import type {
 	CheckedPropType,
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -162,10 +163,15 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _checked?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Makes the element not focusable and ignore all events.
@@ -304,6 +310,11 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Watch('_disabled')
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
+	}
+
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideMsg')

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -5,8 +5,8 @@ import type {
 	ButtonProps,
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -180,10 +180,15 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -296,10 +301,9 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -7,8 +7,8 @@ import type {
 	ButtonProps,
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -209,10 +209,15 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -359,10 +364,9 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -8,8 +8,8 @@ import type {
 	DisabledPropType,
 	FocusableElement,
 	HasCounterPropType,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -163,10 +163,15 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -314,10 +319,9 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -7,8 +7,8 @@ import type {
 	ButtonProps,
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -149,10 +149,15 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -269,10 +274,9 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -7,8 +7,8 @@ import type {
 	ButtonProps,
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -179,10 +179,15 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -328,10 +333,9 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -8,8 +8,8 @@ import type {
 	DisabledPropType,
 	FocusableElement,
 	HasCounterPropType,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -190,10 +190,15 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -348,10 +353,9 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	public validateVariant(value?: PasswordVariantPropType): void {
 		this.controller.validateVariant(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -5,8 +5,8 @@ import clsx from 'clsx';
 import type {
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IdPropType,
 	InputRadioAPI,
@@ -166,10 +166,15 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -280,10 +285,9 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	public validateHideLabel(value?: HideLabelPropType): void {
 		this.controller.validateHideLabel(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hint')

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -6,8 +6,8 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -240,10 +240,15 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -368,10 +373,9 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -9,6 +9,7 @@ import type {
 	DisabledPropType,
 	FocusableElement,
 	HasCounterPropType,
+	HideErrorPropType,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -227,10 +228,15 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -388,6 +394,11 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Watch('_disabled')
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
+	}
+
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideMsg')

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -5,8 +5,8 @@ import clsx from 'clsx';
 import type {
 	DisabledPropType,
 	FocusableElement,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -139,10 +139,15 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -270,10 +275,9 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -2,8 +2,8 @@ import type { JSX } from '@stencil/core';
 import { Component, Element, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
 import type {
 	DisabledPropType,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -539,10 +539,15 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -667,10 +672,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -7,8 +7,8 @@ import type {
 	DisabledPropType,
 	FocusableElement,
 	HasCounterPropType,
+	HideErrorPropType,
 	HideLabelPropType,
-	HideMsgPropType,
 	HintPropType,
 	IconsHorizontalPropType,
 	IdPropType,
@@ -151,10 +151,15 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Prop() public _disabled?: boolean = false;
 
 	/**
+	 * @deprecated Use `_hideMsg` instead.
+	 */
+	@Prop() public _hideError?: boolean;
+
+	/**
 	 * Hides the error message but leaves it in the DOM for the input's aria-describedby.
 	 * @TODO: Change type back to `HideMsgPropType` after Stencil#4663 has been resolved.
 	 */
-	@Prop() public _hideMsg?: boolean = false;
+	@Prop() public _hideMsg?: boolean;
 
 	/**
 	 * Hides the caption by default and displays the caption text with a tooltip when the
@@ -309,10 +314,9 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	public validateDisabled(value?: DisabledPropType): void {
 		this.controller.validateDisabled(value);
 	}
-
-	@Watch('_hideMsg')
-	public validateHideMsg(value?: HideMsgPropType): void {
-		this.controller.validateHideMsg(value);
+	@Watch('_hideError')
+	public validateHideError(value?: HideErrorPropType): void {
+		this.controller.validateHideError(value);
 	}
 
 	@Watch('_hideLabel')

--- a/packages/components/src/schema/components/combobox.ts
+++ b/packages/components/src/schema/components/combobox.ts
@@ -4,6 +4,7 @@ import type {
 	MsgPropType,
 	PropAccessKey,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -29,6 +30,7 @@ type OptionalProps = {
 	value: string;
 } & PropAccessKey &
 	PropDisabled &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -45,6 +47,7 @@ type RequiredStates = {
 	suggestions: W3CInputValue[];
 	value: string;
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {

--- a/packages/components/src/schema/components/input-checkbox.ts
+++ b/packages/components/src/schema/components/input-checkbox.ts
@@ -8,6 +8,7 @@ import type {
 	PropAccessKey,
 	PropChecked,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -33,6 +34,7 @@ type OptionalProps = {
 } & PropAccessKey &
 	PropChecked &
 	PropDisabled &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -50,6 +52,7 @@ type RequiredStates = {
 	value: StencilUnknown;
 	variant: InputCheckboxVariantPropType;
 } & PropChecked &
+	PropHideError &
 	PropHideMsg &
 	PropIndeterminate &
 	PropLabelWithExpertSlot;

--- a/packages/components/src/schema/components/input-color.ts
+++ b/packages/components/src/schema/components/input-color.ts
@@ -5,6 +5,7 @@ import type {
 	PropAccessKey,
 	PropAutoComplete,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -30,6 +31,7 @@ type OptionalProps = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHideLabel &
+	PropHideError &
 	PropHideMsg &
 	PropHint &
 	PropHorizontalIcons &
@@ -42,7 +44,8 @@ type OptionalProps = {
 type RequiredStates = {
 	id: string;
 	suggestions: W3CInputValue[];
-} & PropHideMsg &
+} & PropHideError &
+	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {
 	on: InputTypeOnDefault;

--- a/packages/components/src/schema/components/input-date.ts
+++ b/packages/components/src/schema/components/input-date.ts
@@ -6,6 +6,7 @@ import type {
 	PropAccessKey,
 	PropAutoComplete,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -38,6 +39,7 @@ type OptionalProps = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHideLabel &
+	PropHideError &
 	PropHideMsg &
 	PropHint &
 	PropHorizontalIcons &
@@ -52,6 +54,7 @@ type RequiredStates = {
 	suggestions: W3CInputValue[];
 	type: InputDateTypePropType;
 } & PropLabelWithExpertSlot &
+	PropHideError &
 	PropHideMsg &
 	PropId;
 

--- a/packages/components/src/schema/components/input-email.ts
+++ b/packages/components/src/schema/components/input-email.ts
@@ -5,6 +5,7 @@ import type {
 	PropAccessKey,
 	PropAutoComplete,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -37,6 +38,7 @@ type OptionalProps = {
 } & PropAccessKey &
 	PropAutoComplete &
 	PropDisabled &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -57,6 +59,7 @@ type RequiredStates = {
 	currentLength: number;
 	currentLengthDebounced: number;
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 

--- a/packages/components/src/schema/components/input-file.ts
+++ b/packages/components/src/schema/components/input-file.ts
@@ -4,6 +4,7 @@ import type {
 	MsgPropType,
 	PropAccessKey,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -29,6 +30,7 @@ type OptionalProps = {
 	smartButton: Stringified<ButtonProps>;
 } & PropAccessKey &
 	PropDisabled &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &

--- a/packages/components/src/schema/components/input-number.ts
+++ b/packages/components/src/schema/components/input-number.ts
@@ -6,6 +6,7 @@ import type {
 	PropAccessKey,
 	PropAutoComplete,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -38,6 +39,7 @@ type OptionalProps = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHideLabel &
+	PropHideError &
 	PropHideMsg &
 	PropHint &
 	PropHorizontalIcons &
@@ -51,6 +53,7 @@ type RequiredStates = {
 	hasValue: boolean;
 	suggestions: W3CInputValue[];
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 

--- a/packages/components/src/schema/components/input-password.ts
+++ b/packages/components/src/schema/components/input-password.ts
@@ -6,6 +6,7 @@ import type {
 	PropAutoComplete,
 	PropDisabled,
 	PropHasCounter,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -39,6 +40,7 @@ type OptionalProps = {
 	PropPasswordVariant &
 	PropDisabled &
 	PropHasCounter &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -56,6 +58,7 @@ type RequiredStates = {
 	currentLengthDebounced: number;
 	hasValue: boolean;
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {

--- a/packages/components/src/schema/components/input-radio.ts
+++ b/packages/components/src/schema/components/input-radio.ts
@@ -2,6 +2,7 @@ import type { Generic } from 'adopted-style-sheets';
 import type {
 	MsgPropType,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -25,6 +26,7 @@ type OptionalProps = {
 	value: StencilUnknown;
 } & PropDisabled &
 	PropHideLabel &
+	PropHideError &
 	PropHideMsg &
 	PropHint &
 	PropName &
@@ -38,6 +40,7 @@ type OptionalProps = {
 type RequiredStates = {
 	options: RadioOption<StencilUnknown>[];
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropLabelWithExpertSlot &
 	PropOrientation;

--- a/packages/components/src/schema/components/input-range.ts
+++ b/packages/components/src/schema/components/input-range.ts
@@ -5,6 +5,7 @@ import type {
 	PropAccessKey,
 	PropAutoComplete,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -31,6 +32,7 @@ type OptionalProps = {
 } & PropAccessKey &
 	PropAutoComplete &
 	PropDisabled &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -44,6 +46,7 @@ type OptionalProps = {
 type RequiredStates = {
 	suggestions: W3CInputValue[];
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {

--- a/packages/components/src/schema/components/input-text.ts
+++ b/packages/components/src/schema/components/input-text.ts
@@ -7,6 +7,7 @@ import type {
 	PropAutoComplete,
 	PropDisabled,
 	PropHasCounter,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -41,6 +42,7 @@ type OptionalProps = {
 	PropAutoComplete &
 	PropDisabled &
 	PropHasCounter &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -62,7 +64,8 @@ type RequiredStates = {
 	hasValue: boolean;
 	suggestions: W3CInputValue[];
 	type: InputTextTypePropType;
-} & PropHideMsg &
+} & PropHideError &
+	PropHideMsg &
 	PropId &
 	PropLabelWithExpertSlot;
 type OptionalStates = {

--- a/packages/components/src/schema/components/select.ts
+++ b/packages/components/src/schema/components/select.ts
@@ -4,6 +4,7 @@ import type {
 	MsgPropType,
 	PropAccessKey,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -30,6 +31,7 @@ type OptionalProps = {
 	value: Stringified<StencilUnknown[]> | Stringified<StencilUnknown>;
 } & PropAccessKey &
 	PropDisabled &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -47,6 +49,7 @@ type RequiredStates = {
 	options: SelectOption<W3CInputValue>[];
 	value: StencilUnknown[] | StencilUnknown;
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropMultiple &
 	PropLabelWithExpertSlot;

--- a/packages/components/src/schema/components/single-select.ts
+++ b/packages/components/src/schema/components/single-select.ts
@@ -4,6 +4,7 @@ import type {
 	MsgPropType,
 	PropAccessKey,
 	PropDisabled,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -30,6 +31,7 @@ type OptionalProps = {
 	hideClearButton: boolean;
 } & PropAccessKey &
 	PropDisabled &
+	PropHideError &
 	PropHideMsg &
 	PropHideLabel &
 	PropHint &
@@ -44,6 +46,7 @@ type OptionalProps = {
 type RequiredStates = {
 	options: Option<StencilUnknown>[];
 } & PropId &
+	PropHideError &
 	PropHideMsg &
 	PropLabelWithExpertSlot;
 type OptionalStates = {

--- a/packages/components/src/schema/components/textarea.ts
+++ b/packages/components/src/schema/components/textarea.ts
@@ -6,6 +6,7 @@ import type {
 	PropAdjustHeight,
 	PropDisabled,
 	PropHasCounter,
+	PropHideError,
 	PropHideLabel,
 	PropHideMsg,
 	PropHint,
@@ -41,6 +42,7 @@ type OptionalProps = {
 	PropDisabled &
 	PropHasCounter &
 	PropHideLabel &
+	PropHideError &
 	PropHideMsg &
 	PropHint &
 	PropHorizontalIcons &
@@ -62,6 +64,7 @@ type RequiredStates = {
 	hasValue: boolean;
 	resize: CSSResize;
 } & PropAdjustHeight &
+	PropHideError &
 	PropHideMsg &
 	PropId &
 	PropLabelWithExpertSlot;

--- a/packages/components/src/schema/props/hide-error.ts
+++ b/packages/components/src/schema/props/hide-error.ts
@@ -1,0 +1,25 @@
+import type { Generic } from 'adopted-style-sheets';
+
+import { devHint } from '../utils';
+
+import { type HideMsgPropType, validateHideMsg } from './hide-msg';
+
+/* types */
+export type HideErrorPropType = HideMsgPropType;
+
+/**
+ * @deprecated Use `_hideMsg` instead.
+ */
+export type PropHideError = {
+	/** @deprecated Use `_hideMsg` instead. */
+	hideError: HideErrorPropType;
+};
+
+/* validator */
+/** @deprecated Use `_hideMsg` instead. */
+export const validateHideError = (component: Generic.Element.Component, value?: HideErrorPropType): void => {
+	if (typeof value !== 'undefined') {
+		devHint('Property `_hideError` is deprecated. Use `_hideMsg` instead.');
+	}
+	validateHideMsg(component, value, { defaultValue: component.state?._hideMsg ?? false });
+};

--- a/packages/components/src/schema/props/hide-msg.ts
+++ b/packages/components/src/schema/props/hide-msg.ts
@@ -15,5 +15,6 @@ export type PropHideMsg = {
 
 /* validator */
 export const validateHideMsg = (component: Generic.Element.Component, value?: HideMsgPropType, options?: WatchBooleanOptions): void => {
-	watchBoolean(component, '_hideMsg', value, options);
+	const defaultValue = typeof options?.defaultValue === 'undefined' ? (component.state?._hideMsg ?? false) : options.defaultValue;
+	watchBoolean(component, '_hideMsg', value, { ...options, defaultValue });
 };

--- a/packages/components/src/schema/props/index.ts
+++ b/packages/components/src/schema/props/index.ts
@@ -35,6 +35,7 @@ export * from './has-counter';
 export * from './has-icons-when-expanded';
 export * from './has-settings-menu';
 export * from './has-value';
+export * from './hide-error';
 export * from './hide-label';
 export * from './hide-msg';
 export * from './hint';

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/hide-msg.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/hide-msg.ts
@@ -1,0 +1,21 @@
+import { AbstractTask } from '../../abstract-task';
+import { RenamePropertyNameTask } from '../common/RenamePropertyNameTask';
+
+const TAGS = [
+	'kol-combobox',
+	'kol-input-checkbox',
+	'kol-input-color',
+	'kol-input-date',
+	'kol-input-email',
+	'kol-input-file',
+	'kol-input-number',
+	'kol-input-password',
+	'kol-input-radio',
+	'kol-input-range',
+	'kol-input-text',
+	'kol-select',
+	'kol-single-select',
+	'kol-textarea',
+];
+
+export const HideErrorToHideMsgTasks: AbstractTask[] = TAGS.map((tag) => RenamePropertyNameTask.getInstance(tag, '_hide-error', '_hide-msg', '^4'));

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,4 +1,5 @@
 import { AbstractTask } from '../../abstract-task';
+import { HideErrorToHideMsgTasks } from './hide-msg';
 import { RemoveIdPropTasks } from './id';
 import { RemoveMsgPropsTasks } from './msg';
 import { RemoveToastVariantTask } from './toast';
@@ -7,6 +8,7 @@ import { RemoveToasterGetInstanceOptionsTask } from './toaster';
 export const v4Tasks: AbstractTask[] = [];
 
 v4Tasks.push(...RemoveIdPropTasks);
+v4Tasks.push(...HideErrorToHideMsgTasks);
 v4Tasks.push(...RemoveMsgPropsTasks);
 v4Tasks.push(RemoveToastVariantTask.getInstance('^4'));
 v4Tasks.push(RemoveToasterGetInstanceOptionsTask.getInstance('^4'));


### PR DESCRIPTION
## Summary
- add deprecated `_hideError` prop handling across form components so it maps to `_hideMsg`
- expose new prop schema and adjust hide message validation defaults
- add v4 migration tasks to rename `_hide-error` usages to `_hide-msg`

## Testing
- pnpm format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375991b674832bbd76e970857d4600)