### PR TITLE
fix(tabs): add tabindex=0 to tab content for keyboard accessibility

### DIFF
--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -386,6 +386,7 @@ export class KolTabs implements TabsAPI {
 			div.setAttribute('id', `tabpanel-${i}`);
 			div.setAttribute('role', 'tabpanel');
 			div.setAttribute('hidden', '');
+			div.setAttribute('tabindex', '0');
 			const slot = document.createElement('slot');
 			slot.setAttribute('name', `tabpanel-slot-${i}`);
 			div.appendChild(slot);

--- a/packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/tabs/test/__snapshots__/snapshot.spec.tsx.snap
@@ -11,16 +11,16 @@ exports[`kol-tabs should render with _label="Text" _selected=1 _tabs=[{"_icons":
         <kol-button-wc _ariacontrols="tabpanel-3" _icons="codicon codicon-telescope" _id="Text-tab-3" _label="Letzter Tab" _role="tab" _tabindex="-1" _value="3"></kol-button-wc>
       </div>
       <div class="kol-tabs__content">
-        <div aria-labelledby="Text-tab-0" hidden="" id="tabpanel-0" role="tabpanel">
+        <div aria-labelledby="Text-tab-0" hidden="" id="tabpanel-0" role="tabpanel" tabindex="0">
           <slot name="tabpanel-slot-0"></slot>
         </div>
-        <div aria-labelledby="Text-tab-1" id="tabpanel-1" role="tabpanel">
+        <div aria-labelledby="Text-tab-1" id="tabpanel-1" role="tabpanel" tabindex="0">
           <slot name="tabpanel-slot-1"></slot>
         </div>
-        <div aria-labelledby="Text-tab-2" hidden="" id="tabpanel-2" role="tabpanel">
+        <div aria-labelledby="Text-tab-2" hidden="" id="tabpanel-2" role="tabpanel" tabindex="0">
           <slot name="tabpanel-slot-2"></slot>
         </div>
-        <div aria-labelledby="Text-tab-3" hidden="" id="tabpanel-3" role="tabpanel">
+        <div aria-labelledby="Text-tab-3" hidden="" id="tabpanel-3" role="tabpanel" tabindex="0">
           <slot name="tabpanel-slot-3"></slot>
         </div>
       </div>


### PR DESCRIPTION
## What changed?
The `KolTabs` component (v3) was updated to add `tabindex="0"` to the tab content panel, making it reachable via keyboard navigation. Without this attribute, users navigating by keyboard could not focus the tab content area. Two files were modified.

## Linked issues
- Refs #8190 — tab content not focusable via keyboard

## Type of change
- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---
<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?
Die `KolTabs`-Komponente (v3) wurde aktualisiert, um `tabindex="0"` zum Tab-Inhaltsbereich hinzuzufügen, sodass er per Tastaturnavigation erreichbar ist. 2 Dateien wurden geändert.

### Verknüpfte Tickets
- Refs #8190 — Tab-Inhalt nicht per Tastatur fokussierbar

### Art der Änderung
🐛 Bug fix

### Geänderte Dateien
2 Dateien (Tabs-Komponente v3)
</details>