### PR TITLE
docs(components): standardize JSDoc property descriptions for shared props in v3

### DIFF
--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -186,7 +186,7 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	@Prop() public _type?: ButtonTypePropType = 'button';
 
 	/**
-	 * Defines the value that the button emits on click.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: StencilUnknown;
 }

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -301,7 +301,7 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	@Prop() public _type?: ButtonTypePropType = 'button';
 
 	/**
-	 * Defines the value that the button emits on click.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: StencilUnknown;
 

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -183,7 +183,7 @@ export class KolButton implements ButtonProps, FocusableElement {
 	@Prop() public _type?: ButtonTypePropType = 'button';
 
 	/**
-	 * Defines the value that the button emits on click.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: StencilUnknown;
 

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -523,7 +523,7 @@ export class KolCombobox implements ComboboxAPI {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -255,7 +255,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value: StencilUnknown = true;
 

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -261,7 +261,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: string;
 

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -243,7 +243,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _label!: LabelWithExpertSlotPropType;
 
 	/**
-	 * Defines the largest possible input value.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max?: Iso8601 | Date;
 
@@ -322,7 +322,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Prop() public _type: InputDateTypePropType = 'date';
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: Iso8601 | Date | null;
 

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -276,7 +276,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -213,7 +213,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop() public _label!: LabelWithExpertSlotPropType;
 
 	/**
-	 * Defines the largest possible input value.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max?: number | NumberString;
 
@@ -292,7 +292,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: number | NumberString | null;
 

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -293,7 +293,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -243,7 +243,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 * @see Known bug: https://github.com/ionic-team/stencil/issues/3902
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value: StencilUnknown = null;

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -274,7 +274,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop() public _label!: LabelWithExpertSlotPropType;
 
 	/**
-	 * Defines the largest possible input value.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max?: number | NumberString = 100;
 
@@ -331,7 +331,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: number | NumberString;
 

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -345,7 +345,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Prop() public _type?: InputTextTypePropType = 'text';
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/components/pagination/component.tsx
+++ b/packages/components/src/components/pagination/component.tsx
@@ -239,7 +239,7 @@ export class KolPaginationWc implements PaginationAPI {
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
 
 	/**
-	 * Defines the maximum number of pages.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max!: MaxPropType;
 

--- a/packages/components/src/components/pagination/shadow.tsx
+++ b/packages/components/src/components/pagination/shadow.tsx
@@ -91,7 +91,7 @@ export class KolPagination implements PaginationProps {
 	@Prop() public _tooltipAlign?: TooltipAlignPropType = 'top';
 
 	/**
-	 * Defines the maximum number of pages.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max!: MaxPropType;
 }

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -286,7 +286,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	@Prop() public _type?: ButtonTypePropType = 'button';
 
 	/**
-	 * Defines the value that the button emits on click.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: StencilUnknown;
 

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -202,7 +202,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 	@Prop() public _type?: ButtonTypePropType = 'button';
 
 	/**
-	 * Defines the value that the button emits on click.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: StencilUnknown;
 

--- a/packages/components/src/components/progress/shadow.tsx
+++ b/packages/components/src/components/progress/shadow.tsx
@@ -122,7 +122,7 @@ export class KolProgress implements ProgressAPI {
 	@Prop() public _label?: LabelPropType;
 
 	/**
-	 * Defines at which value the progress display is completed.
+	 * Defines the maximum value of the element.
 	 */
 	@Prop() public _max!: number;
 
@@ -132,7 +132,7 @@ export class KolProgress implements ProgressAPI {
 	@Prop() public _unit?: string = '%';
 
 	/**
-	 * Defines the progress.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value!: number;
 

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -194,7 +194,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop() public _on?: InputTypeOnDefault;
 
 	/**
-	 * Options the user can choose from, also supporting Optgroup.
+	 * Options the user can choose from.
 	 */
 	@Prop() public _options!: OptionsWithOptgroupPropType;
 
@@ -210,7 +210,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop() public _shortKey?: ShortKeyPropType;
 
 	/**
-	 * Defines how many rows of options should be visible at the same time.
+	 * Maximum number of visible rows of the element.
 	 */
 	@Prop() public _rows?: RowsPropType;
 
@@ -237,7 +237,7 @@ export class KolSelect implements SelectAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: Stringified<StencilUnknown[]> | Stringified<StencilUnknown>;
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -621,17 +621,17 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value: StencilUnknown = null;
 
 	/**
-	 * Defines the whether the clear button should be hidden.
+	 * Hides the clear button.
 	 */
 	@Prop() public _hideClearButton?: boolean = false;
 
 	/**
-	 * Maximum number of visible rows in the options dropdown before scrolling.
+	 * Maximum number of visible rows of the element.
 	 */
 	@Prop() public _rows?: RowsPropType;
 

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -236,7 +236,7 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	@Prop() public _type?: ButtonTypePropType = 'button';
 
 	/**
-	 * Defines the value that the button emits on click.
+	 * Defines the value of the element.
 	 */
 	@Prop() public _value?: StencilUnknown;
 

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -238,7 +238,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Prop() public _required?: boolean = false;
 
 	/**
-	 * Defines how many rows of text should be visible at the same time.
+	 * Maximum number of visible rows of the element.
 	 */
 	@Prop({ mutable: true, reflect: false }) public _rows?: RowsPropType;
 
@@ -270,7 +270,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Prop({ mutable: true, reflect: true }) public _touched?: boolean = false;
 
 	/**
-	 * Defines the value of the input.
+	 * Defines the value of the element.
 	 */
 	@Prop({ mutable: true, reflect: true }) public _value?: string;
 

--- a/packages/components/src/schema/props/max.ts
+++ b/packages/components/src/schema/props/max.ts
@@ -9,7 +9,7 @@ import type { RowsPropType } from './rows';
 export type MaxPropType = number;
 
 /**
- * Number of rows of the input element that should be visible at the same time.
+ * Defines the maximum value of the element.
  */
 export type PropMax = {
 	max: MaxPropType;

--- a/packages/components/src/schema/props/rows.ts
+++ b/packages/components/src/schema/props/rows.ts
@@ -6,7 +6,7 @@ import { watchNumber } from '../utils';
 export type RowsPropType = number;
 
 /**
- * Number of rows of the input element that should be visible at the same time.
+ * Maximum number of visible rows of the element.
  */
 export type PropRows = {
 	rows: RowsPropType;


### PR DESCRIPTION
## What changed?

This PR standardises JSDoc descriptions for shared component properties (`_value`, `_max`, `_rows`, `_options`, `_hideClearButton`) in the v3 release branch to use consistent wording across all components. Shared prop schema documentation is also updated to reflect the standardised descriptions. 24 files are changed.

## Linked issues

- Refs #9058 — standardize component property descriptions

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`docs(components): standardize JSDoc property descriptions for shared props in v3`)

> ℹ️ Original title `Standardize component property descriptions` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR vereinheitlicht JSDoc-Beschreibungen für gemeinsam genutzte Komponenten-Properties im v3-Release-Branch. Schema-Dokumentation wird ebenfalls aktualisiert.

### Verknüpfte Tickets

- Refs #9058 — Komponenteneigenschaften-Beschreibungen vereinheitlichen

### Art der Änderung

- [x] 🔧 Intern

### Geänderte Dateien

- 24 Dateien in Components und Schema

</details>