### PR TITLE
ci: attest deploy artifacts for non-NPM outputs

### DIFF
--- a/.github/workflows/benchmark.monitoring.yml
+++ b/.github/workflows/benchmark.monitoring.yml
@@ -7,6 +7,11 @@ concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  attestations: write
+  contents: write
+  id-token: write
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -31,6 +36,11 @@ jobs:
 
       - name: Install and execute benchmark
         uses: ./.github/actions/benchmark
+
+      - name: Attest benchmark result
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: packages/tools/benchmark-tests/benchmark-result.json
 
       - name: Remove husky
         run: rm -rf .husky

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -9,6 +9,11 @@ concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     # Skip this job when the base clone URL may be different from the head clone URL.
@@ -45,6 +50,11 @@ jobs:
 
       - name: Build
         run: pnpm --filter @public-ui/sample-react... build
+
+      - name: Attest sample react build
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: packages/samples/react/dist
 
       - name: Netlify Deploy
         uses: netlify/actions/cli@master

--- a/.github/workflows/mcp-vercel.yml
+++ b/.github/workflows/mcp-vercel.yml
@@ -21,6 +21,11 @@ concurrency:
   group: 'mcp-vercel-${{ github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -86,6 +91,15 @@ jobs:
           }
           NODE
           pnpm exec prettier --write package.json
+
+      - name: Attest MCP build outputs
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            packages/tools/mcp/api
+            packages/tools/mcp/dist
+            packages/tools/mcp/shared/sample-index.json
+
       - name: Deploy to Vercel (production)
         id: deploy_prod
         if: github.ref == 'refs/heads/release/3' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -14,6 +14,11 @@ concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -48,6 +53,11 @@ jobs:
 
       - name: Build
         run: pnpm --filter @public-ui/sample-react... build
+
+      - name: Attest sample react build
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: packages/samples/react/dist
 
       - name: Netlify Deploy
         uses: netlify/actions/cli@master


### PR DESCRIPTION
## What changed?

OIDC-based build provenance attestation was added to four GitHub Actions workflows for non-NPM build outputs. Each affected workflow (`benchmark.monitoring.yml`, `draft-deploy.yml`, `mcp-vercel.yml`, `test-deploy.yml`) received `permissions: attestations: write, id-token: write` and an `actions/attest-build-provenance@v2` step that signs the respective build artifacts (benchmark results, sample React build, MCP outputs). This extends the project's SLSA attestation coverage beyond npm packages.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

OIDC-basierte Build-Provenance-Attestierung wurde zu vier GitHub-Actions-Workflows für Nicht-NPM-Build-Artefakte hinzugefügt. Jeder betroffene Workflow erhielt `permissions: attestations: write, id-token: write` und einen `actions/attest-build-provenance@v2`-Schritt. Dies erweitert die SLSA-Attestierungsabdeckung des Projekts über npm-Pakete hinaus.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/benchmark.monitoring.yml` — Provenance-Attestierung für Benchmark-Ergebnisse
- `.github/workflows/draft-deploy.yml` — Provenance-Attestierung für Sample-React-Build
- `.github/workflows/mcp-vercel.yml` — Provenance-Attestierung für MCP-Build-Outputs
- `.github/workflows/test-deploy.yml` — Provenance-Attestierung für Sample-React-Build

</details>