### PR TITLE
fix: externalize react-hook-form adapter dependencies

### DIFF
--- a/packages/adapters/react-hook-form-adapter/build.config.ts
+++ b/packages/adapters/react-hook-form-adapter/build.config.ts
@@ -10,8 +10,8 @@ export default defineBuildConfig({
 	],
 	clean: true,
 	declaration: true,
+	externals: ['@public-ui/react-v19', 'react', 'react-dom', 'react-hook-form'],
 	rollup: {
 		emitCJS: true,
-		inlineDependencies: true,
 	},
 });

--- a/packages/adapters/react-hook-form-adapter/build.config.ts
+++ b/packages/adapters/react-hook-form-adapter/build.config.ts
@@ -10,8 +10,9 @@ export default defineBuildConfig({
 	],
 	clean: true,
 	declaration: true,
-	externals: ['@public-ui/react-v19', 'react', 'react-dom', 'react-hook-form'],
+	externals: ['@public-ui/components', '@public-ui/react-v19', 'react', 'react-dom', 'react-hook-form'],
 	rollup: {
 		emitCJS: true,
+		inlineDependencies: false,
 	},
 });

--- a/packages/samples/react/vite.config.ts
+++ b/packages/samples/react/vite.config.ts
@@ -15,6 +15,9 @@ function getGitCommitHash(): string | null {
 
 export default defineConfig({
 	plugins: [react(), UnoCSS()],
+	resolve: {
+		dedupe: ['react', 'react-dom'],
+	},
 	define: {
 		'process.env.THEME_MODULE': JSON.stringify(process.env.THEME_MODULE || ''),
 		'process.env.THEME_EXPORT': JSON.stringify(process.env.THEME_EXPORT || ''),


### PR DESCRIPTION
## What changed?
The `react-hook-form` adapter package was updated to externalize its React dependencies instead of bundling them. This prevents duplicate React instances from being included in consumer bundles, resolving conflicts that could arise when applications use their own React version alongside the adapter. Two files were modified to configure the proper peer dependency externalization.

## Linked issues
No linked issues.

## Type of change
- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---
<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?
Das `react-hook-form`-Adapter-Paket wurde aktualisiert, um React-Abhängigkeiten zu externalisieren statt sie zu bündeln. Dies verhindert doppelte React-Instanzen in Consumer-Bundles. 2 Dateien wurden angepasst.

### Verknüpfte Tickets
Keine verknüpften Tickets.

### Art der Änderung
🐛 Bug fix

### Geänderte Dateien
2 Dateien (Adapter-Konfiguration)
</details>