### PR TITLE
fix(components): correct input message e2e helper to start in untouched state

### DIFF
--- a/packages/components/src/e2e/input-msg.ts
+++ b/packages/components/src/e2e/input-msg.ts
@@ -5,7 +5,7 @@ import type { MsgPropType, Stringified } from '../schema';
 const testInputMessage = <ElementType extends { _msg?: Stringified<MsgPropType>; _touched?: boolean } & HTMLElement>(componentName: string) => {
 	test.describe('Input messages', () => {
 		test(`should render a message when provided as object`, async ({ page }) => {
-			await page.setContent(`<${componentName} _label="Input" _msg="{'_description': 'This is a info message', '_type': 'info'}" _touched></${componentName}>`);
+			await page.setContent(`<${componentName} _label="Input" _msg="{'_description': 'This is a info message', '_type': 'info'}"></${componentName}>`);
 			const alert = page.getByTestId('alert');
 
 			await expect(alert).toHaveCount(0);
@@ -27,10 +27,10 @@ const testInputMessage = <ElementType extends { _msg?: Stringified<MsgPropType>;
 
 		test('should display and hide message based on _msg value', async ({ page }) => {
 			await page.setContent(`<${componentName}
-				_label="Input"
-				_msg="{'_description': 'An error message', '_type': 'error'}"
-				_touched
-			></${componentName}>`);
+					_label="Input"
+					_msg="{'_description': 'An error message', '_type': 'error'}"
+					_touched
+				></${componentName}>`);
 			const alert = page.getByTestId('alert');
 
 			await expect(alert).toBeVisible();


### PR DESCRIPTION
## What changed?

This PR fixes the shared input message e2e helper to start with an untouched component before checking alert visibility. The message visibility assertions are correctly driven by toggling `_touched` and `_msg` properties. This ensures e2e tests begin from a deterministic baseline state.

## Linked issues

- Refs #9133 — input message e2e helper

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`fix(components): correct input message e2e helper to start in untouched state`)

> ℹ️ Original title `Adjust input message touched handling in e2e helper` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR korrigiert den gemeinsamen E2E-Helper für Eingabe-Nachrichten, sodass er mit einem unberührten Zustand startet, bevor die Sichtbarkeit von Alerts geprüft wird. Dies gewährleistet einen deterministischen Ausgangszustand für E2E-Tests.

### Verknüpfte Tickets

- Refs #9133 — E2E-Helper für Eingabe-Nachrichten

### Art der Änderung

- [x] 🐛 Bugfix

### Geänderte Dateien

- 1 E2E-Testdatei

</details>