### PR TITLE
fix(components): normalize icon props for Span and InputContainer wrappers

### DIFF
--- a/packages/components/src/functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper.tsx
+++ b/packages/components/src/functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper.tsx
@@ -9,6 +9,7 @@ import {
 	type InputPasswordStates,
 	type InputRangeStates,
 	type InputTextStates,
+	type KoliBriCustomIcon,
 	type KoliBriHorizontalIcons,
 	type MsgPropType,
 	type SelectStates,
@@ -18,7 +19,6 @@ import {
 
 import KolIconButtonFc from '../../functional-components/IconButton';
 import KolInputContainerFc, { type InputContainerProps } from '../../functional-components/InputContainer';
-import { isObject, isString } from '../../schema/validators';
 
 type InputState =
 	| TextareaStates
@@ -33,6 +33,18 @@ type InputState =
 
 export type InputContainerStateWrapperProps = Partial<InputContainerProps> & {
 	state: InputState;
+};
+
+const normalizeIconProps = (icon?: IconOrIconClass): KoliBriCustomIcon | undefined => {
+	if (!icon) {
+		return undefined;
+	}
+
+	if (typeof icon === 'string') {
+		return { icon };
+	}
+
+	return icon;
 };
 
 function getInputContainerProps(state: InputState): {
@@ -68,15 +80,8 @@ const InputContainerStateWrapperFc: FC<InputContainerStateWrapperProps> = (
 ) => {
 	const { icons, smartButton, disabled, msg, touched } = getInputContainerProps(state);
 
-	let leftIconProps: IconOrIconClass | undefined = icons?.left;
-	if (isString(leftIconProps)) {
-		leftIconProps = { icon: leftIconProps };
-	}
-
-	let rightIconProps: IconOrIconClass | undefined = icons?.right;
-	if (isString(rightIconProps)) {
-		rightIconProps = { icon: rightIconProps };
-	}
+	const leftIconProps = normalizeIconProps(icons?.left);
+	const rightIconProps = normalizeIconProps(icons?.right);
 
 	const startAdornment = [];
 	const endAdornment = [];
@@ -90,17 +95,17 @@ const InputContainerStateWrapperFc: FC<InputContainerStateWrapperProps> = (
 	}
 
 	if (leftIconProps) {
-		startAdornment.push(<KolIconButtonFc componentName="icon" class="kol-input-container__icon" {...(isObject(leftIconProps) ? leftIconProps : {})} />);
+		startAdornment.push(<KolIconButtonFc componentName="icon" class="kol-input-container__icon" {...leftIconProps} />);
 	}
 
-	if (isObject(smartButton)) {
+	if (smartButton) {
 		endAdornment.push(
 			<KolIconButtonFc componentName="button" class="kol-input-container__smart-button" {...smartButton} hideLabel={true} disabled={disabled} />,
 		);
 	}
 
 	if (rightIconProps) {
-		endAdornment.push(<KolIconButtonFc componentName="icon" class="kol-input-container__icon" {...(isObject(rightIconProps) ? rightIconProps : {})} />);
+		endAdornment.push(<KolIconButtonFc componentName="icon" class="kol-input-container__icon" {...rightIconProps} />);
 	}
 
 	if (defaultEndAdornment) {

--- a/packages/components/src/functional-components/Span/Span.tsx
+++ b/packages/components/src/functional-components/Span/Span.tsx
@@ -3,11 +3,10 @@ import type { JSXBase } from '@stencil/core/internal';
 import clsx from '../../utils/clsx';
 
 import {
-	isObject,
-	isString,
 	type BadgeTextPropType,
 	type HideLabelPropType,
 	type IconOrIconClass,
+	type KoliBriCustomIcon,
 	type KoliBriIconsProp,
 	type LabelWithExpertSlotPropType,
 } from '../../schema';
@@ -25,6 +24,18 @@ export type SpanProps = JSXBase.HTMLAttributes<HTMLSpanElement> & {
 	hideLabel?: HideLabelPropType;
 };
 
+const normalizeIconProps = (icon?: IconOrIconClass | null): KoliBriCustomIcon | null => {
+	if (!icon) {
+		return null;
+	}
+
+	if (typeof icon === 'string') {
+		return { icon };
+	}
+
+	return icon;
+};
+
 const KolSpanFc: FC<SpanProps> = (props, children) => {
 	const { class: classNames, label, hideLabel = false, badgeText, allowMarkdown, icons, ...other } = props;
 	let topIconProps: IconType = null;
@@ -32,28 +43,26 @@ const KolSpanFc: FC<SpanProps> = (props, children) => {
 	let rightIconProps: IconType = null;
 	let bottomIconProps: IconType = null;
 
-	if (isObject(icons)) {
-		topIconProps = icons.top;
-		leftIconProps = icons.left;
-		rightIconProps = icons.right;
-		bottomIconProps = icons.bottom;
-	} else if (isString(icons)) {
-		leftIconProps = {
-			icon: icons,
-		};
+	if (typeof icons === 'object' && icons !== null) {
+		topIconProps = normalizeIconProps(icons.top);
+		leftIconProps = normalizeIconProps(icons.left);
+		rightIconProps = normalizeIconProps(icons.right);
+		bottomIconProps = normalizeIconProps(icons.bottom);
+	} else if (typeof icons === 'string') {
+		leftIconProps = { icon: icons };
 	}
 
 	return (
 		<span class={clsx('kol-span', { 'kol-span--hide-label': hideLabel }, classNames)} {...other}>
-			{isObject(topIconProps) && <IconHelper class="top" {...topIconProps} />}
+			{topIconProps && <IconHelper class="top" {...topIconProps} />}
 			<span class="kol-span__container">
-				{isObject(leftIconProps) && <IconHelper class="left" {...leftIconProps} />}
+				{leftIconProps && <IconHelper class="left" {...leftIconProps} />}
 				<SpanCoreHelper label={label} hideLabel={hideLabel} allowMarkdown={allowMarkdown} badgeText={badgeText}>
 					{children}
 				</SpanCoreHelper>
-				{isObject(rightIconProps) && <IconHelper class="right" {...rightIconProps} />}
+				{rightIconProps && <IconHelper class="right" {...rightIconProps} />}
 			</span>
-			{isObject(bottomIconProps) && <IconHelper class="bottom" {...bottomIconProps} />}
+			{bottomIconProps && <IconHelper class="bottom" {...bottomIconProps} />}
 		</span>
 	);
 };

--- a/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
+++ b/packages/components/src/functional-components/Span/SpanCoreHelper.tsx
@@ -1,5 +1,4 @@
 import { Fragment, h, type FunctionalComponent as FC } from '@stencil/core';
-import { isString } from '../../schema/validators';
 
 import { showExpertSlot } from '../../schema';
 import LabelHelper from './LabelHelper';
@@ -16,7 +15,7 @@ const KolSpanCoreHelperFc: FC<{ label: string; hideLabel?: boolean; badgeText?: 
 			<span aria-hidden={hideExpertSlot ? 'true' : undefined} class="kol-span__label" hidden={hideExpertSlot}>
 				{children}
 			</span>
-			{isString(badgeText) && badgeText.length > 0 && (
+			{typeof badgeText === 'string' && badgeText.length > 0 && (
 				<kbd class="badge-text-hint" aria-hidden="true">
 					{badgeText}
 				</kbd>


### PR DESCRIPTION
## What changed?

`normalizeIconProps` helpers were added to `InputContainerStateWrapper` and `Span` functional components to convert string icon values to the expected `{ icon: string }` shape and guard `null`/`undefined` values. The `KolIconButtonFc` and `IconHelper` render calls were updated to use strictly typed props, removing unsafe spreads of union types. Badge text rendering in `SpanCoreHelper` was tightened to only render when `badgeText` is a non-empty string. This prevents TypeScript errors and potential runtime crashes from nullable icon props.

## Linked issues

No linked issues.

## Type of change

- [x] 🔧 Internal (no release note needed)

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`normalizeIconProps`-Helpers wurden hinzugefügt, um String-Icon-Werte in die erwartete `{ icon: string }`-Form zu normalisieren. Unsichere Spreads wurden durch typsichere Prop-Übergaben ersetzt. Badge-Text-Rendering in `SpanCoreHelper` wurde für leere Strings abgesichert.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/...Span/...` — `normalizeIconProps` und typsichere Renderpfade
- `packages/components/src/...InputContainer/...` — `normalizeIconProps` hinzugefügt

</details>