### PR TITLE
feat(kolibri-cli): add migration tasks for kolFocus rename and refine v4 breaking change docs

### DIFF
--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -29,9 +29,7 @@ import { defineCustomElements } from '@public-ui/components/loader';
 - The `_id` prop has been removed from components that use Shadow DOM. IDs within a shadow tree are not visible outside, so each component now generates its own stable ID internally and manages all references. For tests or external lookups, set an `id` on the host element instead.
 - The `_msg` prop no longer supports the `_label` and `_variant` options. Messages always render with the `msg` variant and without a label.
 - Input messages only render once the field is marked as `_touched`, regardless of the message type. Ensure `_touched` is set when a message should be displayed.
-- The `kolFocus()` method has been removed. Use the native `focus()` method instead.
-  - **Migration note:** The new `focus()` method has been refactored for better native alignment and interoperability across frameworks. See [Focus Method Refactoring: Native Character & Interoperability](./tutorials/FOCUS_METHOD_REFACTORING.md) for detailed information about the rationale and benefits of this change.
-- The `kolFocus()` method has been removed. Use the native `focus()` method instead.
+- The `kolFocus()` and `kolFocusLink()` methods have been removed. Use the native `focus()` method instead.
   - **Migration note:** The new `focus()` method has been refactored for better native alignment and interoperability across frameworks. See [Focus Method Refactoring: Native Character & Interoperability](./FOCUS_METHOD_REFACTORING.md) for detailed information about the rationale and benefits of this change.
 
 ### kol-combobox & kol-single-select

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/focus.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/focus.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+
+import { FileExtension } from '../../../../types';
+import { filterFilesByExt, MODIFIED_FILES } from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+const FOCUS_METHOD_FILE_EXTENSIONS: FileExtension[] = ['html', 'js', 'jsx', 'ts', 'tsx', 'vue', 'xhtml'];
+
+export class RenameKolFocusMethodsTask extends AbstractTask {
+	private constructor(identifier: string, versionRange: string, dependentTasks: AbstractTask[] = [], options: TaskOptions = {}) {
+		super(identifier, 'Rename kolFocus methods to focus', FOCUS_METHOD_FILE_EXTENSIONS, versionRange, dependentTasks, options);
+	}
+
+	public static getInstance(versionRange: string, dependentTasks: AbstractTask[] = [], options: TaskOptions = {}): RenameKolFocusMethodsTask {
+		const identifier = `rename-kolfocus-methods-${versionRange}`;
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new RenameKolFocusMethodsTask(identifier, versionRange, dependentTasks, options));
+		}
+		return this.instances.get(identifier) as RenameKolFocusMethodsTask;
+	}
+
+	public run(baseDir: string): void {
+		this.transpileFiles(baseDir);
+	}
+
+	private transpileFiles(baseDir: string): void {
+		filterFilesByExt(baseDir, FOCUS_METHOD_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(/\bkolFocusLink\b/g, 'focus').replace(/\bkolFocus\b/g, 'focus');
+
+			if (newContent !== content) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/index.ts
@@ -1,5 +1,6 @@
 import { AbstractTask } from '../../abstract-task';
 import { RenameClearButtonPropTasks } from './clear-button';
+import { RenameKolFocusMethodsTask } from './focus';
 import { RemoveIdPropTasks } from './id';
 import { MapVariantStandaloneToInlineTasks } from './link';
 import { UpdateLoaderImportPathTask } from './loader';
@@ -14,6 +15,7 @@ v4Tasks.push(...MapVariantStandaloneToInlineTasks);
 v4Tasks.push(...RemoveIdPropTasks);
 v4Tasks.push(...RemoveMsgPropsTasks);
 v4Tasks.push(...RenameClearButtonPropTasks);
+v4Tasks.push(RenameKolFocusMethodsTask.getInstance('^4'));
 v4Tasks.push(RenameTagNameKolModalToKolDialog);
 v4Tasks.push(RemoveToastVariantTask.getInstance('^4'));
 v4Tasks.push(RemoveToasterGetInstanceOptionsTask.getInstance('^4'));

--- a/packages/tools/kolibri-cli/test/rename-kolfocus-methods.spec.ts
+++ b/packages/tools/kolibri-cli/test/rename-kolfocus-methods.spec.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import assert from 'node:assert';
+import os from 'os';
+import path from 'path';
+
+import { RenameKolFocusMethodsTask } from '../src/migrate/runner/tasks/v4/focus';
+
+describe('RenameKolFocusMethodsTask', () => {
+	let tmpDir: string;
+
+	before(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+	});
+
+	after(() => {
+		if (fs.existsSync(tmpDir)) {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('renames kolFocus usages to focus', () => {
+		const tsPath = path.join(tmpDir, 'focus-usage.ts');
+		fs.writeFileSync(
+			tsPath,
+			`async function focusButton(button: HTMLElement | undefined, navItem: HTMLElement | undefined) {
+	button?.kolFocus();
+	await navItem?.kolFocus?.();
+	await navItem?.kolFocusLink?.();
+}
+`,
+		);
+
+		const task = RenameKolFocusMethodsTask.getInstance('^4');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(tsPath, 'utf8');
+		assert.ok(content.includes('button?.focus();'));
+		const focusOptionalMatches = content.match(/focus\?\.\(\);/g) ?? [];
+		assert.strictEqual(focusOptionalMatches.length, 2);
+		assert.ok(!content.includes('kolFocus'));
+		assert.ok(!content.includes('kolFocusLink'));
+	});
+
+	it('skips files without kolFocus usages', () => {
+		const tsPath = path.join(tmpDir, 'noop.ts');
+		const originalContent = `export const noop = () => true;
+`;
+		fs.writeFileSync(tsPath, originalContent);
+
+		const task = RenameKolFocusMethodsTask.getInstance('^4');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(tsPath, 'utf8');
+		assert.strictEqual(content, originalContent);
+	});
+});


### PR DESCRIPTION
## What changed?

This PR adds v4 migration tasks to `kolibri-cli` that rename `kolFocus()` and `kolFocusLink()` usages to the native `focus()` method. Unit tests are added to cover the new migration behaviour. The v4 breaking change documentation is clarified to explain the removal of the proprietary focus method.

## Linked issues

- Refs #9128 — native focus methods

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`feat(kolibri-cli): add migration tasks for kolFocus rename and refine v4 breaking change docs`)

> ℹ️ Original title `Add focus migration tasks and refine v4 breaking change note` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR ergänzt v4-Migrations-Tasks in `kolibri-cli`, die `kolFocus()` und `kolFocusLink()` in natives `focus()` umbenennen. Unit-Tests für das neue Verhalten werden hinzugefügt. Die v4-Breaking-Change-Dokumentation wird präzisiert.

### Verknüpfte Tickets

- Refs #9128 — Native Focus-Methoden

### Art der Änderung

- [x] ✨ Neues Feature

### Geänderte Dateien

- 4 Dateien in `packages/tools/kolibri-cli`

</details>