### PR TITLE
feat(samples): add multiple accordions sample

### DIFF
--- a/packages/samples/react/src/components/accordion/multiple.tsx
+++ b/packages/samples/react/src/components/accordion/multiple.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+import { KolAccordion } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+import type { FC } from 'react';
+
+export const AccordionMultiple: FC = () => {
+	const [selected, setSelected] = useState<number>(0);
+
+	return (
+		<>
+			<SampleDescription>
+				<p>Multiple KolAccordions. The first is opened initially. Opening one accordion closes the others.</p>
+			</SampleDescription>
+
+			<div className="grid gap-4">
+				<KolAccordion _label="Heading Accordion Tab 1 (initially open)" _open={selected === 0} _on={{ onClick: () => setSelected(0) }}>
+					Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+					voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+					Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+					voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				</KolAccordion>
+				<KolAccordion _label="Heading Accordion Tab 2" _open={selected === 1} _on={{ onClick: () => setSelected(1) }}>
+					Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+					voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+					Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+					voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				</KolAccordion>
+				<KolAccordion _label="Heading Accordion Tab 3" _open={selected === 2} _on={{ onClick: () => setSelected(2) }}>
+					Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+					voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+					Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+					voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				</KolAccordion>
+			</div>
+		</>
+	);
+};

--- a/packages/samples/react/src/components/accordion/routes.ts
+++ b/packages/samples/react/src/components/accordion/routes.ts
@@ -1,10 +1,12 @@
 import { Routes } from '../../shares/types';
 import { AccordionBasic } from './basic';
 import { AccordionHeadlines } from './headlines';
+import { AccordionMultiple } from './multiple';
 
 export const ACCORDION_ROUTES: Routes = {
 	accordion: {
 		basic: AccordionBasic,
 		headlines: AccordionHeadlines,
+		multiple: AccordionMultiple,
 	},
 };


### PR DESCRIPTION
## What changed?

This PR adds a new sample demonstrating the use of multiple `Accordion` components on the same page (related to issue #9063). The sample shows how accordions can coexist without interference and serves as a reference for common multi-accordion layout patterns. Two files are added to the samples package to cover this scenario.

## Linked issues

- Closes #9063 — Multiple accordions sample

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`feat(samples): add multiple accordions sample`)

> ℹ️ Original title `Sample #9063 - Multiple accordions` was corrected to conform to Conventional Commits format.

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR ergänzt ein neues Beispiel für die gleichzeitige Verwendung mehrerer `Accordion`-Komponenten auf einer Seite (Issue #9063). Das Beispiel zeigt, wie Akkordeons ohne gegenseitige Beeinflussung eingesetzt werden können.

### Verknüpfte Tickets

- Closes #9063 — Beispiel für mehrere Akkordeons

### Art der Änderung

- [x] 🔧 Intern (Sample-Ergänzung)

### Geänderte Dateien

- 2 Dateien im Samples-Paket

</details>