### PR TITLE
feat(sample-react): add input-text pattern sample

### DIFF
--- a/packages/samples/react/src/components/input-text/pattern.tsx
+++ b/packages/samples/react/src/components/input-text/pattern.tsx
@@ -1,0 +1,30 @@
+import type { FC } from 'react';
+import React from 'react';
+
+import { KolInputText } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+const PATTERN = '^[A-Za-z]{3}-\\d{3}$';
+
+export const InputTextPattern: FC = () => (
+	<>
+		<SampleDescription>
+			<p>This sample demonstrates HTML5 pattern validation for both native input and KolInputText components.</p>
+		</SampleDescription>
+		<form className="grid gap-4">
+			<div className="grid gap-2">
+				<label htmlFor="native-input">Native Input (Pattern: AAA-123, case-insensitive)</label>
+				<input id="native-input" name="native-input" pattern={PATTERN} type="text" />
+			</div>
+			<KolInputText
+				_label="KoliBri Input (Pattern: AAA-123, case-insensitive)"
+				_name="kolibri-input"
+				_pattern={PATTERN}
+				_hint="Note: This input is not linked to the form element. The validation inside the Shadow DOM is currently not triggered on form submit."
+			/>
+			<div>
+				<button type="submit">Submit</button>
+			</div>
+		</form>
+	</>
+);

--- a/packages/samples/react/src/components/input-text/routes.ts
+++ b/packages/samples/react/src/components/input-text/routes.ts
@@ -7,6 +7,7 @@ import { InputTextExpertSlot } from './expert-slot';
 import { InputTextHideLabel } from './hide-label';
 import { InputTextHideMsg } from './hide-msg';
 import { InputTextMessageTypes } from './message-types';
+import { InputTextPattern } from './pattern';
 import { InputTextPlaceholder } from './placeholder';
 import { InputTextReadonly } from './readonly';
 import { InputTextSelectRange } from './select-range';
@@ -26,6 +27,7 @@ export const INPUT_TEXT_ROUTES: Routes = {
 		'text-formatter': InputTextFormatterDemo,
 		'smart-button': InputTextSmartButton,
 		'expert-slot': InputTextExpertSlot,
+		pattern: InputTextPattern,
 		'select-range': InputTextSelectRange,
 		background: InputTextBackground,
 	},


### PR DESCRIPTION
## What changed?

A new sample `InputTextPattern` was added to the React sample application demonstrating HTML5 `pattern` attribute validation with `KolInputText`. The sample shows a native `<input>` and a `KolInputText` side-by-side using the pattern `^[A-Za-z]{3}-\d{3}$` (format: AAA-123). A note is included in the sample explaining that `KolInputText` validation inside the Shadow DOM is not triggered on form submit. The route `input-text/pattern` was registered in the input-text routes.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein neues Sample `InputTextPattern` wurde zur React-Beispielanwendung hinzugefügt, das die HTML5-`pattern`-Attribut-Validierung mit `KolInputText` demonstriert. Das Sample zeigt ein natives `<input>` und ein `KolInputText` nebeneinander mit dem Pattern `^[A-Za-z]{3}-\d{3}$` (Format: AAA-123). Ein Hinweis erklärt, dass die `KolInputText`-Validierung im Shadow DOM beim Formular-Submit nicht ausgelöst wird. Die Route `input-text/pattern` wurde registriert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/input-text/pattern.tsx` — Neue Sample-Komponente für Pattern-Validierung
- `packages/samples/react/src/components/input-text/routes.ts` — Route `pattern` registriert

</details>