### PR TITLE
ci: ensure icons package builds before e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
+      - name: Build icons package
+        run: pnpm --filter @public-ui/icons build
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium firefox webkit
       - name: E2E Test components


### PR DESCRIPTION
## What changed?

The CI pipeline was updated to ensure the `@public-ui/icons` package is built before the end-to-end test suite runs. This prevents test failures caused by missing icon font artifacts when the icons package had not yet been built. No component code or public API was changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die CI-Pipeline wurde so angepasst, dass das `@public-ui/icons`-Paket vor der E2E-Test-Suite gebaut wird. Keine Änderungen an Komponenten oder APIs.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/` — Build-Reihenfolge für Icons-Paket vor E2E-Tests angepasst

</details>