### PR TITLE
docs: add SLSA/Provenance section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ We aim for **SLSA Build Level 3** for the npm packages published from this repos
 
 ```bash
 # Inspect provenance metadata for a published package
-npm view @public-ui/components dist.provenance
+pnpm view @public-ui/components dist.provenance
 
 # (Optional) Verify signatures/provenance if your npm client supports it
-npm audit signatures --package=@public-ui/components@<version>
+pnpm audit signatures --package=@public-ui/components@<version>
 ```
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ Let's make KoliBri **better** and **more colorful** together!
 
 Bug reports and pull requests are welcome. Please read our [contribution guide](./CONTRIBUTING.md) before getting started.
 
+## SLSA/Provenance
+
+We aim for **SLSA Build Level 3** for the npm packages published from this repository. Releases are built in GitHub Actions with OIDC-based identity and published with npm provenance (`--provenance`), producing verifiable attestations for the published artifacts. See the [publish workflow](./.github/workflows/publish.yml) for the release steps and npm provenance configuration.
+
+**Verification example**
+
+```bash
+# Inspect provenance metadata for a published package
+npm view @public-ui/components dist.provenance
+
+# (Optional) Verify signatures/provenance if your npm client supports it
+npm audit signatures --package=@public-ui/components@<version>
+```
+
 ## Resources
 
 - [Get Started](https://public-ui.github.io/en/docs/get-started/first-steps)


### PR DESCRIPTION
## What changed?

A SLSA/Provenance section was added to `README.md` explaining the project's SLSA Build Level 3 goal for npm packages. The section describes how releases use OIDC-based identity and npm provenance (`--provenance`) in GitHub Actions, and provides example commands for inspecting provenance metadata via `pnpm view` and `pnpm audit signatures`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein SLSA/Provenance-Abschnitt wurde zur `README.md` hinzugefügt, der das SLSA Build Level 3-Ziel des Projekts für npm-Pakete erklärt. Der Abschnitt beschreibt OIDC-basierte Identität und npm Provenance (`--provenance`) in GitHub Actions sowie Beispielbefehle zur Überprüfung der Provenance-Metadaten.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `README.md` — SLSA/Provenance-Abschnitt mit Verifizierungsbeispielen hinzugefügt

</details>