### PR TITLE
refactor(components): migrate pagination to skeleton controller

### DIFF
--- a/packages/components/src/components/_skeleton/internal/functional-components/pagination/api.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/pagination/api.tsx
@@ -1,0 +1,27 @@
+import type { BoundaryCountProp } from '../../schema/props/boundary-count';
+import type { CustomClassProp } from '../../schema/props/custom-class';
+import type { HasButtonsProp } from '../../schema/props/has-buttons';
+import type { LabelProp } from '../../schema/props/label';
+import type { MaxProp } from '../../schema/props/max';
+import type { PageProp } from '../../schema/props/page';
+import type { PageSizeProp } from '../../schema/props/page-size';
+import type { PageSizeOptionsProp } from '../../schema/props/page-size-options';
+import type { PaginationOnProp } from '../../schema/props/pagination-on';
+import type { SiblingCountProp } from '../../schema/props/sibling-count';
+import type { TooltipAlignProp } from '../../schema/props/tooltip-align';
+import type { ComponentApi } from '../generic-types';
+
+export interface PaginationApi extends ComponentApi {
+	Props: {
+		Required: MaxProp & PageProp & PaginationOnProp;
+		Optional: BoundaryCountProp & CustomClassProp & HasButtonsProp & LabelProp & PageSizeProp & PageSizeOptionsProp & SiblingCountProp & TooltipAlignProp;
+	};
+	Callbacks: {
+		changePageSize: (event: Event, value: unknown) => void;
+		goBackward: (event: Event) => void;
+		goForward: (event: Event) => void;
+		goToEnd: (event: Event) => void;
+		goToFirst: (event: Event) => void;
+		selectPage: (event: Event, page: number) => void;
+	};
+}

--- a/packages/components/src/components/_skeleton/internal/functional-components/pagination/component.tsx
+++ b/packages/components/src/components/_skeleton/internal/functional-components/pagination/component.tsx
@@ -1,0 +1,239 @@
+import type { FunctionalComponent as FC, JSX } from '@stencil/core';
+import { Fragment, h } from '@stencil/core';
+
+import { KolButtonWcTag, KolSelectWcTag } from '../../../../../core/component-names';
+import { translate } from '../../../../../i18n';
+import { nonce } from '../../../../../utils/dev.utils';
+import type { FunctionalComponentProps } from '../generic-types';
+import type { PaginationApi } from './api';
+
+const leftDoubleArrowIcon = {
+	left: 'kolicon-chevron-double-left',
+};
+const leftSingleArrow = {
+	left: 'kolicon-chevron-left',
+};
+const rightSingleArrowIcon = {
+	right: 'kolicon-chevron-right',
+};
+const rightDoubleArrowIcon = {
+	right: 'kolicon-chevron-double-right',
+};
+
+const getUserLanguage = (): string => {
+	const userLanguage = navigator.language || 'de-DE';
+	return userLanguage.includes('-') ? userLanguage : `${userLanguage}-${userLanguage.toUpperCase()}`;
+};
+const NUMBER_FORMATTER = new Intl.NumberFormat(getUserLanguage(), {
+	style: 'decimal',
+	minimumFractionDigits: 0,
+	maximumFractionDigits: 0,
+});
+
+type PaginationFCProps = FunctionalComponentProps<PaginationApi> & {
+	instanceId: string;
+	translateEntriesPerSite: string;
+	translatePage: string;
+	translatePageBack: string;
+	translatePageFirst: string;
+	translatePageLast: string;
+	translatePageNext: string;
+};
+
+const calcCount = (total: number, pageSize = 1): number => Math.ceil(total / pageSize);
+
+const getPageStart = (page: number, pageSize: number): string => (page - 1) * pageSize + 1 + '';
+
+const getPageEnd = (page: number, pageSize: number): string => page * pageSize + '';
+
+const getUnselectedPageButton = (
+	page: number,
+	customClass: PaginationFCProps['customClass'],
+	handleSelectPage: PaginationFCProps['handleSelectPage'],
+	translatePage: string,
+): JSX.Element => {
+	const pageText = NUMBER_FORMATTER.format(page);
+	const ariaDescription = `${translatePage} ${pageText}`;
+	return (
+		<li key={nonce()}>
+			<KolButtonWcTag
+				class="kol-pagination__button"
+				_ariaDescription={ariaDescription}
+				_customClass={customClass}
+				_label={pageText}
+				_on={{
+					onClick: (event: Event) => {
+						handleSelectPage(event, page);
+					},
+				}}
+			></KolButtonWcTag>
+		</li>
+	);
+};
+
+const getSelectedPageButton = (page: number, customClass: PaginationFCProps['customClass'], translatePage: string): JSX.Element => {
+	const pageText = NUMBER_FORMATTER.format(page);
+	const ariaDescription = `${translatePage} ${pageText}`;
+	return (
+		<li key={nonce()}>
+			<KolButtonWcTag
+				aria-current="page"
+				class="kol-pagination__button kol-pagination__button--selected selected"
+				_ariaDescription={ariaDescription}
+				_customClass={customClass}
+				_disabled={true}
+				_label={pageText}
+			></KolButtonWcTag>
+		</li>
+	);
+};
+
+export const PaginationFC: FC<PaginationFCProps> = ({
+	boundaryCount,
+	customClass,
+	hasButtons,
+	instanceId,
+	label,
+	handleChangePageSize,
+	handleGoBackward,
+	handleGoForward,
+	handleGoToEnd,
+	handleGoToFirst,
+	handleSelectPage,
+	max,
+	page,
+	pageSize,
+	pageSizeOptions,
+	siblingCount,
+	tooltipAlign,
+	translateEntriesPerSite,
+	translatePage,
+	translatePageBack,
+	translatePageFirst,
+	translatePageLast,
+	translatePageNext,
+}): JSX.Element => {
+	const count = calcCount(max, pageSize);
+	let ellipsis = false;
+	const pageButtons = Array.from(Array(count).keys())
+		.map((index: number) => index + 1)
+		.map((pageNumber: number) => {
+			if (pageNumber <= boundaryCount || pageNumber > count - boundaryCount || (pageNumber >= page - siblingCount && pageNumber <= page + siblingCount)) {
+				ellipsis = true;
+				if (page === pageNumber) {
+					return getSelectedPageButton(pageNumber, customClass, translatePage);
+				}
+				return getUnselectedPageButton(pageNumber, customClass, handleSelectPage, translatePage);
+			}
+			if (ellipsis) {
+				ellipsis = false;
+				return (
+					<li key={nonce()}>
+						<span class="kol-pagination__separator" aria-hidden="true"></span>
+					</li>
+				);
+			}
+			return null;
+		});
+
+	return (
+		<Fragment>
+			<span role="status" aria-live="polite">
+				{translate('kol-table-visible-range', {
+					placeholders: {
+						start: getPageStart(page, pageSize),
+						end: getPageEnd(page, pageSize),
+						total: max.toString(),
+					},
+				})}
+			</span>
+			<nav class="kol-pagination__navigation" aria-label={label}>
+				<ul class="kol-pagination__navigation-list">
+					{hasButtons.first && (
+						<li>
+							<KolButtonWcTag
+								class="kol-pagination__button kol-pagination__button--first"
+								exportparts="icon"
+								_customClass={customClass}
+								_disabled={page <= 1}
+								_icons={leftDoubleArrowIcon}
+								_hideLabel
+								_label={translatePageFirst}
+								_on={{
+									onClick: handleGoToFirst,
+								}}
+								_tooltipAlign={tooltipAlign}
+							></KolButtonWcTag>
+						</li>
+					)}
+					{hasButtons.previous && (
+						<li>
+							<KolButtonWcTag
+								class="kol-pagination__button kol-pagination__button--previous"
+								exportparts="icon"
+								_customClass={customClass}
+								_disabled={page <= 1}
+								_icons={leftSingleArrow}
+								_hideLabel
+								_label={translatePageBack}
+								_on={{
+									onClick: handleGoBackward,
+								}}
+								_tooltipAlign={tooltipAlign}
+							></KolButtonWcTag>
+						</li>
+					)}
+					{pageButtons}
+					{hasButtons.next && (
+						<li>
+							<KolButtonWcTag
+								class="kol-pagination__button kol-pagination__button--next"
+								exportparts="icon"
+								_customClass={customClass}
+								_disabled={count <= page}
+								_icons={rightSingleArrowIcon}
+								_hideLabel
+								_label={translatePageNext}
+								_on={{
+									onClick: handleGoForward,
+								}}
+								_tooltipAlign={tooltipAlign}
+							></KolButtonWcTag>
+						</li>
+					)}
+					{hasButtons.last && (
+						<li>
+							<KolButtonWcTag
+								class="kol-pagination__button kol-pagination__button--last"
+								exportparts="icon"
+								_customClass={customClass}
+								_disabled={count <= page}
+								_icons={rightDoubleArrowIcon}
+								_hideLabel
+								_label={translatePageLast}
+								_on={{
+									onClick: handleGoToEnd,
+								}}
+								_tooltipAlign={tooltipAlign}
+							></KolButtonWcTag>
+						</li>
+					)}
+				</ul>
+			</nav>
+			{pageSizeOptions.length > 0 && (
+				<div class="page-size">
+					<KolSelectWcTag
+						class="kol-pagination__page-size-select"
+						_id={`pagination-size-${instanceId}`}
+						_label={translateEntriesPerSite}
+						_options={pageSizeOptions}
+						_on={{
+							onChange: handleChangePageSize,
+						}}
+						_value={pageSize}
+					/>
+				</div>
+			)}
+		</Fragment>
+	);
+};

--- a/packages/components/src/components/_skeleton/internal/functional-components/pagination/controller.ts
+++ b/packages/components/src/components/_skeleton/internal/functional-components/pagination/controller.ts
@@ -1,0 +1,354 @@
+import { translate } from '../../../../../i18n';
+import type { KoliBriPaginationButtonCallbacks, Option, PaginationHasButton, Stringified, TooltipAlignPropType } from '../../../../../schema';
+import { parseJson, STATE_CHANGE_EVENT } from '../../../../../schema';
+import { nonce } from '../../../../../utils/dev.utils';
+import { KolEvent } from '../../../../../utils/events';
+import { addNavLabel, removeNavLabel } from '../../../../../utils/unique-nav-labels';
+import { boundaryCountProp, type BoundaryCountPropType } from '../../schema/props/boundary-count';
+import { customClassProp, type CustomClassPropType } from '../../schema/props/custom-class';
+import { hasButtonsProp } from '../../schema/props/has-buttons';
+import { labelProp, type LabelPropType } from '../../schema/props/label';
+import { maxProp, type MaxPropType } from '../../schema/props/max';
+import { pageProp, type PagePropType } from '../../schema/props/page';
+import { pageSizeProp, type PageSizePropType } from '../../schema/props/page-size';
+import { paginationOnProp } from '../../schema/props/pagination-on';
+import { siblingCountProp, type SiblingCountPropType } from '../../schema/props/sibling-count';
+import { tooltipAlignProp } from '../../schema/props/tooltip-align';
+import { BaseController } from '../base-controller';
+import type { ResolvedProps } from '../generic-types';
+import type { PaginationApi } from './api';
+
+export type PaginationControllerDependencies = {
+	dispatchEvent: (type: KolEvent, value: number) => void;
+	setPageSize: (value: number) => void;
+};
+
+type PaginationControllerProps = {
+	boundaryCount?: BoundaryCountPropType;
+	customClass?: CustomClassPropType;
+	hasButtons?: boolean | Stringified<PaginationHasButton>;
+	label?: LabelPropType;
+	max?: MaxPropType;
+	on?: KoliBriPaginationButtonCallbacks;
+	page?: PagePropType;
+	pageSize?: PageSizePropType;
+	pageSizeOptions?: Stringified<number[]>;
+	siblingCount?: SiblingCountPropType;
+	tooltipAlign?: TooltipAlignPropType;
+};
+
+const defaultPaginationLabel = translate('kol-pagination');
+
+export class PaginationController extends BaseController<ResolvedProps<PaginationApi>, PaginationApi['States']> {
+	private readonly dispatchEvent: (type: KolEvent, value: number) => void;
+	private readonly setPageSize: (value: number) => void;
+	private readonly translatePagination = defaultPaginationLabel;
+	public readonly translateEntriesPerSite = translate('kol-entries-per-site');
+	public readonly translatePage = translate('kol-page');
+	public readonly translatePageBack = translate('kol-page-back');
+	public readonly translatePageFirst = translate('kol-page-first');
+	public readonly translatePageLast = translate('kol-page-last');
+	public readonly translatePageNext = translate('kol-page-next');
+	public readonly instanceId = nonce();
+
+	public constructor({ dispatchEvent, setPageSize }: PaginationControllerDependencies) {
+		super({} as PaginationApi['States'], {
+			boundaryCount: 1,
+			customClass: undefined,
+			hasButtons: {
+				first: true,
+				last: true,
+				next: true,
+				previous: true,
+			},
+			label: defaultPaginationLabel,
+			max: 0,
+			on: {
+				onClick: () => null,
+			},
+			page: 0,
+			pageSize: 1,
+			pageSizeOptions: [],
+			siblingCount: 1,
+			tooltipAlign: 'top',
+		});
+		this.dispatchEvent = dispatchEvent;
+		this.setPageSize = setPageSize;
+	}
+
+	public componentWillLoad(props: PaginationControllerProps): void {
+		this.watchBoundaryCount(props.boundaryCount);
+		this.watchCustomClass(props.customClass);
+		this.watchHasButtons(props.hasButtons);
+		this.watchLabel(props.label, true);
+		this.watchOn(props.on);
+		this.watchPage(props.page);
+		this.watchPageSize(props.pageSize);
+		this.watchPageSizeOptions(props.pageSizeOptions);
+		this.watchSiblingCount(props.siblingCount);
+		this.watchTooltipAlign(props.tooltipAlign);
+		this.watchMax(props.max);
+		this.watchPage(props.page);
+	}
+
+	public getRenderProps(): ResolvedProps<PaginationApi> {
+		return this.getProps();
+	}
+
+	public watchBoundaryCount(value?: BoundaryCountPropType): void {
+		const normalized = boundaryCountProp.normalize(value);
+		if (boundaryCountProp.validate(normalized)) {
+			this.setProp('boundaryCount', Math.max(0, normalized));
+		} else if (value === undefined) {
+			this.setProp('boundaryCount', 1);
+		}
+	}
+
+	public watchCustomClass(value?: CustomClassPropType): void {
+		if (value === undefined) {
+			this.setProp('customClass', undefined);
+			return;
+		}
+		const normalized = customClassProp.normalize(value);
+		if (customClassProp.validate(normalized)) {
+			this.setProp('customClass', normalized);
+		}
+	}
+
+	public watchHasButtons(value?: boolean | Stringified<PaginationHasButton>): void {
+		const resolved = this.resolveHasButtons(value);
+		if (hasButtonsProp.validate(resolved)) {
+			this.setProp('hasButtons', resolved);
+		}
+	}
+
+	public watchLabel(value?: LabelPropType, initial = false): void {
+		const normalized = labelProp.normalize(value);
+		const nextLabel = labelProp.validate(normalized) ? normalized : this.getProps().label;
+		if (!initial) {
+			removeNavLabel(this.getProps().label);
+		}
+		this.setProp('label', nextLabel ?? this.translatePagination);
+		addNavLabel(this.getProps().label);
+	}
+
+	public watchOn(value?: KoliBriPaginationButtonCallbacks): void {
+		const normalized = paginationOnProp.normalize(value);
+		if (paginationOnProp.validate(normalized)) {
+			this.setProp('on', normalized);
+		}
+	}
+
+	public watchPage(value?: PagePropType): void {
+		const normalized = pageProp.normalize(value);
+		if (pageProp.validate(normalized)) {
+			const nextPage = this.syncPage(normalized, this.getProps().pageSize, this.getProps().max);
+			this.setProp('page', nextPage);
+		}
+	}
+
+	public watchPageSize(value?: PageSizePropType): void {
+		const normalized = pageSizeProp.normalize(value);
+		if (pageSizeProp.validate(normalized)) {
+			const nextPageSize = this.resolvePageSize(normalized, this.getProps().pageSizeOptions);
+			this.setProp('pageSize', nextPageSize);
+			const nextPage = this.syncPage(this.getProps().page, nextPageSize, this.getProps().max);
+			this.setProp('page', nextPage);
+		}
+	}
+
+	public watchPageSizeOptions(value?: Stringified<number[]>): void {
+		const normalized = this.normalizePageSizeOptions(value);
+		if (!normalized) {
+			return;
+		}
+		this.setProp('pageSizeOptions', normalized);
+		const nextPageSize = this.resolvePageSize(this.getProps().pageSize, normalized);
+		this.setProp('pageSize', nextPageSize);
+		const nextPage = this.syncPage(this.getProps().page, nextPageSize, this.getProps().max);
+		this.setProp('page', nextPage);
+	}
+
+	public watchSiblingCount(value?: SiblingCountPropType): void {
+		const normalized = siblingCountProp.normalize(value);
+		if (siblingCountProp.validate(normalized)) {
+			this.setProp('siblingCount', Math.max(0, normalized));
+		} else if (value === undefined) {
+			this.setProp('siblingCount', 1);
+		}
+	}
+
+	public watchTooltipAlign(value?: TooltipAlignPropType): void {
+		const normalized = tooltipAlignProp.normalize(value);
+		if (tooltipAlignProp.validate(normalized)) {
+			this.setProp('tooltipAlign', normalized);
+		} else if (value === undefined) {
+			this.setProp('tooltipAlign', 'top');
+		}
+	}
+
+	public watchMax(value?: MaxPropType): void {
+		const normalized = maxProp.normalize(value);
+		if (maxProp.validate(normalized)) {
+			this.setProp('max', normalized);
+			const nextPage = this.syncPage(this.getProps().page, this.getProps().pageSize, normalized);
+			this.setProp('page', nextPage);
+		}
+	}
+
+	public handleGoToFirst = (event: Event): void => {
+		this.handleSelectPage(event, 1);
+	};
+
+	public handleGoToEnd = (event: Event): void => {
+		this.handleSelectPage(event, this.getCount());
+	};
+
+	public handleGoBackward = (event: Event): void => {
+		this.handleSelectPage(event, this.getProps().page - 1);
+	};
+
+	public handleGoForward = (event: Event): void => {
+		this.handleSelectPage(event, this.getProps().page + 1);
+	};
+
+	public handleSelectPage = (event: Event, page: number): void => {
+		const { on } = this.getProps();
+		if (typeof on.onClick === 'function') {
+			on.onClick(event, page);
+		}
+		this.dispatchEvent(KolEvent.click, page);
+		this.handleChangePage(event, page);
+	};
+
+	public handleChangePage = (event: Event, page: number): void => {
+		const { on } = this.getProps();
+		const timeout = setTimeout(() => {
+			clearTimeout(timeout);
+			if (typeof on.onChangePage === 'function') {
+				on.onChangePage(event, page);
+			}
+			this.dispatchEvent(KolEvent.changePage, page);
+		});
+	};
+
+	public handleChangePageSize = (event: Event, value: unknown): void => {
+		const parsedValue = parseInt(value as string, 10);
+		if (typeof parsedValue === 'number' && parsedValue > 0 && this.getProps().pageSize !== parsedValue) {
+			this.setPageSize(parsedValue);
+			const { on } = this.getProps();
+			const timeout = setTimeout(() => {
+				clearTimeout(timeout);
+				if (typeof on.onChangePageSize === 'function') {
+					on.onChangePageSize(event, parsedValue);
+				}
+				this.dispatchEvent(KolEvent.changePageSize, parsedValue);
+			});
+		}
+	};
+
+	public disconnect(): void {
+		removeNavLabel(this.getProps().label);
+	}
+
+	private resolveHasButtons(value?: boolean | Stringified<PaginationHasButton>): PaginationHasButton {
+		if (typeof value === 'boolean') {
+			return {
+				first: value,
+				last: value,
+				next: value,
+				previous: value,
+			};
+		}
+
+		let nextValue = value;
+		if (typeof nextValue === 'string') {
+			try {
+				nextValue = parseJson<PaginationHasButton>(nextValue);
+			} catch {
+				return this.getProps().hasButtons;
+			}
+		}
+
+		if (typeof nextValue === 'object' && nextValue !== null) {
+			const current = this.getProps().hasButtons;
+			return {
+				first: typeof nextValue.first === 'boolean' ? nextValue.first : current.first,
+				last: typeof nextValue.last === 'boolean' ? nextValue.last : current.last,
+				next: typeof nextValue.next === 'boolean' ? nextValue.next : current.next,
+				previous: typeof nextValue.previous === 'boolean' ? nextValue.previous : current.previous,
+			};
+		}
+
+		return this.getProps().hasButtons;
+	}
+
+	private normalizePageSizeOptions(value?: Stringified<number[]>): Option<number>[] | null {
+		let nextValue = value;
+		if (typeof nextValue === 'string') {
+			try {
+				nextValue = parseJson<number[]>(nextValue);
+			} catch {
+				return null;
+			}
+		}
+
+		if (typeof nextValue === 'undefined') {
+			return [];
+		}
+
+		if (!Array.isArray(nextValue)) {
+			return null;
+		}
+
+		if (nextValue.every((entry) => typeof entry === 'object' && entry !== null && 'label' in entry && 'value' in entry)) {
+			return nextValue as Option<number>[];
+		}
+
+		const options: Option<number>[] = [];
+		for (const entry of nextValue) {
+			if (typeof entry !== 'number') {
+				return null;
+			}
+			options.push({
+				label: `${entry}`,
+				value: entry,
+			});
+		}
+
+		return options;
+	}
+
+	private resolvePageSize(pageSize: number, options: Option<number>[]): number {
+		if (options.length === 0) {
+			return pageSize;
+		}
+		const match = options.find((option) => option.value === pageSize);
+		return match ? match.value : options[0].value;
+	}
+
+	private syncPage(page: number, pageSize: number, total: number): number {
+		if (total > 0) {
+			const count = this.calcCount(total, pageSize);
+			if (count > 0) {
+				if (page > count) {
+					this.handleChangePage(STATE_CHANGE_EVENT, count);
+					return count;
+				}
+				if (page < 1) {
+					this.handleChangePage(STATE_CHANGE_EVENT, 1);
+					return 1;
+				}
+			}
+		}
+		return page;
+	}
+
+	private calcCount(total: number, pageSize = 1): number {
+		return Math.ceil(total / pageSize);
+	}
+
+	private getCount(): number {
+		return this.calcCount(this.getProps().max, this.getProps().pageSize);
+	}
+}

--- a/packages/components/src/components/_skeleton/internal/schema/props/boundary-count.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/boundary-count.ts
@@ -1,0 +1,6 @@
+import { createPropDefinition, type Prop } from './helpers/factory';
+import { normalizeInteger, validateInteger } from './helpers/integer';
+
+export type BoundaryCountPropType = number;
+export type BoundaryCountProp = Prop<BoundaryCountPropType, 'boundaryCount'>;
+export const boundaryCountProp = createPropDefinition<BoundaryCountProp>(normalizeInteger, validateInteger);

--- a/packages/components/src/components/_skeleton/internal/schema/props/custom-class.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/custom-class.ts
@@ -1,0 +1,6 @@
+import { createPropDefinition, type Prop } from './helpers/factory';
+import { normalizeString, validateString } from './helpers/string';
+
+export type CustomClassPropType = string;
+export type CustomClassProp = Prop<CustomClassPropType, 'customClass'>;
+export const customClassProp = createPropDefinition<CustomClassProp>(normalizeString, validateString);

--- a/packages/components/src/components/_skeleton/internal/schema/props/has-buttons.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/has-buttons.ts
@@ -1,0 +1,10 @@
+import type { PaginationHasButton } from '../../../../../schema';
+import { createPropDefinition, type Prop } from './helpers/factory';
+
+export type HasButtonsPropType = PaginationHasButton;
+export type HasButtonsProp = Prop<HasButtonsPropType, 'hasButtons'>;
+
+const normalizeHasButtons = (value?: unknown): unknown => value;
+const validateHasButtons = (value: unknown): value is HasButtonsPropType => typeof value === 'object' && value !== null;
+
+export const hasButtonsProp = createPropDefinition<HasButtonsProp>(normalizeHasButtons, validateHasButtons);

--- a/packages/components/src/components/_skeleton/internal/schema/props/max.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/max.ts
@@ -1,0 +1,6 @@
+import { createPropDefinition, type Prop } from './helpers/factory';
+import { normalizeNumber, validateNumber } from './helpers/number';
+
+export type MaxPropType = number;
+export type MaxProp = Prop<MaxPropType, 'max'>;
+export const maxProp = createPropDefinition<MaxProp>(normalizeNumber, validateNumber);

--- a/packages/components/src/components/_skeleton/internal/schema/props/page-size-options.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/page-size-options.ts
@@ -1,0 +1,10 @@
+import type { Option } from '../../../../../schema';
+import { createPropDefinition, type Prop } from './helpers/factory';
+
+export type PageSizeOptionsPropType = Option<number>[];
+export type PageSizeOptionsProp = Prop<PageSizeOptionsPropType, 'pageSizeOptions'>;
+
+const normalizePageSizeOptions = (value?: unknown): unknown => value;
+const validatePageSizeOptions = (value: unknown): value is PageSizeOptionsPropType => Array.isArray(value);
+
+export const pageSizeOptionsProp = createPropDefinition<PageSizeOptionsProp>(normalizePageSizeOptions, validatePageSizeOptions);

--- a/packages/components/src/components/_skeleton/internal/schema/props/page-size.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/page-size.ts
@@ -1,0 +1,6 @@
+import { createPropDefinition, type Prop } from './helpers/factory';
+import { normalizeNumber, validateNumber } from './helpers/number';
+
+export type PageSizePropType = number;
+export type PageSizeProp = Prop<PageSizePropType, 'pageSize'>;
+export const pageSizeProp = createPropDefinition<PageSizeProp>(normalizeNumber, validateNumber);

--- a/packages/components/src/components/_skeleton/internal/schema/props/page.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/page.ts
@@ -1,0 +1,6 @@
+import { createPropDefinition, type Prop } from './helpers/factory';
+import { normalizeNumber, validateNumber } from './helpers/number';
+
+export type PagePropType = number;
+export type PageProp = Prop<PagePropType, 'page'>;
+export const pageProp = createPropDefinition<PageProp>(normalizeNumber, validateNumber);

--- a/packages/components/src/components/_skeleton/internal/schema/props/pagination-on.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/pagination-on.ts
@@ -1,0 +1,10 @@
+import type { KoliBriPaginationButtonCallbacks } from '../../../../../schema';
+import { createPropDefinition, type Prop } from './helpers/factory';
+
+export type PaginationOnPropType = KoliBriPaginationButtonCallbacks;
+export type PaginationOnProp = Prop<PaginationOnPropType, 'on'>;
+
+const normalizePaginationOn = (value?: unknown): unknown => value;
+const validatePaginationOn = (value: unknown): value is PaginationOnPropType => typeof value === 'object' && value !== null;
+
+export const paginationOnProp = createPropDefinition<PaginationOnProp>(normalizePaginationOn, validatePaginationOn);

--- a/packages/components/src/components/_skeleton/internal/schema/props/sibling-count.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/sibling-count.ts
@@ -1,0 +1,6 @@
+import { createPropDefinition, type Prop } from './helpers/factory';
+import { normalizeInteger, validateInteger } from './helpers/integer';
+
+export type SiblingCountPropType = number;
+export type SiblingCountProp = Prop<SiblingCountPropType, 'siblingCount'>;
+export const siblingCountProp = createPropDefinition<SiblingCountProp>(normalizeInteger, validateInteger);

--- a/packages/components/src/components/_skeleton/internal/schema/props/tooltip-align.ts
+++ b/packages/components/src/components/_skeleton/internal/schema/props/tooltip-align.ts
@@ -1,0 +1,9 @@
+import { alignPropTypeOptions, type TooltipAlignPropType } from '../../../../../schema';
+import { createPropDefinition, type Prop } from './helpers/factory';
+
+export type TooltipAlignProp = Prop<TooltipAlignPropType, 'tooltipAlign'>;
+
+const normalizeTooltipAlign = (value?: unknown): unknown => value;
+const validateTooltipAlign = (value: unknown): value is TooltipAlignPropType => typeof value === 'string' && alignPropTypeOptions.includes(value);
+
+export const tooltipAlignProp = createPropDefinition<TooltipAlignProp>(normalizeTooltipAlign, validateTooltipAlign);

--- a/packages/components/src/components/pagination/component.tsx
+++ b/packages/components/src/components/pagination/component.tsx
@@ -1,207 +1,55 @@
 import type { JSX } from '@stencil/core';
-import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
-import type {
-	CustomClassPropType,
-	KoliBriPaginationButtonCallbacks,
-	LabelPropType,
-	MaxPropType,
-	Option,
-	PaginationAPI,
-	PaginationHasButton,
-	PaginationStates,
-	Stringified,
-	TooltipAlignPropType,
-} from '../../schema';
-import {
-	parseJson,
-	STATE_CHANGE_EVENT,
-	validateCustomClass,
-	validateLabel,
-	validateMax,
-	validateTooltipAlign,
-	watchJsonArrayString,
-	watchNumber,
-	watchValidator,
-} from '../../schema';
-
-import { KolButtonWcTag, KolSelectWcTag } from '../../core/component-names';
-import { translate } from '../../i18n';
-import { nonce } from '../../utils/dev.utils';
-import { dispatchDomEvent, KolEvent } from '../../utils/events';
-import { addNavLabel, removeNavLabel } from '../../utils/unique-nav-labels';
-
-const leftDoubleArrowIcon = {
-	left: 'kolicon-chevron-double-left',
-};
-const leftSingleArrow = {
-	left: 'kolicon-chevron-left',
-};
-const rightSingleArrowIcon = {
-	right: 'kolicon-chevron-right',
-};
-const rightDoubleArrowIcon = {
-	right: 'kolicon-chevron-double-right',
-};
-
-function getUserLanguage(): string {
-	const userLanguage = navigator.language || 'de-DE';
-	const normalizedLanguage = userLanguage.includes('-') ? userLanguage : `${userLanguage}-${userLanguage.toUpperCase()}`;
-	return normalizedLanguage;
-}
-const userLanguage = getUserLanguage();
-const NUMBER_FORMATTER = new Intl.NumberFormat(userLanguage, {
-	style: 'decimal',
-	minimumFractionDigits: 0,
-	maximumFractionDigits: 0,
-});
+import { Component, Element, h, Host, Prop, Watch } from '@stencil/core';
+import type { KoliBriPaginationButtonCallbacks, PaginationHasButton, Stringified, TooltipAlignPropType } from '../../schema';
+import { dispatchDomEvent } from '../../utils/events';
+import { PaginationFC } from '../_skeleton/internal/functional-components/pagination/component';
+import { PaginationController } from '../_skeleton/internal/functional-components/pagination/controller';
+import type { BoundaryCountPropType } from '../_skeleton/internal/schema/props/boundary-count';
+import type { CustomClassPropType } from '../_skeleton/internal/schema/props/custom-class';
+import type { LabelPropType } from '../_skeleton/internal/schema/props/label';
+import type { MaxPropType } from '../_skeleton/internal/schema/props/max';
+import type { PagePropType } from '../_skeleton/internal/schema/props/page';
+import type { PageSizePropType } from '../_skeleton/internal/schema/props/page-size';
+import type { SiblingCountPropType } from '../_skeleton/internal/schema/props/sibling-count';
 
 @Component({
 	tag: 'kol-pagination-wc',
 	shadow: false,
 })
-export class KolPaginationWc implements PaginationAPI {
+export class KolPaginationWc {
 	@Element() private readonly host?: HTMLKolPaginationElement;
 
-	private readonly nonce = nonce();
-	private readonly translatePageFirst = translate('kol-page-first');
-	private readonly translatePageBack = translate('kol-page-back');
-	private readonly translatePageNext = translate('kol-page-next');
-	private readonly translatePageLast = translate('kol-page-last');
-	private readonly translateEntriesPerSite = translate('kol-entries-per-site');
-	private readonly translatePage = translate('kol-page');
-	private readonly translatePagination = translate('kol-pagination');
-
-	private readonly calcCount = (total: number, pageSize = 1): number => Math.ceil(total / pageSize);
-
-	private readonly getCount = (): number => this.calcCount(this.state._max, this.state._pageSize);
-
-	private getPageStart(): string {
-		return (this.state._page - 1) * this.state._pageSize + 1 + '';
-	}
-
-	private getPageEnd(): string {
-		return this.state._page * this.state._pageSize + '';
-	}
+	private readonly ctrl = new PaginationController({
+		dispatchEvent: (type, value) => {
+			if (this.host) {
+				dispatchDomEvent(this.host, type, value);
+			}
+		},
+		setPageSize: (value) => {
+			this._pageSize = value;
+		},
+	});
 
 	public render(): JSX.Element {
-		let ellipsis = false;
-		const count = this.getCount();
-		const pageButtons = Array.from(Array(count).keys())
-			.map((index: number) => index + 1)
-			.map((page: number) => {
-				if (
-					page <= this.state._boundaryCount ||
-					page > count - this.state._boundaryCount ||
-					(page >= this.state._page - this.state._siblingCount && page <= this.state._page + this.state._siblingCount)
-				) {
-					ellipsis = true;
-					if (this.state._page === page) {
-						return this.getSelectedPageButton(page);
-					} else {
-						return this.getUnselectedPageButton(page);
-					}
-				} else if (ellipsis === true) {
-					ellipsis = false;
-					return (
-						<li key={nonce()}>
-							<span class="kol-pagination__separator" aria-hidden="true"></span>
-						</li>
-					);
-				} else {
-					return null;
-				}
-			});
-
+		const props = this.ctrl.getRenderProps();
 		return (
 			<Host class="kol-pagination">
-				<span role="status" aria-live="polite">
-					{translate('kol-table-visible-range', {
-						placeholders: {
-							start: this.getPageStart(),
-							end: this.getPageEnd(),
-							total: this.state._max.toString(),
-						},
-					})}
-				</span>
-				<nav class="kol-pagination__navigation" aria-label={this.state._label}>
-					<ul class="kol-pagination__navigation-list">
-						{this.state._hasButtons.first && (
-							<li>
-								<KolButtonWcTag
-									class="kol-pagination__button kol-pagination__button--first"
-									exportparts="icon"
-									_customClass={this.state._customClass}
-									_disabled={this.state._page <= 1}
-									_icons={leftDoubleArrowIcon}
-									_hideLabel
-									_label={this.translatePageFirst}
-									_on={this.onGoToFirst}
-									_tooltipAlign={this.state._tooltipAlign}
-								></KolButtonWcTag>
-							</li>
-						)}
-						{this.state._hasButtons.previous && (
-							<li>
-								<KolButtonWcTag
-									class="kol-pagination__button kol-pagination__button--previous"
-									exportparts="icon"
-									_customClass={this.state._customClass}
-									_disabled={this.state._page <= 1}
-									_icons={leftSingleArrow}
-									_hideLabel
-									_label={this.translatePageBack}
-									_on={this.onGoBackward}
-									_tooltipAlign={this.state._tooltipAlign}
-								></KolButtonWcTag>
-							</li>
-						)}
-						{pageButtons}
-						{this.state._hasButtons.next && (
-							<li>
-								<KolButtonWcTag
-									class="kol-pagination__button kol-pagination__button--next"
-									exportparts="icon"
-									_customClass={this.state._customClass}
-									_disabled={count <= this.state._page}
-									_icons={rightSingleArrowIcon}
-									_hideLabel
-									_label={this.translatePageNext}
-									_on={this.onGoForward}
-									_tooltipAlign={this.state._tooltipAlign}
-								></KolButtonWcTag>
-							</li>
-						)}
-						{this.state._hasButtons.last && (
-							<li>
-								<KolButtonWcTag
-									class="kol-pagination__button kol-pagination__button--last"
-									exportparts="icon"
-									_customClass={this.state._customClass}
-									_disabled={count <= this.state._page}
-									_icons={rightDoubleArrowIcon}
-									_hideLabel
-									_label={this.translatePageLast}
-									_on={this.onGoToEnd}
-									_tooltipAlign={this.state._tooltipAlign}
-								></KolButtonWcTag>
-							</li>
-						)}
-					</ul>
-				</nav>
-				{this.state._pageSizeOptions?.length > 0 && (
-					<div class="page-size">
-						<KolSelectWcTag
-							class="kol-pagination__page-size-select"
-							_id={`pagination-size-${this.nonce}`}
-							_label={this.translateEntriesPerSite}
-							_options={this.state._pageSizeOptions}
-							_on={{
-								onChange: this.onChangePageSize,
-							}}
-							_value={this.state._pageSize}
-						/>
-					</div>
-				)}
+				<PaginationFC
+					{...props}
+					handleChangePageSize={this.ctrl.handleChangePageSize}
+					handleGoBackward={this.ctrl.handleGoBackward}
+					handleGoForward={this.ctrl.handleGoForward}
+					handleGoToEnd={this.ctrl.handleGoToEnd}
+					handleGoToFirst={this.ctrl.handleGoToFirst}
+					handleSelectPage={this.ctrl.handleSelectPage}
+					instanceId={this.ctrl.instanceId}
+					translateEntriesPerSite={this.ctrl.translateEntriesPerSite}
+					translatePage={this.ctrl.translatePage}
+					translatePageBack={this.ctrl.translatePageBack}
+					translatePageFirst={this.ctrl.translatePageFirst}
+					translatePageLast={this.ctrl.translatePageLast}
+					translatePageNext={this.ctrl.translatePageNext}
+				/>
 			</Host>
 		);
 	}
@@ -209,7 +57,7 @@ export class KolPaginationWc implements PaginationAPI {
 	/**
 	 * Defines the amount of pages to show next to the outer arrow buttons.
 	 */
-	@Prop() public _boundaryCount?: number = 1;
+	@Prop() public _boundaryCount?: BoundaryCountPropType = 1;
 
 	/**
 	 * Defines the custom class attribute if _variant="custom" is set.
@@ -229,7 +77,7 @@ export class KolPaginationWc implements PaginationAPI {
 	/**
 	 * Defines the current page.
 	 */
-	@Prop() public _page!: number;
+	@Prop() public _page!: PagePropType;
 
 	/**
 	 * Defines the amount of entries to show per page.
@@ -249,7 +97,7 @@ export class KolPaginationWc implements PaginationAPI {
 	/**
 	 * Defines the amount of pages to show next to the current page.
 	 */
-	@Prop() public _siblingCount?: number = 1;
+	@Prop() public _siblingCount?: SiblingCountPropType = 1;
 
 	/**
 	 * Defines where to show the Tooltip preferably: top, right, bottom or left.
@@ -261,329 +109,78 @@ export class KolPaginationWc implements PaginationAPI {
 	 */
 	@Prop() public _max!: MaxPropType;
 
-	@State() public state: PaginationStates = {
-		_boundaryCount: 1,
-		_label: this.translatePagination,
-		_hasButtons: {
-			first: true,
-			last: true,
-			next: true,
-			previous: true,
-		},
-		_on: {
-			onClick: () => null,
-		},
-		_page: 0,
-		_pageSize: 1,
-		_pageSizeOptions: [],
-		_siblingCount: 1,
-		_max: 0,
-	};
-
-	private onClick = (event: Event, page: number) => {
-		if (typeof this.state._on.onClick === 'function') {
-			this.state._on.onClick(event, page);
-		}
-		if (this.host) {
-			dispatchDomEvent(this.host, KolEvent.click, page);
-		}
-		this.onChangePage(event, page);
-	};
-
-	private onChangePage = (event: Event, page: number) => {
-		const timeout = setTimeout(() => {
-			clearTimeout(timeout);
-			if (typeof this.state._on.onChangePage === 'function') {
-				this.state._on.onChangePage(event, page);
-			}
-			if (this.host) {
-				dispatchDomEvent(this.host, KolEvent.changePage, page);
-			}
-		});
-	};
-
-	private onChangePageSize = (event: Event, value: unknown) => {
-		value = parseInt(value as string);
-		if (typeof value === 'number' && value > 0 && this._pageSize !== value) {
-			this._pageSize = value;
-			const timeout = setTimeout(() => {
-				clearTimeout(timeout);
-				if (typeof this.state._on.onChangePageSize === 'function') {
-					this.state._on.onChangePageSize(event, this._pageSize);
-				}
-				if (this.host) {
-					dispatchDomEvent(this.host, KolEvent.changePageSize, this._pageSize);
-				}
-			});
-		}
-	};
-
-	private readonly onGoToFirst = {
-		onClick: (event: Event) => {
-			this.onClick(event, 1);
-		},
-	};
-	private readonly onGoToEnd = {
-		onClick: (event: Event) => {
-			this.onClick(event, this.getCount());
-		},
-	};
-	private readonly onGoBackward = {
-		onClick: (event: Event) => {
-			this.onClick(event, this.state._page - 1);
-		},
-	};
-	private readonly onGoForward = {
-		onClick: (event: Event) => {
-			this.onClick(event, this.state._page + 1);
-		},
-	};
-
-	private getUnselectedPageButton(page: number): JSX.Element {
-		const pageText = NUMBER_FORMATTER.format(page);
-		const ariaDescription = `${this.translatePage} ${pageText}`;
-		return (
-			<li key={nonce()}>
-				<KolButtonWcTag
-					class="kol-pagination__button"
-					_ariaDescription={ariaDescription}
-					_customClass={this.state._customClass}
-					_label={pageText}
-					_on={{
-						onClick: (event: Event) => {
-							this.onClick(event, page);
-						},
-					}}
-				></KolButtonWcTag>
-			</li>
-		);
-	}
-
-	private getSelectedPageButton(page: number): JSX.Element {
-		const pageText = NUMBER_FORMATTER.format(page);
-		const ariaDescription = `${this.translatePage} ${pageText}`;
-		return (
-			<li key={nonce()}>
-				<KolButtonWcTag
-					aria-current="page"
-					class="kol-pagination__button kol-pagination__button--selected selected"
-					_ariaDescription={ariaDescription}
-					_customClass={this.state._customClass}
-					_disabled={true}
-					_label={pageText}
-				></KolButtonWcTag>
-			</li>
-		);
-	}
-
 	@Watch('_boundaryCount')
-	public validateBoundaryCount(value?: number): void {
-		watchNumber(this, '_boundaryCount', Math.max(0, value ?? 1));
+	public watchBoundaryCount(value?: BoundaryCountPropType): void {
+		this.ctrl.watchBoundaryCount(value);
 	}
 
 	@Watch('_customClass')
-	public validateCustomClass(value?: CustomClassPropType): void {
-		validateCustomClass(this, value);
+	public watchCustomClass(value?: CustomClassPropType): void {
+		this.ctrl.watchCustomClass(value);
 	}
 
 	@Watch('_label')
-	public validateLabel(label?: LabelPropType, _oldValue?: LabelPropType, initial = false) {
-		if (!initial) {
-			removeNavLabel(this.state._label);
-		}
-		validateLabel(this, label);
-		addNavLabel(this.state._label); // add the state instead of prop, because the prop could be invalid and not set as new label
+	public watchLabel(value?: LabelPropType): void {
+		this.ctrl.watchLabel(value);
 	}
 
 	@Watch('_hasButtons')
-	public validateHasButtons(value?: string | boolean | Stringified<PaginationHasButton>): void {
-		watchValidator(
-			this,
-			'_hasButtons',
-			(value) => typeof value === 'boolean' || typeof value === 'string' || (typeof value === 'object' && value !== null),
-			new Set(['Boolean', 'PaginationHasButton']),
-			value,
-			{
-				hooks: {
-					beforePatch: (nextValue: unknown, nextState: Map<string, unknown>) => {
-						if (typeof nextValue === 'boolean') {
-							nextState.set('_hasButtons', {
-								first: nextValue,
-								last: nextValue,
-								next: nextValue,
-								previous: nextValue,
-							});
-						} else {
-							if (typeof nextValue === 'string') {
-								try {
-									nextValue = parseJson<PaginationHasButton>(nextValue);
-								} catch (e) {
-									nextState.delete('_hasButtons');
-								}
-							}
-
-							if (typeof nextValue === 'object' && nextValue !== null) {
-								nextState.set('_hasButtons', {
-									...this.state._hasButtons,
-									first:
-										typeof (nextValue as PaginationHasButton).first === 'boolean'
-											? (nextValue as PaginationHasButton).first === true
-											: this.state._hasButtons.first,
-									last:
-										typeof (nextValue as PaginationHasButton).last === 'boolean'
-											? (nextValue as PaginationHasButton).last === true
-											: this.state._hasButtons.last,
-									next:
-										typeof (nextValue as PaginationHasButton).next === 'boolean'
-											? (nextValue as PaginationHasButton).next === true
-											: this.state._hasButtons.next,
-									previous:
-										typeof (nextValue as PaginationHasButton).previous === 'boolean'
-											? (nextValue as PaginationHasButton).previous === true
-											: this.state._hasButtons.previous,
-								});
-							}
-						}
-					},
-				},
-			},
-		);
+	public watchHasButtons(value?: boolean | Stringified<PaginationHasButton>): void {
+		this.ctrl.watchHasButtons(value);
 	}
 
 	@Watch('_on')
-	public validateOn(value?: KoliBriPaginationButtonCallbacks): void {
-		if (typeof value === 'object' && value !== null) {
-			this.state = {
-				...this.state,
-				_on: value,
-			};
-		}
+	public watchOn(value?: KoliBriPaginationButtonCallbacks): void {
+		this.ctrl.watchOn(value);
 	}
 
 	@Watch('_page')
-	public validatePage(value?: number): void {
-		watchNumber(this, '_page', value, {
-			hooks: {
-				beforePatch: (_nextValue: unknown, nextState: Map<string, unknown>) => {
-					const pageSize = nextState.has('_pageSize') ? (nextState.get('_pageSize') as number) : this.state._pageSize;
-					const total = nextState.has('_max') ? (nextState.get('_max') as number) : this.state._max;
-					this.syncPage(nextState, _nextValue as number, pageSize, total);
-				},
-			},
-		});
+	public watchPage(value?: PagePropType): void {
+		this.ctrl.watchPage(value);
 	}
 
-	private beforePageSize = (_nextValue: unknown, nextState: Map<string, unknown>) => {
-		let pageSize = nextState.has('_pageSize') ? (nextState.get('_pageSize') as number) : this.state._pageSize;
-		const pageSizeOptions = nextState.has('_pageSizeOptions') ? (nextState.get('_pageSizeOptions') as Option<number>[]) : this.state._pageSizeOptions;
-		if (Array.isArray(pageSizeOptions) && pageSizeOptions.length > 0) {
-			const find = pageSizeOptions.find((option) => option.value === pageSize);
-			if (find === undefined) {
-				pageSize = pageSizeOptions[0].value;
-			} else {
-				pageSize = find.value;
-			}
-			nextState.set('_pageSize', pageSize);
-		}
-		const page = nextState.has('_page') ? (nextState.get('_page') as number) : this.state._page;
-		const total = nextState.has('_max') ? (nextState.get('_max') as number) : this.state._max;
-		this.syncPage(nextState, page, nextState.get('_pageSize') as number, total);
-	};
-
-	private syncPage = (nextState: Map<string, unknown>, page: number, pageSize: number, total: number) => {
-		// count === 0 means no data
-		if (total > 0) {
-			const count = this.calcCount(total, pageSize);
-			if (count > 0) {
-				if (page > count) {
-					nextState.set('_page', count);
-					this.onChangePage(STATE_CHANGE_EVENT, count);
-				} else if (page < 1) {
-					nextState.set('_page', 1);
-					this.onChangePage(STATE_CHANGE_EVENT, 1);
-				}
-			}
-		}
-	};
-
-	private beforePageSizeOptions = (nextValue: unknown, nextState: Map<string, unknown>) => {
-		const options: Option<number>[] = [];
-		if (Array.isArray(nextValue)) {
-			for (const value of nextValue) {
-				if (typeof value === 'number') {
-					options.push({
-						label: `${value}`,
-						value: value,
-					});
-				}
-			}
-		}
-		nextState.set('_pageSizeOptions', options);
-		this.beforePageSize(options, nextState);
-	};
-
 	@Watch('_pageSize')
-	public validatePageSize(value?: number): void {
-		watchNumber(this, '_pageSize', value, {
-			hooks: {
-				beforePatch: this.beforePageSize,
-			},
-		});
+	public watchPageSize(value?: PageSizePropType): void {
+		this.ctrl.watchPageSize(value);
 	}
 
 	@Watch('_pageSizeOptions')
-	public validatePageSizeOptions(value?: Stringified<number[]>): void {
-		watchJsonArrayString(this, '_pageSizeOptions', (value) => typeof value === 'number', value, undefined, {
-			hooks: {
-				beforePatch: this.beforePageSizeOptions,
-			},
-		});
+	public watchPageSizeOptions(value?: Stringified<number[]>): void {
+		this.ctrl.watchPageSizeOptions(value);
 	}
 
 	@Watch('_siblingCount')
-	public validateSiblingCount(value?: number): void {
-		watchNumber(this, '_siblingCount', Math.max(0, value ?? 1));
-	}
-
-	@Watch('_max')
-	public validateMax(value?: MaxPropType): void {
-		validateMax(this, value, {
-			hooks: {
-				beforePatch: (_nextValue: unknown, nextState: Map<string, unknown>) => {
-					const page = nextState.has('_page') ? (nextState.get('_page') as number) : this.state._page;
-					const pageSize = nextState.has('_pageSize') ? (nextState.get('_pageSize') as number) : this.state._pageSize;
-					this.syncPage(nextState, page, pageSize, _nextValue as number);
-				},
-			},
-		});
+	public watchSiblingCount(value?: SiblingCountPropType): void {
+		this.ctrl.watchSiblingCount(value);
 	}
 
 	@Watch('_tooltipAlign')
-	public validateTooltipAlign(value?: TooltipAlignPropType): void {
-		validateTooltipAlign(this, value);
+	public watchTooltipAlign(value?: TooltipAlignPropType): void {
+		this.ctrl.watchTooltipAlign(value);
+	}
+
+	@Watch('_max')
+	public watchMax(value?: MaxPropType): void {
+		this.ctrl.watchMax(value);
 	}
 
 	public componentWillLoad(): void {
-		this.validateBoundaryCount(this._boundaryCount);
-		this.validateCustomClass(this._customClass);
-		this.validateHasButtons(this._hasButtons);
-		this.validateLabel(this._label, undefined, true);
-		this.validateOn(this._on);
-		this.validatePage(this._page);
-		this.validatePageSize(this._pageSize);
-		this.validatePageSizeOptions(this._pageSizeOptions);
-		this.validateSiblingCount(this._siblingCount);
-		this.validateTooltipAlign(this._tooltipAlign);
-		this.validateMax(this._max);
-
-		/**
-		 * Die Seite muss als letztes gesetzt werden, da sonst die Seite
-		 * nicht korrekt berechnet wird.
-		 */
-		this.validatePage(this._page);
+		this.ctrl.componentWillLoad({
+			boundaryCount: this._boundaryCount,
+			customClass: this._customClass,
+			hasButtons: this._hasButtons,
+			label: this._label,
+			max: this._max,
+			on: this._on,
+			page: this._page,
+			pageSize: this._pageSize,
+			pageSizeOptions: this._pageSizeOptions,
+			siblingCount: this._siblingCount,
+			tooltipAlign: this._tooltipAlign,
+		});
 	}
 
 	public disconnectedCallback(): void {
-		removeNavLabel(this.state._label);
+		this.ctrl.disconnect();
 	}
 }


### PR DESCRIPTION
### Motivation
- Bring die `pagination`-Komponente auf das gleiche `_skeleton`-Pattern wie `kol-icon`, so dass API, Controller und Props im `_skeleton` liegen und nur die Web Component / Styling in `components/pagination` verbleibt.
- Zentralisiere Prop-Normalisierung, Validierung und Rendering-Logic in einer wiederverwendbaren Controller/Functional-Component-Schicht.

### Description
- Verschoben: Pagination API, Controller und funktionales Rendering nach `src/components/_skeleton/internal/functional-components/pagination/` (`api.tsx`, `controller.ts`, `component.tsx`).
- Neue Prop-Definitionen angelegt unter `src/components/_skeleton/internal/schema/props/` (`boundary-count.ts`, `custom-class.ts`, `has-buttons.ts`, `max.ts`, `page.ts`, `page-size.ts`, `page-size-options.ts`, `pagination-on.ts`, `sibling-count.ts`, `tooltip-align.ts`).
- Die Web-Component in `packages/components/src/components/pagination/component.tsx` wurde vereinfacht und delegiert nun an `PaginationController` und `PaginationFC`, übernimmt nur noch die Prop-Watcher und das Styling/Shadow-WC-Wrapping.
- Event-Dispatching wurde entkoppelt: der Controller akzeptiert nun eine `dispatchEvent`-Dependency statt direkte DOM-Dispatches, und Übersetzungen werden im Controller gehalten und an die FC weitergereicht.
- Controller expose `getRenderProps()` / `instanceId` und Übersetzungs-Strings, so dass Rendering vollständig aus dem Skeleton-Teil erfolgt.

### Testing
- Dependencies installiert mit `pnpm i` and code formatted with `pnpm format` (repo-wide), which completed successfully and fixed style issues in a few files.
- Paket-spezifische Formatierung ausgeführt mit `pnpm --filter @public-ui/components format`, die ebenfalls erfolgreich lief and reported no remaining Prettier issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f1afcbb4832b8033093ddccdeb93)