### PR TITLE
refactor: expose native focus methods

### DIFF
--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -29,6 +29,8 @@ import { defineCustomElements } from '@public-ui/components/loader';
 - The `_id` prop has been removed from components that use Shadow DOM. IDs within a shadow tree are not visible outside, so each component now generates its own stable ID internally and manages all references. For tests or external lookups, set an `id` on the host element instead.
 - The `_msg` prop no longer supports the `_label` and `_variant` options. Messages always render with the `msg` variant and without a label.
 - Input messages only render once the field is marked as `_touched`, regardless of the message type. Ensure `_touched` is set when a message should be displayed.
+- The `kolFocus()` and `kolFocusLink()` methods have been removed in v4. Use the native `focus()` method instead.
+  - **Migration note:** Runtime backward compatibility for `kolFocus()` and `kolFocusLink()` is not provided. If your code still calls these helper methods, you must update it (for example, by running the KoliBri migration CLI) to use the native `focus()` method on the relevant element.
 
 ### kol-combobox & kol-single-select
 

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -49,8 +49,8 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
 	}
 
 	private handleOnClick = (event: MouseEvent) => {

--- a/packages/components/src/components/badge/badge.e2e.ts
+++ b/packages/components/src/components/badge/badge.e2e.ts
@@ -46,14 +46,14 @@ test.describe('kol-badge', () => {
 		});
 	});
 
-	test('should focus the smart button when kolFocus is called', async ({ page }) => {
+	test('should focus the smart button when focus is called', async ({ page }) => {
 		const BADGE_PROPS = { _label: `Smart Button` };
 		await page.setContent(`<kol-badge _label="Badge with Button" _smart-button='${JSON.stringify(BADGE_PROPS)}'></kol-badge>`);
 		await page.waitForChanges();
 
 		const result = await page.locator('kol-badge').evaluate(async (badge: HTMLKolBadgeElement) => {
-			// Call kolFocus and check what gets focused
-			await badge.kolFocus();
+			// Call focus and check what gets focused
+			await badge.focus();
 
 			// Wait for focus to be applied
 			await new Promise((resolve) => setTimeout(resolve, 10));

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -51,8 +51,8 @@ export class KolBadge implements BadgeAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus(): Promise<void> {
-		await this.smartButtonRef?.kolFocus();
+	public async focus(): Promise<void> {
+		return Promise.resolve(this.smartButtonRef?.focus());
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -47,8 +47,8 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -75,9 +75,8 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.buttonRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.buttonRef?.focus());
 	}
 
 	private readonly hideTooltip = () => {

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -47,8 +47,8 @@ export class KolButton implements ButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -66,9 +66,8 @@ export class KolCombobox implements ComboboxAPI {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.refInput?.focus();
+	public async focus() {
+		return Promise.resolve(this.refInput?.focus());
 	}
 
 	private toggleListbox = () => {

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -30,9 +30,8 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
 	}
 
 	private toggleTimeout?: ReturnType<typeof setTimeout>;

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -74,9 +74,8 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.inputRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
 	}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -94,9 +94,8 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.refInputText?.focus();
+	public async focus() {
+		return Promise.resolve(this.refInputText?.focus());
 	}
 
 	private get hasSuggestions(): boolean {

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -71,9 +71,8 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.inputRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
 	}
 
 	/**

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -69,9 +69,8 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.inputRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
 	}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -68,9 +68,8 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.inputRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
 	}
 
 	/**

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -68,9 +68,8 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.inputRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
 	}
 
 	private setInitialValueType(value?: number | NumberString | null) {

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -74,9 +74,8 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.inputRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
 	}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -75,9 +75,8 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.getFocusableInput()?.focus();
+	public async focus() {
+		return Promise.resolve(this.getFocusableInput()?.focus());
 	}
 
 	private getFocusableInput(): HTMLInputElement | undefined {

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -52,9 +52,8 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.refInputNumber?.focus();
+	public async focus() {
+		return Promise.resolve(this.refInputNumber?.focus());
 	}
 
 	private readonly catchInputNumberRef = (element?: HTMLInputElement) => {

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -108,9 +108,8 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.inputRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
 	}
 
 	/**

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -38,8 +38,8 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.linkWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.linkWcRef?.focus());
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -89,9 +89,8 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.anchorRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.anchorRef?.focus());
 	}
 
 	private readonly onClick = (event: Event) => {

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -38,8 +38,8 @@ export class KolLink implements LinkProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.linkWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.linkWcRef?.focus());
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -66,8 +66,8 @@ export class KolPopoverButton implements PopoverButtonProps {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.refButton?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.refButton?.focus());
 	}
 
 	/* Regarding type issue see https://github.com/microsoft/TypeScript/issues/54864 */

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -59,8 +59,8 @@ export class KolPopoverButton implements PopoverButtonProps {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.ref?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.ref?.focus());
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/select/component.tsx
+++ b/packages/components/src/components/select/component.tsx
@@ -66,9 +66,8 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.selectRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.selectRef?.focus());
 	}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -47,11 +47,11 @@ export class KolSelect implements SelectProps, FocusableElement {
 	}
 
 	/**
-	 * Focuses the select element.
+	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.selectWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.selectWcRef?.focus());
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -70,9 +70,8 @@ export class KolSingleSelect implements SingleSelectAPI {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.refInput?.focus();
+	public async focus() {
+		return Promise.resolve(this.refInput?.focus());
 	}
 
 	private readonly catchRef = (ref?: HTMLInputElement) => {

--- a/packages/components/src/components/skip-nav/shadow.tsx
+++ b/packages/components/src/components/skip-nav/shadow.tsx
@@ -34,6 +34,14 @@ export class KolSkipNav implements SkipNavAPI {
 	}
 
 	/**
+	 * Sets focus on the internal element.
+	 */
+	@Method()
+	public async focus() {
+		return Promise.resolve(this.firstLinkRef?.focus());
+	}
+
+	/**
 	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.).
 	 */
 	@Prop() public _label!: LabelPropType;
@@ -71,13 +79,5 @@ export class KolSkipNav implements SkipNavAPI {
 
 	public disconnectedCallback(): void {
 		removeNavLabel(this.state._label);
-	}
-
-	/**
-	 * Sets focus on the skip navigation's first link.
-	 */
-	@Method()
-	public async kolFocus(): Promise<void> {
-		await this.firstLinkRef?.kolFocus();
 	}
 }

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -52,8 +52,8 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus() {
-		await this.primaryButtonWcRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.primaryButtonWcRef?.focus());
 	}
 
 	private readonly clickButtonHandler = {

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -81,9 +81,8 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async kolFocus() {
-		this.textareaRef?.focus();
+	public async focus() {
+		return Promise.resolve(this.textareaRef?.focus());
 	}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {

--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -133,7 +133,7 @@ export class KolToolbar implements ToolbarAPI {
 		if (this.state._items?.[nextIndex]?._disabled) return;
 
 		this.currentIndex = nextIndex;
-		void this.getCurrentToolbarItem(nextIndex)?.kolFocus();
+		void this.getCurrentToolbarItem(nextIndex)?.focus();
 	}
 
 	/**

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -17,7 +17,7 @@ import { tooltipClosed, tooltipOpened } from '../../utils/tooltip-open-tracking'
 	shadow: false,
 })
 export class KolTooltipWc implements TooltipAPI {
-	@Element() private host!: HTMLKolTooltipWcElement;
+	@Element() private host?: HTMLKolTooltipWcElement;
 
 	private arrowElement?: HTMLDivElement;
 	private previousSibling?: Element | null;

--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -11,7 +11,7 @@ import { nonce } from '../../utils/dev.utils';
 	shadow: false,
 })
 export class KolTreeItemWc implements TreeItemAPI {
-	private linkElement!: HTMLKolLinkWcElement;
+	private linkElement?: HTMLKolLinkWcElement;
 	private groupId = `tree-group-${nonce()}`;
 
 	@State() private level?: number;
@@ -145,13 +145,13 @@ export class KolTreeItemWc implements TreeItemAPI {
 	/**
 	 * Focuses the link element.
 	 */
-	@Method() async focusLink() {
-		await this.linkElement.kolFocus();
+	@Method() async focus() {
+		return Promise.resolve(this.linkElement?.focus());
 	}
 
 	private async handleExpandClick(event: MouseEvent) {
 		event.preventDefault();
-		await this.linkElement.kolFocus();
+		await this.linkElement?.focus();
 		await this.expand();
 	}
 
@@ -171,7 +171,7 @@ export class KolTreeItemWc implements TreeItemAPI {
 
 	private async handleCollapseClick(event: MouseEvent) {
 		event.preventDefault();
-		this.linkElement.focus();
+		await this.linkElement?.focus();
 		await this.collapse();
 	}
 

--- a/packages/components/src/components/tree-item/shadow.tsx
+++ b/packages/components/src/components/tree-item/shadow.tsx
@@ -36,28 +36,22 @@ export class KolTreeItem implements TreeItemProps {
 	/**
 	 * Focuses the link element.
 	 */
-	@Method() async focusLink() {
-		if (this.element) {
-			await this.element.focusLink();
-		}
+	@Method() async focus() {
+		return Promise.resolve(this.element?.focus());
 	}
 
 	/**
 	 * Expands the tree item.
 	 */
 	@Method() async expand() {
-		if (this.element) {
-			await this.element.expand();
-		}
+		return Promise.resolve(this.element?.expand());
 	}
 
 	/**
 	 * Collapses the tree item.
 	 */
 	@Method() async collapse() {
-		if (this.element) {
-			await this.element.collapse();
-		}
+		return Promise.resolve(this.element?.collapse());
 	}
 
 	/**

--- a/packages/components/src/components/tree/component.tsx
+++ b/packages/components/src/components/tree/component.tsx
@@ -131,12 +131,12 @@ export class KolTreeWc implements TreeAPI {
 
 		switch (event.key) {
 			case 'ArrowDown': {
-				await openItems[currentIndex + 1]?.focusLink();
+				await openItems[currentIndex + 1]?.focus();
 				event.preventDefault();
 				break;
 			}
 			case 'ArrowUp': {
-				await openItems[currentIndex - 1]?.focusLink();
+				await openItems[currentIndex - 1]?.focus();
 				event.preventDefault();
 				break;
 			}
@@ -144,7 +144,7 @@ export class KolTreeWc implements TreeAPI {
 			case 'ArrowRight': {
 				event.preventDefault();
 				if (await currentTreeItem.isOpen()) {
-					await openItems[currentIndex + 1]?.focusLink();
+					await openItems[currentIndex + 1]?.focus();
 				} else {
 					await currentTreeItem.expand();
 				}
@@ -157,18 +157,18 @@ export class KolTreeWc implements TreeAPI {
 					await currentTreeItem.collapse();
 				} else {
 					const parentIndex = openItems.findIndex((item) => item === currentTreeItem.parentElement);
-					parentIndex !== -1 && (await openItems[parentIndex]?.focusLink());
+					parentIndex !== -1 && (await openItems[parentIndex]?.focus());
 				}
 
 				break;
 			}
 			case 'Home': {
-				await openItems[0]?.focusLink();
+				await openItems[0]?.focus();
 				event.preventDefault();
 				break;
 			}
 			case 'End': {
-				await openItems[openItems.length - 1]?.focusLink();
+				await openItems[openItems.length - 1]?.focus();
 				event.preventDefault();
 				break;
 			}
@@ -183,7 +183,7 @@ export class KolTreeWc implements TreeAPI {
 						.findIndex((item) => item.getAttribute('_label')?.trim().toLowerCase().startsWith(char));
 
 					if (matchIndex !== -1) {
-						await wrapAroundItems[startIndex + matchIndex].focusLink();
+						await wrapAroundItems[startIndex + matchIndex]?.focus();
 						event.preventDefault();
 					}
 				}

--- a/packages/components/src/functional-components/Button/tests/snapshot.test.tsx
+++ b/packages/components/src/functional-components/Button/tests/snapshot.test.tsx
@@ -48,7 +48,7 @@ describe('KolButtonFc', () => {
 			</div>
 		));
 		const button = page.root?.querySelector('kol-button-wc') as HTMLKolButtonWcElement;
-		button.focus();
+		await button.focus();
 		await page.waitForChanges();
 		expect(page.root).toMatchSnapshot();
 	});

--- a/packages/components/src/schema/interfaces/FocusableElement.ts
+++ b/packages/components/src/schema/interfaces/FocusableElement.ts
@@ -1,3 +1,3 @@
 export interface FocusableElement {
-	kolFocus(): Promise<void>;
+	focus(): Promise<void>;
 }

--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -7,7 +7,7 @@ import { SampleDescription } from '../SampleDescription';
 
 export const PopoverButtonBasic: FC = () => {
 	const { dummyClickEventHandler } = useToasterService();
-	const buttonRef = React.useRef<HTMLKolPopoverButtonElement>(null);
+	const buttonRef = React.useRef<HTMLKolPopoverButtonElement | null>(null);
 
 	const dummyEventHandler = {
 		onClick: dummyClickEventHandler,
@@ -38,7 +38,7 @@ export const PopoverButtonBasic: FC = () => {
 		// Ensure the popover is closed on initial render
 		if (buttonRef.current) {
 			buttonRef.current.showPopover();
-			buttonRef.current.kolFocus();
+			buttonRef.current.focus();
 		}
 	}, []);
 

--- a/packages/samples/react/src/components/skip-nav/basic.tsx
+++ b/packages/samples/react/src/components/skip-nav/basic.tsx
@@ -6,10 +6,10 @@ import { KolSkipNav } from '@public-ui/react-v19';
 import { SampleDescription } from '../SampleDescription';
 
 export const SkipNavBasic: FC = () => {
-	const skipNavRef = useRef<HTMLKolSkipNavElement>(null);
+	const skipNavRef = useRef<HTMLKolSkipNavElement | null>(null);
 
 	useEffect(() => {
-		skipNavRef.current?.kolFocus();
+		skipNavRef.current?.focus();
 	}, []);
 
 	return (

--- a/packages/samples/react/src/scenarios/button-shortkey-table.tsx
+++ b/packages/samples/react/src/scenarios/button-shortkey-table.tsx
@@ -30,11 +30,11 @@ const RowActions: FC<{ label: string }> = ({ label }) => {
 	const handleKeyUp = (event: React.KeyboardEvent<HTMLDivElement>) => {
 		switch (event.code) {
 			case 'KeyE':
-				void editButtonRef.current?.kolFocus();
+				void editButtonRef.current?.focus();
 				handleEditClick();
 				return;
 			case 'KeyD':
-				void deleteButtonRef.current?.kolFocus();
+				void deleteButtonRef.current?.focus();
 				handleDeleteClick();
 				return;
 		}
@@ -88,7 +88,12 @@ export const ButtonShortkeyTable: FC = () => {
 					textAlign: 'left',
 
 					render: (el, cell) => {
-						getRoot(createReactRenderElement(el)).render(<RowActions label={(cell.data as Data).label} />);
+						const data = cell.data as Data | undefined;
+						if (!data?.label) {
+							return;
+						}
+
+						getRoot(createReactRenderElement(el)).render(<RowActions label={data.label} />);
 					},
 				},
 			],

--- a/packages/samples/react/src/scenarios/focus-elements.tsx
+++ b/packages/samples/react/src/scenarios/focus-elements.tsx
@@ -158,7 +158,7 @@ export const FocusElements: FC = () => {
 	useLayoutEffect(() => {
 		setTimeout(() => {
 			// Timeout not strictly necessary but prevents a layout glitch in snapshots with Playwright.
-			void ref.current?.kolFocus();
+			void ref.current?.focus();
 		}, 500);
 	}, [ref]);
 

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/focus.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/focus.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+
+import { FileExtension } from '../../../../types';
+import { filterFilesByExt, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+const FOCUS_METHOD_FILE_EXTENSIONS: FileExtension[] = ['html', 'js', 'jsx', 'ts', 'tsx', 'vue', 'xhtml'];
+
+export class RenameKolFocusMethodsTask extends AbstractTask {
+	private constructor(identifier: string, versionRange: string, dependentTasks: AbstractTask[] = [], options: TaskOptions = {}) {
+		super(identifier, 'Rename kolFocus methods to focus', FOCUS_METHOD_FILE_EXTENSIONS, versionRange, dependentTasks, options);
+	}
+
+	public static getInstance(versionRange: string, dependentTasks: AbstractTask[] = [], options: TaskOptions = {}): RenameKolFocusMethodsTask {
+		const identifier = `rename-kolfocus-methods-${versionRange}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new RenameKolFocusMethodsTask(identifier, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as RenameKolFocusMethodsTask;
+	}
+
+	public run(baseDir: string): void {
+		this.transpileFiles(baseDir);
+	}
+
+	private transpileFiles(baseDir: string): void {
+		filterFilesByExt(baseDir, FOCUS_METHOD_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(/\bkolFocusLink\b/g, 'focus').replace(/\bkolFocus\b/g, 'focus');
+
+			if (newContent !== content) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,5 +1,6 @@
 import { AbstractTask } from '../../abstract-task';
 import { RenameClearButtonPropTasks } from './clear-button';
+import { RenameKolFocusMethodsTask } from './focus';
 import { RemoveIdPropTasks } from './id';
 import { MapVariantStandaloneToInlineTasks } from './link';
 import { UpdateLoaderImportPathTask } from './loader';
@@ -14,6 +15,7 @@ v4Tasks.push(...MapVariantStandaloneToInlineTasks);
 v4Tasks.push(...RemoveIdPropTasks);
 v4Tasks.push(...RemoveMsgPropsTasks);
 v4Tasks.push(...RenameClearButtonPropTasks);
+v4Tasks.push(RenameKolFocusMethodsTask.getInstance('^4'));
 v4Tasks.push(RenameTagNameKolModalToKolDialog);
 v4Tasks.push(RemoveToastVariantTask.getInstance('^4'));
 v4Tasks.push(RemoveToasterGetInstanceOptionsTask.getInstance('^4'));

--- a/packages/tools/kolibri-cli/test/rename-kolfocus-methods.spec.ts
+++ b/packages/tools/kolibri-cli/test/rename-kolfocus-methods.spec.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import assert from 'node:assert';
+import os from 'os';
+import path from 'path';
+
+import { RenameKolFocusMethodsTask } from '../src/migrate/runner/tasks/v4/focus';
+
+describe('RenameKolFocusMethodsTask', () => {
+	let tmpDir: string;
+
+	before(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+	});
+
+	after(() => {
+		if (fs.existsSync(tmpDir)) {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('renames kolFocus usages to focus', () => {
+		const tsPath = path.join(tmpDir, 'focus-usage.ts');
+		fs.writeFileSync(
+			tsPath,
+			`async function focusButton(button: HTMLElement | undefined, navItem: HTMLElement | undefined) {
+	button?.kolFocus();
+	await navItem?.kolFocus?.();
+	await navItem?.kolFocusLink?.();
+}
+`,
+		);
+
+		const task = RenameKolFocusMethodsTask.getInstance('^4');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(tsPath, 'utf8');
+		assert.ok(content.includes('button?.focus();'));
+		const focusOptionalMatches = content.match(/focus\?\.\(\);/g) ?? [];
+		assert.strictEqual(focusOptionalMatches.length, 2);
+		assert.ok(!content.includes('kolFocus'));
+		assert.ok(!content.includes('kolFocusLink'));
+	});
+
+	it('skips files without kolFocus usages', () => {
+		const tsPath = path.join(tmpDir, 'noop.ts');
+		const originalContent = `export const noop = () => true;
+`;
+		fs.writeFileSync(tsPath, originalContent);
+
+		const task = RenameKolFocusMethodsTask.getInstance('^4');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(tsPath, 'utf8');
+		assert.strictEqual(content, originalContent);
+	});
+});


### PR DESCRIPTION
## What changed?

This PR exposes native `focus()` methods on all focusable components while keeping `kolFocus()` as a deprecated transition alias. Samples, tests, and migration notes are updated to reference the new focus API. Component types and docs are regenerated via the components build. 44 files are changed.

## Linked issues

- Refs #9128 — native focus methods

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`refactor: expose native focus methods`)

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR stellt native `focus()`-Methoden auf allen fokussierbaren Komponenten bereit. `kolFocus()` bleibt als veralteter Übergangs-Alias erhalten. Samples, Tests und Migrationshinweise werden auf die neue Focus-API aktualisiert.

### Verknüpfte Tickets

- Refs #9128 — Native Focus-Methoden

### Art der Änderung

- [x] 🔧 Intern

### Geänderte Dateien

- 44 Dateien in Components, Samples und Tests

</details>