### PR TITLE
refactor(components): remove shadow-root query selector deps and use native query selectors

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -102,8 +102,6 @@
 		"figlet": "1.9.4",
 		"lodash-es": "4.17.22",
 		"markdown-it": "14.1.0",
-		"query-selector-all-shadow-root": "0.0.3",
-		"query-selector-shadow-root": "0.0.3",
 		"rgba-convert": "0.3.0",
 		"typed-bem": "1.0.2",
 		"wcag-contrast": "3.0.0"

--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -1,7 +1,5 @@
 import type { Generic } from 'adopted-style-sheets';
 import { getCssStyle, patchTheme, patchThemeTag } from 'adopted-style-sheets';
-import { querySelectorAll } from 'query-selector-all-shadow-root';
-import { querySelector } from 'query-selector-shadow-root';
 import rgba from 'rgba-convert';
 import { hex, score } from 'wcag-contrast';
 
@@ -299,11 +297,78 @@ export const mapStringOrBoolean2String = (value?: string | boolean): string | un
 	return typeof value === 'string' ? value : mapBoolean2String(value);
 };
 
+const querySelectorShadow = <T extends Element>(selector: string, rootNode: Document | HTMLElement | ShadowRoot): T | null => {
+	const visited = new Set<Node>();
+	const queue: ParentNode[] = [rootNode];
+	let index = 0;
+	while (index < queue.length) {
+		const current = queue[index++];
+		if (visited.has(current)) {
+			continue;
+		}
+		visited.add(current);
+		if (current instanceof Element && current.matches(selector)) {
+			return current as T;
+		}
+		const children = Array.from(current.children || []);
+		for (let i = 0; i < children.length; i++) {
+			queue.push(children[i]);
+		}
+		if (current instanceof HTMLElement && current.shadowRoot) {
+			queue.push(current.shadowRoot);
+		}
+		if (current instanceof HTMLSlotElement) {
+			const assigned = current.assignedNodes({ flatten: true });
+			for (let i = 0; i < assigned.length; i++) {
+				if (assigned[i] instanceof Element) {
+					queue.push(assigned[i] as HTMLElement);
+				}
+			}
+		}
+	}
+	return null;
+};
+
+const querySelectorAllShadow = <T extends Element>(selector: string, rootNode: Document | HTMLElement | ShadowRoot): T[] => {
+	const visited = new Set<Node>();
+	const results: T[] = [];
+	const resultSet = new Set<Element>();
+	const queue: ParentNode[] = [rootNode];
+	let index = 0;
+	while (index < queue.length) {
+		const current = queue[index++];
+		if (visited.has(current)) {
+			continue;
+		}
+		visited.add(current);
+		if (current instanceof Element && current.matches(selector) && !resultSet.has(current)) {
+			results.push(current as T);
+			resultSet.add(current);
+		}
+		const children = Array.from(current.children || []);
+		for (let i = 0; i < children.length; i++) {
+			queue.push(children[i]);
+		}
+		if (current instanceof HTMLElement && current.shadowRoot) {
+			queue.push(current.shadowRoot);
+		}
+		if (current instanceof HTMLSlotElement) {
+			const assigned = current.assignedNodes({ flatten: true });
+			for (let i = 0; i < assigned.length; i++) {
+				if (assigned[i] instanceof Element) {
+					queue.push(assigned[i] as HTMLElement);
+				}
+			}
+		}
+	}
+	return results;
+};
+
 export const koliBriQuerySelector = <T extends Element>(selector: string, node?: Document | HTMLElement | ShadowRoot): T | null =>
-	querySelector<T>(selector, node || getDocument());
+	querySelectorShadow<T>(selector, node || getDocument());
 
 export const koliBriQuerySelectorAll = <T extends Element>(selector: string, node?: Document | HTMLElement | ShadowRoot): T[] =>
-	querySelectorAll<T>(selector, node || getDocument());
+	querySelectorAllShadow<T>(selector, node || getDocument());
 
 interface A11yColorContrast {
 	backgroundColor: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,12 +475,6 @@ importers:
       markdown-it:
         specifier: 14.1.0
         version: 14.1.0
-      query-selector-all-shadow-root:
-        specifier: 0.0.3
-        version: 0.0.3
-      query-selector-shadow-root:
-        specifier: 0.0.3
-        version: 0.0.3
       rgba-convert:
         specifier: 0.3.0
         version: 0.3.0
@@ -12800,14 +12794,8 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  query-selector-all-shadow-root@0.0.3:
-    resolution: {integrity: sha512-J7TPo7c+Ut6Wl7Ujk/dToR15eqwu84vJAazgzkcUxCeCtoxbDJPsFs9mBaYoSUfS0ZN3xspLDGBajr0G8d2QZQ==}
-
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
-
-  query-selector-shadow-root@0.0.3:
-    resolution: {integrity: sha512-QXU2+N4fR2g8gqjGRjwg7x2oCiudc+nUAbaOqLtXvAlF7nQ32sRlkgFdpHLwzfeBvyvBgJzN/QFCogGCSjB/bQ==}
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -29113,11 +29101,7 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  query-selector-all-shadow-root@0.0.3: {}
-
   query-selector-shadow-dom@1.0.1: {}
-
-  query-selector-shadow-root@0.0.3: {}
 
   querystringify@2.2.0: {}
 


### PR DESCRIPTION
## What changed?

The third-party packages `query-selector-all-shadow-root` and `query-selector-shadow-root` were removed as dependencies from `@public-ui/components`. Their functionality was replaced by two native, self-contained BFS implementations (`querySelectorShadow` and `querySelectorAllShadow`) written directly in `prop.validators.ts`. Both traverse shadow roots and assigned slots without any external dependency. The public utility functions `koliBriQuerySelector` and `koliBriQuerySelectorAll` now delegate to these native implementations.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Drittanbieter-Pakete `query-selector-all-shadow-root` und `query-selector-shadow-root` wurden als Abhängigkeiten aus `@public-ui/components` entfernt. Ihre Funktionalität wurde durch zwei native, eigenständige BFS-Implementierungen (`querySelectorShadow` und `querySelectorAllShadow`) ersetzt, die direkt in `prop.validators.ts` implementiert wurden und Shadow Roots sowie zugewiesene Slots traversieren. Die öffentlichen Hilfsfunktionen `koliBriQuerySelector` und `koliBriQuerySelectorAll` delegieren nun an diese nativen Implementierungen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/package.json` — Abhängigkeiten `query-selector-all-shadow-root` und `query-selector-shadow-root` entfernt
- `packages/components/src/schema/utils/prop.validators.ts` — Native BFS-Implementierungen für Shadow-DOM-Queries hinzugefügt
- `pnpm-lock.yaml` — Lock-Datei aktualisiert

</details>