### PR TITLE
refactor(components): render icons via functional component and import kolicons styles

### DIFF
--- a/packages/components/src/components/alert/style.scss
+++ b/packages/components/src/components/alert/style.scss
@@ -1,5 +1,6 @@
 @use '../../styles/global' as *;
 @use '../../styles/kol-alert-mixin' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/alert/test/__snapshots__/snapshot.spec.tsx.snap
@@ -10,7 +10,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -36,7 +38,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -62,7 +66,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -88,7 +94,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -114,7 +122,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -140,7 +150,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -166,7 +178,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -192,7 +206,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -218,7 +234,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -244,7 +262,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -270,7 +290,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -296,7 +318,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -322,7 +346,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -348,7 +374,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -374,7 +402,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -400,7 +430,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -426,7 +458,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -452,7 +486,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -478,7 +514,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -504,7 +542,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -530,7 +570,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -556,7 +598,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -582,7 +626,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -608,7 +654,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -634,7 +682,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -660,7 +710,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -686,7 +738,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -712,7 +766,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -738,7 +794,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -764,7 +822,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -790,7 +850,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -816,7 +878,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -842,7 +906,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -868,7 +934,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -894,7 +962,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=false _level=
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -920,7 +990,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -946,7 +1018,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -972,7 +1046,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -998,7 +1074,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -1024,7 +1102,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=0
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
               Überschrift
@@ -1050,7 +1130,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -1076,7 +1158,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -1102,7 +1186,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -1128,7 +1214,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -1154,7 +1242,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=1
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h1 class="kol-alert__heading kol-alert__heading--h1 kol-headline kol-headline--h1 kol-headline--single" id="heading">
               Überschrift
@@ -1180,7 +1270,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -1206,7 +1298,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -1232,7 +1326,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -1258,7 +1354,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -1284,7 +1382,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=2
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h2 class="kol-alert__heading kol-alert__heading--h2 kol-headline kol-headline--h2 kol-headline--single" id="heading">
               Überschrift
@@ -1310,7 +1410,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -1336,7 +1438,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -1362,7 +1466,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -1388,7 +1494,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -1414,7 +1522,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=3
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h3 class="kol-alert__heading kol-alert__heading--h3 kol-headline kol-headline--h3 kol-headline--single" id="heading">
               Überschrift
@@ -1440,7 +1550,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -1466,7 +1578,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -1492,7 +1606,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -1518,7 +1634,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -1544,7 +1662,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=4
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h4 class="kol-alert__heading kol-alert__heading--h4 kol-headline kol-headline--h4 kol-headline--single" id="heading">
               Überschrift
@@ -1570,7 +1690,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -1596,7 +1718,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -1622,7 +1746,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -1648,7 +1774,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -1674,7 +1802,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=5
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h5 class="kol-alert__heading kol-alert__heading--h5 kol-headline kol-headline--h5 kol-headline--single" id="heading">
               Überschrift
@@ -1700,7 +1830,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
           <span class="visually-hidden">
             kol-message
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -1726,7 +1858,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
           <span class="visually-hidden">
             kol-error
           </span>
-          <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -1752,7 +1886,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
           <span class="visually-hidden">
             kol-info
           </span>
-          <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -1778,7 +1914,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
           <span class="visually-hidden">
             kol-success
           </span>
-          <kol-icon _icons="kolicon-alert-success" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-success" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift
@@ -1804,7 +1942,9 @@ exports[`kol-alert should render with _label="Überschrift" _alert=true _level=6
           <span class="visually-hidden">
             kol-warning
           </span>
-          <kol-icon _icons="kolicon-alert-warning" _label="" class="kol-alert__icon"></kol-icon>
+          <span class="kol-alert__icon kol-icon">
+            <i aria-hidden="true" class="kol-icon__icon kolicon-alert-warning" part="icon" role="presentation"></i>
+          </span>
           <div class="kol-alert__container-content">
             <h6 class="kol-alert__heading kol-alert__heading--h6 kol-headline kol-headline--h6 kol-headline--single" id="heading">
               Überschrift

--- a/packages/components/src/components/badge/style.scss
+++ b/packages/components/src/components/badge/style.scss
@@ -1,6 +1,7 @@
 @use '../@shared/mixins' as *;
 @use '../../styles/global' as *;
 @use '../tooltip/style.scss' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	.kol-badge {

--- a/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/badge/test/__snapshots__/snapshot.spec.tsx.snap
@@ -61,7 +61,9 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
     <span class="kol-badge" style="background-color: #000; color: #959595;">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
-          <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+          <span class="icon kol-icon left">
+            <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+          </span>
           <span class="kol-span__label md">
             Text
           </span>
@@ -79,7 +81,9 @@ exports[`kol-badge should render with _label="Text" _icons="codicon codicon-home
     <span class="kol-badge" style="background-color: #000; color: #959595;">
       <span class="kol-badge__label kol-span">
         <span class="kol-span__container">
-          <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+          <span class="icon kol-icon left">
+            <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+          </span>
           <span class="kol-span__label md">
             Text
           </span>

--- a/packages/components/src/components/breadcrumb/shadow.tsx
+++ b/packages/components/src/components/breadcrumb/shadow.tsx
@@ -6,7 +6,8 @@ import { addNavLabel, removeNavLabel } from '../../utils/unique-nav-labels';
 import { watchNavLinks } from '../nav/validation';
 
 import type { JSX } from '@stencil/core';
-import { KolIconTag, KolLinkWcTag } from '../../core/component-names';
+import { KolLinkWcTag } from '../../core/component-names';
+import { KolIconFc } from '../../functional-components';
 
 @Component({
 	tag: 'kol-breadcrumb',
@@ -23,7 +24,7 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 				{index === lastIndex ? (
 					<span class="kol-breadcrumb__list-element-span" aria-current="page">
 						{link._hideLabel ? (
-							<KolIconTag class="kol-breadcrumb__icon" _label={link._label} _icons={typeof link._icons === 'string' ? link._icons : 'kolicon-link'} />
+							<KolIconFc class="kol-breadcrumb__icon" label={link._label} icons={typeof link._icons === 'string' ? link._icons : 'kolicon-link'} />
 						) : (
 							<>{link._label}</>
 						)}
@@ -31,7 +32,7 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 				) : (
 					<KolLinkWcTag class="kol-breadcrumb__link" _inline={false} {...link}></KolLinkWcTag>
 				)}
-				{index !== lastIndex && <KolIconTag class="kol-breadcrumb__separator" _label="" _icons="kolicon-chevron-right" />}
+				{index !== lastIndex && <KolIconFc class="kol-breadcrumb__separator" label="" icons="kolicon-chevron-right" />}
 			</li>
 		);
 	};
@@ -42,7 +43,7 @@ export class KolBreadcrumb implements BreadcrumbAPI {
 				<ul class="kol-breadcrumb__list">
 					{this.state._links.length === 0 && (
 						<li>
-							<KolIconTag class="kol-breadcrumb_icon" _label="" _icons="kolicon-house" />…
+							<KolIconFc class="kol-breadcrumb_icon" label="" icons="kolicon-house" />…
 						</li>
 					)}
 					{this.state._links.map(this.renderLink)}

--- a/packages/components/src/components/breadcrumb/style.scss
+++ b/packages/components/src/components/breadcrumb/style.scss
@@ -1,6 +1,7 @@
 @use '../../styles/global' as *;
 @use '../@shared/kol-link-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-link-styles('kol-link');

--- a/packages/components/src/components/button/style.scss
+++ b/packages/components/src/components/button/style.scss
@@ -1,6 +1,7 @@
 @use '../@shared/mixins' as *;
 @use '../../styles/global' as *;
 @use '../@shared/kol-button-mixin' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-button-styles('kol-button');

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -1,12 +1,13 @@
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
 import clsx from 'clsx';
-import { KolButtonWcTag, KolIconTag } from '../../core/component-names';
+import { KolButtonWcTag } from '../../core/component-names';
 import { getRenderStates } from '../../functional-component-wrappers/_helpers/getRenderStates';
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper';
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import type { InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import KolInputStateWrapperFc from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
+import { KolIconFc } from '../../functional-components';
 import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggestionsOption/CustomSuggestionsOption';
 import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
 import { translate } from '../../i18n';
@@ -280,9 +281,9 @@ export class KolCombobox implements ComboboxAPI {
 								}}
 							/>
 						)}
-						<KolIconTag
-							_icons="kolicon-chevron-down"
-							_label=""
+						<KolIconFc
+							icons="kolicon-chevron-down"
+							label=""
 							class={clsx('kol-custom-suggestions-toggle', {
 								'kol-custom-suggestions-toggle--disabled': isDisabled,
 							})}

--- a/packages/components/src/components/combobox/style.scss
+++ b/packages/components/src/components/combobox/style.scss
@@ -7,6 +7,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -18,7 +18,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -45,7 +47,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -72,7 +76,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input kol-input--disabled" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _disabled="" _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete kol-combobox__delete--disabled" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle kol-custom-suggestions-toggle--disabled"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-custom-suggestions-toggle--disabled kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -99,7 +105,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -126,17 +134,23 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -159,13 +173,17 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end"></div>
@@ -194,11 +212,15 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -224,7 +246,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-error" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input kol-input--error kol-input--touched" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -251,7 +275,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-msg" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -278,7 +304,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -306,7 +334,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-keyshortcuts="S" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -333,7 +363,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input kol-input--touched" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -360,7 +392,9 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
               <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" class="kol-combobox__delete" data-testid="combobox-delete"></kol-button-wc>
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>

--- a/packages/components/src/components/details/style.scss
+++ b/packages/components/src/components/details/style.scss
@@ -21,7 +21,7 @@
 		}
 
 		.collapsible--open &__heading-button {
-			.kol-icon::part(icon) {
+			.kol-icon__icon {
 				transform: rotate(90deg);
 			}
 		}

--- a/packages/components/src/components/icon/shadow.tsx
+++ b/packages/components/src/components/icon/shadow.tsx
@@ -3,8 +3,8 @@ import type { IconAPI, IconStates, LabelPropType } from '../../schema';
 import { IconController } from './controller';
 
 import type { JSX } from '@stencil/core';
-import clsx from 'clsx';
-import { BEM_CLASS_ICON, BEM_CLASS_ICON__ICON } from './bem';
+import KolIconFc from '../../functional-components/Icon';
+import { BEM_CLASS_ICON } from './bem';
 
 /**
  * @part icon - Ermöglicht das Styling des inneren Icons.
@@ -19,22 +19,9 @@ import { BEM_CLASS_ICON, BEM_CLASS_ICON__ICON } from './bem';
 export class KolIcon implements IconAPI {
 	private readonly controller: IconController;
 	public render(): JSX.Element {
-		const hasAriaLabel = this.state._label.length > 0;
 		return (
 			<Host exportparts="icon" class={BEM_CLASS_ICON}>
-				<i
-					/**
-					 * Die Auszeichnung `aria-hidden` ist eigentlich nicht erforderlich, da die aktuellen
-					 * Screenreader, wie NVDA und JAWS, es auch ohne `aria-hidden` nicht vorlesen.
-					 *
-					 * Referenz: https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden
-					 */
-					aria-hidden={hasAriaLabel ? undefined : 'true'}
-					aria-label={hasAriaLabel ? this.state._label : undefined}
-					class={clsx(BEM_CLASS_ICON__ICON, this.state._icons)}
-					part="icon"
-					role={hasAriaLabel ? 'img' : 'presentation'}
-				></i>
+				<KolIconFc icons={this.state._icons} label={this.state._label} />
 			</Host>
 		);
 	}

--- a/packages/components/src/components/icon/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/icon/test/__snapshots__/snapshot.spec.tsx.snap
@@ -3,7 +3,9 @@
 exports[`kol-icon should render with _label="Aria-Label" _icons="codicon codicon-home" 1`] = `
 <kol-icon class="kol-icon" exportparts="icon">
   <template shadowrootmode="open">
-    <i aria-label="Aria-Label" class="codicon codicon-home kol-icon__icon" part="icon" role="img"></i>
+    <span class="kol-icon">
+      <i aria-label="Aria-Label" class="codicon codicon-home kol-icon__icon" part="icon" role="img"></i>
+    </span>
   </template>
 </kol-icon>
 `;

--- a/packages/components/src/components/input-checkbox/style.scss
+++ b/packages/components/src/components/input-checkbox/style.scss
@@ -4,6 +4,7 @@
 @use '../@shared/mixins' as *;
 @use '../host-display-block' as *;
 @use '../tooltip/style' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-form-field;
@@ -55,7 +56,7 @@
 			z-index: 1;
 			pointer-events: none;
 
-			&::part(icon) {
+			.kol-icon__icon {
 				display: none;
 			}
 		}
@@ -67,7 +68,7 @@
 
 		&#{$root}--checked,
 		&#{$root}--indeterminate {
-			.kol-icon::part(icon) {
+			.kol-icon__icon {
 				display: block;
 			}
 		}

--- a/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-checkbox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -16,7 +16,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -42,7 +44,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -68,7 +72,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--disabled kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--disabled" disabled="" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -94,7 +100,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -123,7 +131,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -149,7 +159,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -175,7 +187,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -201,7 +215,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--error kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--error kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -227,7 +243,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -253,7 +271,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -280,7 +300,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -306,7 +328,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -332,7 +356,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -351,7 +377,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -378,7 +406,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -404,7 +434,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--disabled kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--disabled visually-hidden" disabled="" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -430,7 +462,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -459,7 +493,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -485,7 +521,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -511,7 +549,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -537,7 +577,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--error kol-checkbox--touched kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--error kol-input--touched visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -563,7 +605,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -589,7 +633,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -615,7 +661,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -642,7 +690,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--touched kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--touched visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -668,7 +718,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -694,7 +746,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -721,7 +775,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -747,7 +803,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--disabled kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--disabled" disabled="" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -773,7 +831,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -802,7 +862,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -828,7 +890,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -854,7 +918,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -880,7 +946,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--error kol-checkbox--touched kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--error kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -906,7 +974,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -932,7 +1002,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -958,7 +1030,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -985,7 +1059,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--touched kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1011,7 +1087,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-cross" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-cross" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1045,7 +1123,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1071,7 +1151,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1097,7 +1179,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--disabled kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--disabled" disabled="" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1123,7 +1207,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1152,7 +1238,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1178,7 +1266,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1204,7 +1294,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1230,7 +1322,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--error kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--error kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1256,7 +1350,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1282,7 +1378,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1309,7 +1407,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1335,7 +1435,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1361,7 +1463,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
           </label>
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1380,7 +1484,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1407,7 +1513,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1433,7 +1541,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--disabled kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--disabled" disabled="" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1459,7 +1569,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1488,7 +1600,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1514,7 +1628,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1540,7 +1656,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1566,7 +1684,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--error kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--error kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1592,7 +1712,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1618,7 +1740,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1644,7 +1768,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1671,7 +1797,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1697,7 +1825,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1723,7 +1853,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1750,7 +1882,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1776,7 +1910,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--disabled kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--disabled visually-hidden" disabled="" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1802,7 +1938,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1831,7 +1969,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1857,7 +1997,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1883,7 +2025,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1909,7 +2053,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--error kol-checkbox--touched kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--error kol-input--touched visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1935,7 +2081,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1961,7 +2109,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -1987,7 +2137,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2014,7 +2166,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--touched kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--touched visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2040,7 +2194,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-button">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-button">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input visually-hidden" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2066,7 +2222,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2093,7 +2251,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2119,7 +2279,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--disabled kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--disabled" disabled="" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2145,7 +2307,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2174,7 +2338,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2200,7 +2366,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2226,7 +2394,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2252,7 +2422,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--error kol-checkbox--touched kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--error kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2278,7 +2450,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2304,7 +2478,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2330,7 +2506,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2357,7 +2535,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--touched kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input kol-input--touched" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2383,7 +2563,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--checked kol-input-checkbox__field-control--variant-switch">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--checked kol-checkbox--variant-switch">
-              <kol-icon _icons="kolicon-check" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-check" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" checked="" class="kol-checkbox__input kol-input" id="id-nonce" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2409,7 +2591,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input accesskey="V" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2436,7 +2620,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2462,7 +2648,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--disabled kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--disabled kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--disabled" disabled="" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2488,7 +2676,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2517,7 +2707,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2543,7 +2735,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2569,7 +2763,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2595,7 +2791,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--error kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--error kol-checkbox--indeterminate kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--error kol-input--touched" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2621,7 +2819,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2647,7 +2847,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2673,7 +2875,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2700,7 +2904,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-field-control--touched kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--touched kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input kol-input--touched" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>
@@ -2726,7 +2932,9 @@ exports[`kol-input-checkbox should render with _label="Label" _name="field" _pla
         <div class="kol-field-control kol-field-control--label-align-right kol-input-checkbox__field-control kol-input-checkbox__field-control--indeterminate kol-input-checkbox__field-control--variant-default">
           <div class="kol-field-control__input">
             <label class="kol-checkbox kol-checkbox--indeterminate kol-checkbox--variant-default">
-              <kol-icon _icons="kolicon-minus" _label="" class="kol-checkbox__icon"></kol-icon>
+              <span class="kol-checkbox__icon kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
               <input autocapitalize="off" autocorrect="off" class="kol-checkbox__input kol-input" id="id-nonce" indeterminate="" name="field" type="checkbox" value="true">
             </label>
           </div>

--- a/packages/components/src/components/input-color/style.scss
+++ b/packages/components/src/components/input-color/style.scss
@@ -4,6 +4,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-color/test/__snapshots__/snapshot.spec.tsx.snap
@@ -122,7 +122,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -131,7 +133,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -154,7 +158,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -191,7 +197,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -457,7 +465,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -466,7 +476,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -489,7 +501,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-color__inputs-wrapper">
@@ -526,7 +540,9 @@ exports[`kol-input-color should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-date/style.scss
+++ b/packages/components/src/components/input-date/style.scss
@@ -4,6 +4,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-date/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,17 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="9999-12-31" name="field" type="date" value="2025-01-01">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -139,7 +143,9 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="9999-12-31" name="field" type="date" value="2025-01-01">
@@ -170,7 +176,9 @@ exports[`kol-input-date should render with _label="Label" _name="field" _placeho
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" max="9999-12-31" name="field" type="date" value="2025-01-01">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-email/style.scss
+++ b/packages/components/src/components/input-email/style.scss
@@ -4,6 +4,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-email/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,17 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -139,7 +143,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
@@ -170,7 +176,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -432,7 +440,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
@@ -443,7 +453,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -466,7 +478,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" name="field" placeholder="Hier steht ein Platzhaltertext" type="email" value="email@example.com">
@@ -507,7 +521,9 @@ exports[`kol-input-email should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-file/style.scss
+++ b/packages/components/src/components/input-file/style.scss
@@ -5,6 +5,7 @@
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
 @use '../@shared/kol-button-mixin' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-file/test/__snapshots__/snapshot.spec.tsx.snap
@@ -126,7 +126,9 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <span class="kol-input-container__filename">
@@ -136,7 +138,9 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
             <kol-button-wc _buttonvariant="primary" _label="kol-data-browse-text" class="kol-input-container__button"></kol-button-wc>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -159,7 +163,9 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <span class="kol-input-container__filename">
@@ -198,7 +204,9 @@ exports[`kol-input-file should render with _label="Label" _name="field" _placeho
             <kol-button-wc _buttonvariant="primary" _label="kol-data-browse-text" class="kol-input-container__button"></kol-button-wc>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-number/style.scss
+++ b/packages/components/src/components/input-number/style.scss
@@ -4,6 +4,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-number/test/__snapshots__/snapshot.spec.tsx.snap
@@ -16,7 +16,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -24,7 +26,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -49,7 +53,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -57,7 +63,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -105,7 +113,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -113,7 +123,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -141,17 +153,25 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="number">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -176,16 +196,22 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="number">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -210,16 +236,22 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="number">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -244,7 +276,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container kol-input-container--error">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -252,7 +286,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -277,7 +313,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -285,7 +323,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -337,7 +377,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -345,7 +387,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -370,7 +414,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -379,7 +425,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -405,7 +453,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -418,7 +468,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -443,7 +495,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -456,7 +510,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -509,7 +565,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -522,7 +580,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -550,9 +610,13 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" name="field" placeholder="Hier steht ein Platzhaltertext" type="number">
@@ -563,9 +627,13 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -590,9 +658,13 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" list="id-nonce-list" name="field" placeholder="Hier steht ein Platzhaltertext" type="number">
@@ -604,7 +676,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -629,7 +703,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -641,9 +717,13 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -668,7 +748,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container kol-input-container--error">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -681,7 +763,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -706,7 +790,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -719,7 +805,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -776,7 +864,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -789,7 +879,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -814,7 +906,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -828,7 +922,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <kol-button-wc _hidelabel="" _label="einblenden" class="kol-input-container__smart-button"></kol-button-wc>
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -853,7 +949,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -866,7 +964,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -891,7 +991,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -904,7 +1006,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -929,7 +1033,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -937,7 +1043,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>
@@ -962,7 +1070,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-down" data-testid="kol-input-number-step-down" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-minus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-minus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
           <div class="kol-input-container__container">
@@ -970,7 +1080,9 @@ exports[`kol-input-number should render with _label="Label" _name="field" _place
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
             <button class="kol-input-container__smart-button kol-input-number__step-button kol-input-number__step-button-up" data-testid="kol-input-number-step-up" tabindex="-1" type="button">
-              <kol-icon _icons="kolicon-plus" _label=""></kol-icon>
+              <span class="kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-plus" part="icon" role="presentation"></i>
+              </span>
             </button>
           </div>
         </div>

--- a/packages/components/src/components/input-password/style.scss
+++ b/packages/components/src/components/input-password/style.scss
@@ -4,6 +4,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-password/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,17 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="password" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -139,7 +143,9 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="password" value="Value">
@@ -170,7 +176,9 @@ exports[`kol-input-password should render with _label="Label" _name="field" _pla
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="password" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-range/style.scss
+++ b/packages/components/src/components/input-range/style.scss
@@ -4,6 +4,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-range/test/__snapshots__/snapshot.spec.tsx.snap
@@ -122,7 +122,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 2em);">
@@ -131,7 +133,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -154,7 +158,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 2em);">
@@ -191,7 +197,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -475,7 +483,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 2em);">
@@ -496,7 +506,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -519,7 +531,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-input-range__inputs-wrapper" style="--kolibri-input-range--input-number--width: calc(2ch + 2em);">
@@ -580,7 +594,9 @@ exports[`kol-input-range should render with _label="Label" _name="field" _placeh
             </datalist>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/input-text/style.scss
+++ b/packages/components/src/components/input-text/style.scss
@@ -4,6 +4,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/input-text/test/__snapshots__/snapshot.spec.tsx.snap
@@ -110,13 +110,17 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" spellcheck="" type="text" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -139,7 +143,9 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" spellcheck="" type="text" value="Value">
@@ -170,7 +176,9 @@ exports[`kol-input-text should render with _label="Label" _name="field" _placeho
             <input autocapitalize="off" autocomplete="off" autocorrect="off" class="kol-input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" spellcheck="" type="text" value="Value">
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
-import { KolIconTag, KolTooltipWcTag } from '../../core/component-names';
+import { KolTooltipWcTag } from '../../core/component-names';
 import type {
 	AccessKeyPropType,
 	AlternativeButtonLinkRolePropType,
@@ -57,7 +57,7 @@ import type { UnsubscribeFunction } from './ariaCurrentService';
 import { onLocationChange } from './ariaCurrentService';
 
 import clsx from 'clsx';
-import { KolSpanFc } from '../../functional-components';
+import { KolIconFc, KolSpanFc } from '../../functional-components';
 import { translate } from '../../i18n';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 
@@ -197,10 +197,10 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 						<slot name="expert" slot="expert"></slot>
 					</KolSpanFc>
 					{isExternal && (
-						<KolIconTag
+						<KolIconFc
 							class="kol-link__icon"
-							_label={this.state._hideLabel ? '' : this.translateOpenLinkInTab}
-							_icons={'kolicon-link-external'}
+							label={this.state._hideLabel ? '' : this.translateOpenLinkInTab}
+							icons={'kolicon-link-external'}
 							aria-hidden={this.state._hideLabel}
 						/>
 					)}

--- a/packages/components/src/components/link/style.scss
+++ b/packages/components/src/components/link/style.scss
@@ -1,6 +1,7 @@
 @use '../@shared/mixins' as *;
 @use '../../styles/global' as *;
 @use '../@shared/kol-link-mixin' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-link-styles('kol-link');

--- a/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -8,7 +8,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
       <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
-            <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+            <span class="icon kol-icon left">
+              <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <span class="kol-span__label">
               Label
             </span>
@@ -17,7 +19,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             </span>
           </span>
         </span>
-        <kol-icon _icons="kolicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
+        <span class="kol-icon kol-link__icon">
+          <i aria-label="kol-open-link-in-tab" class="kol-icon__icon kolicon-link-external" part="icon" role="img"></i>
+        </span>
       </a>
     </kol-link-wc>
   </template>
@@ -32,7 +36,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
       <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
-            <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+            <span class="icon kol-icon left">
+              <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <span class="kol-span__label">
               Label
             </span>
@@ -41,7 +47,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             </span>
           </span>
         </span>
-        <kol-icon _icons="kolicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
+        <span class="kol-icon kol-link__icon">
+          <i aria-label="kol-open-link-in-tab" class="kol-icon__icon kolicon-link-external" part="icon" role="img"></i>
+        </span>
       </a>
     </kol-link-wc>
   </template>
@@ -56,7 +64,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
       <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
-            <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+            <span class="icon kol-icon left">
+              <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <span class="kol-span__label">
               Label
             </span>
@@ -65,7 +75,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             </span>
           </span>
         </span>
-        <kol-icon _icons="kolicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
+        <span class="kol-icon kol-link__icon">
+          <i aria-label="kol-open-link-in-tab" class="kol-icon__icon kolicon-link-external" part="icon" role="img"></i>
+        </span>
       </a>
     </kol-link-wc>
   </template>
@@ -80,13 +92,17 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
       <a aria-label="Label (kol-open-link-in-tab)" class="kol-link kol-link--external-link kol-link--hide-label kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span kol-span--hide-label">
           <span class="kol-span__container">
-            <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+            <span class="icon kol-icon left">
+              <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <span aria-hidden="true" class="kol-span__label" hidden="">
               <slot name="expert" slot="expert"></slot>
             </span>
           </span>
         </span>
-        <kol-icon _icons="kolicon-link-external" _label="" aria-hidden="" class="kol-link__icon"></kol-icon>
+        <span aria-hidden="" class="kol-icon kol-link__icon">
+          <i aria-hidden="true" class="kol-icon__icon kolicon-link-external" part="icon" role="presentation"></i>
+        </span>
       </a>
       <kol-tooltip-wc _align="top" _label="Label" aria-hidden="true" class="kol-link__tooltip"></kol-tooltip-wc>
     </kol-link-wc>
@@ -102,7 +118,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
       <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
-            <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+            <span class="icon kol-icon left">
+              <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <span class="kol-span__label">
               Label
             </span>
@@ -111,7 +129,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             </span>
           </span>
         </span>
-        <kol-icon _icons="kolicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
+        <span class="kol-icon kol-link__icon">
+          <i aria-label="kol-open-link-in-tab" class="kol-icon__icon kolicon-link-external" part="icon" role="img"></i>
+        </span>
       </a>
     </kol-link-wc>
   </template>
@@ -126,7 +146,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
       <a class="kol-link kol-link--external-link kol-link--inline kol-link--normal" href="https://example.com" rel="noopener" target="self">
         <span class="kol-link__text kol-span">
           <span class="kol-span__container">
-            <kol-icon _icons="codicon codicon-home" _label="" class="icon left"></kol-icon>
+            <span class="icon kol-icon left">
+              <i aria-hidden="true" class="codicon codicon-home kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
             <span class="kol-span__label">
               Label
             </span>
@@ -135,7 +157,9 @@ exports[`kol-link should render with _href="https://example.com" _icons="codicon
             </span>
           </span>
         </span>
-        <kol-icon _icons="kolicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
+        <span class="kol-icon kol-link__icon">
+          <i aria-label="kol-open-link-in-tab" class="kol-icon__icon kolicon-link-external" part="icon" role="img"></i>
+        </span>
       </a>
     </kol-link-wc>
   </template>
@@ -158,7 +182,9 @@ exports[`kol-link should render with _label="Label" _href="" _download="download
             </span>
           </span>
         </span>
-        <kol-icon _icons="kolicon-link-external" _label="kol-open-link-in-tab" class="kol-link__icon"></kol-icon>
+        <span class="kol-icon kol-link__icon">
+          <i aria-label="kol-open-link-in-tab" class="kol-icon__icon kolicon-link-external" part="icon" role="img"></i>
+        </span>
       </a>
     </kol-link-wc>
   </template>

--- a/packages/components/src/components/select/style.scss
+++ b/packages/components/src/components/select/style.scss
@@ -1,4 +1,5 @@
 @use '../@shared/kol-select-mixin' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-select;

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -26,12 +26,13 @@ import type {
 } from '../../schema';
 
 import clsx from 'clsx';
-import { KolButtonWcTag, KolIconTag } from '../../core/component-names';
+import { KolButtonWcTag } from '../../core/component-names';
 import { getRenderStates } from '../../functional-component-wrappers/_helpers/getRenderStates';
 import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../../functional-component-wrappers/FormFieldStateWrapper/FormFieldStateWrapper';
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import type { InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import KolInputStateWrapperFc from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
+import { KolIconFc } from '../../functional-components';
 import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggestionsOption/CustomSuggestionsOption';
 import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
 import { translate } from '../../i18n';
@@ -349,9 +350,9 @@ export class KolSingleSelect implements SingleSelectAPI {
 							/>
 						)}
 
-						<KolIconTag
-							_icons="kolicon-chevron-down"
-							_label=""
+						<KolIconFc
+							icons="kolicon-chevron-down"
+							label=""
 							class={clsx('kol-custom-suggestions-toggle', {
 								'kol-custom-suggestions-toggle--disabled': isDisabled,
 							})}

--- a/packages/components/src/components/single-select/style.scss
+++ b/packages/components/src/components/single-select/style.scss
@@ -7,6 +7,7 @@
 @use '../../styles/kol-input-container-mixin' as *;
 @use '../../styles/kol-input-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	@include kol-alert;

--- a/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -17,7 +17,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -43,7 +45,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -69,7 +73,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-single-select__input" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle kol-custom-suggestions-toggle--disabled"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-custom-suggestions-toggle--disabled kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -95,7 +101,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -122,16 +130,22 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -154,12 +168,16 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end"></div>
@@ -187,11 +205,15 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -216,7 +238,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -242,7 +266,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -268,7 +294,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -295,7 +323,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -321,7 +351,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--touched kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>
@@ -347,7 +379,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
               <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" type="text" value="">
-              <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle"></kol-icon>
+              <span class="kol-custom-suggestions-toggle kol-icon">
+                <i aria-hidden="true" class="kol-icon__icon kolicon-chevron-down" part="icon" role="presentation"></i>
+              </span>
             </div>
           </div>
         </div>

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -3,7 +3,8 @@ import { Component, Element, Fragment, h, Listen, Prop, State, Watch } from '@st
 
 import clsx from 'clsx';
 import { isEqual } from 'lodash-es';
-import { KolButtonWcTag, KolIconTag, KolTableSettingsWcTag, KolTooltipWcTag } from '../../core/component-names';
+import { KolButtonWcTag, KolTableSettingsWcTag, KolTooltipWcTag } from '../../core/component-names';
+import { KolIconFc } from '../../functional-components';
 import type { TranslationKey } from '../../i18n';
 import { translate } from '../../i18n';
 import type {
@@ -526,7 +527,7 @@ export class KolTableStateless implements TableStatelessAPI {
 								'kol-table__selection-label--disabled': disabled,
 							})}
 						>
-							<KolIconTag class="kol-table__selection-icon" _icons={`kolicon ${selected ? 'kolicon-check' : ''}`} _label="" />
+							<KolIconFc class="kol-table__selection-icon" icons={`kolicon ${selected ? 'kolicon-check' : ''}`} label="" />
 							<input
 								class={clsx('kol-table__selection-input kol-table__selection-input--checkbox')}
 								ref={(el) => el && this.checkboxRefs.push(el)}
@@ -791,7 +792,7 @@ export class KolTableStateless implements TableStatelessAPI {
 					})}
 				>
 					<label class="kol-table__selection-label">
-						<KolIconTag class="kol-table__selection-icon" _icons={`kolicon ${indeterminate ? 'kolicon-minus' : isChecked ? 'kolicon-check' : ''}`} _label="" />
+						<KolIconFc class="kol-table__selection-icon" icons={`kolicon ${indeterminate ? 'kolicon-minus' : isChecked ? 'kolicon-check' : ''}`} label="" />
 						<input
 							class={clsx('kol-table__selection-input kol-table__selection-input--checkbox')}
 							data-testid="selection-checkbox-all"

--- a/packages/components/src/components/table-stateless/style.scss
+++ b/packages/components/src/components/table-stateless/style.scss
@@ -4,6 +4,7 @@
 @use '../@shared/kol-popover-button-mixin' as *;
 @use '../@shared/kol-table-stateless-mixin' as *;
 @use '../@shared/mixins' as *;
+@use '../../../assets/kolicons/style' as *;
 @use '../host-display-block' as *;
 @use '../tooltip/style' as *;
 

--- a/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/textarea/test/__snapshots__/snapshot.spec.tsx.snap
@@ -106,12 +106,16 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container"><textarea autocapitalize="off" autocorrect="off" class="kol-textarea" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" rows="5" value="Value" style="resize: vertical;"></textarea>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>
@@ -134,7 +138,9 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
       <div class="kol-form-field__input">
         <div class="kol-input-container">
           <div class="kol-input-container__adornment kol-input-container__adornment--start">
-            <kol-icon _icons="codicon codicon-arrow-left" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-left kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
           <div class="kol-input-container__container"><textarea autocapitalize="off" autocorrect="off" class="kol-textarea" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" rows="5" value="Value" style="resize: vertical;"></textarea>
           </div>
@@ -163,7 +169,9 @@ exports[`kol-textarea should render with _label="Label" _name="field" _placehold
           <div class="kol-input-container__container"><textarea autocapitalize="off" autocorrect="off" class="kol-textarea" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" rows="5" value="Value" style="resize: vertical;"></textarea>
           </div>
           <div class="kol-input-container__adornment kol-input-container__adornment--end">
-            <kol-icon _icons="codicon codicon-arrow-right" _label="" class="kol-input-container__icon"></kol-icon>
+            <span class="kol-icon kol-input-container__icon" hidelabel="">
+              <i aria-hidden="true" class="codicon codicon-arrow-right kol-icon__icon" part="icon" role="presentation"></i>
+            </span>
           </div>
         </div>
       </div>

--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -1,7 +1,8 @@
 import { Component, Element, h, Host, type JSX, Method, Prop, State, Watch } from '@stencil/core';
 
 import clsx from 'clsx';
-import { KolIconTag, KolLinkWcTag, KolTreeTag } from '../../core/component-names';
+import { KolLinkWcTag, KolTreeTag } from '../../core/component-names';
+import { KolIconFc } from '../../functional-components';
 import type { ActivePropType, HrefPropType, LabelPropType, OpenPropType, TreeItemAPI, TreeItemStates } from '../../schema';
 import { validateActive, validateHref, validateLabel, validateOpen } from '../../schema';
 import { nonce } from '../../utils/dev.utils';
@@ -47,10 +48,10 @@ export class KolTreeItemWc implements TreeItemAPI {
 									class="kol-tree-item__toggle-button"
 									onClick={(event) => (_open ? void this.handleCollapseClick(event) : void this.handleExpandClick(event))}
 								>
-									<KolIconTag
+									<KolIconFc
 										class="kol-tree-item__toggle-button-icon"
-										_icons={`kolicon kolicon-${_open ? 'chevron-down' : 'chevron-right'}`}
-										_label={'' /* Label deliberately left empty */}
+										icons={`kolicon kolicon-${_open ? 'chevron-down' : 'chevron-right'}`}
+										label={'' /* Label deliberately left empty */}
 									/>
 								</span>
 							) : (

--- a/packages/components/src/components/tree-item/style.scss
+++ b/packages/components/src/components/tree-item/style.scss
@@ -1,5 +1,6 @@
 @use '../@shared/mixins' as *;
 @use '../../styles/global' as *;
+@use '../../../assets/kolicons/style' as *;
 
 @layer kol-component {
 	$base-horizontal-padding: to-rem(8);

--- a/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Alert/test/__snapshots__/snapshot.test.tsx.snap
@@ -6,7 +6,9 @@ exports[`KolAlertFc should render 1`] = `
     <span class="visually-hidden">
       kol-message
     </span>
-    <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+    <span class="kol-alert__icon kol-icon">
+      <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+    </span>
     <div class="kol-alert__container-content">
       <span class="kol-alert__content"></span>
     </div>

--- a/packages/components/src/functional-components/AlertIcon/AlertIcon.tsx
+++ b/packages/components/src/functional-components/AlertIcon/AlertIcon.tsx
@@ -1,8 +1,8 @@
 import { Fragment, h, type FunctionalComponent as FC } from '@stencil/core';
-import { KolIconTag } from '../../core/component-names';
 import { translate } from '../../i18n';
 import type { AlertType } from '../../schema';
 import { BEM_CLASS_ALERT__ICON } from '../Alert/bem';
+import KolIconFc from '../Icon';
 
 const translateError = translate('kol-error');
 const translateInfo = translate('kol-info');
@@ -19,7 +19,7 @@ const Icon: FC<{ ariaLabel: string; icon: string; label?: string }> = ({ ariaLab
 	return (
 		<>
 			<span class="visually-hidden">{ariaLabel}</span>
-			<KolIconTag class={BEM_CLASS_ALERT__ICON} _label="" _icons={icon} />
+			<KolIconFc class={BEM_CLASS_ALERT__ICON} label="" icons={icon} />
 		</>
 	);
 };

--- a/packages/components/src/functional-components/FormField/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/FormField/tests/__snapshots__/snapshot.test.tsx.snap
@@ -82,7 +82,9 @@ exports[`KolFormFieldFc should render with error message 1`] = `
       <span class="visually-hidden">
         kol-error
       </span>
-      <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+      <span class="kol-alert__icon kol-icon">
+        <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+      </span>
       <div class="kol-alert__container-content">
         <span class="kol-alert__content">
           Error message

--- a/packages/components/src/functional-components/FormFieldMsg/tests/__snapshots__/snapshort.test.tsx.snap
+++ b/packages/components/src/functional-components/FormFieldMsg/tests/__snapshots__/snapshort.test.tsx.snap
@@ -6,7 +6,9 @@ exports[`FormFieldMsgFc should render with all props 1`] = `
     <span class="visually-hidden">
       kol-error
     </span>
-    <kol-icon _icons="kolicon-alert-error" _label="" class="kol-alert__icon"></kol-icon>
+    <span class="kol-alert__icon kol-icon">
+      <i aria-hidden="true" class="kol-icon__icon kolicon-alert-error" part="icon" role="presentation"></i>
+    </span>
     <div class="kol-alert__container-content">
       <span class="kol-alert__content">
         This is an error message

--- a/packages/components/src/functional-components/Icon/Icon.tsx
+++ b/packages/components/src/functional-components/Icon/Icon.tsx
@@ -1,17 +1,38 @@
 import { h, type FunctionalComponent as FC } from '@stencil/core';
-import { KolIconTag } from '../../core/component-names';
+import type { JSXBase } from '@stencil/core/internal';
+import clsx from 'clsx';
+import { BEM_CLASS_ICON, BEM_CLASS_ICON__ICON } from '../../components/icon/bem';
 import type { InternalIconProps } from '../../schema';
 
-export type IconProps = InternalIconProps & {
-	class?: string;
-	style?: { [key: string]: string };
-	onClick?: (event: MouseEvent) => void;
-};
+export type IconProps = InternalIconProps &
+	Omit<JSXBase.HTMLAttributes<HTMLSpanElement>, 'class' | 'style' | 'onClick'> & {
+		class?: string;
+		style?: { [key: string]: string };
+		onClick?: (event: MouseEvent) => void;
+	};
 
 const KolIconFc: FC<IconProps> = (props) => {
-	const { class: classNames, style, icons, label, onClick } = props;
+	const { class: classNames, style, icons, label, onClick, ...other } = props;
+	const labelText = label ?? '';
+	const hasAriaLabel = labelText.length > 0;
 
-	return <KolIconTag class={classNames} style={style} onClick={onClick} _icons={icons} _label={label} />;
+	return (
+		<span class={clsx(BEM_CLASS_ICON, classNames)} style={style} onClick={onClick} {...other}>
+			<i
+				/**
+				 * Die Auszeichnung `aria-hidden` ist eigentlich nicht erforderlich, da die aktuellen
+				 * Screenreader, wie NVDA und JAWS, es auch ohne `aria-hidden` nicht vorlesen.
+				 *
+				 * Referenz: https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden
+				 */
+				aria-hidden={hasAriaLabel ? undefined : 'true'}
+				aria-label={hasAriaLabel ? labelText : undefined}
+				class={clsx(BEM_CLASS_ICON__ICON, icons)}
+				part="icon"
+				role={hasAriaLabel ? 'img' : 'presentation'}
+			></i>
+		</span>
+	);
 };
 
 export default KolIconFc;

--- a/packages/components/src/functional-components/Icon/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Icon/tests/__snapshots__/snapshot.test.tsx.snap
@@ -1,30 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`KolIconFc should render correctly 1`] = `
-<kol-icon
-  _icons="test"
-  _label="test"
-/>
+<span class="kol-icon">
+  <i aria-label="test" class="kol-icon__icon test" part="icon" role="img"></i>
+</span>
 `;
 
 exports[`KolIconFc should render with the correct class 1`] = `
-<kol-icon
-  _icons="test"
-  _label="test"
-  class="test-class"
-/>
+<span class="kol-icon test-class">
+  <i aria-label="test" class="kol-icon__icon test" part="icon" role="img"></i>
+</span>
 `;
 
 exports[`KolIconFc should render with the correct icons and label 1`] = `
-<kol-icon
-  _icons="test-icons"
-  _label="test-label"
-/>
+<span class="kol-icon">
+  <i aria-label="test-label" class="kol-icon__icon test-icons" part="icon" role="img"></i>
+</span>
 `;
 
 exports[`KolIconFc should render with the correct style 1`] = `
-<kol-icon
-  _icons="test"
-  _label="test"
-/>
+<span class="kol-icon" style="color: red;">
+  <i aria-label="test" class="kol-icon__icon test" part="icon" role="img"></i>
+</span>
 `;

--- a/packages/components/src/functional-components/Icon/tests/snapshot.test.tsx
+++ b/packages/components/src/functional-components/Icon/tests/snapshot.test.tsx
@@ -34,7 +34,8 @@ describe('KolIconFc', () => {
 		const label = 'test-label';
 		const page = await renderFunctionalComponentToSpecPage(() => <KolIconFc icons={icons} label={label} />);
 		expect(page.root).toMatchSnapshot();
-		expect(page.root?.getAttribute('_icons')).toBe(icons);
-		expect(page.root?.getAttribute('_label')).toBe(label);
+		const iconElement = page.root?.querySelector('i');
+		expect(iconElement?.classList.contains(icons)).toBe(true);
+		expect(iconElement?.getAttribute('aria-label')).toBe(label);
 	});
 });

--- a/packages/components/src/functional-components/IconButton/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/IconButton/tests/__snapshots__/snapshot.test.tsx.snap
@@ -9,10 +9,9 @@ exports[`KolIconButtonFc should render button component correctly 1`] = `
 `;
 
 exports[`KolIconButtonFc should render icon component correctly 1`] = `
-<kol-icon
-  _icons="test-icon"
-  _label=""
-/>
+<span class="kol-icon" hidelabel="">
+  <i aria-hidden="true" class="kol-icon__icon test-icon" part="icon" role="presentation"></i>
+</span>
 `;
 
 exports[`KolIconButtonFc should render with additional props 1`] = `

--- a/packages/components/src/functional-components/IconButton/tests/snapshot.test.tsx
+++ b/packages/components/src/functional-components/IconButton/tests/snapshot.test.tsx
@@ -16,7 +16,7 @@ describe('KolIconButtonFc', () => {
 		const props: IconButtonProps = { componentName: 'icon', icon: 'test-icon' };
 		const page = await renderFunctionalComponentToSpecPage(() => <KolIconButtonFc {...props} />);
 		expect(page.root).toMatchSnapshot();
-		expect(page.root?.tagName).toBe('KOL-ICON');
+		expect(page.root?.tagName).toBe('SPAN');
 	});
 
 	it('should handle onClick event', async () => {

--- a/packages/components/src/functional-components/InputAdornment/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/InputAdornment/tests/__snapshots__/snapshot.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`KolInputContainerFc should render correctly 1`] = `<div class="kol-inpu
 
 exports[`KolInputContainerFc should render with children 1`] = `
 <div class="kol-input-container__adornment kol-input-container__adornment--start">
-  <kol-icon _icons="start-icon" _label=""></kol-icon>
+  <span class="kol-icon" hidelabel="">
+    <i aria-hidden="true" class="kol-icon__icon start-icon" part="icon" role="presentation"></i>
+  </span>
 </div>
 `;

--- a/packages/components/src/functional-components/InputContainer/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/InputContainer/tests/__snapshots__/snapshot.test.tsx.snap
@@ -9,11 +9,15 @@ exports[`KolInputContainerFc should render correctly 1`] = `
 exports[`KolInputContainerFc should render with both startAdornment and endAdornment 1`] = `
 <div class="kol-input-container">
   <div class="kol-input-container__adornment kol-input-container__adornment--start">
-    <kol-icon _icons="start-icon" _label=""></kol-icon>
+    <span class="kol-icon" hidelabel="">
+      <i aria-hidden="true" class="kol-icon__icon start-icon" part="icon" role="presentation"></i>
+    </span>
   </div>
   <div class="kol-input-container__container"></div>
   <div class="kol-input-container__adornment kol-input-container__adornment--end">
-    <kol-icon _icons="end-icon" _label=""></kol-icon>
+    <span class="kol-icon" hidelabel="">
+      <i aria-hidden="true" class="end-icon kol-icon__icon" part="icon" role="presentation"></i>
+    </span>
   </div>
 </div>
 `;
@@ -31,7 +35,9 @@ exports[`KolInputContainerFc should render with endAdornment 1`] = `
   <div class="kol-input-container__adornment kol-input-container__adornment--start"></div>
   <div class="kol-input-container__container"></div>
   <div class="kol-input-container__adornment kol-input-container__adornment--end">
-    <kol-icon _icons="end-icon" _label=""></kol-icon>
+    <span class="kol-icon" hidelabel="">
+      <i aria-hidden="true" class="end-icon kol-icon__icon" part="icon" role="presentation"></i>
+    </span>
   </div>
 </div>
 `;
@@ -39,7 +45,9 @@ exports[`KolInputContainerFc should render with endAdornment 1`] = `
 exports[`KolInputContainerFc should render with startAdornment 1`] = `
 <div class="kol-input-container">
   <div class="kol-input-container__adornment kol-input-container__adornment--start">
-    <kol-icon _icons="start-icon" _label=""></kol-icon>
+    <span class="kol-icon" hidelabel="">
+      <i aria-hidden="true" class="kol-icon__icon start-icon" part="icon" role="presentation"></i>
+    </span>
   </div>
   <div class="kol-input-container__container"></div>
   <div class="kol-input-container__adornment kol-input-container__adornment--end"></div>

--- a/packages/components/src/functional-components/InputContainer/tests/snapshot.test.tsx
+++ b/packages/components/src/functional-components/InputContainer/tests/snapshot.test.tsx
@@ -16,7 +16,7 @@ describe('KolInputContainerFc', () => {
 			<KolInputContainerFc startAdornment={(<KolIconButtonFc componentName="icon" icon="start-icon" />) as VNode} />
 		));
 		expect(page.root).toMatchSnapshot();
-		expect(page.root?.querySelector('kol-icon')).not.toBeNull();
+		expect(page.root?.querySelector('.kol-icon')).not.toBeNull();
 	});
 
 	it('should render with endAdornment', async () => {
@@ -24,7 +24,7 @@ describe('KolInputContainerFc', () => {
 			<KolInputContainerFc endAdornment={(<KolIconButtonFc componentName="icon" icon="end-icon" />) as VNode} />
 		));
 		expect(page.root).toMatchSnapshot();
-		expect(page.root?.querySelector('kol-icon')).not.toBeNull();
+		expect(page.root?.querySelector('.kol-icon')).not.toBeNull();
 	});
 
 	it('should render with both startAdornment and endAdornment', async () => {
@@ -35,7 +35,7 @@ describe('KolInputContainerFc', () => {
 			/>
 		));
 		expect(page.root).toMatchSnapshot();
-		expect(page.root?.querySelectorAll('kol-icon')).toHaveLength(2);
+		expect(page.root?.querySelectorAll('.kol-icon')).toHaveLength(2);
 	});
 
 	it('should render with children', async () => {

--- a/packages/components/src/functional-components/Span/test/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/Span/test/__snapshots__/snapshot.test.tsx.snap
@@ -51,15 +51,23 @@ exports[`KolSpanFc should render with default props 1`] = `
 
 exports[`KolSpanFc should render with icons 1`] = `
 <span class="kol-span">
-  <kol-icon _icons="top-icon" _label="" class="icon top"></kol-icon>
+  <span class="icon kol-icon top">
+    <i aria-hidden="true" class="kol-icon__icon top-icon" part="icon" role="presentation"></i>
+  </span>
   <span class="kol-span__container">
-    <kol-icon _icons="left-icon" _label="" class="icon left"></kol-icon>
+    <span class="icon kol-icon left">
+      <i aria-hidden="true" class="kol-icon__icon left-icon" part="icon" role="presentation"></i>
+    </span>
     <span class="kol-span__label">
       Label with Icons
     </span>
     <span aria-hidden="true" class="kol-span__label" hidden=""></span>
-    <kol-icon _icons="right-icon" _label="" class="icon right"></kol-icon>
+    <span class="icon kol-icon right">
+      <i aria-hidden="true" class="kol-icon__icon right-icon" part="icon" role="presentation"></i>
+    </span>
   </span>
-  <kol-icon _icons="bottom-icon" _label="" class="bottom icon"></kol-icon>
+  <span class="bottom icon kol-icon">
+    <i aria-hidden="true" class="bottom-icon kol-icon__icon" part="icon" role="presentation"></i>
+  </span>
 </span>
 `;

--- a/packages/components/src/functional-components/ToastItem/tests/__snapshots__/snapshot.test.tsx.snap
+++ b/packages/components/src/functional-components/ToastItem/tests/__snapshots__/snapshot.test.tsx.snap
@@ -7,7 +7,9 @@ exports[`ToastItemFc should render with basic props and status 1`] = `
       <span class="visually-hidden">
         kol-info
       </span>
-      <kol-icon _icons="kolicon-alert-info" _label="" class="kol-alert__icon"></kol-icon>
+      <span class="kol-alert__icon kol-icon">
+        <i aria-hidden="true" class="kol-icon__icon kolicon-alert-info" part="icon" role="presentation"></i>
+      </span>
       <div class="kol-alert__container-content">
         <strong class="kol-alert__heading kol-alert__heading--h0 kol-headline kol-headline--single kol-headline--strong" id="heading">
           Test Toast

--- a/packages/components/src/styles/_global.scss
+++ b/packages/components/src/styles/_global.scss
@@ -1,6 +1,7 @@
 @use '../components/a11y' as *;
 @use '../components/preset' as *;
 @use '../components/@shared/mixins' as *;
+@use '../../assets/kolicons/style' as *;
 
 @layer kol-global {
 	:host {

--- a/packages/themes/default/src/components/breadcrumb.scss
+++ b/packages/themes/default/src/components/breadcrumb.scss
@@ -10,7 +10,7 @@
 		}
 
 		&__link {
-			&::part(icon) {
+			.kol-icon__icon {
 				font-size: to-rem(20);
 			}
 		}

--- a/packages/themes/default/src/components/tree-item.scss
+++ b/packages/themes/default/src/components/tree-item.scss
@@ -34,7 +34,7 @@
 			}
 		}
 
-		&__toggle-button:hover &__toggle-button-icon::part(icon) {
+		&__toggle-button:hover &__toggle-button-icon .kol-icon__icon {
 			transform: scale(1.6);
 		}
 

--- a/packages/themes/ecl/src/ecl-ec/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/nav.scss
@@ -41,11 +41,11 @@
 				margin: auto;
 			}
 
-			&--expanded .kol-icon::part(icon)::before {
+			&--expanded .kol-icon__icon::before {
 				content: '\eab4';
 			}
 
-			&:not(&--expanded) .kol-icon::part(icon)::before {
+			&:not(&--expanded) .kol-icon__icon::before {
 				content: '\eab6';
 			}
 		}

--- a/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-ec/components/tree-item.scss
@@ -44,7 +44,7 @@
 			}
 		}
 
-		&__toggle-button:hover &__toggle-button-icon::part(icon) {
+		&__toggle-button:hover &__toggle-button-icon .kol-icon__icon {
 			transform: scale(1.3);
 		}
 

--- a/packages/themes/ecl/src/ecl-eu/components/accordion.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/accordion.scss
@@ -64,7 +64,7 @@
 			.kol-icon {
 				margin-right: to-rem(12);
 
-				&::part(icon)::before {
+				.kol-icon__icon::before {
 					color: #0e47cb;
 
 					font-family: 'Font Awesome 6 Free';
@@ -93,12 +93,12 @@
 				border-start-start-radius: to-rem(8);
 			}
 
-			.kol-icon::part(icon)::before {
+			.kol-icon__icon::before {
 				content: '\f077';
 			}
 		}
 
-		:not(.collapsible--open) &__heading-button .kol-button .kol-icon::part(icon)::before {
+		:not(.collapsible--open) &__heading-button .kol-button .kol-icon__icon::before {
 			content: '\f078';
 		}
 	}

--- a/packages/themes/ecl/src/ecl-eu/components/nav.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/nav.scss
@@ -45,11 +45,11 @@
 				margin: auto;
 			}
 
-			&--expanded .kol-icon::part(icon)::before {
+			&--expanded .kol-icon__icon::before {
 				content: '\eab4';
 			}
 
-			&:not(&--expanded) .kol-icon::part(icon)::before {
+			&:not(&--expanded) .kol-icon__icon::before {
 				content: '\eab6';
 			}
 		}

--- a/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
+++ b/packages/themes/ecl/src/ecl-eu/components/tree-item.scss
@@ -47,7 +47,7 @@
 			color: var(--color-blue);
 		}
 
-		&__toggle-button:hover &__toggle-button-icon::part(icon) {
+		&__toggle-button:hover &__toggle-button-icon .kol-icon__icon {
 			transform: scale(1.3);
 		}
 


### PR DESCRIPTION
### Motivation

- Unify icon rendering by extracting the markup into a functional component so other functional components can reuse the same inline DOM instead of relying on the `kol-icon` web component.
- Ensure icons rendered with the icon font are visible when rendering via the functional component by importing the KolIcons CSS where needed and adapting style selectors.

### Description

- Added `KolIconFc` functional component and refactored `kol-icon` to delegate its rendering to `KolIconFc`, emitting an inline `<span><i/></span>` structure instead of relying on the custom element output.
- Replaced usages of the web-component wrapper (previously `KolIconTag`/`<kol-icon>`) in multiple components with `KolIconFc` (examples: `link`, `tree-item`, `combobox`, `single-select`, `table-stateless`, `breadcrumb`, `alert`, `input-*` components and several functional components).
- Imported the `kolicons` stylesheet into component SCSS (and the components global SCSS) and updated theme/style rules to target the inner icon element (replacing `::part(icon)` with selectors like `.kol-icon__icon` and adjusting other icon selectors accordingly).
- Updated snapshot tests and unit test expectations to reflect the new markup (icon rendered as a `.kol-icon` span with an inner `<i>`), and adapted a few tests to query `.kol-icon` instead of `kol-icon`.

### Testing

- Ran unit snapshot update with `pnpm --filter @public-ui/components test:update:unit`; all test suites passed after adjustments (final run: 80 test suites passed, snapshots updated where intended). 
- Ran code formatting with `pnpm format` to ensure style consistency and updated affected files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ae5ce168c832f8cf56adce43e611a)