### PR TITLE
fix(workspace): correct typo in pnpm-workspace.yaml for kolibri-cli path

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ packages:
   - packages/themes/ecl
   - packages/themes
   - packages/tools/benchmark-tests
-  - packages/tools/kolibri-clix
+  - packages/tools/kolibri-cli
   - packages/tools/hydrate-server
   - packages/tools/mcp
   - packages/tools/visual-tests


### PR DESCRIPTION
## What changed?

A typo in `pnpm-workspace.yaml` caused the `@public-ui/kolibri-cli` package to be unrecognised by pnpm workspace commands (`packages/tools/kolibri-clix` was listed instead of `packages/tools/kolibri-cli`). The single-character correction ensures the CLI package is properly included in the monorepo and discoverable by all workspace operations.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein Tippfehler in `pnpm-workspace.yaml` verhinderte, dass das `@public-ui/kolibri-cli`-Paket von pnpm-Workspace-Befehlen erkannt wurde (`kolibri-clix` statt `kolibri-cli`). Die Korrektur stellt sicher, dass das CLI-Paket korrekt im Monorepo registriert ist.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `pnpm-workspace.yaml` — Tippfehler in Workspace-Pfad korrigiert (`kolibri-clix` → `kolibri-cli`)

</details>