### PR TITLE
chore(release): bump all packages to version 4.0.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -24,5 +24,5 @@
 		"packages/tools/visual-tests"
 	],
 	"useNx": true,
-	"version": "4.0.1-rc.2"
+	"version": "4.0.1"
 }

--- a/packages/adapters/angular/v19/package.json
+++ b/packages/adapters/angular/v19/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/angular-v19",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/angular/v20/package.json
+++ b/packages/adapters/angular/v20/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/angular-v20",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/angular/v21/package.json
+++ b/packages/adapters/angular/v21/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/angular-v21",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/hydrate/package.json
+++ b/packages/adapters/hydrate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/hydrate",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/preact/package.json
+++ b/packages/adapters/preact/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/preact",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/react-hook-form-adapter/package.json
+++ b/packages/adapters/react-hook-form-adapter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/react-hook-form-adapter",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/react-standalone/package.json
+++ b/packages/adapters/react-standalone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/react-standalone",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/react-v19/package.json
+++ b/packages/adapters/react-v19/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/react-v19",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/react/package.json
+++ b/packages/adapters/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/react",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/solid/package.json
+++ b/packages/adapters/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/solid",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/svelte/package.json
+++ b/packages/adapters/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/svelte",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/adapters/vue/package.json
+++ b/packages/adapters/vue/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/vue",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/components",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/components/src/styles/_kol-card-mixin.scss
+++ b/packages/components/src/styles/_kol-card-mixin.scss
@@ -1,7 +1,10 @@
 @use '../components/@shared/mixins' as *;
+@use '../components/@shared/kol-button-mixin' as *;
 
 @mixin kol-card {
 	.kol-card {
+		@include kol-button-styles('kol-button');
+
 		/* Visible with forced colors  */
 		outline: transparent solid to-rem(1);
 

--- a/packages/samples/presentation/package.json
+++ b/packages/samples/presentation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/presentation",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"description": "This package contains presentation samples for the KoliBri/Public UI",
 	"license": "EUPL-1.2",
 	"repository": {

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/sample-react",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"description": "This app contains samples for the KoliBri/Public UI",
 	"license": "EUPL-1.2",
 	"repository": {

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/theme-default",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/themes/ecl/package.json
+++ b/packages/themes/ecl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/theme-ecl",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/themes",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/tools/hydrate-server/package.json
+++ b/packages/tools/hydrate-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/hydrate-server",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/tools/kolibri-cli/package.json
+++ b/packages/tools/kolibri-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/kolibri-cli",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/tools/mcp/package.json
+++ b/packages/tools/mcp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/mcp",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@public-ui/visual-tests",
-	"version": "4.0.1-rc.2",
+	"version": "4.0.1",
 	"license": "EUPL-1.2",
 	"homepage": "https://public-ui.github.io",
 	"repository": {

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -3,8 +3,8 @@ name: KoliBri – Die barrierefreie WebComponent-Bibliothek
 genericName: Accessible WebComponent Library
 url: https://github.com/public-ui/kolibri
 landingURL: https://github.com/public-ui
-releaseDate: '2026-01-13'
-softwareVersion: 4.0.1-rc.2
+releaseDate: '2026-01-15'
+softwareVersion: 4.0.1
 logo: kolibri.logo.png
 developmentStatus: stable
 softwareType: library


### PR DESCRIPTION
## What changed?

All packages in the monorepo were bumped from `4.0.1-rc.2` to the stable `4.0.1` release. This includes all framework adapters (Angular v19/v20/v21, React, React v19, Solid, Svelte, Vue, Preact, Hydrate), the core components package, themes (default, ECL), tooling packages (kolibri-cli, mcp, hydrate-server, visual-tests), and sample packages. The `publiccode.yml` release date and version were updated accordingly. Additionally, the `_kol-card-mixin.scss` fix (button styles include for close button) was included in this release commit.

## Linked issues

- Refs #9208 — Card close button style included in this release

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Alle Pakete des Monorepos wurden von `4.0.1-rc.2` auf die stabile Version `4.0.1` angehoben. Dies umfasst alle Framework-Adapter, das Kern-Komponenten-Paket, Themes, Tooling-Pakete und Beispiel-Pakete. `publiccode.yml` wurde mit dem Release-Datum und der neuen Version aktualisiert. Zusätzlich wurde der `_kol-card-mixin.scss`-Fix (Button-Styles für Schließen-Button) in diesen Release-Commit aufgenommen.

### Verknüpfte Tickets

- Referenziert #9208 — Card-Close-Button-Stil in diesem Release enthalten

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `lerna.json` — Version auf 4.0.1 gesetzt
- Alle `package.json`-Dateien — Versionen auf 4.0.1 angehoben
- `packages/components/src/styles/_kol-card-mixin.scss` — Button-Styles-Include hinzugefügt
- `publiccode.yml` — Release-Datum und Version aktualisiert

</details>