### PR TITLE
docs: add KolIcons migration guide to v4 breaking changes and howto

### DIFF
--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -6,6 +6,24 @@ New major versions of KoliBri are developed with the goal of simplifying mainten
 
 For more information, see the [KoliBri Maintenance and Support Strategy](https://github.com/public-ui/kolibri/blob/develop/MIGRATION.md).
 
+## Kolicons instead of Codicons
+
+KolBri introduced its own set of icons, named Kolicons. Please make sure you provide them like you provided the codicons before in your index.html.
+
+**Before:**
+
+```html
+<link rel="stylesheet" href="/assets/codicons/codicon.css" />
+```
+
+**After:**
+
+```html
+<link rel="stylesheet" href="/assets/kolicons/style.css" />
+<!-- if you use codicons in your app you have to provide both fonts -->
+<link rel="stylesheet" href="/assets/codicons/codicon.css" />
+```
+
 ## Loader entry point
 
 Import the component loader from `@public-ui/components/loader`. The previous `@public-ui/components/dist/loader` path is no longer part of the public API surface.

--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -8,20 +8,83 @@ For more information, see the [KoliBri Maintenance and Support Strategy](https:/
 
 ## Kolicons instead of Codicons
 
-KolBri introduced its own set of icons, named Kolicons. Please make sure you provide them like you provided the codicons before in your index.html.
+KoliBri now provides its own comprehensive icon set called **Kolicons**, replacing the previous dependency on Microsoft's Codicons. This change provides better control over iconography, improved consistency across the component library, and reduced external dependencies.
 
-**Before:**
+### Asset Loading
+
+In HTML documents, load the Kolicons stylesheet instead of Codicons:
+
+**Before (v3):**
 
 ```html
 <link rel="stylesheet" href="/assets/codicons/codicon.css" />
 ```
 
-**After:**
+**After (v4):**
 
 ```html
 <link rel="stylesheet" href="/assets/kolicons/style.css" />
-<!-- if you use codicons in your app you have to provide both fonts -->
+```
+
+### Using Codicons Alongside Kolicons (Optional)
+
+If your application still uses Codicons, you can include both stylesheets. However, this is **optional** and most projects can migrate fully to Kolicons:
+
+```html
+<link rel="stylesheet" href="/assets/kolicons/style.css" />
+<!-- Only if you still use Codicons elsewhere in your app -->
 <link rel="stylesheet" href="/assets/codicons/codicon.css" />
+```
+
+### CSS Import
+
+In modern bundlers (webpack, Vite, etc.), import Kolicons in your main entry point:
+
+**Before (v3):**
+
+```ts
+import '@public-ui/components/assets/codicons/codicon.css';
+```
+
+**After (v4):**
+
+```ts
+import '@public-ui/components/assets/kolicons/style.css';
+```
+
+### Icon Class Names
+
+Update all icon references in your code from `codicon` to `kolicon`. For example:
+
+**Before (v3):**
+
+```tsx
+<KolButton _label="Save" _icons="codicon codicon-save" />
+<KolIcon _icon="codicon codicon-check" />
+```
+
+**After (v4):**
+
+```tsx
+<KolButton _label="Save" _icons="kolicon kolicon-save" />
+<KolIcon _icon="kolicon kolicon-check" />
+```
+
+See the [Kolicons documentation](https://github.com/public-ui/kolibri/tree/develop/packages/components/src/assets/kolicons) for the complete list of available icon names.
+
+### Font Files
+
+The font file is now located at:
+
+```
+node_modules/@public-ui/components/assets/kolicons/kolicons.ttf
+```
+
+If you're manually copying assets to a public folder for custom builds:
+
+```bash
+cp node_modules/@public-ui/components/assets/kolicons/style.css dist/assets/kolicons/
+cp node_modules/@public-ui/components/assets/kolicons/kolicons.ttf dist/assets/kolicons/
 ```
 
 ## Loader entry point

--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -6,13 +6,13 @@ New major versions of KoliBri are developed with the goal of simplifying mainten
 
 For more information, see the [KoliBri Maintenance and Support Strategy](https://github.com/public-ui/kolibri/blob/develop/MIGRATION.md).
 
-## Kolicons instead of Codicons
+## KolIcons instead of Codicons
 
-KoliBri now provides its own comprehensive icon set called **Kolicons**, replacing the previous dependency on Microsoft's Codicons. This change provides better control over iconography, improved consistency across the component library, and reduced external dependencies.
+KoliBri now provides its own comprehensive icon set called **KolIcons**, replacing the previous dependency on Microsoft's Codicons. This change provides better control over iconography, improved consistency across the component library, and reduced external dependencies.
 
 ### Asset Loading
 
-In HTML documents, load the Kolicons stylesheet instead of Codicons:
+In HTML documents, load the KolIcons stylesheet instead of Codicons:
 
 **Before (v3):**
 
@@ -26,9 +26,9 @@ In HTML documents, load the Kolicons stylesheet instead of Codicons:
 <link rel="stylesheet" href="/assets/kolicons/style.css" />
 ```
 
-### Using Codicons Alongside Kolicons (Optional)
+### Using Codicons Alongside KolIcons (Optional)
 
-If your application still uses Codicons, you can include both stylesheets. However, this is **optional** and most projects can migrate fully to Kolicons:
+If your application still uses Codicons, you can include both stylesheets. However, this is **optional** and most projects can migrate fully to KolIcons:
 
 ```html
 <link rel="stylesheet" href="/assets/kolicons/style.css" />
@@ -38,7 +38,7 @@ If your application still uses Codicons, you can include both stylesheets. Howev
 
 ### CSS Import
 
-In modern bundlers (webpack, Vite, etc.), import Kolicons in your main entry point:
+In modern bundlers (webpack, Vite, etc.), import KolIcons in your main entry point:
 
 **Before (v3):**
 
@@ -70,7 +70,7 @@ Update all icon references in your code from `codicon` to `kolicon`. For example
 <KolIcon _icon="kolicon kolicon-check" />
 ```
 
-See the [Kolicons documentation](https://github.com/public-ui/kolibri/tree/develop/packages/components/src/assets/kolicons) for the complete list of available icon names.
+See the [KolIcons documentation](https://github.com/public-ui/kolibri/tree/develop/packages/components/src/assets/kolicons) for the complete list of available icon names.
 
 ### Font Files
 

--- a/docs/HOWTO_ICON_FONTS.md
+++ b/docs/HOWTO_ICON_FONTS.md
@@ -1,12 +1,14 @@
 # HOWTO: Bundle KoliBri Icon Fonts
 
-KoliBri ships the [`kol-icon`](https://public-ui.github.io/components/icon/) component to render pictograms. The component expects a font-based icon set such as [Codicon](https://github.com/microsoft/vscode-codicons) to be available at runtime. If the font files are missing, `kol-icon` falls back to empty boxes.
+KoliBri ships the [`kol-icon`](https://public-ui.github.io/components/icon/) component to render pictograms. Starting with **v4**, KoliBri includes its own font-based icon set called **Kolicons**. Previously, this relied on [Codicon](https://github.com/microsoft/vscode-codicons).
 
-This guide shows how to install and bundle the font assets that are published with `@public-ui/components`.
+This guide shows how to install and bundle the Kolicons font assets that are published with `@public-ui/components`.
+
+> **Migration from v3 to v4:** If you're upgrading from v3, see [BREAKING_CHANGES.v4.md](./BREAKING_CHANGES.v4.md#kolicons-instead-of-codicons) for migration details.
 
 ## 1. Install the assets
 
-The icon fonts are part of the KoliBri component package. Ensure your project depends on it:
+The Kolicons font files are part of the KoliBri component package. Ensure your project depends on it:
 
 ```bash
 pnpm add @public-ui/components
@@ -14,45 +16,61 @@ pnpm add @public-ui/components
 npm install @public-ui/components
 ```
 
-After installation the font files live inside `node_modules/@public-ui/components/assets/codicons/`.
+After installation, the font files live inside `node_modules/@public-ui/components/assets/kolicons/`.
 
-## 2. Import the CSS next to your global styles
+## 2. Import the CSS in your application
 
-The CSS file declares the `codicon` font-face and points to the matching `codicon.ttf` file. Import it once inside your application entry point or global stylesheet:
+The CSS file declares the `kolicon` font-face and points to the matching `kolicons.ttf` file. Import it once inside your application entry point or global stylesheet:
 
 ```ts
 // main.ts / index.tsx
-import '@public-ui/components/assets/codicons/codicon.css';
+import '@public-ui/components/assets/kolicons/style.css';
 ```
 
-For bundlers that do not understand CSS imports, copy `codicon.css` and `codicon.ttf` into your public assets folder and load them manually in `index.html`:
+For bundlers that do not understand CSS imports, copy `style.css` and `kolicons.ttf` into your public assets folder and load them manually in `index.html`:
 
 ```html
-<link rel="stylesheet" href="/assets/codicons/codicon.css" />
+<link rel="stylesheet" href="/assets/kolicons/style.css" />
 ```
 
-Make sure the relative path inside `codicon.css` still points to the TTF file after copying.
+Make sure the relative path inside `style.css` still points to the TTF file after copying.
 
 ## 3. Reference the icons from components
 
-Use Codicon class names via the `_icons` property. Multiple icons can be provided by separating classes with a space:
+Use Kolicon class names via the `_icons` property. Multiple icons can be provided by separating classes with a space:
 
 ```tsx
-<KolButton _label="Save" _icons="codicon codicon-save" />
+<KolButton _label="Save" _icons="kolicon kolicon-save" />
+<KolIcon _icon="kolicon kolicon-check" />
 ```
 
-The first class (`codicon`) ensures the font family is applied, the second selects the glyph.
+The first class (`kolicon`) ensures the font family is applied, the second selects the glyph.
+
+### Available Icon Names
+
+View the complete list of available Kolicons in the [Kolicons directory](https://github.com/public-ui/kolibri/tree/develop/packages/components/src/assets/kolicons). Icon names follow the pattern `kolicon-{name}`.
 
 ## 4. Serve the font file
 
-Verify that your build pipeline copies `codicon.ttf` into the final distribution folder. Frameworks such as Next.js, Vite, and Angular CLI automatically include imported assets when the CSS file is referenced. For custom setups, add a build step that copies the font file alongside your compiled assets:
+Verify that your build pipeline copies `kolicons.ttf` into the final distribution folder. Frameworks such as Next.js, Vite, and Angular CLI automatically include imported assets when the CSS file is referenced. For custom setups, add a build step that copies the font file alongside your compiled assets:
 
 ```bash
-cp node_modules/@public-ui/components/assets/codicons/codicon.ttf dist/assets/codicons/
+cp node_modules/@public-ui/components/assets/kolicons/kolicons.ttf dist/assets/kolicons/
 ```
 
 ## 5. Test your setup
 
-Load a page that renders `kol-icon` or any component using `_icons`. You should no longer see empty boxes. Browser developer tools let you check that the `codicon.ttf` file is requested successfully.
+Load a page that renders `kol-icon` or any component using `_icons`. You should no longer see empty boxes. Browser developer tools let you check that the `kolicons.ttf` file is requested successfully.
 
 Keeping the CSS import in place ensures AI agents and developers alike ship the correct assets whenever `kol-icon` is used.
+
+## Using Codicons (Optional Legacy Support)
+
+If your application still uses Codicons from an earlier version, you can optionally load both fonts:
+
+```ts
+import '@public-ui/components/assets/kolicons/style.css';
+import '@public-ui/components/assets/codicons/codicon.css';
+```
+
+However, we recommend migrating all Codicons to Kolicons for consistency and reduced bundle size.

--- a/docs/HOWTO_ICON_FONTS.md
+++ b/docs/HOWTO_ICON_FONTS.md
@@ -1,14 +1,14 @@
 # HOWTO: Bundle KoliBri Icon Fonts
 
-KoliBri ships the [`kol-icon`](https://public-ui.github.io/components/icon/) component to render pictograms. Starting with **v4**, KoliBri includes its own font-based icon set called **Kolicons**. Previously, this relied on [Codicon](https://github.com/microsoft/vscode-codicons).
+KoliBri ships the [`kol-icon`](https://public-ui.github.io/components/icon/) component to render pictograms. Starting with **v4**, KoliBri includes its own font-based icon set called **KolIcons**. Previously, this relied on [Codicon](https://github.com/microsoft/vscode-codicons).
 
-This guide shows how to install and bundle the Kolicons font assets that are published with `@public-ui/components`.
+This guide shows how to install and bundle the KolIcons font assets that are published with `@public-ui/components`.
 
 > **Migration from v3 to v4:** If you're upgrading from v3, see [BREAKING_CHANGES.v4.md](./BREAKING_CHANGES.v4.md#kolicons-instead-of-codicons) for migration details.
 
 ## 1. Install the assets
 
-The Kolicons font files are part of the KoliBri component package. Ensure your project depends on it:
+The KolIcons font files are part of the KoliBri component package. Ensure your project depends on it:
 
 ```bash
 pnpm add @public-ui/components
@@ -37,7 +37,7 @@ Make sure the relative path inside `style.css` still points to the TTF file afte
 
 ## 3. Reference the icons from components
 
-Use Kolicon class names via the `_icons` property. Multiple icons can be provided by separating classes with a space:
+Use KolIcon class names via the `_icons` property. Multiple icons can be provided by separating classes with a space:
 
 ```tsx
 <KolButton _label="Save" _icons="kolicon kolicon-save" />
@@ -48,7 +48,7 @@ The first class (`kolicon`) ensures the font family is applied, the second selec
 
 ### Available Icon Names
 
-View the complete list of available Kolicons in the [Kolicons directory](https://github.com/public-ui/kolibri/tree/develop/packages/components/src/assets/kolicons). Icon names follow the pattern `kolicon-{name}`.
+View the complete list of available KolIcons in the [KolIcons directory](https://github.com/public-ui/kolibri/tree/develop/packages/components/src/assets/kolicons). Icon names follow the pattern `kolicon-{name}`.
 
 ## 4. Serve the font file
 
@@ -73,4 +73,4 @@ import '@public-ui/components/assets/kolicons/style.css';
 import '@public-ui/components/assets/codicons/codicon.css';
 ```
 
-However, we recommend migrating all Codicons to Kolicons for consistency and reduced bundle size.
+However, we recommend migrating all Codicons to KolIcons for consistency and reduced bundle size.


### PR DESCRIPTION
## What changed?

A comprehensive migration section was added to `docs/BREAKING_CHANGES.v4.md` explaining the replacement of Codicons with KolIcons in v4. The section covers asset loading, CSS import changes, icon class name updates (`codicon` → `kolicon`), and font file paths. `docs/HOWTO_ICON_FONTS.md` was updated throughout to reference KolIcons instead of Codicons, and a migration hint linking to the breaking changes guide was added.

## Linked issues

- Refs #9219 — missing migration documentation for KolIcons

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein umfassender Migrations-Abschnitt wurde zu `docs/BREAKING_CHANGES.v4.md` hinzugefügt, der den Wechsel von Codicons zu KolIcons in v4 beschreibt: Asset-Loading, CSS-Import-Änderungen, Icon-Klassen-Umbenennung (`codicon` → `kolicon`) und Font-Dateipfade. `docs/HOWTO_ICON_FONTS.md` wurde durchgängig auf KolIcons aktualisiert.

### Verknüpfte Tickets

- Referenziert #9219 — fehlende Migrationsdokumentation für KolIcons

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `docs/BREAKING_CHANGES.v4.md` — KolIcons-Migrationsanleitung hinzugefügt
- `docs/HOWTO_ICON_FONTS.md` — Referenzen von Codicons auf KolIcons aktualisiert

</details>