### PR TITLE
ci: adjust github checkout depth for workflows

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ matrix.base }}
           persist-credentials: false
       - uses: actions/setup-node@v6

--- a/.github/workflows/benchmark.baseline.yml
+++ b/.github/workflows/benchmark.baseline.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install and execute benchmark

--- a/.github/workflows/benchmark.monitoring.yml
+++ b/.github/workflows/benchmark.monitoring.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install and execute benchmark

--- a/.github/workflows/benchmark.pr-check.yml
+++ b/.github/workflows/benchmark.pr-check.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: true
 
       - name: Install and execute benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
       - name: Build
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
       - name: Install Playwright browsers
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
       - name: Install Playwright browsers

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.github/workflows/mcp-vercel.yml
+++ b/.github/workflows/mcp-vercel.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Setup pnpm workspace

--- a/.github/workflows/security-scan-schedule.yml
+++ b/.github/workflows/security-scan-schedule.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
           ref: ${{ matrix.branch }}
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-          fetch-depth: 0
+          fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
 
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - uses: ./.github/actions/pnpm-setup
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - uses: ./.github/actions/pnpm-setup


### PR DESCRIPTION
## What changed?

The GitHub Actions checkout step in one or more workflow files was adjusted to set an explicit checkout depth (fetch depth), ensuring that CI workflows have access to the required commit history. No component code or public API was changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der GitHub-Actions-Checkout-Schritt in Workflow-Dateien wurde angepasst, um eine explizite Checkout-Tiefe zu setzen. Keine Änderungen am Komponenten-Code oder an öffentlichen APIs.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/` — Checkout-Tiefe in Workflow-Konfiguration angepasst

</details>