### PR TITLE
chore(ci): remove explicit fetch-depth overrides from workflow checkouts in v2

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       # - uses: pnpm/action-setup@v4

--- a/.github/workflows/benchmark.baseline.yml
+++ b/.github/workflows/benchmark.baseline.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install and execute benchmark

--- a/.github/workflows/benchmark.monitoring.yml
+++ b/.github/workflows/benchmark.monitoring.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install and execute benchmark

--- a/.github/workflows/benchmark.pr-check.yml
+++ b/.github/workflows/benchmark.pr-check.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: true
 
       - name: Install and execute benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
       - name: Build
@@ -42,7 +41,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
       - name: Install Playwright browsers
@@ -68,7 +66,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/pnpm-setup
       - name: Install Playwright browsers

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,6 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Node.js

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 

--- a/.github/workflows/sync-to-opencode.yml
+++ b/.github/workflows/sync-to-opencode.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
           ref: 'develop'
       - name: git-sync

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
-          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       # https://github.com/pnpm/action-setup#use-cache-to-reduce-installation-time

--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Determine package paths
@@ -76,7 +75,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
           persist-credentials: false
 
       - uses: ./.github/actions/pnpm-setup


### PR DESCRIPTION
## What changed?

This PR removes explicit `fetch-depth` overrides from checkout steps in all GitHub Actions workflows in the v2 release branch, relying on the default shallow clone (depth 1) instead. 12 workflow files are updated.

## Linked issues

- Refs #9115 — CI workflow cleanup

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`chore(ci): remove explicit fetch-depth overrides from workflow checkouts in v2`)

> ℹ️ Original title `Remove explicit fetch depth from workflow checkouts` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR entfernt explizite `fetch-depth`-Overrides aus Checkout-Schritten in allen GitHub-Actions-Workflows des v2-Release-Branches. 12 Workflow-Dateien werden aktualisiert.

### Verknüpfte Tickets

- Refs #9115 — CI-Workflow-Aufräumung

### Art der Änderung

- [x] 🔧 Intern

### Geänderte Dateien

- 12 GitHub-Actions-Workflow-Dateien

</details>