### PR TITLE
fix(components): correct aria-describedby assignment based on message type and touch state

### DIFF
--- a/packages/components/src/components/input/controller.spec.ts
+++ b/packages/components/src/components/input/controller.spec.ts
@@ -1,0 +1,207 @@
+import { getRenderStates } from './controller';
+
+describe('getRenderStates', () => {
+	describe('msg-type: undefiniert', () => {
+		it('touched: undefined → aria-describedby: -', () => {
+			const { ariaDescribedBy } = getRenderStates({
+				_id: 'field',
+				_touched: undefined,
+			});
+
+			expect(ariaDescribedBy).toEqual([]);
+		});
+
+		it('touched: true → aria-describedby: -', () => {
+			const { ariaDescribedBy } = getRenderStates({
+				_id: 'field',
+				_touched: true,
+			});
+
+			expect(ariaDescribedBy).toEqual([]);
+		});
+
+		it('touched: false → aria-describedby: -', () => {
+			const { ariaDescribedBy } = getRenderStates({
+				_id: 'field',
+				_touched: false,
+			});
+
+			expect(ariaDescribedBy).toEqual([]);
+		});
+	});
+
+	describe('msg-type: error', () => {
+		it('touched: undefined → aria-describedby: -', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Fehler', _type: 'error' },
+				_touched: undefined,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual([]);
+		});
+
+		it('touched: true → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Fehler', _type: 'error' },
+				_touched: true,
+			});
+
+			expect(hasError).toBe(true);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: false → aria-describedby: -', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Fehler', _type: 'error' },
+				_touched: false,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual([]);
+		});
+	});
+
+	describe('msg-type: info', () => {
+		it('touched: undefined → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Info', _type: 'info' },
+				_touched: undefined,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: true → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Info', _type: 'info' },
+				_touched: true,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: false → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Info', _type: 'info' },
+				_touched: false,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+	});
+
+	describe('msg-type: default', () => {
+		it('touched: undefined → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Hinweis' },
+				_touched: undefined,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: true → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Hinweis' },
+				_touched: true,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: false → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Hinweis' },
+				_touched: false,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+	});
+
+	describe('msg-type: success', () => {
+		it('touched: undefined → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Erfolg', _type: 'success' },
+				_touched: undefined,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: true → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Erfolg', _type: 'success' },
+				_touched: true,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: false → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Erfolg', _type: 'success' },
+				_touched: false,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+	});
+
+	describe('msg-type: warning', () => {
+		it('touched: undefined → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Warnung', _type: 'warning' },
+				_touched: undefined,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: true → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Warnung', _type: 'warning' },
+				_touched: true,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+
+		it('touched: false → aria-describedby: id-error', () => {
+			const { ariaDescribedBy, hasError } = getRenderStates({
+				_id: 'field',
+				_msg: { _description: 'Warnung', _type: 'warning' },
+				_touched: false,
+			});
+
+			expect(hasError).toBe(false);
+			expect(ariaDescribedBy).toEqual(['field-error']);
+		});
+	});
+});

--- a/packages/components/src/components/input/controller.ts
+++ b/packages/components/src/components/input/controller.ts
@@ -18,12 +18,31 @@ export const getRenderStates = (state: {
 	hasHint: boolean;
 	ariaDescribedBy: string[];
 } => {
-	const isMessageValidError = Boolean(state._msg && state._msg._description && state._msg._description?.length > 0);
-	const hasError = isMessageValidError && state._touched === true;
+	const hasValidMsg = Boolean(state._msg && state._msg._description && state._msg._description?.length > 0);
+	const msgType = state._msg?._type ?? 'default';
 	const hasHint = typeof state._hint === 'string' && state._hint.length > 0;
 
 	const ariaDescribedBy: string[] = [];
-	if (hasError === true) {
+
+	// Wenn keine Message vorhanden ist, keine field-error ID hinzufügen
+	if (!hasValidMsg) {
+		if (hasHint === true) {
+			ariaDescribedBy.push(`${state._id}-hint`);
+		}
+
+		if (state._hasCounter) {
+			ariaDescribedBy.push(`${state._id}-counter`);
+		}
+
+		return { hasError: false, hasHint, ariaDescribedBy };
+	}
+
+	// Für error-Messages: nur anzeigen wenn touched === true
+	// Für alle anderen Messages (info, warning, success, default): immer anzeigen
+	const showMsg = msgType === 'error' ? state._touched === true : true;
+	const hasError = showMsg && msgType === 'error';
+
+	if (showMsg) {
 		ariaDescribedBy.push(`${state._id}-error`);
 	}
 
@@ -34,5 +53,6 @@ export const getRenderStates = (state: {
 	if (state._hasCounter) {
 		ariaDescribedBy.push(`${state._id}-counter`);
 	}
+
 	return { hasError, hasHint, ariaDescribedBy };
 };


### PR DESCRIPTION
## What changed?

The `getRenderStates` function in `packages/components/src/components/input/controller.ts` was refactored to fix `aria-describedby` assignment for form inputs. Previously, only error messages that were also "touched" contributed to `aria-describedby`; now the logic distinguishes by message type: `error` messages are only linked after the field is touched (`_touched === true`), while `info`, `warning`, `success`, and default messages are linked immediately regardless of touch state. Fields without any message no longer inject a `field-error` ID at all. A new `controller.spec.ts` test file with 18 test cases across all six message-type/touch-state combinations was added to cover the updated logic.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Funktion `getRenderStates` in `input/controller.ts` wurde überarbeitet, um die `aria-describedby`-Zuweisung korrekt zu gestalten. Fehlermeldungen (`error`) werden nur nach Benutzerinteraktion (`_touched === true`) verlinkt; alle anderen Nachrichtentypen (`info`, `warning`, `success`, Standard) werden immer verlinkt. Felder ohne Nachricht fügen gar keine `field-error`-ID hinzu. Eine neue Testdatei `controller.spec.ts` mit 18 Fällen deckt alle Kombinationen ab.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input/controller.ts` — `aria-describedby`-Logik nach Nachrichtentyp und Touch-State getrennt
- `packages/components/src/components/input/controller.spec.ts` — Neue Unit-Tests hinzugefügt (18 Testfälle)

</details>