### PR TITLE
refactor(icon): inline icon rendering via KolIcon functional component and import icon font styles

### DIFF
--- a/packages/components/src/components/alert/style.scss
+++ b/packages/components/src/components/alert/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 

--- a/packages/components/src/components/badge/style.scss
+++ b/packages/components/src/components/badge/style.scss
@@ -1,5 +1,6 @@
-@use '../@shared/mixins' as *;
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
+@use '../@shared/mixins' as *;
 @use '../tooltip/style.scss' as *;
 
 @layer kol-component {

--- a/packages/components/src/components/breadcrumb/shadow.tsx
+++ b/packages/components/src/components/breadcrumb/shadow.tsx
@@ -6,7 +6,8 @@ import { addNavLabel, removeNavLabel } from '../../utils/unique-nav-labels';
 import { watchNavLinks } from '../nav/validation';
 
 import type { JSX } from '@stencil/core';
-import { KolIconTag, KolLinkWcTag } from '../../core/component-names';
+import { KolLinkWcTag } from '../../core/component-names';
+import { KolIconFc } from '../../functional-components';
 
 @Component({
 	tag: 'kol-breadcrumb',
@@ -23,7 +24,7 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 				{index === lastIndex ? (
 					<span class="kol-breadcrumb__list-element-span" aria-current="page">
 						{link._hideLabel ? (
-							<KolIconTag class="kol-breadcrumb__icon" _label={link._label} _icons={typeof link._icons === 'string' ? link._icons : 'kolicon-link'} />
+							<KolIconFc class="kol-breadcrumb__icon" label={link._label} icons={typeof link._icons === 'string' ? link._icons : 'kolicon-link'} />
 						) : (
 							<>{link._label}</>
 						)}
@@ -31,7 +32,7 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 				) : (
 					<KolLinkWcTag class="kol-breadcrumb__link" _inline={false} {...link}></KolLinkWcTag>
 				)}
-				{index !== lastIndex && <KolIconTag class="kol-breadcrumb__separator" _label="" _icons="kolicon-chevron-right" />}
+				{index !== lastIndex && <KolIconFc class="kol-breadcrumb__separator" label="" icons="kolicon-chevron-right" />}
 			</li>
 		);
 	};
@@ -42,7 +43,7 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 				<ul class="kol-breadcrumb__list">
 					{this.state._links.length === 0 && (
 						<li>
-							<KolIconTag class="kol-breadcrumb_icon" _label="" _icons="kolicon-house" />…
+							<KolIconFc class="kol-breadcrumb_icon" label="" icons="kolicon-house" />…
 						</li>
 					)}
 					{this.state._links.map(this.renderLink)}

--- a/packages/components/src/components/breadcrumb/style.scss
+++ b/packages/components/src/components/breadcrumb/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../@shared/kol-link-mixin' as *;
 @use '../@shared/mixins' as *;

--- a/packages/components/src/components/button/style.scss
+++ b/packages/components/src/components/button/style.scss
@@ -1,6 +1,7 @@
-@use '../@shared/mixins' as *;
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../@shared/kol-button-mixin' as *;
+@use '../@shared/mixins' as *;
 
 @layer kol-component {
 	@include kol-button-styles('kol-button');

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -1,12 +1,13 @@
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
 import clsx from 'clsx';
-import { KolButtonWcTag, KolIconTag } from '../../core/component-names';
+import { KolButtonWcTag } from '../../core/component-names';
 import { getRenderStates } from '../../functional-component-wrappers/_helpers/getRenderStates';
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper';
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import type { InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import KolInputStateWrapperFc from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
+import { KolIconFc } from '../../functional-components';
 import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggestionsOption/CustomSuggestionsOption';
 import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
 import { translate } from '../../i18n';
@@ -280,9 +281,9 @@ export class KolCombobox implements ComboboxAPI {
 								}}
 							/>
 						)}
-						<KolIconTag
-							_icons="kolicon-chevron-down"
-							_label=""
+						<KolIconFc
+							icons="kolicon-chevron-down"
+							label=""
 							class={clsx('kol-custom-suggestions-toggle', {
 								'kol-custom-suggestions-toggle--disabled': isDisabled,
 							})}

--- a/packages/components/src/components/combobox/style.scss
+++ b/packages/components/src/components/combobox/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-custom-suggestions-option' as *;

--- a/packages/components/src/components/details/style.scss
+++ b/packages/components/src/components/details/style.scss
@@ -1,7 +1,8 @@
-@use '../@shared/mixins' as *;
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
-@use '../host-display-block' as *;
 @use '../../functional-components/Collapsible/collapsible' as *;
+@use '../@shared/mixins' as *;
+@use '../host-display-block' as *;
 
 @layer kol-component {
 	.kol-details {
@@ -21,7 +22,7 @@
 		}
 
 		.collapsible--open &__heading-button {
-			.kol-icon::part(icon) {
+			.kol-icon__icon {
 				transform: rotate(90deg);
 			}
 		}

--- a/packages/components/src/components/icon/shadow.tsx
+++ b/packages/components/src/components/icon/shadow.tsx
@@ -3,8 +3,8 @@ import type { IconAPI, IconStates, LabelPropType } from '../../schema';
 import { IconController } from './controller';
 
 import type { JSX } from '@stencil/core';
-import clsx from 'clsx';
-import { BEM_CLASS_ICON, BEM_CLASS_ICON__ICON } from './bem';
+import { KolIconFc } from '../../functional-components';
+import { BEM_CLASS_ICON } from './bem';
 
 /**
  * @part icon - Ermöglicht das Styling des inneren Icons.
@@ -19,22 +19,9 @@ import { BEM_CLASS_ICON, BEM_CLASS_ICON__ICON } from './bem';
 export class KolIcon implements IconAPI {
 	private readonly controller: IconController;
 	public render(): JSX.Element {
-		const hasAriaLabel = this.state._label.length > 0;
 		return (
 			<Host exportparts="icon" class={BEM_CLASS_ICON}>
-				<i
-					/**
-					 * Die Auszeichnung `aria-hidden` ist eigentlich nicht erforderlich, da die aktuellen
-					 * Screenreader, wie NVDA und JAWS, es auch ohne `aria-hidden` nicht vorlesen.
-					 *
-					 * Referenz: https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden
-					 */
-					aria-hidden={hasAriaLabel ? undefined : 'true'}
-					aria-label={hasAriaLabel ? this.state._label : undefined}
-					class={clsx(BEM_CLASS_ICON__ICON, this.state._icons)}
-					part="icon"
-					role={hasAriaLabel ? 'img' : 'presentation'}
-				></i>
+				<KolIconFc icons={this.state._icons} label={this.state._label} />
 			</Host>
 		);
 	}

--- a/packages/components/src/components/icon/style.scss
+++ b/packages/components/src/components/icon/style.scss
@@ -3,7 +3,8 @@
 
 @layer kol-component {
 	/* :host implicitly inherits font-size, see below */
-	:host {
+	:host,
+	.kol-icon {
 		color: inherit;
 		display: contents;
 

--- a/packages/components/src/components/input-checkbox/style.scss
+++ b/packages/components/src/components/input-checkbox/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-field-control-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;
@@ -55,7 +56,7 @@
 			z-index: 1;
 			pointer-events: none;
 
-			&::part(icon) {
+			.kol-icon__icon {
 				display: none;
 			}
 		}
@@ -67,7 +68,7 @@
 
 		&#{$root}--checked,
 		&#{$root}--indeterminate {
-			.kol-icon::part(icon) {
+			.kol-icon__icon {
 				display: block;
 			}
 		}

--- a/packages/components/src/components/input-color/style.scss
+++ b/packages/components/src/components/input-color/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/input-date/style.scss
+++ b/packages/components/src/components/input-date/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/input-email/style.scss
+++ b/packages/components/src/components/input-email/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/input-file/style.scss
+++ b/packages/components/src/components/input-file/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/input-number/style.scss
+++ b/packages/components/src/components/input-number/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/input-password/style.scss
+++ b/packages/components/src/components/input-password/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/input-radio/style.scss
+++ b/packages/components/src/components/input-radio/style.scss
@@ -1,4 +1,5 @@
 @use '../@shared/mixins' as *;
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../host-display-block' as *;
 @use '../../styles/kol-alert-mixin' as *;

--- a/packages/components/src/components/input-range/style.scss
+++ b/packages/components/src/components/input-range/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/input-text/style.scss
+++ b/packages/components/src/components/input-text/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
-import { KolIconTag, KolTooltipWcTag } from '../../core/component-names';
+import { KolTooltipWcTag } from '../../core/component-names';
 import type {
 	AccessKeyPropType,
 	AlternativeButtonLinkRolePropType,
@@ -57,7 +57,7 @@ import type { UnsubscribeFunction } from './ariaCurrentService';
 import { onLocationChange } from './ariaCurrentService';
 
 import clsx from 'clsx';
-import { KolSpanFc } from '../../functional-components';
+import { KolIconFc, KolSpanFc } from '../../functional-components';
 import { translate } from '../../i18n';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 
@@ -197,10 +197,10 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 						<slot name="expert" slot="expert"></slot>
 					</KolSpanFc>
 					{isExternal && (
-						<KolIconTag
+						<KolIconFc
 							class="kol-link__icon"
-							_label={this.state._hideLabel ? '' : this.translateOpenLinkInTab}
-							_icons={'kolicon-link-external'}
+							label={this.state._hideLabel ? '' : this.translateOpenLinkInTab}
+							icons="kolicon-link-external"
 							aria-hidden={this.state._hideLabel}
 						/>
 					)}

--- a/packages/components/src/components/link/style.scss
+++ b/packages/components/src/components/link/style.scss
@@ -1,6 +1,7 @@
-@use '../@shared/mixins' as *;
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../@shared/kol-link-mixin' as *;
+@use '../@shared/mixins' as *;
 
 @layer kol-component {
 	@include kol-link-styles('kol-link');

--- a/packages/components/src/components/select/style.scss
+++ b/packages/components/src/components/select/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../@shared/kol-select-mixin' as *;
 
 @layer kol-component {

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -26,12 +26,13 @@ import type {
 } from '../../schema';
 
 import clsx from 'clsx';
-import { KolButtonWcTag, KolIconTag } from '../../core/component-names';
+import { KolButtonWcTag } from '../../core/component-names';
 import { getRenderStates } from '../../functional-component-wrappers/_helpers/getRenderStates';
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper';
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import type { InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import KolInputStateWrapperFc from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
+import { KolIconFc } from '../../functional-components';
 import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggestionsOption/CustomSuggestionsOption';
 import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
 import { translate } from '../../i18n';
@@ -349,9 +350,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 							/>
 						)}
 
-						<KolIconTag
-							_icons="kolicon-chevron-down"
-							_label=""
+						<KolIconFc
+							icons="kolicon-chevron-down"
+							label=""
 							class={clsx('kol-custom-suggestions-toggle', {
 								'kol-custom-suggestions-toggle--disabled': isDisabled,
 							})}

--- a/packages/components/src/components/single-select/style.scss
+++ b/packages/components/src/components/single-select/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-custom-suggestions-option' as *;

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -3,7 +3,8 @@ import { Component, Element, Fragment, h, Listen, Prop, State, Watch } from '@st
 
 import clsx from 'clsx';
 import { isEqual } from 'lodash-es';
-import { KolButtonWcTag, KolIconTag, KolTableSettingsWcTag, KolTooltipWcTag } from '../../core/component-names';
+import { KolButtonWcTag, KolTableSettingsWcTag, KolTooltipWcTag } from '../../core/component-names';
+import { KolIconFc } from '../../functional-components';
 import type { TranslationKey } from '../../i18n';
 import { translate } from '../../i18n';
 import type {
@@ -526,7 +527,7 @@ export class KolTableStateless implements TableStatelessAPI {
 								'kol-table__selection-label--disabled': disabled,
 							})}
 						>
-							<KolIconTag class="kol-table__selection-icon" _icons={`kolicon ${selected ? 'kolicon-check' : ''}`} _label="" />
+							<KolIconFc class="kol-table__selection-icon" icons={`kolicon ${selected ? 'kolicon-check' : ''}`} label="" />
 							<input
 								class={clsx('kol-table__selection-input kol-table__selection-input--checkbox')}
 								ref={(el) => el && this.checkboxRefs.push(el)}
@@ -791,7 +792,7 @@ export class KolTableStateless implements TableStatelessAPI {
 					})}
 				>
 					<label class="kol-table__selection-label">
-						<KolIconTag class="kol-table__selection-icon" _icons={`kolicon ${indeterminate ? 'kolicon-minus' : isChecked ? 'kolicon-check' : ''}`} _label="" />
+						<KolIconFc class="kol-table__selection-icon" icons={`kolicon ${indeterminate ? 'kolicon-minus' : isChecked ? 'kolicon-check' : ''}`} label="" />
 						<input
 							class={clsx('kol-table__selection-input kol-table__selection-input--checkbox')}
 							data-testid="selection-checkbox-all"

--- a/packages/components/src/components/table-stateless/style.scss
+++ b/packages/components/src/components/table-stateless/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../@shared/kol-button-mixin' as *;

--- a/packages/components/src/components/textarea/style.scss
+++ b/packages/components/src/components/textarea/style.scss
@@ -1,3 +1,4 @@
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
 @use '../../styles/kol-form-field-mixin' as *;

--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -1,7 +1,8 @@
 import { Component, Element, h, Host, type JSX, Method, Prop, State, Watch } from '@stencil/core';
 
 import clsx from 'clsx';
-import { KolIconTag, KolLinkWcTag, KolTreeTag } from '../../core/component-names';
+import { KolLinkWcTag, KolTreeTag } from '../../core/component-names';
+import { KolIconFc } from '../../functional-components';
 import type { ActivePropType, HrefPropType, LabelPropType, OpenPropType, TreeItemAPI, TreeItemStates } from '../../schema';
 import { validateActive, validateHref, validateLabel, validateOpen } from '../../schema';
 import { nonce } from '../../utils/dev.utils';
@@ -47,10 +48,10 @@ export class KolTreeItemWc implements TreeItemAPI {
 									class="kol-tree-item__toggle-button"
 									onClick={(event) => (_open ? void this.handleCollapseClick(event) : void this.handleExpandClick(event))}
 								>
-									<KolIconTag
+									<KolIconFc
 										class="kol-tree-item__toggle-button-icon"
-										_icons={`kolicon kolicon-${_open ? 'chevron-down' : 'chevron-right'}`}
-										_label={'' /* Label deliberately left empty */}
+										icons={`kolicon kolicon-${_open ? 'chevron-down' : 'chevron-right'}`}
+										label={'' /* Label deliberately left empty */}
 									/>
 								</span>
 							) : (

--- a/packages/components/src/components/tree-item/style.scss
+++ b/packages/components/src/components/tree-item/style.scss
@@ -1,5 +1,6 @@
-@use '../@shared/mixins' as *;
+@use '../../assets/kolicons/style' as *;
 @use '../../styles/global' as *;
+@use '../@shared/mixins' as *;
 
 @layer kol-component {
 	$base-horizontal-padding: to-rem(8);

--- a/packages/components/src/functional-components/AlertIcon/AlertIcon.tsx
+++ b/packages/components/src/functional-components/AlertIcon/AlertIcon.tsx
@@ -1,8 +1,8 @@
 import { Fragment, h, type FunctionalComponent as FC } from '@stencil/core';
-import { KolIconTag } from '../../core/component-names';
 import { translate } from '../../i18n';
 import type { AlertType } from '../../schema';
 import { BEM_CLASS_ALERT__ICON } from '../Alert/bem';
+import { KolIconFc } from '../Icon';
 
 const translateError = translate('kol-error');
 const translateInfo = translate('kol-info');
@@ -19,7 +19,7 @@ const Icon: FC<{ ariaLabel: string; icon: string; label?: string }> = ({ ariaLab
 	return (
 		<>
 			<span class="visually-hidden">{ariaLabel}</span>
-			<KolIconTag class={BEM_CLASS_ALERT__ICON} _label="" _icons={icon} />
+			<KolIconFc class={BEM_CLASS_ALERT__ICON} label="" icons={icon} />
 		</>
 	);
 };

--- a/packages/components/src/functional-components/Icon/Icon.tsx
+++ b/packages/components/src/functional-components/Icon/Icon.tsx
@@ -1,17 +1,33 @@
 import { h, type FunctionalComponent as FC } from '@stencil/core';
-import { KolIconTag } from '../../core/component-names';
+import type { JSXBase } from '@stencil/core/internal';
+import clsx from 'clsx';
+import { BEM_CLASS_ICON, BEM_CLASS_ICON__ICON } from '../../components/icon/bem';
 import type { InternalIconProps } from '../../schema';
 
-export type IconProps = InternalIconProps & {
-	class?: string;
-	style?: { [key: string]: string };
-	onClick?: (event: MouseEvent) => void;
-};
+export type IconProps = InternalIconProps &
+	Omit<JSXBase.HTMLAttributes<HTMLElement>, 'class' | 'style' | 'onClick'> & {
+		class?: string;
+		style?: { [key: string]: string };
+		onClick?: (event: MouseEvent) => void;
+	};
 
 const KolIconFc: FC<IconProps> = (props) => {
-	const { class: classNames, style, icons, label, onClick } = props;
+	const { class: classNames, style, icons, label, onClick, ...other } = props;
+	const labelText = label ?? '';
+	const hasAriaLabel = labelText.length > 0;
 
-	return <KolIconTag class={classNames} style={style} onClick={onClick} _icons={icons} _label={label} />;
+	return (
+		<i
+			aria-hidden={hasAriaLabel ? undefined : 'true'}
+			aria-label={hasAriaLabel ? labelText : undefined}
+			class={clsx(BEM_CLASS_ICON, BEM_CLASS_ICON__ICON, icons, classNames)}
+			part="icon"
+			role={hasAriaLabel ? 'img' : 'presentation'}
+			style={style}
+			onClick={onClick}
+			{...other}
+		></i>
+	);
 };
 
 export default KolIconFc;


### PR DESCRIPTION
### Motivation
- Centralise the icon render output so functional components can reuse the same DOM markup instead of relying on the `kol-icon` web component tag. 
- Ensure icons rendered inline by functional components are styled correctly by importing the icon font CSS where needed. 

### Description
- Introduced `KolIconFc` (functional component) which renders the icon `<i>` element with the expected ARIA attributes and classes and replaced many `KolIconTag` usages with `KolIconFc` (examples: `kol-icon` shadow, `link`, `breadcrumb`, `combobox`, `single-select`, `tree-item`, `table-stateless`, `AlertIcon`).
- Updated the `kol-icon` shadow implementation to delegate rendering to `KolIconFc` so behaviour remains consistent for both WC and FC usage. 
- Imported the icon font stylesheet `@use '../../assets/kolicons/style' as *;` into component SCSS files that now render icons inline and adjusted style selectors (e.g. replacing `::part(icon)` usages with selectors matching the inline markup such as `.kol-icon__icon`).
- Minor type/prop updates for `KolIconFc` to accept standard HTML attributes and pass them through when used inline; closes `https://github.com/public-ui/kolibri/issues/8177`.

### Testing
- Ran the repository formatter with `pnpm format` and applied fixes, which completed successfully. 
- No additional automated unit or e2e tests were executed as part of this change in the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ae5a97544832f810b265285a7558c)