### PR TITLE
docs: update KolIcons documentation link in v4 breaking changes guide

### DIFF
--- a/docs/BREAKING_CHANGES.v4.md
+++ b/docs/BREAKING_CHANGES.v4.md
@@ -70,7 +70,7 @@ Update all icon references in your code from `codicon` to `kolicon`. For example
 <KolIcon _icon="kolicon kolicon-check" />
 ```
 
-See the [KolIcons documentation](https://github.com/public-ui/kolibri/tree/develop/packages/components/src/assets/kolicons) for the complete list of available icon names.
+See the [KolIcons documentation](https://develop--kolibri-public-ui.netlify.app/#/icon/all-kolicons) for the complete list of available icon names.
 
 ### Font Files
 


### PR DESCRIPTION
## What changed?

The KolIcons documentation link in `docs/BREAKING_CHANGES.v4.md` was updated from the GitHub source tree path to the live Netlify sample app URL (`https://develop--kolibri-public-ui.netlify.app/#/icon/all-kolicons`), making it easier for consumers to browse available icon names.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der KolIcons-Dokumentationslink in `docs/BREAKING_CHANGES.v4.md` wurde von dem GitHub-Quellbaum-Pfad auf die Live-Netlify-URL der Sample-App aktualisiert, um das Durchsuchen verfügbarer Icon-Namen zu erleichtern.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `docs/BREAKING_CHANGES.v4.md` — KolIcons-Dokumentationslink auf Live-URL aktualisiert

</details>