### PR TITLE
feat(kolibri-cli): extend clear button migration task to cover dashed and camelCase prop variants

### DIFF
--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -30,6 +30,10 @@ import { defineCustomElements } from '@public-ui/components/loader';
 - The `_msg` prop no longer supports the `_label` and `_variant` options. Messages always render with the `msg` variant and without a label.
 - Input messages only render once the field is marked as `_touched`, regardless of the message type. Ensure `_touched` is set when a message should be displayed.
 
+### kol-combobox & kol-single-select
+
+- `_hideClearButton` has been replaced with `_hasClearButton` (default: `true`). Set `_hasClearButton="false"` to hide the clear button while keeping existing values intact. The migration CLI rewrites `_hide-clear-button` attributes and `_hideClearButton` props automatically.
+
 ### kol-nav
 
 - The `orientation` property has been removed from kol-nav. It is now always in vertical mode by default.

--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -32,7 +32,7 @@ import { defineCustomElements } from '@public-ui/components/loader';
 
 ### kol-combobox & kol-single-select
 
-- `_hideClearButton` has been replaced with `_hasClearButton` (default: `true`). Set `_hasClearButton="false"` to hide the clear button while keeping existing values intact. The migration CLI rewrites `_hide-clear-button` attributes and `_hideClearButton` props automatically.
+- `_hideClearButton` has been replaced with `_hasClearButton` (default: `true`). Set `_hasClearButton="false"` to hide the clear button while keeping existing values intact. The migration CLI rewrites `_hide-clear-button` attributes and `_hideClearButton` props automatically, flipping boolean values so behaviour stays the same.
 
 ### kol-nav
 

--- a/packages/components/src/components/combobox/controller.ts
+++ b/packages/components/src/components/combobox/controller.ts
@@ -13,8 +13,8 @@ export class ComboboxController extends InputIconController implements ComboboxW
 		this.component = component;
 	}
 
-	public validateHideClearButton(value?: boolean): void {
-		watchBoolean(this.component, '_hideClearButton', value);
+	public validateHasClearButton(value?: boolean): void {
+		watchBoolean(this.component, '_hasClearButton', value);
 	}
 
 	public validatePlaceholder(value?: PlaceholderPropType): void {
@@ -35,7 +35,7 @@ export class ComboboxController extends InputIconController implements ComboboxW
 
 	public componentWillLoad(): void {
 		super.componentWillLoad();
-		this.validateHideClearButton(this.component._hideClearButton);
+		this.validateHasClearButton(this.component._hasClearButton);
 		this.validatePlaceholder(this.component._placeholder);
 		this.validateRequired(this.component._required);
 		this.validateSuggestions(this.component._suggestions);

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -47,7 +47,7 @@ import { ComboboxController } from './controller';
 	shadow: true,
 })
 export class KolCombobox implements ComboboxAPI {
-	@Element() private readonly host?: HTMLKolComboboxElement;
+	@Element() private readonly host?: HTMLElement;
 	private refInput?: HTMLInputElement;
 	private refSuggestions: HTMLLIElement[] = [];
 	private _focusedOptionIndex: number = -1;
@@ -256,7 +256,7 @@ export class KolCombobox implements ComboboxAPI {
 				<KolInputContainerFc state={this.state}>
 					<div class="kol-combobox__group">
 						<KolInputStateWrapperFc {...this.getInputProps()} />
-						{this.state._value && !this.state._hideClearButton && (
+						{this.state._value && this.state._hasClearButton && (
 							<KolButtonWcTag
 								_icons="codicon codicon-close"
 								_label={this.translateDeleteSelection}
@@ -485,9 +485,9 @@ export class KolCombobox implements ComboboxAPI {
 	@Prop() public _on?: InputTypeOnDefault;
 
 	/**
-	 * Hides the clear button.
+	 * Shows the clear button if enabled.
 	 */
-	@Prop() public _hideClearButton?: boolean = false;
+	@Prop() public _hasClearButton?: boolean = true;
 
 	/**
 	 * Suggestions to provide for the input.
@@ -529,7 +529,7 @@ export class KolCombobox implements ComboboxAPI {
 
 	@State() public state: ComboboxStates = {
 		_hasValue: false,
-		_hideClearButton: false,
+		_hasClearButton: true,
 		_hideMsg: false,
 		_id: `id-${nonce()}`,
 		_label: '', // ⚠ required
@@ -619,9 +619,9 @@ export class KolCombobox implements ComboboxAPI {
 		this._filteredSuggestions = value;
 	}
 
-	@Watch('_hideClearButton')
-	public validateHideClearButton(value?: boolean): void {
-		this.controller.validateHideClearButton(value);
+	@Watch('_hasClearButton')
+	public validateHasClearButton(value?: boolean): void {
+		this.controller.validateHasClearButton(value);
 	}
 
 	@Watch('_required')

--- a/packages/components/src/components/single-select/controller.ts
+++ b/packages/components/src/components/single-select/controller.ts
@@ -60,8 +60,8 @@ export class SingleSelectController extends InputIconController implements Singl
 		validatePlaceholder(this.component, value);
 	}
 
-	public validateHideClearButton(value?: boolean): void {
-		watchBoolean(this.component, '_hideClearButton', value);
+	public validateHasClearButton(value?: boolean): void {
+		watchBoolean(this.component, '_hasClearButton', value);
 	}
 
 	public validateRows(value?: number): void {
@@ -74,7 +74,7 @@ export class SingleSelectController extends InputIconController implements Singl
 		this.validateRequired(this.component._required);
 		this.validateValue(this.component._value);
 		this.validatePlaceholder(this.component._placeholder);
-		this.validateHideClearButton(this.component._hideClearButton);
+		this.validateHasClearButton(this.component._hasClearButton);
 		this.validateRows(this.component._rows);
 	}
 }

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -50,7 +50,7 @@ import { SingleSelectController } from './controller';
 	shadow: true,
 })
 export class KolSingleSelect implements SingleSelectAPI {
-	@Element() private readonly host?: HTMLKolSingleSelectElement;
+	@Element() private readonly host?: HTMLElement;
 	private refInput?: HTMLInputElement;
 	private refOptions: HTMLLIElement[] = [];
 	private readonly translateDeleteSelection = translate('kol-delete-selection');
@@ -320,7 +320,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 					<div class="kol-single-select__group">
 						<KolInputStateWrapperFc {...this.getInputProps()} />
 
-						{this._inputValue && !this.state._hideClearButton && (
+						{this._inputValue && this.state._hasClearButton && (
 							<KolButtonWcTag
 								_icons="codicon codicon-close"
 								_label={this.translateDeleteSelection}
@@ -626,9 +626,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 	@Prop({ mutable: true, reflect: true }) public _value: StencilUnknown = null;
 
 	/**
-	 * Hides the clear button.
+	 * Shows the clear button if enabled.
 	 */
-	@Prop() public _hideClearButton?: boolean = false;
+	@Prop() public _hasClearButton?: boolean = true;
 
 	/**
 	 * Maximum number of visible rows of the element.
@@ -640,7 +640,7 @@ export class KolSingleSelect implements SingleSelectAPI {
 		_id: `id-${nonce()}`,
 		_label: '', // ⚠ required
 		_options: [],
-		_hideClearButton: false,
+		_hasClearButton: true,
 	};
 
 	@State() private inputHasFocus = false;
@@ -747,9 +747,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 		this.updateInputValue(value);
 	}
 
-	@Watch('_hideClearButton ')
-	public validateHideClearButton(value?: boolean): void {
-		this.controller.validateHideClearButton(value);
+	@Watch('_hasClearButton')
+	public validateHasClearButton(value?: boolean): void {
+		this.controller.validateHasClearButton(value);
 	}
 
 	@Watch('_rows')

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -59,7 +59,7 @@ test.describe(COMPONENT_NAME, () => {
 			await page.keyboard.press('ArrowDown');
 			await page.keyboard.press('Enter');
 
-			const value = await page.locator('kol-single-select').evaluate((el: HTMLKolInputDateElement) => el._value);
+			const value = await page.locator('kol-single-select').evaluate<string | null>((element: HTMLKolSingleSelectElement) => element._value as string | null);
 			expect(value).toBe('S');
 		});
 
@@ -77,7 +77,7 @@ test.describe(COMPONENT_NAME, () => {
 			await page.keyboard.press('ArrowDown');
 			await page.keyboard.press('Enter');
 
-			const value = await page.locator('kol-single-select').evaluate((el: HTMLKolInputDateElement) => el._value);
+			const value = await page.locator('kol-single-select').evaluate<string | null>((element: HTMLKolSingleSelectElement) => element._value as string | null);
 			expect(value).toBe('W');
 		});
 
@@ -99,8 +99,8 @@ test.describe(COMPONENT_NAME, () => {
 			await expect(input).toHaveValue('');
 		});
 
-		test('should not render clear button when _hideClearButton is true', async ({ page }) => {
-			await page.setContent(`<kol-single-select _label="Input" _hideClearButton="true" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
+		test('should not render clear button when _hasClearButton is false', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _hasClearButton="false" _options='${JSON.stringify(OPTIONS)}'></kol-single-select>`);
 
 			const input = page.locator('input.kol-single-select__input');
 			await input.click();

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -59,7 +59,9 @@ test.describe(COMPONENT_NAME, () => {
 			await page.keyboard.press('ArrowDown');
 			await page.keyboard.press('Enter');
 
-			const value = await page.locator('kol-single-select').evaluate<string | null>((element: HTMLKolSingleSelectElement) => element._value as string | null);
+			const value = await page
+				.locator('kol-single-select')
+				.evaluate<string | null>((element) => (element as HTMLKolSingleSelectElement)._value as string | null);
 			expect(value).toBe('S');
 		});
 
@@ -77,7 +79,9 @@ test.describe(COMPONENT_NAME, () => {
 			await page.keyboard.press('ArrowDown');
 			await page.keyboard.press('Enter');
 
-			const value = await page.locator('kol-single-select').evaluate<string | null>((element: HTMLKolSingleSelectElement) => element._value as string | null);
+			const value = await page
+				.locator('kol-single-select')
+				.evaluate<string | null>((element) => (element as HTMLKolSingleSelectElement)._value as string | null);
 			expect(value).toBe('W');
 		});
 

--- a/packages/components/src/schema/components/combobox.ts
+++ b/packages/components/src/schema/components/combobox.ts
@@ -22,7 +22,7 @@ import type { InputTypeOnDefault, KoliBriHIcons, Stringified, W3CInputValue } fr
 
 type RequiredProps = PropLabelWithExpertSlot & PropSuggestions;
 type OptionalProps = {
-	hideClearButton: boolean;
+	hasClearButton: boolean;
 	msg: Stringified<MsgPropType>;
 	on: InputTypeOnDefault;
 	placeholder: string;
@@ -41,7 +41,7 @@ type OptionalProps = {
 
 type RequiredStates = {
 	hasValue: boolean;
-	hideClearButton: boolean;
+	hasClearButton: boolean;
 	suggestions: W3CInputValue[];
 	value: string;
 } & PropId &

--- a/packages/components/src/schema/components/single-select.ts
+++ b/packages/components/src/schema/components/single-select.ts
@@ -27,7 +27,7 @@ type OptionalProps = {
 	on: InputTypeOnDefault;
 	placeholder: string;
 	value: StencilUnknown;
-	hideClearButton: boolean;
+	hasClearButton: boolean;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideMsg &
@@ -49,7 +49,7 @@ type RequiredStates = {
 type OptionalStates = {
 	on: InputTypeOnDefault;
 	placeholder: string;
-	hideClearButton: boolean;
+	hasClearButton: boolean;
 } & PropAccessKey &
 	PropDisabled &
 	PropHideLabel &

--- a/packages/components/src/schema/props/max.ts
+++ b/packages/components/src/schema/props/max.ts
@@ -12,7 +12,7 @@ export type MaxPropType = number;
  * Defines the maximum value of the element.
  */
 export type PropMax = {
-        max: MaxPropType;
+	max: MaxPropType;
 };
 
 /* validator */

--- a/packages/samples/react/src/components/single-select/partials/cases.tsx
+++ b/packages/samples/react/src/components/single-select/partials/cases.tsx
@@ -39,7 +39,7 @@ export const SingleSelectCases = (props: Components.KolSingleSelect) => {
 			<KolSingleSelect {...props} _label="With access key" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _accessKey="c" />
 			<KolSingleSelect {...props} _label="With short key" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _shortKey="s" />
 			<KolSingleSelect {...props} _label="With long labels" _options={LONG_OPTIONS as Option<StencilUnknown>[]} _placeholder="Placeholder" />
-			<KolSingleSelect {...props} _label="Without clear button" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _hasClearButton={false} />
+			<KolSingleSelect {...props} _label="With hidden clear button" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _hasClearButton={false} />
 			<KolSingleSelect
 				{...props}
 				_hint={HINT_MSG}

--- a/packages/samples/react/src/components/single-select/partials/cases.tsx
+++ b/packages/samples/react/src/components/single-select/partials/cases.tsx
@@ -39,7 +39,7 @@ export const SingleSelectCases = (props: Components.KolSingleSelect) => {
 			<KolSingleSelect {...props} _label="With access key" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _accessKey="c" />
 			<KolSingleSelect {...props} _label="With short key" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _shortKey="s" />
 			<KolSingleSelect {...props} _label="With long labels" _options={LONG_OPTIONS as Option<StencilUnknown>[]} _placeholder="Placeholder" />
-			<KolSingleSelect {...props} _label="With hidden clear button" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _hideClearButton />
+			<KolSingleSelect {...props} _label="Without clear button" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _hasClearButton={false} />
 			<KolSingleSelect
 				{...props}
 				_hint={HINT_MSG}

--- a/packages/samples/react/src/components/single-select/partials/cases.tsx
+++ b/packages/samples/react/src/components/single-select/partials/cases.tsx
@@ -39,7 +39,13 @@ export const SingleSelectCases = (props: Components.KolSingleSelect) => {
 			<KolSingleSelect {...props} _label="With access key" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _accessKey="c" />
 			<KolSingleSelect {...props} _label="With short key" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _shortKey="s" />
 			<KolSingleSelect {...props} _label="With long labels" _options={LONG_OPTIONS as Option<StencilUnknown>[]} _placeholder="Placeholder" />
-			<KolSingleSelect {...props} _label="With hidden clear button" _options={COUNTRY_OPTIONS as Option<StencilUnknown>[]} _value={'de'} _hasClearButton={false} />
+			<KolSingleSelect
+				{...props}
+				_label="With hidden clear button"
+				_options={COUNTRY_OPTIONS as Option<StencilUnknown>[]}
+				_value={'de'}
+				_hasClearButton={false}
+			/>
 			<KolSingleSelect
 				{...props}
 				_hint={HINT_MSG}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/clear-button.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/clear-button.ts
@@ -20,7 +20,27 @@ export class RenameClearButtonPropTask extends AbstractTask {
 	public run(baseDir: string): void {
 		filterFilesByExt(baseDir, MARKUP_EXTENSIONS).forEach((file) => {
 			const content = fs.readFileSync(file, 'utf8');
-			const newContent = content.replace(/_hide-clear-button/g, '_has-clear-button').replace(/_hideClearButton/g, '_hasClearButton');
+			const newContent = content
+				.replace(/_hide-clear-button\s*=\s*"(true|false)"/g, (_match, value: string) => {
+					return `_has-clear-button="${value === 'true' ? 'false' : 'true'}"`;
+				})
+				.replace(/_hide-clear-button\s*=\s*'(true|false)'/g, (_match, value: string) => {
+					return `_has-clear-button='${value === 'true' ? 'false' : 'true'}'`;
+				})
+				.replace(/_hide-clear-button\s*=\s*\{\s*(true|false)\s*\}/g, (_match, value: string) => {
+					return `_has-clear-button={${value === 'true' ? 'false' : 'true'}}`;
+				})
+				.replace(/_hideClearButton\s*=\s*"(true|false)"/g, (_match, value: string) => {
+					return `_hasClearButton="${value === 'true' ? 'false' : 'true'}"`;
+				})
+				.replace(/_hideClearButton\s*=\s*'(true|false)'/g, (_match, value: string) => {
+					return `_hasClearButton='${value === 'true' ? 'false' : 'true'}'`;
+				})
+				.replace(/_hideClearButton\s*=\s*\{\s*(true|false)\s*\}/g, (_match, value: string) => {
+					return `_hasClearButton={${value === 'true' ? 'false' : 'true'}}`;
+				})
+				.replace(/_hide-clear-button(?=[\s/>])/g, '_has-clear-button="false"')
+				.replace(/_hideClearButton(?=[\s/>])/g, '_hasClearButton={false}');
 
 			if (content !== newContent) {
 				fs.writeFileSync(file, newContent);

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/clear-button.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/clear-button.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+
+import { MARKUP_EXTENSIONS } from '../../../../types';
+import { filterFilesByExt, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask } from '../../abstract-task';
+
+export class RenameClearButtonPropTask extends AbstractTask {
+	private constructor(identifier: string, versionRange: string) {
+		super(identifier, 'Rename _hide-clear-button to _has-clear-button', MARKUP_EXTENSIONS, versionRange);
+	}
+
+	public static getInstance(versionRange: string): RenameClearButtonPropTask {
+		const identifier = 'rename-clear-button-prop';
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new RenameClearButtonPropTask(identifier, versionRange));
+		}
+		return this.instances.get(identifier) as RenameClearButtonPropTask;
+	}
+
+	public run(baseDir: string): void {
+		filterFilesByExt(baseDir, MARKUP_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(/_hide-clear-button/g, '_has-clear-button').replace(/_hideClearButton/g, '_hasClearButton');
+
+			if (content !== newContent) {
+				fs.writeFileSync(file, newContent);
+				MODIFIED_FILES.add(file);
+			}
+		});
+	}
+}
+
+export const RenameClearButtonPropTasks: AbstractTask[] = [RenameClearButtonPropTask.getInstance('^4')];

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,4 +1,5 @@
 import { AbstractTask } from '../../abstract-task';
+import { RenameClearButtonPropTasks } from './clear-button';
 import { RemoveIdPropTasks } from './id';
 import { MapVariantStandaloneToInlineTasks } from './link';
 import { UpdateLoaderImportPathTask } from './loader';
@@ -11,6 +12,7 @@ export const v4Tasks: AbstractTask[] = [];
 v4Tasks.push(...MapVariantStandaloneToInlineTasks);
 v4Tasks.push(...RemoveIdPropTasks);
 v4Tasks.push(...RemoveMsgPropsTasks);
+v4Tasks.push(...RenameClearButtonPropTasks);
 v4Tasks.push(RemoveToastVariantTask.getInstance('^4'));
 v4Tasks.push(RemoveToasterGetInstanceOptionsTask.getInstance('^4'));
 v4Tasks.push(UpdateLoaderImportPathTask.getInstance('^4'));

--- a/packages/tools/kolibri-cli/test/clear-button-migration.spec.ts
+++ b/packages/tools/kolibri-cli/test/clear-button-migration.spec.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { RenameClearButtonPropTask } from '../src/migrate/runner/tasks/v4/clear-button';
+
+describe('RenameClearButtonPropTask', () => {
+        it('renames kebab-case attribute and inverts explicit boolean strings', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const htmlPath = path.join(tmpDir, 'sample.html');
+                fs.writeFileSync(htmlPath, '<kol-combobox _hide-clear-button="true"></kol-combobox>');
+
+                RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
+
+                const content = fs.readFileSync(htmlPath, 'utf8');
+                assert.ok(!content.includes('_hide-clear-button'));
+                assert.ok(content.includes('_has-clear-button="false"'));
+        });
+
+        it('renames camelCase prop and inverts JSX boolean props', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const tsxPath = path.join(tmpDir, 'sample.tsx');
+                fs.writeFileSync(tsxPath, '<KolCombobox _hideClearButton={false} />');
+
+                RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
+
+                const content = fs.readFileSync(tsxPath, 'utf8');
+                assert.ok(!content.includes('_hideClearButton'));
+                assert.ok(content.includes('_hasClearButton={true}'));
+        });
+
+        it('maps bare attributes to disabled clear buttons', () => {
+                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+                const tsxPath = path.join(tmpDir, 'implicit.tsx');
+                fs.writeFileSync(tsxPath, '<KolCombobox _hideClearButton />');
+
+                RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
+
+                const content = fs.readFileSync(tsxPath, 'utf8');
+                assert.ok(content.includes('_hasClearButton={false}'));
+        });
+});


### PR DESCRIPTION
## What changed?

This PR extends the clear button migration task in `kolibri-cli` to rewrite both dashed (`_has-clear-button`) and camelCase (`_hasClearButton`) attribute usages. The breaking change documentation is also clarified to mention the prop rewrite. 13 files are updated.

## Linked issues

- Refs #9125 — clear button migration coverage

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`feat(kolibri-cli): extend clear button migration task to cover dashed and camelCase prop variants`)

> ℹ️ Original title `Expand clear button migration coverage` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR erweitert die Clear-Button-Migrations-Task in `kolibri-cli`, um sowohl Dashed- (`_has-clear-button`) als auch CamelCase- (`_hasClearButton`) Attributschreibweisen umzuschreiben. Die Breaking-Change-Dokumentation wird präzisiert.

### Verknüpfte Tickets

- Refs #9125 — Clear-Button-Migrationsabdeckung

### Art der Änderung

- [x] ✨ Neues Feature

### Geänderte Dateien

- 13 Dateien in `kolibri-cli` und Dokumentation

</details>