### PR TITLE
fix(components): add type guards for validators

### DIFF
--- a/packages/components/src/schema/validators/common.ts
+++ b/packages/components/src/schema/validators/common.ts
@@ -1,6 +1,6 @@
-export const isObject = (value: unknown): boolean => typeof value === 'object' && value !== null;
+export const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 
-export const isString = (value: unknown, minLength = 0): boolean => typeof value === 'string' && value.length >= minLength;
+export const isString = (value: unknown, minLength = 0): value is string => typeof value === 'string' && value.length >= minLength;
 
 export const isEqual = (left: unknown, right: unknown): boolean => {
 	if (Object.is(left, right)) {


### PR DESCRIPTION
## What changed?

The `isObject` and `isString` helper functions in `packages/components/src/schema/validators/common.ts` were changed to return TypeScript type predicates (`value is Record<string, unknown>` and `value is string`). This enables proper TypeScript narrowing in callers and unblocks `tsc` without changing any runtime behavior. The change is 2 additions and 2 deletions in a single file.

## Linked issues

No linked issues.

## Type of change

- [x] 🔧 Internal (no release note needed)

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`isObject` und `isString` in `schema/validators/common.ts` wurden zu TypeScript-Typ-Prädikaten geändert (`value is Record<string, unknown>` / `value is string`), um korrekte TypeScript-Verengung zu ermöglichen. Keine Laufzeitänderung.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/schema/validators/common.ts` — Typ-Prädikate für `isObject` und `isString`

</details>