### PR TITLE
fix(toast): correct mobile display issue in v2

### DIFF
--- a/packages/components/src/components/toaster/style.scss
+++ b/packages/components/src/components/toaster/style.scss
@@ -8,6 +8,7 @@
 		display: flex;
 		position: fixed;
 		z-index: 200;
+		max-width: 90vw;
 		flex-direction: column;
 	}
 


### PR DESCRIPTION
## What changed?

This PR fixes a mobile display issue (#9112) in the `Toast` component in the v2 release branch. One CSS file is updated to correct the rendering.

## Linked issues

- Closes #9112 — toast mobile display

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`fix(toast): correct mobile display issue in v2`)

> ℹ️ Original title `Fix/9112 toast mobile` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR behebt einen Mobil-Darstellungsfehler (#9112) in der `Toast`-Komponente im v2-Release-Branch.

### Verknüpfte Tickets

- Closes #9112 — Toast mobil

### Art der Änderung

- [x] 🐛 Bugfix

### Geänderte Dateien

- 1 CSS-Datei in der Toast-Komponente

</details>