### PR TITLE
fix(select): prune stale values when options change

### DIFF
--- a/packages/components/src/components/input-radio/test/boolean-values.spec.tsx
+++ b/packages/components/src/components/input-radio/test/boolean-values.spec.tsx
@@ -1,0 +1,28 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolInputRadio } from '../shadow';
+
+describe('KolInputRadio boolean values', () => {
+	it('accepts boolean option values without errors', async () => {
+		const page = await newSpecPage({
+			components: [KolInputRadio],
+			html: `<kol-input-radio _label="Choose"></kol-input-radio>`,
+		});
+		const component = page.rootInstance as KolInputRadio;
+
+		component.validateOptions([
+			{
+				label: 'Yes',
+				value: true,
+			},
+			{
+				label: 'No',
+				value: false,
+			},
+		]);
+		component.validateValue(false);
+		await page.waitForChanges();
+
+		expect(component.state._value).toBe(false);
+	});
+});

--- a/packages/components/src/components/select/component.tsx
+++ b/packages/components/src/components/select/component.tsx
@@ -488,7 +488,7 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 	private onInput(event: Event): void {
 		this._value = Array.from(this.selectRef?.options || [])
 			.filter((option) => option.selected === true)
-			.map((option) => this.controller.getOptionByKey(option.value)?.value as string);
+			.map((option) => this.controller.getOptionByKey(option.value)?.value as W3CInputValue);
 
 		// Event handling
 		tryToDispatchKoliBriEvent('input', this.host, this._value);

--- a/packages/components/src/components/select/controller.ts
+++ b/packages/components/src/components/select/controller.ts
@@ -26,20 +26,18 @@ export class SelectController extends InputIconController implements SelectWatch
 
 	public readonly getOptionByKey = (key: string): Option<W3CInputValue> | undefined => this.keyOptionMap.get(key);
 
-	private readonly isValueInOptions = (value: string, options: SelectOption<W3CInputValue>[]): boolean => {
-		return (
-			options.find((option) =>
-				typeof (option as Option<W3CInputValue>).value === 'string'
-					? (option as Option<W3CInputValue>).value === value
-					: Array.isArray((option as Optgroup<string>).options)
-						? this.isValueInOptions(value, (option as Optgroup<string>).options)
-						: false,
-			) !== undefined
-		);
+	private readonly isValueInOptions = (value: W3CInputValue, options: SelectOption<W3CInputValue>[]): boolean => {
+		return options.some((option) => {
+			if (Array.isArray((option as Optgroup<W3CInputValue>).options)) {
+				return this.isValueInOptions(value, (option as Optgroup<W3CInputValue>).options);
+			}
+
+			return (option as Option<W3CInputValue>).value === value;
+		});
 	};
 
-	private readonly filterValuesInOptions = (values: string[], options: SelectOption<W3CInputValue>[]): string[] => {
-		return values.filter((value) => this.isValueInOptions(value, options) !== undefined);
+	private readonly filterValuesInOptions = (values: W3CInputValue[], options: SelectOption<W3CInputValue>[]): W3CInputValue[] => {
+		return values.filter((value) => this.isValueInOptions(value, options));
 	};
 
 	protected readonly afterPatchOptions = (value: unknown, _state: Record<string, unknown>, _component: Generic.Element.Component, key: string): void => {
@@ -55,14 +53,14 @@ export class SelectController extends InputIconController implements SelectWatch
 			fillKeyOptionMap(this.keyOptionMap, options as SelectOption<W3CInputValue>[]);
 			const value = nextState.has('_value') ? nextState.get('_value') : this.component.state._value;
 			const selected = this.filterValuesInOptions(
-				Array.isArray(value) && value.length > 0 ? (value as string[]) : [],
+				Array.isArray(value) && value.length > 0 ? (value as W3CInputValue[]) : [],
 				options as SelectOption<W3CInputValue>[],
 			);
 			if (this.component._multiple === false && selected.length === 0) {
 				nextState.set('_value', [
 					(
 						options[0] as {
-							value: string;
+							value: W3CInputValue;
 						}
 					).value,
 				]);

--- a/packages/components/src/components/select/test/options-change.spec.tsx
+++ b/packages/components/src/components/select/test/options-change.spec.tsx
@@ -36,4 +36,40 @@ describe('KolSelectWc options', () => {
 
 		expect(component.state._value).toEqual([2]);
 	});
+
+	it('keeps boolean option values intact when options persist', async () => {
+		const page = await newSpecPage({
+			components: [KolSelectWc],
+			html: `<kol-select-wc _multiple="true"></kol-select-wc>`,
+		});
+		const component = page.rootInstance as KolSelectWc;
+
+		component.validateMultiple(true);
+		component.validateOptions([
+			{
+				label: 'True',
+				value: true,
+			},
+			{
+				label: 'False',
+				value: false,
+			},
+		]);
+		component.validateValue([false]);
+		await page.waitForChanges();
+
+		component.validateOptions([
+			{
+				label: 'False',
+				value: false,
+			},
+			{
+				label: 'True',
+				value: true,
+			},
+		]);
+		await page.waitForChanges();
+
+		expect(component.state._value).toEqual([false]);
+	});
 });

--- a/packages/components/src/components/select/test/options-change.spec.tsx
+++ b/packages/components/src/components/select/test/options-change.spec.tsx
@@ -1,0 +1,39 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolSelectWc } from '../component';
+
+describe('KolSelectWc options', () => {
+	it('removes values that no longer exist after options change', async () => {
+		const page = await newSpecPage({
+			components: [KolSelectWc],
+			html: `<kol-select-wc _multiple="true"></kol-select-wc>`,
+		});
+		const component = page.rootInstance as KolSelectWc;
+
+		component.validateMultiple(true);
+		component.validateOptions([
+			{
+				label: 'One',
+				value: 1,
+			},
+			{
+				label: 'Two',
+				value: 2,
+			},
+		]);
+		component.validateValue([1, 2]);
+		await page.waitForChanges();
+
+		expect(component.state._value).toEqual([1, 2]);
+
+		component.validateOptions([
+			{
+				label: 'Two',
+				value: 2,
+			},
+		]);
+		await page.waitForChanges();
+
+		expect(component.state._value).toEqual([2]);
+	});
+});

--- a/packages/components/src/components/single-select/controller.ts
+++ b/packages/components/src/components/single-select/controller.ts
@@ -8,7 +8,7 @@ import type { Generic } from 'adopted-style-sheets';
 
 export class SingleSelectController extends InputIconController implements SingleSelectWatches {
 	protected readonly component: Generic.Element.Component & SingleSelectProps;
-	private readonly keyOptionMap = new Map<string, Option<string>>();
+	private readonly keyOptionMap = new Map<string, Option<W3CInputValue>>();
 
 	public constructor(component: Generic.Element.Component & SingleSelectProps, name: string, host?: HTMLElement) {
 		super(component, name, host);

--- a/packages/components/src/components/single-select/test/boolean-values.spec.tsx
+++ b/packages/components/src/components/single-select/test/boolean-values.spec.tsx
@@ -1,0 +1,30 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolSingleSelect } from '../shadow';
+
+describe('KolSingleSelect boolean values', () => {
+	it('accepts boolean option values without errors', async () => {
+		const page = await newSpecPage({
+			components: [KolSingleSelect],
+			html: `<kol-single-select _label="Test"></kol-single-select>`,
+		});
+		const component = page.rootInstance as KolSingleSelect;
+
+		component.validateOptions([
+			{
+				label: 'Yes',
+				value: true,
+			},
+			{
+				label: 'No',
+				value: false,
+			},
+		]);
+		component._value = false;
+		component.validateValue(false);
+		await page.waitForChanges();
+
+		expect(component._value).toBe(false);
+		expect(component.state._value).toBe(false);
+	});
+});

--- a/packages/components/src/schema/types/w3c.ts
+++ b/packages/components/src/schema/types/w3c.ts
@@ -1,1 +1,1 @@
-export type W3CInputValue = string | number; // | boolean;
+export type W3CInputValue = string | number | boolean;


### PR DESCRIPTION
## Summary
- ensure select value filtering only retains entries still present in available options, including non-string values
- add regression coverage confirming selected values are pruned when options change

## Testing
- pnpm --filter @public-ui/components test -- --spec --runTestsByPath packages/components/src/components/select/test/options-change.spec.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694356633888832bbb716a254304b100)