### PR TITLE
chore: unify property descriptions

### DIFF
--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -80,7 +80,7 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -191,7 +191,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	private readonly controller: AssociatedInputController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -82,7 +82,7 @@ export class KolButton implements ButtonProps, FocusableElement {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -421,7 +421,7 @@ export class KolCombobox implements ComboboxAPI {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -523,7 +523,7 @@ export class KolCombobox implements ComboboxAPI {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -150,7 +150,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	private readonly controller: InputCheckboxController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -255,7 +255,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value: StencilUnknown = true;
 

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -164,7 +164,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	private readonly controller: InputColorController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -261,7 +261,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: string;
 

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -193,7 +193,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	private readonly controller: InputDateController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -243,7 +243,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _label!: LabelWithExpertSlotPropType;
 
 	/**
-	 * Defines the largest possible input value.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max?: Iso8601 | Date;
 
@@ -322,7 +322,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _type: InputDateTypePropType = 'date';
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: Iso8601 | Date | null;
 

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -137,7 +137,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	private readonly controller: InputEmailController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -276,7 +276,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -138,7 +138,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Prop() public _accept?: string;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -208,7 +208,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	private readonly controller: InputNumberController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -258,7 +258,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop() public _label!: LabelWithExpertSlotPropType;
 
 	/**
-	 * Defines the largest possible input value.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max?: number | NumberString;
 
@@ -337,7 +337,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: number | NumberString | null;
 

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -164,7 +164,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	private readonly controller: InputPasswordController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -293,7 +293,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -243,7 +243,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 * @see Known bug: https://github.com/ionic-team/stencil/issues/3902
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value: StencilUnknown = null;

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -224,7 +224,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	private readonly controller: InputRangeController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -274,7 +274,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop() public _label!: LabelWithExpertSlotPropType;
 
 	/**
-	 * Defines the largest possible input value.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max?: number | NumberString = 100;
 
@@ -331,7 +331,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: number | NumberString;
 

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -201,7 +201,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	private readonly controller: InputTextController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 
@@ -345,7 +345,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Prop() public _type?: InputTextTypePropType = 'text';
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -69,7 +69,7 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -226,7 +226,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -73,7 +73,7 @@ export class KolLink implements LinkProps, FocusableElement {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/pagination/component.tsx
+++ b/packages/components/src/components/pagination/component.tsx
@@ -239,7 +239,7 @@ export class KolPaginationWc implements PaginationAPI {
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
 
 	/**
-	 * Defines the maximum number of pages.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max!: MaxPropType;
 

--- a/packages/components/src/components/pagination/shadow.tsx
+++ b/packages/components/src/components/pagination/shadow.tsx
@@ -91,7 +91,7 @@ export class KolPagination implements PaginationProps {
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
 
 	/**
-	 * Defines the maximum number of pages.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max!: MaxPropType;
 }

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -182,7 +182,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -96,7 +96,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/progress/shadow.tsx
+++ b/packages/components/src/components/progress/shadow.tsx
@@ -122,7 +122,7 @@ export class KolProgress implements ProgressAPI {
 	@Prop() public _label?: LabelPropType;
 
 	/**
-	 * Defines at which value the progress display is completed.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max!: number;
 

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -128,7 +128,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	private readonly controller: SelectController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -194,7 +194,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop() public _on?: InputTypeOnDefault;
 
 	/**
-	 * Options the user can choose from, also supporting Optgroup.
+	 * Options the user can choose from.
 	 */
 	@Prop() public _options!: OptionsWithOptgroupPropType;
 
@@ -210,7 +210,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop() public _shortKey?: ShortKeyPropType;
 
 	/**
-	 * Defines how many rows of options should be visible at the same time.
+	 * Maximum number of visible rows of the element.
 	 */
 	@Prop() public _rows?: RowsPropType;
 
@@ -237,7 +237,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: Stringified<StencilUnknown[]> | Stringified<StencilUnknown>;
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -621,17 +621,17 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value: StencilUnknown = null;
 
 	/**
-	 * Defines the whether the clear button should be hidden.
+	 * Hides the clear button.
 	 */
 	@Prop() public _hideClearButton?: boolean = false;
 
 	/**
-	 * Maximum number of visible rows in the options dropdown before scrolling.
+	 * Maximum number of visible rows of the element.
 	 */
 	@Prop() public _rows?: RowsPropType;
 

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -140,7 +140,7 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	}
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: AccessKeyPropType;
 

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -134,7 +134,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	private readonly controller: TextareaController;
 
 	/**
-	 * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+	 * Defines the key combination that can be used to trigger or focus the component's interactive element.
 	 */
 	@Prop() public _accessKey?: string;
 
@@ -270,7 +270,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/schema/props/access-key.ts
+++ b/packages/components/src/schema/props/access-key.ts
@@ -5,7 +5,7 @@ import { watchString } from '../utils';
 export type AccessKeyPropType = string;
 
 /**
- * Defines the key combination that can be used to trigger or focus the component’s interactive element.
+ * Defines the key combination that can be used to trigger or focus the component's interactive element.
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey
  */
 export type PropAccessKey = {

--- a/packages/components/src/schema/props/max.ts
+++ b/packages/components/src/schema/props/max.ts
@@ -9,10 +9,10 @@ import type { RowsPropType } from './rows';
 export type MaxPropType = number;
 
 /**
- * Number of rows of the input element that should be visible at the same time.
+ * Defines the maximum value of the element.
  */
 export type PropMax = {
-	max: MaxPropType;
+        max: MaxPropType;
 };
 
 /* validator */

--- a/packages/components/src/schema/props/options.ts
+++ b/packages/components/src/schema/props/options.ts
@@ -24,7 +24,7 @@ export type PropRadioOptions = {
 };
 
 /**
- * Options the user can choose from, also supporting Optgroup.
+ * Options the user can choose from.
  */
 export type PropOptionsWithOptgroup = {
 	options: OptionsWithOptgroupPropType;

--- a/packages/components/src/schema/props/rows.ts
+++ b/packages/components/src/schema/props/rows.ts
@@ -6,7 +6,7 @@ import { watchNumber } from '../utils';
 export type RowsPropType = number;
 
 /**
- * Number of rows of the input element that should be visible at the same time.
+ * Maximum number of visible rows of the element.
  */
 export type PropRows = {
 	rows: RowsPropType;


### PR DESCRIPTION
## What changed?

This PR standardises component property JSDoc strings across the v4 development branch for shared props including access keys, values, options, rows, max, href, and the clear button. All descriptions are aligned with consolidated wording to ensure consistency across the schema and component files. 30 files are changed.

## Linked issues

- Refs #9058 — standardize component property descriptions

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`chore: unify property descriptions`)

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR vereinheitlicht JSDoc-Beschreibungen für gemeinsam genutzte Komponenten-Properties im v4-Entwicklungs-Branch. Alle Beschreibungen werden auf eine konsistente Formulierung angeglichen.

### Verknüpfte Tickets

- Refs #9058 — Komponenteneigenschaften-Beschreibungen vereinheitlichen

### Art der Änderung

- [x] 🔧 Intern

### Geänderte Dateien

- 30 Dateien in Components und Schema

</details>