### PR TITLE
feat(sample-react): add input-text pattern sample

### DIFF
--- a/packages/samples/react/src/components/input-text/pattern.tsx
+++ b/packages/samples/react/src/components/input-text/pattern.tsx
@@ -5,23 +5,35 @@ import { KolInputText } from '@public-ui/react-v19';
 import { SampleDescription } from '../SampleDescription';
 
 const PATTERN = '^[A-Z]{3}-\\d{3}$';
+const PATTERN_HINT = 'Use three uppercase letters, a dash, and three digits (example: ABC-123).';
 
 export const InputTextPattern: FC = () => (
 	<>
 		<SampleDescription>
-			<p>This sample demonstrates HTML5 pattern validation for a native input and KolInputText.</p>
+			<p>This sample demonstrates HTML5 pattern validation for a native input and shows how to mirror a KolInputText value to a form-controlled input.</p>
 		</SampleDescription>
 		<form className="grid gap-4">
 			<div className="grid gap-2">
 				<label htmlFor="native-pattern">Native code (AAA-123)</label>
 				<input aria-describedby="native-pattern-help" id="native-pattern" name="native-pattern" pattern={PATTERN} required type="text" />
-				<p id="native-pattern-help">Use three uppercase letters, a dash, and three digits (example: ABC-123).</p>
+				<p id="native-pattern-help">{PATTERN_HINT}</p>
 			</div>
 			<KolInputText
 				_label="KoliBri code (AAA-123)"
-				_msg={{ _description: 'Use three uppercase letters, a dash, and three digits (example: ABC-123).', _type: 'info' }}
+				_msg={{ _description: `${PATTERN_HINT} (Mirrored into a hidden native input for HTML5 validation.)`, _type: 'info' }}
 				_pattern={PATTERN}
 				_required
+				_syncValueBySelector="#kolibri-pattern-proxy"
+			/>
+			<input
+				aria-hidden="true"
+				className="visually-hidden"
+				id="kolibri-pattern-proxy"
+				name="kolibri-pattern-proxy"
+				pattern={PATTERN}
+				required
+				tabIndex={-1}
+				type="text"
 			/>
 			<button type="submit">Submit</button>
 		</form>

--- a/packages/samples/react/src/components/input-text/pattern.tsx
+++ b/packages/samples/react/src/components/input-text/pattern.tsx
@@ -1,0 +1,29 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { KolInputText } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+const PATTERN = '^[A-Z]{3}-\\d{3}$';
+
+export const InputTextPattern: FC = () => (
+	<>
+		<SampleDescription>
+			<p>This sample demonstrates HTML5 pattern validation for a native input and KolInputText.</p>
+		</SampleDescription>
+		<form className="grid gap-4">
+			<div className="grid gap-2">
+				<label htmlFor="native-pattern">Native code (AAA-123)</label>
+				<input aria-describedby="native-pattern-help" id="native-pattern" name="native-pattern" pattern={PATTERN} required type="text" />
+				<p id="native-pattern-help">Use three uppercase letters, a dash, and three digits (example: ABC-123).</p>
+			</div>
+			<KolInputText
+				_label="KoliBri code (AAA-123)"
+				_msg={{ _description: 'Use three uppercase letters, a dash, and three digits (example: ABC-123).', _type: 'info' }}
+				_pattern={PATTERN}
+				_required
+			/>
+			<button type="submit">Submit</button>
+		</form>
+	</>
+);

--- a/packages/samples/react/src/components/input-text/routes.ts
+++ b/packages/samples/react/src/components/input-text/routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '../../shares/types';
 import { InputTextBasic } from './basic';
 import { InputTextExpertSlot } from './expert-slot';
 import { InputTextHideMsg } from './hide-msg';
+import { InputTextPattern } from './pattern';
 import { InputTextSelectRange } from './select-range';
 import { InputTextSmartButton } from './smart-button';
 import { InputTextFormatterDemo } from './text-formatter';
@@ -9,10 +10,11 @@ import { InputTextFormatterDemo } from './text-formatter';
 export const INPUT_TEXT_ROUTES: Routes = {
 	'input-text': {
 		basic: InputTextBasic,
-		'hide-msg': InputTextHideMsg,
-		'text-formatter': InputTextFormatterDemo,
-		'smart-button': InputTextSmartButton,
 		'expert-slot': InputTextExpertSlot,
+		'hide-msg': InputTextHideMsg,
+		pattern: InputTextPattern,
 		'select-range': InputTextSelectRange,
+		'smart-button': InputTextSmartButton,
+		'text-formatter': InputTextFormatterDemo,
 	},
 };


### PR DESCRIPTION
### Motivation
- Provide a small accessible sample that demonstrates native HTML5 `pattern` validation side-by-side with the `KolInputText` component in a classic `<form>` to make browser validation behaviour visible.

### Description
- Add `packages/samples/react/src/components/input-text/pattern.tsx` implementing a form with a labelled native `<input type="text" pattern="..." required>` plus a `KolInputText` using `_pattern` and `_required`, and register the story in `packages/samples/react/src/components/input-text/routes.ts` under the `pattern` key.

### Testing
- Ran `pnpm format` across the repo and the formatting step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cb21191c832fbad88c3f05b7fced)