### PR TITLE
feat(samples): add linked headline sample for KolLink with KolHeading

### DIFF
--- a/packages/samples/react/src/components/link/linked-headline.tsx
+++ b/packages/samples/react/src/components/link/linked-headline.tsx
@@ -11,7 +11,7 @@ export const LinkHeadline: FC = () => (
 		</SampleDescription>
 
 		<div className="grid gap-4">
-			<KolLink _href="#headline2" _label="">
+			<KolLink _href="/#/link/linked-headline#headline2" _label="">
 				<KolHeading _label="I'm a H2-heading" _level={2} slot="expert" id="headline2" />
 			</KolLink>
 		</div>

--- a/packages/samples/react/src/components/link/linked-headline.tsx
+++ b/packages/samples/react/src/components/link/linked-headline.tsx
@@ -1,0 +1,19 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { KolHeading, KolLink } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+export const LinkHeadline: FC = () => (
+	<>
+		<SampleDescription>
+			<p>This sample shows a linked headline with anchor.</p>
+		</SampleDescription>
+
+		<div className="grid gap-4">
+			<KolLink _href="#headline2" _label="">
+				<KolHeading _label="I'm a H2-heading" _level={2} slot="expert" id="headline2" />
+			</KolLink>
+		</div>
+	</>
+);

--- a/packages/samples/react/src/components/link/linked-headline.tsx
+++ b/packages/samples/react/src/components/link/linked-headline.tsx
@@ -11,9 +11,69 @@ export const LinkHeadline: FC = () => (
 		</SampleDescription>
 
 		<div className="grid gap-4">
-			<KolLink _href="/#/link/linked-headline#headline2" _label="">
-				<KolHeading _label="I'm a H2-heading" _level={2} slot="expert" id="headline2" />
+			<KolLink _href="/#/link/linked-headline#headline1" _label="">
+				<KolHeading _label="I'm H2-heading number one" _level={2} slot="expert" id="headline1" />
 			</KolLink>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<KolLink _href="/#/link/linked-headline#headline2" _label="">
+				<KolHeading _label="I'm H2-heading number two" _level={2} slot="expert" id="headline2" />
+			</KolLink>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<KolLink _href="/#/link/linked-headline#headline3" _label="">
+				<KolHeading _label="I'm H2-heading number three" _level={2} slot="expert" id="headline3" />
+			</KolLink>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
+			<p>
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+				Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+				voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			</p>
 		</div>
 	</>
 );

--- a/packages/samples/react/src/components/link/routes.ts
+++ b/packages/samples/react/src/components/link/routes.ts
@@ -5,6 +5,7 @@ import { LinkBasic } from './basic';
 import { LinkIcons } from './icons';
 import { LinkImage } from './image';
 import { LinkReactRouter } from './link-react-router';
+import { LinkHeadline } from './linked-headline';
 import { LinkShortKey } from './short-key';
 import { LinkTarget } from './target';
 
@@ -18,5 +19,6 @@ export const LINK_ROUTES: Routes = {
 		'access-key': LinkAccessKey,
 		'short-key': LinkShortKey,
 		'react-router': LinkReactRouter,
+		'linked-headline': LinkHeadline,
 	},
 };


### PR DESCRIPTION
## What changed?

A new sample `LinkHeadline` was added to the React sample application demonstrating how to wrap `KolHeading` inside a `KolLink` using the `expert` slot to create anchor-linked headings. The sample shows three headings with in-page anchor links. The route `link/linked-headline` was registered in the link routes.

## Linked issues

- Refs #9000 — sample for linked headlines

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein neues Sample `LinkHeadline` wurde zur React-Beispielanwendung hinzugefügt, das zeigt, wie `KolHeading` innerhalb eines `KolLink` über den `expert`-Slot eingebettet wird, um ankerverknüpfte Überschriften zu erstellen. Das Sample zeigt drei Überschriften mit In-Page-Ankerlinks. Die Route `link/linked-headline` wurde registriert.

### Verknüpfte Tickets

- Referenziert #9000 — Sample für verknüpfte Überschriften

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/link/linked-headline.tsx` — Neue Sample-Komponente mit verknüpften Überschriften
- `packages/samples/react/src/components/link/routes.ts` — Route `linked-headline` registriert

</details>