### PR TITLE
chore(components): restore typed-bem and ignore it in knip

### DIFF
--- a/packages/components/.knip.json
+++ b/packages/components/.knip.json
@@ -28,6 +28,7 @@
 		"rgba-convert",
 		"stencil-awesome-test",
 		"tslib",
+		"typed-bem",
 		"twig",
 		"wcag-contrast"
 	],


### PR DESCRIPTION
## What changed?

The `typed-bem` package was restored as an explicit dependency in `packages/components/package.json` after it was inadvertently removed. It was also added to the `ignoreDependencies` list in `packages/components/.knip.json` to prevent the unused-dependency checker from flagging it. The lockfile was updated accordingly.

## Linked issues

No linked issues.

## Type of change

- [x] 🔧 Internal (no release note needed)

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `typed-bem`-Abhängigkeit wurde in `package.json` wiederhergestellt und in `.knip.json` unter `ignoreDependencies` eingetragen, um false-positive Warnungen des Unused-Dependency-Checkers zu verhindern.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/package.json` — `typed-bem` wiederhergestellt
- `packages/components/.knip.json` — `typed-bem` zu `ignoreDependencies` hinzugefügt

</details>