### PR TITLE
fix(nav): center expand button alignment

### DIFF
--- a/packages/components/src/components/nav/style.scss
+++ b/packages/components/src/components/nav/style.scss
@@ -13,6 +13,19 @@
 			#{$root}:not(#{$root}--is-compact) & {
 				width: 100%;
 			}
+
+			.kol-span {
+				width: 100%;
+				justify-content: flex-start;
+
+				&__container {
+					width: 100%;
+
+					.kol-span__label {
+						flex: 1;
+					}
+				}
+			}
 		}
 
 		&__list {
@@ -34,18 +47,5 @@
 
 	.kol-button {
 		text-align: left;
-	}
-
-	.kol-span {
-		width: 100%;
-		justify-content: flex-start;
-
-		&__container {
-			width: 100%;
-
-			.kol-span__label {
-				flex: 1;
-			}
-		}
 	}
 }

--- a/packages/themes/default/src/components/nav.scss
+++ b/packages/themes/default/src/components/nav.scss
@@ -89,7 +89,6 @@
 					border-radius: var(--border-radius);
 					min-width: var(--a11y-min-size);
 					min-height: var(--a11y-min-size);
-					justify-content: center;
 
 					transition-duration: 0.5s;
 					transition-property: background-color, color, border-color;


### PR DESCRIPTION
## What changed?

This PR fixes the vertical alignment of the expand button in the `Nav` component (v4) so it is properly centred. The fix addresses a layout inconsistency reported in the internal themes repository. Two files are updated to correct the CSS positioning.

## Linked issues

- Refs https://github.com/public-ui/interne-themes/issues/4 — Nav expand button alignment

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`fix(nav): center expand button alignment`)

> ℹ️ Original title `fix - nav expand button centered` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR behebt die vertikale Ausrichtung der Ausklapp-Schaltfläche in der `Nav`-Komponente (v4), sodass sie korrekt zentriert dargestellt wird. Die Korrektur erfolgt über zwei CSS-Dateien.

### Verknüpfte Tickets

- Refs interne-themes/issues/4 — Nav Expand-Button-Ausrichtung

### Art der Änderung

- [x] 🐛 Bugfix

### Geänderte Dateien

- 2 Dateien in der Nav-Komponente

</details>