### PR TITLE
refactor(components): inline message type helper and remove single-use state flag variables

### DIFF
--- a/packages/components/src/functional-component-wrappers/_helpers/getRenderStates.ts
+++ b/packages/components/src/functional-component-wrappers/_helpers/getRenderStates.ts
@@ -1,4 +1,4 @@
-import type { MsgPropType, Stringified, TouchedPropType } from '../../schema';
+import { getMsgType, type MsgPropType, type Stringified, type TouchedPropType } from '../../schema';
 
 /**
  * Berechnet in Abhängigkeit des Component-State, wie die
@@ -21,7 +21,7 @@ export const getRenderStates = (state: {
 } => {
 	const msg = state._msg;
 	const description = typeof msg === 'string' ? msg : msg?._description;
-	const type = typeof msg === 'string' ? 'error' : (msg?._type ?? 'error');
+	const type = getMsgType(msg);
 	const hasMessage = Boolean(description && description.length > 0);
 	const isMessageValidError = type === 'error' && hasMessage;
 	const hasError = isMessageValidError && state._touched === true;

--- a/packages/components/src/functional-components/FieldControl/FieldControl.tsx
+++ b/packages/components/src/functional-components/FieldControl/FieldControl.tsx
@@ -3,6 +3,7 @@ import type { JSXBase } from '@stencil/core/internal';
 import clsx from 'clsx';
 import {
 	buildBadgeTextString,
+	getMsgType,
 	isMsgDefinedAndInputTouched,
 	showExpertSlot,
 	type AlignPropType,
@@ -113,7 +114,7 @@ const KolFieldControlFc: FC<FieldControlProps> = (props, children) => {
 		['kol-field-control--touched']: Boolean(touched),
 		['kol-field-control--hide-label']: Boolean(hideLabel),
 		['kol-field-control--read-only']: Boolean(readonly),
-		[`kol-field-control--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: Boolean(isMsgDefinedAndInputTouched(msg, touched)),
+		[`kol-field-control--${getMsgType(msg)}`]: Boolean(isMsgDefinedAndInputTouched(msg, touched)),
 		[`kol-field-control--label-align-${labelAlign}`]: Boolean(labelAlign),
 	};
 

--- a/packages/components/src/functional-components/FieldControl/FieldControl.tsx
+++ b/packages/components/src/functional-components/FieldControl/FieldControl.tsx
@@ -78,11 +78,9 @@ const KolFieldControlFc: FC<FieldControlProps> = (props, children) => {
 
 	const canShowHint = !renderNoHint;
 	const canShowTooltip = !renderNoTooltip;
-	const showMsg = isMsgDefinedAndInputTouched(msg, touched);
 	const hasExpertSlot = showExpertSlot(label);
 	const useTooltipInsteadOfLabel = canShowTooltip && !hasExpertSlot && hideLabel;
 	const badgeText = buildBadgeTextString(accessKey, shortKey);
-	const msgType = typeof msg === 'string' ? 'error' : msg?._type;
 
 	const components = [
 		<>
@@ -115,7 +113,7 @@ const KolFieldControlFc: FC<FieldControlProps> = (props, children) => {
 		['kol-field-control--touched']: Boolean(touched),
 		['kol-field-control--hide-label']: Boolean(hideLabel),
 		['kol-field-control--read-only']: Boolean(readonly),
-		[`kol-field-control--${msgType || 'error'}`]: Boolean(showMsg),
+		[`kol-field-control--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: Boolean(isMsgDefinedAndInputTouched(msg, touched)),
 		[`kol-field-control--label-align-${labelAlign}`]: Boolean(labelAlign),
 	};
 

--- a/packages/components/src/functional-components/FormField/FormField.tsx
+++ b/packages/components/src/functional-components/FormField/FormField.tsx
@@ -3,7 +3,7 @@ import { h, type FunctionalComponent as FC } from '@stencil/core';
 import type { JSXBase } from '@stencil/core/internal';
 import clsx from 'clsx';
 import type { AlignPropType, MaxLengthBehaviorPropType, MsgPropType, Stringified } from '../../schema';
-import { buildBadgeTextString, isMsgDefinedAndInputTouched, showExpertSlot } from '../../schema';
+import { buildBadgeTextString, getMsgType, isMsgDefinedAndInputTouched, showExpertSlot } from '../../schema';
 import KolFormFieldCharacterLimitHintFc from '../FormFieldCharacterLimitHint/FormFieldCharacterLimitHint';
 import KolFormFieldCounterFc from '../FormFieldCounter';
 import KolFormFieldHintFc from '../FormFieldHint/FormFieldHint';
@@ -106,8 +106,6 @@ const KolFormFieldFc: FC<FormFieldProps> = (props, children) => {
 	const badgeText = buildBadgeTextString(accessKey, shortKey);
 	const useTooltipInsteadOfLabel = showTooltip && !hasExpertSlot && hideLabel;
 
-	const msgType = typeof msg === 'string' ? 'error' : (msg?._type ?? 'error');
-
 	let stateCssClasses = {
 		['kol-form-field--disabled']: Boolean(disabled),
 		['kol-form-field--required']: Boolean(required),
@@ -118,6 +116,8 @@ const KolFormFieldFc: FC<FormFieldProps> = (props, children) => {
 	};
 
 	if (showMsg) {
+		const msgType = getMsgType(msg);
+
 		stateCssClasses = {
 			...stateCssClasses,
 			[`kol-form-field--${msgType || 'error'}`]: true,

--- a/packages/components/src/functional-components/FormField/FormField.tsx
+++ b/packages/components/src/functional-components/FormField/FormField.tsx
@@ -120,7 +120,7 @@ const KolFormFieldFc: FC<FormFieldProps> = (props, children) => {
 
 		stateCssClasses = {
 			...stateCssClasses,
-			[`kol-form-field--${msgType || 'error'}`]: true,
+			[`kol-form-field--${msgType}`]: true,
 			[`kol-form-field--${getModifierClassNameByMsgType({ type: msgType })}`]: true,
 		};
 	}

--- a/packages/components/src/functional-components/InputContainer/InputContainer.tsx
+++ b/packages/components/src/functional-components/InputContainer/InputContainer.tsx
@@ -1,7 +1,7 @@
 import { h, type FunctionalComponent as FC } from '@stencil/core';
 import type { JSXBase, VNode } from '@stencil/core/internal';
 import clsx from 'clsx';
-import { isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../schema';
+import { getMsgType, isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../schema';
 import InputAdornment from '../InputAdornment';
 
 type InputAdornmentType = VNode | VNode[] | null;
@@ -38,7 +38,7 @@ const KolInputContainerFc: FC<InputContainerProps> = (props, children) => {
 	const { class: classNames, startAdornment, endAdornment, disabled, msg, touched, containerProps, startAdornmentProps, endAdornmentProps, ...other } = props;
 	const stateCssClasses = {
 		['kol-input-container--disabled']: disabled,
-		[`kol-input-container--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
+		[`kol-input-container--${getMsgType(msg)}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const baseProps: JSXBase.HTMLAttributes<HTMLDivElement> = {

--- a/packages/components/src/functional-components/InputContainer/InputContainer.tsx
+++ b/packages/components/src/functional-components/InputContainer/InputContainer.tsx
@@ -36,12 +36,9 @@ const Container: FC<JSXBase.HTMLAttributes<HTMLDivElement>> = ({ class: classNam
 
 const KolInputContainerFc: FC<InputContainerProps> = (props, children) => {
 	const { class: classNames, startAdornment, endAdornment, disabled, msg, touched, containerProps, startAdornmentProps, endAdornmentProps, ...other } = props;
-	const showMsg = isMsgDefinedAndInputTouched(msg, touched);
-	const msgType = typeof msg === 'string' ? 'error' : msg?._type;
-
 	const stateCssClasses = {
 		['kol-input-container--disabled']: disabled,
-		[`kol-input-container--${msgType || 'error'}`]: showMsg,
+		[`kol-input-container--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const baseProps: JSXBase.HTMLAttributes<HTMLDivElement> = {

--- a/packages/components/src/functional-components/inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/functional-components/inputs/Checkbox/Checkbox.tsx
@@ -20,9 +20,6 @@ const InputWrapperFc: FC<InputProps> = ({ class: classNames, ...other }) => {
 };
 
 const CheckboxFc: FC<CheckboxProps> = ({ class: classNames, variant = 'default', icon, inputProps, ...other }) => {
-	const showMsg = isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched);
-	const msgType = typeof inputProps?.msg === 'string' ? 'error' : inputProps?.msg?._type;
-
 	const cssVariants = {
 		[`kol-checkbox--variant-${variant}`]: true,
 		[`kol-checkbox--checked`]: inputProps?.checked,
@@ -30,7 +27,9 @@ const CheckboxFc: FC<CheckboxProps> = ({ class: classNames, variant = 'default',
 		['kol-checkbox--disabled']: Boolean(inputProps?.disabled),
 		['kol-checkbox--required']: Boolean(inputProps?.required),
 		['kol-checkbox--touched']: Boolean(inputProps?.touched),
-		[`kol-checkbox--${msgType || 'error'}`]: Boolean(showMsg),
+		[`kol-checkbox--${(typeof inputProps?.msg === 'string' ? 'error' : inputProps?.msg?._type) || 'error'}`]: Boolean(
+			isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched),
+		),
 	};
 
 	return (

--- a/packages/components/src/functional-components/inputs/Checkbox/Checkbox.tsx
+++ b/packages/components/src/functional-components/inputs/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
 import { h, type FunctionalComponent as FC } from '@stencil/core';
 import type { JSXBase } from '@stencil/core/internal';
 import clsx from 'clsx';
-import { isMsgDefinedAndInputTouched } from '../../../schema';
+import { getMsgType, isMsgDefinedAndInputTouched } from '../../../schema';
 import KolIconFc, { type IconProps } from '../../Icon';
 import KolInputFc, { type InputProps } from '../Input';
 
@@ -27,9 +27,7 @@ const CheckboxFc: FC<CheckboxProps> = ({ class: classNames, variant = 'default',
 		['kol-checkbox--disabled']: Boolean(inputProps?.disabled),
 		['kol-checkbox--required']: Boolean(inputProps?.required),
 		['kol-checkbox--touched']: Boolean(inputProps?.touched),
-		[`kol-checkbox--${(typeof inputProps?.msg === 'string' ? 'error' : inputProps?.msg?._type) || 'error'}`]: Boolean(
-			isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched),
-		),
+		[`kol-checkbox--${getMsgType(inputProps?.msg)}`]: Boolean(isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched)),
 	};
 
 	return (

--- a/packages/components/src/functional-components/inputs/Input/Input.tsx
+++ b/packages/components/src/functional-components/inputs/Input/Input.tsx
@@ -20,15 +20,12 @@ export type InputProps = DefaultInputProps<JSXBase.InputHTMLAttributes<HTMLInput
 const InputFc: FC<InputProps> = (props) => {
 	const { class: classNames, msg, required, disabled, touched, readonly, ariaDescribedBy, hideLabel, label, suggestions, value, ...other } = props;
 
-	const showMsg = isMsgDefinedAndInputTouched(msg, touched);
-	const msgType = typeof msg === 'string' ? 'error' : msg?._type;
-
 	const stateCssClasses = {
 		['kol-input--disabled']: Boolean(disabled),
 		['kol-input--required']: Boolean(required),
 		['kol-input--touched']: Boolean(touched),
 		['kol-input--readonly']: Boolean(readonly),
-		[`kol-input--${msgType || 'error'}`]: showMsg,
+		[`kol-input--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const inputProps: JSXBase.InputHTMLAttributes<HTMLInputElement> = {

--- a/packages/components/src/functional-components/inputs/Input/Input.tsx
+++ b/packages/components/src/functional-components/inputs/Input/Input.tsx
@@ -2,7 +2,7 @@
 import { Fragment, h, type FunctionalComponent as FC } from '@stencil/core';
 import type { JSXBase, VNode } from '@stencil/core/internal';
 import clsx from 'clsx';
-import { isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../../schema';
+import { getMsgType, isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../../schema';
 import { getDefaultProps } from '../_helpers/getDefaultProps';
 import type { DefaultInputProps } from '../_types';
 
@@ -25,7 +25,7 @@ const InputFc: FC<InputProps> = (props) => {
 		['kol-input--required']: Boolean(required),
 		['kol-input--touched']: Boolean(touched),
 		['kol-input--readonly']: Boolean(readonly),
-		[`kol-input--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
+		[`kol-input--${getMsgType(msg)}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const inputProps: JSXBase.InputHTMLAttributes<HTMLInputElement> = {

--- a/packages/components/src/functional-components/inputs/NativeSelect/NativeSelect.tsx
+++ b/packages/components/src/functional-components/inputs/NativeSelect/NativeSelect.tsx
@@ -34,14 +34,11 @@ const NativeSelectFc: FC<SelectProps> = (props) => {
 		...other
 	} = props;
 
-	const showMsg = isMsgDefinedAndInputTouched(msg, touched);
-	const msgType = typeof msg === 'string' ? 'error' : msg?._type;
-
 	const stateCssClasses = {
 		['kol-select--disabled']: Boolean(disabled),
 		['kol-select--required']: Boolean(required),
 		['kol-select--touched']: Boolean(touched),
-		[`kol-select--${msgType || 'error'}`]: showMsg,
+		[`kol-select--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const inputProps: SelectAttributes = {

--- a/packages/components/src/functional-components/inputs/NativeSelect/NativeSelect.tsx
+++ b/packages/components/src/functional-components/inputs/NativeSelect/NativeSelect.tsx
@@ -1,7 +1,7 @@
 import { h, type FunctionalComponent as FC } from '@stencil/core';
 import type { JSXBase } from '@stencil/core/internal';
 import clsx from 'clsx';
-import { isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../../schema';
+import { getMsgType, isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../../schema';
 import { getDefaultProps } from '../_helpers/getDefaultProps';
 import type { DefaultInputProps } from '../_types';
 import NativeOptionListFc, { type NativeOptionListProps } from '../NativeOptionList';
@@ -38,7 +38,7 @@ const NativeSelectFc: FC<SelectProps> = (props) => {
 		['kol-select--disabled']: Boolean(disabled),
 		['kol-select--required']: Boolean(required),
 		['kol-select--touched']: Boolean(touched),
-		[`kol-select--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
+		[`kol-select--${getMsgType(msg)}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const inputProps: SelectAttributes = {

--- a/packages/components/src/functional-components/inputs/Radio/Radio.tsx
+++ b/packages/components/src/functional-components/inputs/Radio/Radio.tsx
@@ -13,15 +13,14 @@ const InputWrapperFc: FC<InputProps> = ({ class: classNames, ...other }) => {
 };
 
 const RadioFc: FC<RadioProps> = ({ class: classNames, inputProps, ...other }) => {
-	const showMsg = isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched);
-	const msgType = typeof inputProps?.msg === 'string' ? 'error' : inputProps?.msg?._type;
-
 	const cssVariants = {
 		['kol-input-radio--checked']: inputProps?.checked,
 		['kol-input-radio--disabled']: Boolean(inputProps?.disabled),
 		['kol-input-radio--required']: Boolean(inputProps?.required),
 		['kol-input-radio--touched']: Boolean(inputProps?.touched),
-		[`kol-input-radio--${msgType || 'error'}`]: Boolean(showMsg),
+		[`kol-input-radio--${(typeof inputProps?.msg === 'string' ? 'error' : inputProps?.msg?._type) || 'error'}`]: Boolean(
+			isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched),
+		),
 	};
 
 	return (

--- a/packages/components/src/functional-components/inputs/Radio/Radio.tsx
+++ b/packages/components/src/functional-components/inputs/Radio/Radio.tsx
@@ -1,7 +1,7 @@
 import { h, type FunctionalComponent as FC } from '@stencil/core';
 import type { JSXBase } from '@stencil/core/internal';
 import clsx from 'clsx';
-import { isMsgDefinedAndInputTouched } from '../../../schema';
+import { getMsgType, isMsgDefinedAndInputTouched } from '../../../schema';
 import KolInputFc, { type InputProps } from '../Input';
 
 export type RadioProps = JSXBase.HTMLAttributes<HTMLLabelElement> & {
@@ -18,9 +18,7 @@ const RadioFc: FC<RadioProps> = ({ class: classNames, inputProps, ...other }) =>
 		['kol-input-radio--disabled']: Boolean(inputProps?.disabled),
 		['kol-input-radio--required']: Boolean(inputProps?.required),
 		['kol-input-radio--touched']: Boolean(inputProps?.touched),
-		[`kol-input-radio--${(typeof inputProps?.msg === 'string' ? 'error' : inputProps?.msg?._type) || 'error'}`]: Boolean(
-			isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched),
-		),
+		[`kol-input-radio--${getMsgType(inputProps?.msg)}`]: Boolean(isMsgDefinedAndInputTouched(inputProps?.msg, inputProps?.touched)),
 	};
 
 	return (

--- a/packages/components/src/functional-components/inputs/TextArea/TextArea.tsx
+++ b/packages/components/src/functional-components/inputs/TextArea/TextArea.tsx
@@ -1,7 +1,7 @@
 import { h, type FunctionalComponent as FC } from '@stencil/core';
 import type { JSXBase } from '@stencil/core/internal';
 import clsx from 'clsx';
-import { isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../../schema';
+import { getMsgType, isMsgDefinedAndInputTouched, type MsgPropType, type Stringified } from '../../../schema';
 import { getDefaultProps } from '../_helpers/getDefaultProps';
 import type { DefaultInputProps } from '../_types';
 
@@ -22,7 +22,7 @@ const TextAreaFc: FC<TextAreaProps> = (props) => {
 		['kol-textarea--required']: Boolean(required),
 		['kol-textarea--touched']: Boolean(touched),
 		['kol-textarea--readonly']: Boolean(readonly),
-		[`kol-textarea--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
+		[`kol-textarea--${getMsgType(msg)}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const inputProps: JSXBase.TextareaHTMLAttributes<HTMLTextAreaElement> = {

--- a/packages/components/src/functional-components/inputs/TextArea/TextArea.tsx
+++ b/packages/components/src/functional-components/inputs/TextArea/TextArea.tsx
@@ -17,15 +17,12 @@ export type TextAreaProps = DefaultInputProps<JSXBase.TextareaHTMLAttributes<HTM
 const TextAreaFc: FC<TextAreaProps> = (props) => {
 	const { class: classNames, msg, touched, readonly, disabled, required, ariaDescribedBy, hideLabel, label, ...other } = props;
 
-	const showMsg = isMsgDefinedAndInputTouched(msg, touched);
-	const msgType = typeof msg === 'string' ? 'error' : msg?._type;
-
 	const stateCssClasses = {
 		['kol-textarea--disabled']: Boolean(disabled),
 		['kol-textarea--required']: Boolean(required),
 		['kol-textarea--touched']: Boolean(touched),
 		['kol-textarea--readonly']: Boolean(readonly),
-		[`kol-textarea--${msgType || 'error'}`]: showMsg,
+		[`kol-textarea--${(typeof msg === 'string' ? 'error' : msg?._type) || 'error'}`]: isMsgDefinedAndInputTouched(msg, touched),
 	};
 
 	const inputProps: JSXBase.TextareaHTMLAttributes<HTMLTextAreaElement> = {

--- a/packages/components/src/schema/props/msg.ts
+++ b/packages/components/src/schema/props/msg.ts
@@ -75,3 +75,11 @@ export function normalizeMsg(msg?: Stringified<MsgPropType>): MsgPropType | unde
 	}
 	return msg;
 }
+
+export function getMsgType(msg?: Stringified<MsgPropType>): MsgPropType['_type'] | 'error' {
+	if (typeof msg === 'string') {
+		return 'error';
+	}
+
+	return msg?._type ?? 'error';
+}

--- a/packages/tools/mcp/src/data.ts
+++ b/packages/tools/mcp/src/data.ts
@@ -109,7 +109,8 @@ function loadSampleData(): { entries: SampleEntry[]; metadata: SampleIndexMetada
 
 	try {
 		// Try to load from shared/sample-index.json (static, pre-generated)
-		const parsed = JSON.parse(readFileSync(fileURLToPath(new URL('../shared/sample-index.json', import.meta.url)), 'utf8')) as SerializedSampleIndex;
+		const indexPath = fileURLToPath(new URL('../shared/sample-index.json', import.meta.url));
+		const parsed = JSON.parse(readFileSync(indexPath, 'utf8')) as SerializedSampleIndex;
 		const entries = Array.isArray(parsed.entries) ? parsed.entries.map(normalizeEntry) : [];
 
 		if (entries.length === 0) {

--- a/packages/tools/mcp/src/data.ts
+++ b/packages/tools/mcp/src/data.ts
@@ -45,8 +45,7 @@ function calculateCounts(entries: SampleEntry[]): SampleIndexCounts {
 	const byKind: Record<string, number> = {};
 
 	for (const entry of entries) {
-		const key = entry.kind;
-		byKind[key] = (byKind[key] ?? 0) + 1;
+		byKind[entry.kind] = (byKind[entry.kind] ?? 0) + 1;
 	}
 
 	return {
@@ -110,10 +109,7 @@ function loadSampleData(): { entries: SampleEntry[]; metadata: SampleIndexMetada
 
 	try {
 		// Try to load from shared/sample-index.json (static, pre-generated)
-		const sharedIndexUrl = new URL('../shared/sample-index.json', import.meta.url);
-		const filePath = fileURLToPath(sharedIndexUrl);
-		const raw = readFileSync(filePath, 'utf8');
-		const parsed = JSON.parse(raw) as SerializedSampleIndex;
+		const parsed = JSON.parse(readFileSync(fileURLToPath(new URL('../shared/sample-index.json', import.meta.url)), 'utf8')) as SerializedSampleIndex;
 		const entries = Array.isArray(parsed.entries) ? parsed.entries.map(normalizeEntry) : [];
 
 		if (entries.length === 0) {
@@ -124,9 +120,10 @@ function loadSampleData(): { entries: SampleEntry[]; metadata: SampleIndexMetada
 		cachedData = { entries, metadata };
 		return cachedData;
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
 		throw new Error(
-			`Failed to load sample index from shared/sample-index.json. ` + `Please run 'pnpm generate-index' to create the index file. ` + `Error: ${message}`,
+			`Failed to load sample index from shared/sample-index.json. ` +
+				`Please run 'pnpm generate-index' to create the index file. ` +
+				`Error: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
 }


### PR DESCRIPTION
## What changed?

Across ten input-related functional components (`FieldControl`, `FormField`, `InputContainer`, `Checkbox`, `Input`, `NativeSelect`, `Radio`, `TextArea`) and the `schema/props/msg.ts` module, the duplicated inline `msgType`/`showMsg` variable patterns were replaced with calls to a new shared `getMsgType()` helper function exported from the schema. This eliminates the repeated `typeof msg === 'string' ? 'error' : msg?._type` expression and the `|| 'error'` fallback, consolidating the logic in one place. Additionally, `packages/tools/mcp/src/data.ts` received minor code-style simplifications (inlined intermediate variables). No behaviour change.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In zehn input-bezogenen Funktionskomponenten und `schema/props/msg.ts` wurden die wiederholten Inline-Variablen `msgType`/`showMsg` durch eine neue gemeinsame `getMsgType()`-Hilfsfunktion ersetzt. Keine Verhaltensänderung — reines Refactoring zur Code-Konsolidierung.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/schema/props/msg.ts` — Neue `getMsgType()`-Funktion hinzugefügt
- `packages/components/src/functional-components/**` — 8 Dateien auf `getMsgType()` umgestellt
- `packages/components/src/functional-component-wrappers/_helpers/getRenderStates.ts` — Auf `getMsgType()` umgestellt
- `packages/tools/mcp/src/data.ts` — Kleinere Code-Stil-Vereinfachungen

</details>