### PR TITLE
chore(ci): use frozen-lockfile install in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,7 @@ jobs:
             ${{ runner.os }}-pnpm-store
 
       - name: Install
-        run: pnpm i --no-frozen-lockfile --no-verify-store-integrity
+        run: pnpm i --frozen-lockfile
 
       - name: Configure Git user
         run: |


### PR DESCRIPTION
## What changed?

The install step in the publish workflow was changed from `pnpm i --no-frozen-lockfile --no-verify-store-integrity` to `pnpm i --frozen-lockfile`. This enforces exact lockfile adherence during publishing, preventing unintended dependency drift in CI-produced release artifacts.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Installationsschritt im Publish-Workflow wurde von `pnpm i --no-frozen-lockfile --no-verify-store-integrity` auf `pnpm i --frozen-lockfile` umgestellt. Dies erzwingt exakte Lock-Datei-Einhaltung beim Veröffentlichen und verhindert unbeabsichtigten Dependency-Drift in CI-generierten Release-Artefakten.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/publish.yml` — Install-Flag von `--no-frozen-lockfile` auf `--frozen-lockfile` geändert

</details>