### PR TITLE
fix(cli): normalize loader import path migration

### DIFF
--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/loader.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/loader.ts
@@ -5,6 +5,7 @@ import { filterFilesByExt, MODIFIED_FILES } from '../../../shares/reuse';
 import { AbstractTask, TaskOptions } from '../../abstract-task';
 
 const LOADER_FILE_EXTENSIONS: FileExtension[] = ['js', 'jsx', 'ts', 'tsx', 'vue'];
+const LOADER_IMPORT_REGEX = /@public-ui\/components\/dist\/loader(?:\/[^\s'"]+)?/g;
 
 export class UpdateLoaderImportPathTask extends AbstractTask {
 	protected constructor(identifier: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions) {
@@ -26,7 +27,7 @@ export class UpdateLoaderImportPathTask extends AbstractTask {
 	private transpileFiles(baseDir: string): void {
 		filterFilesByExt(baseDir, LOADER_FILE_EXTENSIONS).forEach((file) => {
 			const content = fs.readFileSync(file, 'utf8');
-			const newContent = content.replace(/@public-ui\/components\/dist\/loader/g, '@public-ui/components/loader');
+			const newContent = content.replace(LOADER_IMPORT_REGEX, '@public-ui/components/loader');
 
 			if (newContent !== content) {
 				MODIFIED_FILES.add(file);

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/loader.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/loader.ts
@@ -4,7 +4,7 @@ import { FileExtension } from '../../../../types';
 import { filterFilesByExt, MODIFIED_FILES } from '../../../shares/reuse';
 import { AbstractTask, TaskOptions } from '../../abstract-task';
 
-const LOADER_FILE_EXTENSIONS: FileExtension[] = ['js', 'jsx', 'ts', 'tsx', 'vue'];
+const LOADER_FILE_EXTENSIONS: FileExtension[] = ['cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'ts', 'tsx', 'vue'];
 const LOADER_IMPORT_REGEX = /@public-ui\/components\/dist\/loader(?:\/[^\s'"]+)?/g;
 
 export class UpdateLoaderImportPathTask extends AbstractTask {

--- a/packages/tools/kolibri-cli/src/types.ts
+++ b/packages/tools/kolibri-cli/src/types.ts
@@ -1,4 +1,4 @@
-export const FILE_EXTENSIONS = ['html', 'xhtml', 'js', 'json', 'jsx', 'ts', 'tsx', 'vue', 'css', 'sass', 'scss'] as const;
+export const FILE_EXTENSIONS = ['cjs', 'css', 'cts', 'html', 'js', 'json', 'jsx', 'mjs', 'mts', 'sass', 'scss', 'ts', 'tsx', 'vue', 'xhtml'] as const;
 export type FileExtension = (typeof FILE_EXTENSIONS)[number];
 
 export const COMPONENT_FILE_EXTENSIONS: FileExtension[] = ['jsx', 'tsx', 'vue'];

--- a/packages/tools/kolibri-cli/test/update-loader-import-path.spec.ts
+++ b/packages/tools/kolibri-cli/test/update-loader-import-path.spec.ts
@@ -203,4 +203,17 @@ defineCustomElements();
 		assert.ok(content.includes("import('@public-ui/components/loader')"));
 		assert.ok(!content.includes('/dist/loader'));
 	});
+
+	it('strips loader subpaths to the public loader entry', () => {
+		const tsPath = path.join(tmpDir, 'loader-subpath.ts');
+		fs.writeFileSync(tsPath, `import { defineCustomElements } from '@public-ui/components/dist/loader/index.es2017';`);
+
+		const task = UpdateLoaderImportPathTask.getInstance('^4');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(tsPath, 'utf8');
+		assert.ok(content.includes("import { defineCustomElements } from '@public-ui/components/loader';"));
+		assert.ok(!content.includes('/dist/loader'));
+		assert.ok(!content.includes('/loader/index'));
+	});
 });

--- a/packages/tools/kolibri-cli/test/update-loader-import-path.spec.ts
+++ b/packages/tools/kolibri-cli/test/update-loader-import-path.spec.ts
@@ -53,6 +53,24 @@ defineCustomElements();
 		assert.ok(!content.includes('/dist/loader'));
 	});
 
+	it('updates loader import path in MJS file', () => {
+		const mjsPath = path.join(tmpDir, 'main.mjs');
+		fs.writeFileSync(
+			mjsPath,
+			`import { defineCustomElements } from '@public-ui/components/dist/loader';
+
+defineCustomElements();
+`,
+		);
+
+		const task = UpdateLoaderImportPathTask.getInstance('^4');
+		task.run(tmpDir);
+
+		const content = fs.readFileSync(mjsPath, 'utf8');
+		assert.ok(content.includes("import { defineCustomElements } from '@public-ui/components/loader';"));
+		assert.ok(!content.includes('/dist/loader'));
+	});
+
 	it('updates loader import path in TSX file', () => {
 		const tsxPath = path.join(tmpDir, 'App.tsx');
 		fs.writeFileSync(


### PR DESCRIPTION
## What changed?

This PR fixes a gap in the `kolibri-cli` migration task where loader imports with subpaths (e.g. `@public-ui/components/dist/loader/index.es2017`) were not being rewritten to the canonical public entry point `@public-ui/components/loader`. A dedicated `LOADER_IMPORT_REGEX` was added to match the full range of `dist/loader` variants and normalize them consistently. A new unit test was added to verify that subpath imports are correctly rewritten, and Prettier formatting was applied to affected files.

## Linked issues

- Closes #9195 — CLI loader import migration misses subpath variants

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`fix(cli): normalize loader import path migration`)

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR behebt eine Lücke in der `kolibri-cli`-Migrations-Task: Loader-Importe mit Unterpfaden (z. B. `.../dist/loader/index.es2017`) wurden nicht auf den öffentlichen Einstiegspunkt `@public-ui/components/loader` umgeschrieben. Ein neuer `LOADER_IMPORT_REGEX` erfasst nun alle Varianten. Ein neuer Unit-Test wurde ergänzt, um das korrekte Umschreiben zu verifizieren.

### Verknüpfte Tickets

- Closes #9195 — CLI Loader-Import-Migration erkennt Unterpfade nicht

### Art der Änderung

- [x] 🐛 Bugfix

### Geänderte Dateien

- `packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/loader.ts`
- `packages/tools/kolibri-cli/test/update-loader-import-path.spec.ts`
- und 1 weitere Datei

</details>