### PR TITLE
refactor: expose native focus methods

### DIFF
--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -12,8 +12,31 @@ For more information, see the [KoliBri Maintenance and Support Strategy](https:/
 
 - The `_id` prop has been removed from components that use Shadow DOM. IDs within a shadow tree are not visible outside, so each component now generates its own stable ID internally and manages all references. For tests or external lookups, set an `id` on the host element instead.
 - The `_msg` prop no longer supports the `_label` and `_variant` options. Messages always render with the `msg` variant and without a label.
+- Input messages only render once the field is marked as `_touched`, regardless of the message type. Ensure `_touched` is set when a message should be displayed.
+- The `kolFocus()` and `kolFocusLink()` methods have been deprecated and will be removed in a future major version. Use the native `focus()` method instead (the deprecated methods currently delegate to `focus()` for backward compatibility).
+  - **Migration note:** The new `focus()` method has been refactored for better native alignment and interoperability across frameworks while preserving backward compatibility with the deprecated helper methods.
 
-### Toast System
+### kol-combobox & kol-single-select
+
+- `_hideClearButton` has been replaced with `_hasClearButton` (default: `true`). Set `_hasClearButton="false"` to hide the clear button while keeping existing values intact. The migration CLI rewrites `_hide-clear-button` attributes and `_hideClearButton` props automatically, flipping boolean values so behaviour stays the same.
+
+### kol-nav
+
+- The `orientation` property has been removed from kol-nav. It is now always in vertical mode by default.
+
+**Before:**
+
+```html
+<kol-nav _orientation="vertical" _label="" _links="[]"></kol-nav>
+```
+
+**After (v4):**
+
+```html
+<kol-nav _label="" _links="[]"></kol-nav>
+```
+
+### ToasterService and toast component
 
 - The `variant` property has been removed from Toast objects. All toasts now use the `card` variant by default.
 - The `defaultVariant` option has been removed from `ToasterService.getInstance()`. The service no longer accepts variant configuration.

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -49,8 +49,16 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	private handleOnClick = (event: MouseEvent) => {

--- a/packages/components/src/components/badge/badge.e2e.ts
+++ b/packages/components/src/components/badge/badge.e2e.ts
@@ -46,14 +46,14 @@ test.describe('kol-badge', () => {
 		});
 	});
 
-	test('should focus the smart button when kolFocus is called', async ({ page }) => {
+	test('should focus the smart button when focus is called', async ({ page }) => {
 		const BADGE_PROPS = { _label: `Smart Button` };
 		await page.setContent(`<kol-badge _label="Badge with Button" _smart-button='${JSON.stringify(BADGE_PROPS)}'></kol-badge>`);
 		await page.waitForChanges();
 
 		const result = await page.locator('kol-badge').evaluate(async (badge: HTMLKolBadgeElement) => {
-			// Call kolFocus and check what gets focused
-			await badge.kolFocus();
+			// Call focus and check what gets focused
+			await badge.focus();
 
 			// Wait for focus to be applied
 			await new Promise((resolve) => setTimeout(resolve, 10));

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -51,8 +51,16 @@ export class KolBadge implements BadgeAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async kolFocus(): Promise<void> {
-		await this.smartButtonRef?.kolFocus();
+	public async focus() {
+		return Promise.resolve(this.smartButtonRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
+	public async kolFocus() {
+		return this.focus();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -48,8 +48,16 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -75,9 +75,16 @@ export class KolButtonWc implements InternalButtonAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.buttonRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.buttonRef?.focus();
+		return this.focus();
 	}
 
 	private readonly hideTooltip = () => {

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -47,8 +47,16 @@ export class KolButton implements ButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -66,9 +66,16 @@ export class KolCombobox implements ComboboxAPI {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.refInput?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.refInput?.focus();
+		return this.focus();
 	}
 
 	private toggleListbox = () => {

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -30,9 +30,16 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.buttonWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.buttonWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	private toggleTimeout?: ReturnType<typeof setTimeout>;

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -74,9 +74,16 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.inputRef?.focus();
+		return this.focus();
 	}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -94,9 +94,16 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.refInputText?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.refInputText?.focus();
+		return this.focus();
 	}
 
 	private get hasSuggestions(): boolean {

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -71,9 +71,16 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.inputRef?.focus();
+		return this.focus();
 	}
 
 	/**

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -69,9 +69,16 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.inputRef?.focus();
+		return this.focus();
 	}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -68,9 +68,16 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.inputRef?.focus();
+		return this.focus();
 	}
 
 	/**

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -67,9 +67,16 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.inputRef?.focus();
+		return this.focus();
 	}
 
 	private setInitialValueType(value?: number | NumberString | null) {

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -74,9 +74,16 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.inputRef?.focus();
+		return this.focus();
 	}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -75,9 +75,16 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.getFocusableInput()?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.getFocusableInput()?.focus();
+		return this.focus();
 	}
 
 	private getFocusableInput(): HTMLInputElement | undefined {

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -52,9 +52,16 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.refInputNumber?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.refInputNumber?.focus();
+		return this.focus();
 	}
 
 	private readonly catchInputNumberRef = (element?: HTMLInputElement) => {

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -108,9 +108,16 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.inputRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.inputRef?.focus();
+		return this.focus();
 	}
 
 	/**

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -38,8 +38,16 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.linkWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.linkWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -89,9 +89,16 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.anchorRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.anchorRef?.focus();
+		return this.focus();
 	}
 
 	private readonly onClick = (event: Event) => {

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -39,8 +39,16 @@ export class KolLink implements LinkProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.linkWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.linkWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -66,8 +66,16 @@ export class KolPopoverButton implements PopoverButtonProps {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.refButton?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.refButton?.kolFocus();
+		return this.focus();
 	}
 
 	/* Regarding type issue see https://github.com/microsoft/TypeScript/issues/54864 */

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -59,8 +59,16 @@ export class KolPopoverButton implements PopoverButtonProps {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.ref?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.ref?.kolFocus();
+		return this.focus();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/select/component.tsx
+++ b/packages/components/src/components/select/component.tsx
@@ -66,9 +66,16 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.selectRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.selectRef?.focus();
+		return this.focus();
 	}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -47,11 +47,19 @@ export class KolSelect implements SelectProps, FocusableElement {
 	}
 
 	/**
-	 * Focuses the select element.
+	 * Sets focus on the internal element.
+	 */
+	@Method()
+	public async focus() {
+		return Promise.resolve(this.selectWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
 	 */
 	@Method()
 	public async kolFocus() {
-		await this.selectWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	public render(): JSX.Element {

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -70,9 +70,16 @@ export class KolSingleSelect implements SingleSelectAPI {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.refInput?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.refInput?.focus();
+		return this.focus();
 	}
 
 	private readonly catchRef = (ref?: HTMLInputElement) => {

--- a/packages/components/src/components/skip-nav/shadow.tsx
+++ b/packages/components/src/components/skip-nav/shadow.tsx
@@ -34,6 +34,22 @@ export class KolSkipNav implements SkipNavAPI {
 	}
 
 	/**
+	 * Sets focus on the internal element.
+	 */
+	@Method()
+	public async focus() {
+		return Promise.resolve(this.firstLinkRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
+	public async kolFocus() {
+		return this.focus();
+	}
+
+	/**
 	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.).
 	 */
 	@Prop() public _label!: LabelPropType;
@@ -71,10 +87,5 @@ export class KolSkipNav implements SkipNavAPI {
 
 	public disconnectedCallback(): void {
 		removeNavLabel(this.state._label);
-	}
-
-	@Method()
-	public async kolFocus(): Promise<void> {
-		await this.firstLinkRef?.kolFocus();
 	}
 }

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -52,8 +52,16 @@ export class KolSplitButton implements SplitButtonProps /*, SplitButtonAPI*/ {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
+	public async focus() {
+		return Promise.resolve(this.primaryButtonWcRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		await this.primaryButtonWcRef?.kolFocus();
+		return this.focus();
 	}
 
 	private readonly clickButtonHandler = {

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -81,9 +81,16 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	// eslint-disable-next-line @typescript-eslint/require-await
+	public async focus() {
+		return Promise.resolve(this.textareaRef?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
 	public async kolFocus() {
-		this.textareaRef?.focus();
+		return this.focus();
 	}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {

--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -133,7 +133,7 @@ export class KolToolbar implements ToolbarAPI {
 		if (this.state._items?.[nextIndex]?._disabled) return;
 
 		this.currentIndex = nextIndex;
-		void this.getCurrentToolbarItem(nextIndex)?.kolFocus();
+		void this.getCurrentToolbarItem(nextIndex)?.focus();
 	}
 
 	/**

--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -17,7 +17,7 @@ import { tooltipClosed, tooltipOpened } from '../../utils/tooltip-open-tracking'
 	shadow: false,
 })
 export class KolTooltipWc implements TooltipAPI {
-	@Element() private host!: HTMLKolTooltipWcElement;
+	@Element() private host?: HTMLKolTooltipWcElement;
 
 	private arrowElement?: HTMLDivElement;
 	private previousSibling?: Element | null;

--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -11,7 +11,7 @@ import { nonce } from '../../utils/dev.utils';
 	shadow: false,
 })
 export class KolTreeItemWc implements TreeItemAPI {
-	private linkElement!: HTMLKolLinkWcElement;
+	private linkElement?: HTMLKolLinkWcElement;
 	private groupId = `tree-group-${nonce()}`;
 
 	@State() private level?: number;
@@ -145,13 +145,21 @@ export class KolTreeItemWc implements TreeItemAPI {
 	/**
 	 * Focuses the link element.
 	 */
-	@Method() async focusLink() {
-		await this.linkElement.kolFocus();
+	@Method() async focus() {
+		return Promise.resolve(this.linkElement?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
+	public async focusLink() {
+		return this.focus();
 	}
 
 	private async handleExpandClick(event: MouseEvent) {
 		event.preventDefault();
-		await this.linkElement.kolFocus();
+		await this.linkElement?.focus();
 		await this.expand();
 	}
 
@@ -171,7 +179,7 @@ export class KolTreeItemWc implements TreeItemAPI {
 
 	private async handleCollapseClick(event: MouseEvent) {
 		event.preventDefault();
-		this.linkElement.focus();
+		await this.linkElement?.focus();
 		await this.collapse();
 	}
 

--- a/packages/components/src/components/tree-item/shadow.tsx
+++ b/packages/components/src/components/tree-item/shadow.tsx
@@ -36,28 +36,30 @@ export class KolTreeItem implements TreeItemProps {
 	/**
 	 * Focuses the link element.
 	 */
-	@Method() async focusLink() {
-		if (this.element) {
-			await this.element.focusLink();
-		}
+	@Method() async focus() {
+		return Promise.resolve(this.element?.focus());
+	}
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	@Method()
+	public async focusLink() {
+		return this.focus();
 	}
 
 	/**
 	 * Expands the tree item.
 	 */
 	@Method() async expand() {
-		if (this.element) {
-			await this.element.expand();
-		}
+		return Promise.resolve(this.element?.expand());
 	}
 
 	/**
 	 * Collapses the tree item.
 	 */
 	@Method() async collapse() {
-		if (this.element) {
-			await this.element.collapse();
-		}
+		return Promise.resolve(this.element?.collapse());
 	}
 
 	/**

--- a/packages/components/src/components/tree/component.tsx
+++ b/packages/components/src/components/tree/component.tsx
@@ -131,12 +131,12 @@ export class KolTreeWc implements TreeAPI {
 
 		switch (event.key) {
 			case 'ArrowDown': {
-				await openItems[currentIndex + 1]?.focusLink();
+				await openItems[currentIndex + 1]?.focus();
 				event.preventDefault();
 				break;
 			}
 			case 'ArrowUp': {
-				await openItems[currentIndex - 1]?.focusLink();
+				await openItems[currentIndex - 1]?.focus();
 				event.preventDefault();
 				break;
 			}
@@ -144,7 +144,7 @@ export class KolTreeWc implements TreeAPI {
 			case 'ArrowRight': {
 				event.preventDefault();
 				if (await currentTreeItem.isOpen()) {
-					await openItems[currentIndex + 1]?.focusLink();
+					await openItems[currentIndex + 1]?.focus();
 				} else {
 					await currentTreeItem.expand();
 				}
@@ -157,18 +157,18 @@ export class KolTreeWc implements TreeAPI {
 					await currentTreeItem.collapse();
 				} else {
 					const parentIndex = openItems.findIndex((item) => item === currentTreeItem.parentElement);
-					parentIndex !== -1 && (await openItems[parentIndex]?.focusLink());
+					parentIndex !== -1 && (await openItems[parentIndex]?.focus());
 				}
 
 				break;
 			}
 			case 'Home': {
-				await openItems[0]?.focusLink();
+				await openItems[0]?.focus();
 				event.preventDefault();
 				break;
 			}
 			case 'End': {
-				await openItems[openItems.length - 1]?.focusLink();
+				await openItems[openItems.length - 1]?.focus();
 				event.preventDefault();
 				break;
 			}
@@ -183,7 +183,7 @@ export class KolTreeWc implements TreeAPI {
 						.findIndex((item) => item.getAttribute('_label')?.trim().toLowerCase().startsWith(char));
 
 					if (matchIndex !== -1) {
-						await wrapAroundItems[startIndex + matchIndex].focusLink();
+						await wrapAroundItems[startIndex + matchIndex]?.focus();
 						event.preventDefault();
 					}
 				}

--- a/packages/components/src/functional-components/Button/tests/snapshot.test.tsx
+++ b/packages/components/src/functional-components/Button/tests/snapshot.test.tsx
@@ -48,7 +48,7 @@ describe('KolButtonFc', () => {
 			</div>
 		));
 		const button = page.root?.querySelector('kol-button-wc') as HTMLKolButtonWcElement;
-		button.focus();
+		await button.focus();
 		await page.waitForChanges();
 		expect(page.root).toMatchSnapshot();
 	});

--- a/packages/components/src/schema/interfaces/FocusableElement.ts
+++ b/packages/components/src/schema/interfaces/FocusableElement.ts
@@ -1,3 +1,8 @@
 export interface FocusableElement {
-	kolFocus(): Promise<void>;
+	focus(): Promise<void>;
+
+	/**
+	 * @deprecated Use {@link focus} instead.
+	 */
+	kolFocus?(): Promise<void>;
 }

--- a/packages/samples/react/src/components/popover-button/basic.tsx
+++ b/packages/samples/react/src/components/popover-button/basic.tsx
@@ -6,7 +6,7 @@ import { SampleDescription } from '../SampleDescription';
 
 export const PopoverButtonBasic: FC = () => {
 	const { dummyClickEventHandler } = useToasterService();
-	const buttonRef = React.useRef<HTMLKolPopoverButtonElement>(null);
+	const buttonRef = React.useRef<HTMLKolPopoverButtonElement | null>(null);
 
 	const dummyEventHandler = {
 		onClick: dummyClickEventHandler,
@@ -34,7 +34,7 @@ export const PopoverButtonBasic: FC = () => {
 		// Ensure the popover is closed on initial render
 		if (buttonRef.current) {
 			buttonRef.current.showPopover();
-			buttonRef.current.kolFocus();
+			buttonRef.current.focus();
 		}
 	}, []);
 

--- a/packages/samples/react/src/components/skip-nav/basic.tsx
+++ b/packages/samples/react/src/components/skip-nav/basic.tsx
@@ -6,10 +6,10 @@ import { KolSkipNav } from '@public-ui/react-v19';
 import { SampleDescription } from '../SampleDescription';
 
 export const SkipNavBasic: FC = () => {
-	const skipNavRef = useRef<HTMLKolSkipNavElement>(null);
+	const skipNavRef = useRef<HTMLKolSkipNavElement | null>(null);
 
 	useEffect(() => {
-		skipNavRef.current?.kolFocus();
+		skipNavRef.current?.focus();
 	}, []);
 
 	return (

--- a/packages/samples/react/src/scenarios/focus-elements.tsx
+++ b/packages/samples/react/src/scenarios/focus-elements.tsx
@@ -158,7 +158,7 @@ export const FocusElements: FC = () => {
 	useLayoutEffect(() => {
 		setTimeout(() => {
 			// Timeout not strictly necessary but prevents a layout glitch in snapshots with Playwright.
-			void ref.current?.kolFocus();
+			void ref.current?.focus();
 		}, 500);
 	}, [ref]);
 


### PR DESCRIPTION
## What changed?

This PR refactors the v3 components to expose native `focus()` and `blur()` methods directly, replacing the proprietary `kolFocus()` interface. 40 files are updated across the components package to rename the internal focus handling. This is an internal refactoring that aligns the public API with native DOM conventions.

## Linked issues

- Refs #9151 — expose native focus methods

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`refactor: expose native focus methods`)

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR refaktoriert die v3-Komponenten, um native `focus()`- und `blur()`-Methoden direkt bereitzustellen und die proprietäre `kolFocus()`-Schnittstelle zu ersetzen. 40 Dateien werden im Components-Paket aktualisiert.

### Verknüpfte Tickets

- Refs #9151 — Native Focus-Methoden bereitstellen

### Art der Änderung

- [x] 🔧 Intern

### Geänderte Dateien

- 40 Dateien im Components-Paket

</details>