### PR TITLE
chore(ci): remove explicit fetch-depth overrides from publish and sync workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,6 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install Node.js

--- a/.github/workflows/sync-to-opencode.yml
+++ b/.github/workflows/sync-to-opencode.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           persist-credentials: false
           ref: develop
 


### PR DESCRIPTION
## What changed?

This PR removes explicit `fetch-depth` overrides from the publish workflow checkout and the sync-to-opencode workflow checkout in the v3 branch, relying on the default shallow clone depth instead. Two files are changed.

## Linked issues

- Refs #9116 — CI workflow cleanup

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`chore(ci): remove explicit fetch-depth overrides from publish and sync workflows`)

> ℹ️ Original title `Remove explicit checkout fetch depth settings` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR entfernt explizite `fetch-depth`-Overrides aus dem Publish-Workflow und dem Sync-to-OpenCode-Workflow im v3-Branch. Zwei Workflow-Dateien werden aktualisiert.

### Verknüpfte Tickets

- Refs #9116 — CI-Workflow-Aufräumung

### Art der Änderung

- [x] 🔧 Intern

### Geänderte Dateien

- 2 GitHub-Actions-Workflow-Dateien

</details>