### PR TITLE
fix(card): include button styles in card mixin for close button

### DIFF
--- a/packages/components/src/styles/_kol-card-mixin.scss
+++ b/packages/components/src/styles/_kol-card-mixin.scss
@@ -1,7 +1,10 @@
 @use '../components/@shared/mixins' as *;
+@use '../components/@shared/kol-button-mixin' as *;
 
 @mixin kol-card {
 	.kol-card {
+		@include kol-button-styles('kol-button');
+
 		/* Visible with forced colors  */
 		outline: transparent solid to-rem(1);
 


### PR DESCRIPTION
## What changed?

The `kol-card` mixin in `_kol-card-mixin.scss` now includes `@include kol-button-styles('kol-button')`, ensuring that the close button rendered inside `KolCard` receives correct button styles from the component stylesheet. Previously, button styles were missing from the card's style scope, causing visual inconsistencies for the close button.

## Linked issues

- Refs #9208 — Card close button style incorrect

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das `kol-card`-Mixin in `_kol-card-mixin.scss` inkludiert nun `@include kol-button-styles('kol-button')`, damit der Schließen-Button in `KolCard` korrekte Button-Styles aus dem Komponenten-Stylesheet erhält. Zuvor fehlten die Button-Styles im Style-Scope der Karte.

### Verknüpfte Tickets

- Referenziert #9208 — Falscher Stil des Schließen-Buttons in KolCard

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/styles/_kol-card-mixin.scss` — `kol-button-styles`-Include hinzugefügt

</details>