### PR TITLE
fix(samples): fix handout table card responsive layout for v2

### DIFF
--- a/packages/samples/react/src/components/handout/basic.tsx
+++ b/packages/samples/react/src/components/handout/basic.tsx
@@ -497,8 +497,8 @@ export const HandoutBasic: FC = () => {
 						</div>
 					</KolForm>
 				</KolCard>
-				<KolCard className="col-span-6 sm:col-span-6 md:col-span-4 xl:col-span-5" _label="Table with Pagination" _level={2}>
-					<div slot="" className="grid gap-2 p-2">
+				<KolCard className="col-span-6 sm:col-span-6 md:col-span-6 xl:col-span-5" _label="Table with Pagination" _level={2}>
+					<div slot="" className="grid gap-2 p-2 handout-table-card-content">
 						<KolTable _label="Table" _headers={TABLE_HEADERS} _data={TABLE_DATA} _pagination></KolTable>
 					</div>
 				</KolCard>

--- a/packages/samples/react/src/style.scss
+++ b/packages/samples/react/src/style.scss
@@ -89,3 +89,9 @@ hr {
 		display: none !important;
 	}
 }
+
+
+.handout-table-card-content {
+	max-width: calc(100vw - 95px);
+	overflow: auto;
+}


### PR DESCRIPTION
## What changed?

The handout sample's table card grid span was corrected from `md:col-span-4` to `md:col-span-6` to prevent clipping on medium-width viewports. A new CSS class `handout-table-card-content` was added with `max-width: calc(100vw - 95px)` and `overflow: auto` to allow horizontal scrolling when the table exceeds the viewport width. This fix applies to the v2 sample application only.

## Linked issues

- Refs #9260 — handout table card clipped on responsive layouts

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Grid-Span-Klasse der Tabellenkarte im Handout-Sample wurde von `md:col-span-4` auf `md:col-span-6` korrigiert, um ein Abschneiden auf mittelbreiten Viewports zu vermeiden. Eine neue CSS-Klasse `handout-table-card-content` mit `max-width: calc(100vw - 95px)` und `overflow: auto` wurde hinzugefügt, damit die Tabelle bei Überschreitung der Viewport-Breite horizontal scrollbar ist. Dieser Fix betrifft ausschließlich die v2-Sample-Anwendung.

### Verknüpfte Tickets

- Referenziert #9260 — Tabellenkarte im Handout auf responsiven Layouts abgeschnitten

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/samples/react/src/components/handout/basic.tsx` — Grid-Span-Klasse korrigiert, CSS-Klasse hinzugefügt
- `packages/samples/react/src/style.scss` — `.handout-table-card-content`-Klasse mit overflow-Verhalten hinzugefügt

</details>