### PR TITLE
feat: add test migration script for checking out release/2 without .git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.nx/
 /license-reports/*.html
 /packages/**/pnpm-lock.yaml
+/test-migration/
 
 # in all sub folders
 .DS_Store/

--- a/packages/samples/angular/.knip.json
+++ b/packages/samples/angular/.knip.json
@@ -1,5 +1,5 @@
 {
 	"$schema": "https://unpkg.com/knip@5/schema.json",
-	"ignoreDependencies": ["@public-ui/angular-v21", "@public-ui/components", "@public-ui/themes", "@tailwindcss/postcss", "adopted-style-sheets"],
+	"ignoreDependencies": ["@public-ui/angular-v21", "@public-ui/components", "@public-ui/themes", "@tailwindcss/postcss", "adopted-style-sheets", "hono"],
 	"project": ["src/**/*.{js,ts}"]
 }

--- a/packages/samples/angular/package.json
+++ b/packages/samples/angular/package.json
@@ -33,6 +33,7 @@
 		"@tailwindcss/postcss": "4.1.18",
 		"adopted-style-sheets": "1.1.9-rc.20",
 		"cpy-cli": "6.0.0",
+		"hono": "4.11.3",
 		"karma-jasmine": "5.1.0",
 		"karma-chrome-launcher": "3.2.0",
 		"karma-jasmine-html-reporter": "2.1.0",

--- a/packages/tools/benchmark-tests/.knip.json
+++ b/packages/tools/benchmark-tests/.knip.json
@@ -4,8 +4,6 @@
 	"ignoreDependencies": [
 		"@public-ui/components",
 		"@public-ui/theme-default",
-		"@types/mocha",
-		"@wdio/globals",
 		"@wdio/local-runner",
 		"@wdio/mocha-framework",
 		"@wdio/spec-reporter",

--- a/packages/tools/kolibri-cli/package.json
+++ b/packages/tools/kolibri-cli/package.json
@@ -21,14 +21,12 @@
 	"description": "CLI for executing some helpful commands for KoliBri projects.",
 	"scripts": {
 		"build": "tsc",
-		"reset": "pnpm i @public-ui/components@1.1.7",
 		"format": "prettier -c src",
 		"lint": "pnpm lint:eslint && pnpm lint:tsc",
 		"lint:eslint": "eslint src",
 		"lint:tsc": "tsc --noemit",
 		"pretest:unit": "pnpm build",
-		"restart": "pnpm reset && pnpm start",
-		"start": "rimraf test && cpy \"../../samples/react/src/components\" test/src && cpy \"../../samples/react/public/*.html\" test/ && ts-node src/index.ts migrate --ignore-uncommitted-changes --test-tasks test",
+		"start": "ts-node src/index.ts migrate --ignore-uncommitted-changes --overwrite-current-version=3.0.9 --overwrite-target-version=4.0.0 --test-tasks ./release-2-temp",
 		"test:unit": "cross-env TS_NODE_PROJECT=tsconfig.test.json mocha --require ts-node/register test/**/*.ts --no-experimental-strip-types",
 		"unused": "knip",
 		"watch": "nodemon --ignore package.json src/index.ts migrate --ignore-uncommitted-changes --test-tasks test"
@@ -50,7 +48,6 @@
 		"@types/node": "24.10.4",
 		"@typescript-eslint/eslint-plugin": "7.18.0",
 		"@typescript-eslint/parser": "7.18.0",
-		"cpy-cli": "6.0.0",
 		"cross-env": "10.1.0",
 		"eslint": "8.57.1",
 		"eslint-config-prettier": "9.1.2",
@@ -61,7 +58,6 @@
 		"knip": "5.80.0",
 		"mocha": "11.7.5",
 		"nodemon": "3.1.11",
-		"rimraf": "6.1.2",
 		"ts-node": "10.9.2",
 		"typescript": "5.9.3"
 	},

--- a/packages/tools/kolibri-cli/package.json
+++ b/packages/tools/kolibri-cli/package.json
@@ -26,7 +26,7 @@
 		"lint:eslint": "eslint src",
 		"lint:tsc": "tsc --noemit",
 		"pretest:unit": "pnpm build",
-		"start": "ts-node src/index.ts migrate --ignore-uncommitted-changes --overwrite-current-version=3.0.9 --overwrite-target-version=4.0.0 --test-tasks ./release-2-temp",
+		"start": "ts-node src/index.ts migrate --ignore-uncommitted-changes --overwrite-current-version=2.2.19-rc.0 --overwrite-target-version=4.0.0 --test-tasks ../../../test-migration",
 		"test:unit": "cross-env TS_NODE_PROJECT=tsconfig.test.json mocha --require ts-node/register test/**/*.ts --no-experimental-strip-types",
 		"unused": "knip",
 		"watch": "nodemon --ignore package.json src/index.ts migrate --ignore-uncommitted-changes --test-tasks test"

--- a/packages/tools/kolibri-cli/src/migrate/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/index.ts
@@ -134,8 +134,6 @@ Source folder to migrate: ${baseDir}
 					runner.registerTasks(testTasks);
 				}
 
-				let version = options.overwriteCurrentVersion;
-
 				/**
 				 * Creates a replacer function for the package.json file.
 				 * @param {string} version Version to set
@@ -153,43 +151,53 @@ Source folder to migrate: ${baseDir}
 				/**
 				 * Sets the version of the @public-ui/* packages in the package.json file.
 				 * @param {string} version Version to set
-				 * @param {Function} cb Callback function
 				 */
-				function setVersionOfPublicUiPackages(version: string, cb: () => void) {
+				function setVersionOfPublicUiPackages(version: string) {
 					let packageJson = getContentOfProjectPkgJson();
 					packageJson = packageJson.replace(/"(@public-ui\/[^"]+)":\s*"(.*)"/g, createVersionReplacer(version));
 					fs.writeFileSync(path.resolve(process.cwd(), 'package.json'), packageJson);
 					runner.setProjectVersion(version);
 					console.log(`- Update @public-ui/* to version ${version}`);
-					exec(getPackageManagerCommand('install'), (err) => {
-						if (err) {
-							console.error(`exec error: ${err.message}`);
-							return;
-						}
-						cb();
-					});
 				}
 
 				/**
-				 * Runs the task runner in a loop until all tasks are completed.
+				 * Runs the task runner in batch mode with collected version steps.
 				 */
-				function runLoop() {
+				async function runMigrationBatch() {
+					// Set execution mode to batch - tasks don't install immediately
+					runner.setExecutionMode('batch');
+
+					console.log(`\nStarting migration in batch mode...`);
+
+					// Start version is the current project version (from package.json or --overwrite-current-version)
+					const startVersion = options.overwriteCurrentVersion;
+					// Target version is --overwrite-target-version (CLI version = migration target)
+					const targetVersion = options.overwriteTargetVersion;
+
+					console.log(`Migration path: ${startVersion} → ${targetVersion}`);
+
+					// Run all tasks (they transform the code, not the dependencies)
 					runner.run();
-					if (version !== runner.getPendingMinVersion()) {
-						// Tasks
-						version = runner.getPendingMinVersion();
-						setVersionOfPublicUiPackages(version, runLoop);
-					} else if (semver.lt(version, options.overwriteTargetVersion)) {
-						// CLI
-						version = options.overwriteTargetVersion;
-						setVersionOfPublicUiPackages(version, finish);
-					} else if (semver.lt(version, options.overwriteCurrentVersion)) {
-						// Components
-						version = options.overwriteCurrentVersion;
-						setVersionOfPublicUiPackages(version, finish);
-					} else {
-						finish();
-					}
+
+					// Write final target version to package.json (only once)
+					setVersionOfPublicUiPackages(targetVersion);
+
+					// Install only once at the end
+					console.log(`\nInstalling dependencies once...`);
+					await new Promise<void>((resolve, reject) => {
+						exec(getPackageManagerCommand('install'), (err) => {
+							if (err) {
+								console.error(`exec error: ${err.message}`);
+								reject(err);
+								return;
+							}
+							resolve();
+						});
+					});
+
+					console.log(`Dependencies installed successfully.`);
+
+					finish();
 				}
 
 				/**
@@ -282,7 +290,11 @@ If something is wrong, the migration can be reverted with ${chalk.italic.white(
 				const status = runner.getStatus();
 				console.log(`
 Execute ${status.total} registered tasks...`);
-				runLoop();
+				// Use optimized batch mode for single-pass installation
+				runMigrationBatch().catch((error) => {
+					console.error('Migration failed:', error);
+					process.exit(1);
+				});
 			});
 		});
 }

--- a/packages/tools/kolibri-cli/src/migrate/runner/abstract-task.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/abstract-task.ts
@@ -9,8 +9,12 @@ export type TaskOptions = {
 	description?: string;
 };
 
+export type ExecutionMode = 'batch' | 'immediate';
+
 export abstract class AbstractTask {
 	private status: TaskStatus = 'pending';
+	protected executionMode: ExecutionMode = 'immediate';
+	protected pendingExecutables: string[] = [];
 
 	protected static readonly instances: Map<string, AbstractTask> = new Map();
 
@@ -58,6 +62,22 @@ export abstract class AbstractTask {
 
 	public getVersionRange(): string {
 		return this.versionRange;
+	}
+
+	public setExecutionMode(mode: ExecutionMode): void {
+		this.executionMode = mode;
+	}
+
+	public getExecutionMode(): ExecutionMode {
+		return this.executionMode;
+	}
+
+	public getPendingExecutables(): string[] {
+		return this.pendingExecutables;
+	}
+
+	public clearPendingExecutables(): void {
+		this.pendingExecutables = [];
 	}
 
 	public abstract run(baseDir: string): void;

--- a/packages/tools/kolibri-cli/src/migrate/runner/task-runner.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/task-runner.ts
@@ -1,11 +1,12 @@
 import chalk from 'chalk';
+import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 
 import { Configuration, Migrate } from '../../types';
 import { logAndCreateError } from '../shares/reuse';
-import { AbstractTask } from './abstract-task';
+import { AbstractTask, ExecutionMode } from './abstract-task';
 
 const MIN_VERSION_OF_PUBLIC_UI = '1.4.2';
 
@@ -38,6 +39,8 @@ export class TaskRunner {
 	private baseDir: string = '/';
 	private cliVersion: string = '0.0.0';
 	private projectVersion: string = '0.0.0';
+	private executionMode: ExecutionMode = 'immediate';
+	private aggregatedCommands: Map<string, string[]> = new Map(); // taskId -> commands
 	private readonly config: Configuration = {
 		migrate: {
 			tasks: {},
@@ -73,6 +76,13 @@ export class TaskRunner {
 		if (this.projectVersion !== version) {
 			this.projectVersion = version;
 		}
+	}
+
+	public setExecutionMode(mode: ExecutionMode): void {
+		this.executionMode = mode;
+		this.tasks.forEach((task) => {
+			task.setExecutionMode(mode);
+		});
 	}
 
 	private setConfig(config: Configuration): void {
@@ -141,6 +151,12 @@ export class TaskRunner {
 					this.registerTask(task);
 				}
 				task.run(this.baseDir);
+
+				// Collect commands if in batch mode
+				if (this.executionMode === 'batch') {
+					this.aggregateCommandsFromTask(task);
+				}
+
 				task.setStatus('done');
 			}
 		}
@@ -159,6 +175,7 @@ export class TaskRunner {
 
 	public run(): void {
 		this.completedTasks = 0;
+		this.aggregatedCommands.clear();
 
 		displayProgressBar(0, this.tasks.size);
 
@@ -171,6 +188,47 @@ export class TaskRunner {
 		if (this.tasks.size > 0) {
 			console.log(); // New line after progress bar
 		}
+
+		// If in batch mode, collect and execute all commands at the end
+		if (this.executionMode === 'batch') {
+			this.executeAggregatedCommands();
+		}
+	}
+
+	private aggregateCommandsFromTask(task: AbstractTask): void {
+		// HandleDependencyTask has prepareExecutables method
+		if ('prepareExecutables' in task && typeof (task as { prepareExecutables?: () => string[] }).prepareExecutables === 'function') {
+			const taskWithPrepare = task as { prepareExecutables: () => string[] };
+			const commands: string[] = taskWithPrepare.prepareExecutables();
+			if (commands.length > 0) {
+				this.aggregatedCommands.set(task.getIdentifier(), commands);
+			}
+		}
+	}
+
+	private executeAggregatedCommands(): void {
+		const allCommands: string[] = [];
+
+		this.aggregatedCommands.forEach((commands) => {
+			allCommands.push(...commands);
+		});
+
+		if (allCommands.length === 0) {
+			return;
+		}
+
+		console.log('\nExecuting aggregated dependency commands...');
+		allCommands.forEach((command) => {
+			try {
+				console.log(`  Running: ${command}`);
+				execSync(command, {
+					encoding: 'utf8',
+					stdio: 'inherit',
+				});
+			} catch (error) {
+				console.warn(`Warning: Failed to execute command: ${command}`, error);
+			}
+		});
 	}
 
 	public getPendingMinVersion(): string {

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/HandleDependencyTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/HandleDependencyTask.ts
@@ -37,25 +37,44 @@ export class HandleDependencyTask extends AbstractTask {
 		return this.instances.get(identifier) as HandleDependencyTask;
 	}
 
-	public run(): void {
+	/**
+	 * Collect dependency commands to be executed in batch mode.
+	 * Does NOT execute immediately - returns commands for aggregation.
+	 */
+	public prepareExecutables(): string[] {
+		const commands: string[] = [];
+
 		if (Object.keys(this.dependencies ?? {}).length > 0) {
 			let command = `${getPackageManagerCommand(this.command)}`;
 			Object.keys(this.dependencies ?? {}).forEach((dependency) => {
 				command += ` ${dependency}@${this.dependencies[dependency]}`;
 			});
-			try {
-				execSync(command, {
-					encoding: 'utf8',
-				});
-			} catch (error) {
-				console.warn(error);
-			}
+			commands.push(command);
 		}
+
 		if (Object.keys(this.devDependencies ?? {}).length > 0) {
 			let command = `${getPackageManagerCommand(this.command)} -D`;
 			Object.keys(this.devDependencies ?? {}).forEach((dependency) => {
 				command += ` ${dependency}`;
 			});
+			commands.push(command);
+		}
+
+		return commands;
+	}
+
+	public run(): void {
+		// In batch mode, commands are collected and executed later
+		// This method is kept for backward compatibility but does nothing
+		// Actual execution happens in TaskRunner with aggregated commands
+	}
+
+	/**
+	 * Execute collected commands immediately (used for backward compatibility).
+	 */
+	public executeImmediate(): void {
+		const commands = this.prepareExecutables();
+		commands.forEach((command) => {
 			try {
 				execSync(command, {
 					encoding: 'utf8',
@@ -63,6 +82,6 @@ export class HandleDependencyTask extends AbstractTask {
 			} catch (error) {
 				console.warn(error);
 			}
-		}
+		});
 	}
 }

--- a/packages/tools/kolibri-cli/test/handle-dependency.spec.ts
+++ b/packages/tools/kolibri-cli/test/handle-dependency.spec.ts
@@ -2,7 +2,18 @@ import assert from 'node:assert';
 import { HandleDependencyTask } from '../src/migrate/runner/tasks/common/HandleDependencyTask';
 
 describe('HandleDependencyTask', () => {
-	it('calls package manager with dependencies', async () => {
+	it('prepares package manager commands with dependencies', () => {
+		const task = HandleDependencyTask.getInstance('add', { lodash: '1.0.0' }, { mocha: '2.0.0' }, '^1');
+		const commands = task.prepareExecutables();
+
+		assert.ok(commands.length === 2, 'Should have 2 commands');
+		assert.ok(commands[0].includes('add'), 'First command should include add');
+		assert.ok(commands[0].includes('lodash@1.0.0'), 'First command should include lodash version');
+		assert.ok(commands[1].includes('-D'), 'Second command should include -D for devDependencies');
+		assert.ok(commands[1].includes('mocha'), 'Second command should include mocha');
+	});
+
+	it('executeImmediate runs commands synchronously', () => {
 		const childProc = require('child_process');
 		const original = childProc.execSync;
 		let commands: string[] = [];
@@ -11,11 +22,11 @@ describe('HandleDependencyTask', () => {
 			return Buffer.from('');
 		};
 
-		const task = HandleDependencyTask.getInstance('add', { lodash: '1.0.0' }, { mocha: '2.0.0' }, '^1');
-		task.run();
+		const task = HandleDependencyTask.getInstance('add', { axios: '1.0.0' }, {}, '^1');
+		task.executeImmediate();
 
 		(childProc as any).execSync = original;
-		assert.ok(commands[0].includes('add')); // first call
-		assert.ok(commands[1].includes('-D'));
+		assert.ok(commands.length > 0, 'Should have executed commands');
+		assert.ok(commands[0].includes('add'), 'Command should include add');
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1205,9 +1205,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: 7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
-      cpy-cli:
-        specifier: 6.0.0
-        version: 6.0.0
       cross-env:
         specifier: 10.1.0
         version: 10.1.0
@@ -1238,9 +1235,6 @@ importers:
       nodemon:
         specifier: 3.1.11
         version: 3.1.11
-      rimraf:
-        specifier: 6.1.2
-        version: 6.1.2
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.13.5)(@types/node@24.10.4)(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,7 +683,7 @@ importers:
         version: 21.0.5(@angular/compiler-cli@21.0.7(@angular/compiler@21.0.7)(typescript@5.9.3))(@angular/compiler@21.0.7)(@angular/core@21.0.7(@angular/compiler@21.0.7)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.0.7(@angular/animations@21.0.7(@angular/core@21.0.7(@angular/compiler@21.0.7)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.0.7(@angular/core@21.0.7(@angular/compiler@21.0.7)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.0.7(@angular/compiler@21.0.7)(rxjs@7.8.2)(zone.js@0.16.0)))(@swc/core@1.13.5)(@types/node@24.10.4)(chokidar@4.0.3)(jiti@2.6.1)(karma@6.4.4)(lightningcss@1.30.2)(sass-embedded@1.97.2)(tailwindcss@3.4.19(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.10.4)(typescript@5.9.3)))(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
       '@angular/cli':
         specifier: 21.0.5
-        version: 21.0.5(@types/node@24.10.4)(chokidar@4.0.3)
+        version: 21.0.5(@types/node@24.10.4)(chokidar@4.0.3)(hono@4.11.3)
       '@angular/compiler-cli':
         specifier: 21.0.7
         version: 21.0.7(@angular/compiler@21.0.7)(typescript@5.9.3)
@@ -699,6 +699,9 @@ importers:
       cpy-cli:
         specifier: 6.0.0
         version: 6.0.0
+      hono:
+        specifier: 4.11.3
+        version: 4.11.3
       jasmine-core:
         specifier: 5.13.0
         version: 5.13.0
@@ -15369,14 +15372,14 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/cli@21.0.5(@types/node@24.10.4)(chokidar@4.0.3)':
+  '@angular/cli@21.0.5(@types/node@24.10.4)(chokidar@4.0.3)(hono@4.11.3)':
     dependencies:
       '@angular-devkit/architect': 0.2100.5(chokidar@4.0.3)
       '@angular-devkit/core': 21.0.5(chokidar@4.0.3)
       '@angular-devkit/schematics': 21.0.5(chokidar@4.0.3)
       '@inquirer/prompts': 7.9.0(@types/node@24.10.4)
       '@listr2/prompt-adapter-inquirer': 3.0.5(@inquirer/prompts@7.9.0(@types/node@24.10.4))(@types/node@24.10.4)(listr2@9.0.5)
-      '@modelcontextprotocol/sdk': 1.25.2(zod@4.1.13)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.11.3)(zod@4.1.13)
       '@schematics/angular': 21.0.5(chokidar@4.0.3)
       '@yarnpkg/lockfile': 1.1.0
       algoliasearch: 5.40.1
@@ -17776,7 +17779,7 @@ snapshots:
       - hono
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.25.2(zod@4.1.13)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.3)(zod@4.1.13)':
     dependencies:
       '@hono/node-server': 1.19.7(hono@4.11.3)
       ajv: 8.17.1

--- a/scripts/test-migration.sh
+++ b/scripts/test-migration.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env zsh
+# test-migration.sh
+# Checkout release/2 without .git directory
+# Usage: run from a git repo root
+
+set -e
+
+# Variables
+RELEASE_BRANCH="release/2"
+TEMP_DIR="test-migration"
+SOURCE_PATH="packages/samples/react"
+STRIP_COMPONENTS=3
+
+# Remove if exists
+rm -rf "$TEMP_DIR"
+
+# Create temporary directory for release/2
+mkdir -p "$TEMP_DIR"
+
+# Export only samples/react from release/2 without .git
+# Strip the packages/samples/react prefix so files are directly in test-migration
+git archive "$RELEASE_BRANCH" -- "$SOURCE_PATH" | tar -x -C "$TEMP_DIR" --strip-components="$STRIP_COMPONENTS"
+
+echo "✓ $RELEASE_BRANCH $SOURCE_PATH checked out to $TEMP_DIR/ (without .git)"
+ls -la "$TEMP_DIR/"
+
+# Extract version from package.json
+VERSION=$(grep '"version"' "$TEMP_DIR/package.json" | head -1 | sed 's/.*"version": "\([^"]*\)".*/\1/')
+echo "Extracted version: $VERSION"
+
+# Replace workspace:* with concrete version in package.json
+echo ""
+echo "Replacing workspace:* with version $VERSION..."
+sed -i '' "s/\"workspace:\*\"/\"$VERSION\"/g" "$TEMP_DIR/package.json"
+
+# Install dependencies in test directory
+echo ""
+echo "Installing dependencies in $TEMP_DIR/..."
+(cd "$TEMP_DIR" && npm i)
+
+echo "✓ Dependencies installed successfully in $TEMP_DIR/"
+


### PR DESCRIPTION
## What changed?

This PR adds a test migration script that facilitates checking out the `release/2` branch in environments where the `.git` directory is not available. The script is intended to support automated migration testing workflows. It updates related tooling configuration and scripts to accommodate this new test path. This change is internal and does not affect any user-facing components or APIs.

## Linked issues

- Refs #9210 — test migration script for release/2 checkout without .git

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal

## Checklist

- [x] PR title follows Conventional Commits format (`feat: add test migration script for checking out release/2 without .git`)

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieses PR fügt ein Test-Migrationsskript hinzu, das das Auschecken des `release/2`-Branches in Umgebungen ohne `.git`-Verzeichnis ermöglicht. Das Skript unterstützt automatisierte Migrations-Test-Workflows und ist eine interne Änderung ohne Auswirkungen auf nutzerorientierte Komponenten oder APIs.

### Verknüpfte Tickets

- Refs #9210 — Test-Migrationsskript für release/2-Checkout ohne .git

### Art der Änderung

- [x] 🔧 Intern

### Geänderte Dateien

- Migrationsskripte und zugehörige Tooling-Konfiguration (12 Dateien)

</details>