### PR TITLE
fix(components): revert skeleton helper changes and ignore them in knip

### DIFF
--- a/packages/components/.knip.json
+++ b/packages/components/.knip.json
@@ -1,6 +1,11 @@
 {
 	"$schema": "https://unpkg.com/knip@5/schema.json",
 	"entry": ["src/components/_skeleton/**/*.tsx"],
+	"ignore": [
+		"src/components/_skeleton/internal/functional-components/icon/controller.ts",
+		"src/components/_skeleton/internal/schema/props/helpers/number.ts",
+		"src/components/_skeleton/internal/schema/props/show.ts"
+	],
 	"ignoreDependencies": [
 		"@floating-ui/dom",
 		"@jest/globals",


### PR DESCRIPTION
## What changed?
Skeleton helper changes introduced in a previous commit were reverted, and the affected files were added to the knip ignore list to prevent them from being flagged as unused code. This is a housekeeping change that restores the previous state of skeleton helpers while ensuring the build tooling does not report false positives.

## Linked issues
No linked issues.

## Type of change
- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---
<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?
Skeleton-Helper-Änderungen aus einem früheren Commit wurden rückgängig gemacht, und die betroffenen Dateien wurden zur Knip-Ignore-Liste hinzugefügt, um falsche Positivmeldungen zu vermeiden.

### Verknüpfte Tickets
Keine verknüpften Tickets.

### Art der Änderung
🔧 Intern (kein Release-Hinweis erforderlich)

### Geänderte Dateien
1 Datei (Knip-Konfiguration)
</details>