### PR TITLE
fix(button-link): add min-width unset for inline button-link variant

### DIFF
--- a/packages/components/src/components/button-link/style.scss
+++ b/packages/components/src/components/button-link/style.scss
@@ -5,8 +5,9 @@
 @layer kol-component {
 	@include kol-link-styles('kol-button');
 
+	// Inline may have the height and width of the flowing text and do not necessarily have to be 44px high or width.
 	.kol-button--inline {
 		min-width: unset;
-		min-height: unset; // Inline links may have the height of the flowing text and do not necessarily have to be 44px high.
+		min-height: unset;
 	}
 }

--- a/packages/components/src/components/button-link/style.scss
+++ b/packages/components/src/components/button-link/style.scss
@@ -6,6 +6,7 @@
 	@include kol-link-styles('kol-button');
 
 	.kol-button--inline {
+		min-width: unset;
 		min-height: unset; // Inline links may have the height of the flowing text and do not necessarily have to be 44px high.
 	}
 }


### PR DESCRIPTION
## What changed?

The `.kol-button--inline` CSS rule in `button-link/style.scss` was missing `min-width: unset`, causing inline button-link elements to maintain their 44px minimum width and break out of inline text flow. The fix adds `min-width: unset` alongside the existing `min-height: unset` for inline variants. The explanatory comment was also updated to cover both dimensions.

## Linked issues

- Refs #8973 — Link button min width

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In der CSS-Regel `.kol-button--inline` fehlte `min-width: unset`, was dazu führte, dass Inline-Button-Link-Elemente ihre 44px-Mindestbreite beibehielten. Die Korrektur fügt `min-width: unset` hinzu und ergänzt den Kommentar um beide Dimensionen.

### Verknüpfte Tickets

- Referenziert #8973 — Link-Button Mindestbreite

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/button-link/style.scss` — `min-width: unset` für `.kol-button--inline` hinzugefügt

</details>