### PR TITLE
docs: add Tailwind theming example

### DIFF
--- a/docs/examples/tailwind-theme/tailwind.config.cjs
+++ b/docs/examples/tailwind-theme/tailwind.config.cjs
@@ -1,0 +1,35 @@
+module.exports = {
+	content: ['./src/**/*.tsx', './src/**/*.ts', './src/**/*.html'],
+	theme: {
+		extend: {
+			borderRadius: {
+				'kolibri-md': '0.375rem',
+				'kolibri-sm': '0.25rem',
+			},
+			colors: {
+				'kolibri-primary': '#1b6cfb',
+				'kolibri-primary-contrast': '#ffffff',
+				'kolibri-surface': '#ffffff',
+				'kolibri-text': '#111827',
+			},
+			fontFamily: {
+				kolibri: ['"Inter"', 'Verdana', 'Arial', 'sans-serif'],
+			},
+		},
+	},
+	plugins: [
+		function tokensPlugin({ addBase, theme }) {
+			addBase({
+				':root': {
+					'--kolibri-color-primary': theme('colors.kolibri-primary'),
+					'--kolibri-color-primary-contrast': theme('colors.kolibri-primary-contrast'),
+					'--kolibri-color-surface': theme('colors.kolibri-surface'),
+					'--kolibri-color-text': theme('colors.kolibri-text'),
+					'--kolibri-font-family': theme('fontFamily.kolibri').join(', '),
+					'--kolibri-radius-md': theme('borderRadius.kolibri-md'),
+					'--kolibri-radius-sm': theme('borderRadius.kolibri-sm'),
+				},
+			});
+		},
+	],
+};

--- a/docs/examples/tailwind-theme/theme.components.scss
+++ b/docs/examples/tailwind-theme/theme.components.scss
@@ -1,0 +1,11 @@
+@layer kol-theme-component {
+	.kol-button {
+		background-color: var(--color-primary);
+		border-radius: var(--radius-md);
+		color: var(--color-primary-contrast);
+	}
+
+	.kol-link {
+		color: var(--color-primary);
+	}
+}

--- a/docs/examples/tailwind-theme/theme.global.scss
+++ b/docs/examples/tailwind-theme/theme.global.scss
@@ -1,0 +1,19 @@
+@layer kol-theme-global {
+	:host {
+		--color-primary: var(--kolibri-color-primary);
+		--color-primary-contrast: var(--kolibri-color-primary-contrast);
+		--color-surface: var(--kolibri-color-surface);
+		--color-text: var(--kolibri-color-text);
+		--font-family: var(--kolibri-font-family, Verdana, Arial, sans-serif);
+		--radius-md: var(--kolibri-radius-md);
+		--radius-sm: var(--kolibri-radius-sm);
+	}
+
+	:host {
+		font-size: var(--font-size, 1rem);
+
+		* {
+			font-family: var(--font-family);
+		}
+	}
+}

--- a/docs/examples/tailwind-theme/tokens.css
+++ b/docs/examples/tailwind-theme/tokens.css
@@ -1,0 +1,9 @@
+:root {
+	--kolibri-color-primary: #1b6cfb;
+	--kolibri-color-primary-contrast: #ffffff;
+	--kolibri-color-surface: #ffffff;
+	--kolibri-color-text: #111827;
+	--kolibri-font-family: "Inter", Verdana, Arial, sans-serif;
+	--kolibri-radius-md: 0.375rem;
+	--kolibri-radius-sm: 0.25rem;
+}

--- a/docs/tutorials/TAILWIND_THEMING.md
+++ b/docs/tutorials/TAILWIND_THEMING.md
@@ -1,0 +1,44 @@
+# TailwindCSS Theme Example (KoliBri)
+
+This tutorial shows an **example** TailwindCSS-based theming workflow for KoliBri. It keeps Tailwind as a token source and applies the values through the **Theme Global/Component layers** so the Shadow DOM components receive the correct styling.
+
+> ℹ️ The example files live in `docs/examples/tailwind-theme/` and are not wired into the build. They are meant as a reference.
+
+## 1) Example file layout
+
+```
+docs/examples/tailwind-theme/
+├── tailwind.config.cjs
+├── tokens.css
+├── theme.components.scss
+└── theme.global.scss
+```
+
+## 2) Tailwind config (token source)
+
+`tailwind.config.cjs` defines the design tokens. A real implementation could export these tokens to CSS variables (e.g., via a small plugin or build script). The example file includes a minimal mapping for colors, radii, and fonts.
+
+## 3) Token output (`tokens.css`)
+
+`tokens.css` demonstrates **generated** CSS variables. In a real pipeline, Tailwind’s config would be the single source of truth and a script would emit these variables.
+
+## 4) Theme Global Layer
+
+`theme.global.scss` shows how the generated variables are applied in `@layer kol-theme-global`. This is where you set defaults such as fonts and base token values for all components.
+
+## 5) Theme Component Layer
+
+`theme.components.scss` demonstrates component-specific overrides via `@layer kol-theme-component`. Only override what the theme really customizes.
+
+## 6) Suggested build approach (conceptual)
+
+1. Run Tailwind to produce `tokens.css` from `tailwind.config.cjs`.
+2. Import or inline the generated tokens into `theme.global.scss`.
+3. Build the theme package and use it with KoliBri.
+
+## 7) Notes
+
+- Tailwind utilities **do not reach Shadow DOM**; use them for page layout only.
+- Keep layout styles in KoliBri’s **basis layers**, not in theme layers.
+- Do not place `@layer` declarations in utility/partial files.
+- Spell KoliBri consistently in documentation.


### PR DESCRIPTION
### Motivation

- Provide a concrete example and guidance for using TailwindCSS as a token source when creating KoliBri themes.
- Show how to emit Tailwind tokens as CSS variables and apply them through KoliBri’s `@layer kol-theme-global` and `@layer kol-theme-component` so Shadow DOM components receive correct styling.

### Description

- Add a tutorial at `docs/tutorials/TAILWIND_THEMING.md` that documents the example workflow and file layout. 
- Add an example Tailwind config at `docs/examples/tailwind-theme/tailwind.config.cjs` that demonstrates token-to-CSS-variable output via a small plugin. 
- Add a sample generated token file `docs/examples/tailwind-theme/tokens.css` containing CSS variable exports. 
- Add theme layer examples `docs/examples/tailwind-theme/theme.global.scss` and `docs/examples/tailwind-theme/theme.components.scss` that map the generated variables into KoliBri’s global and component layers; the examples are reference-only and not wired into the build.

### Testing

- Ran `pnpm format` (Prettier) across the repository and it completed successfully. 
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696486d06a64832fa9e18bba17fc5941)