### PR TITLE
chore(visual-tests): remove icon/basic visual test route

### DIFF
--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -296,17 +296,6 @@ ROUTES.set('heading/paragraph', {
 		},
 	},
 });
-ROUTES.set('icon/basic', {
-	snapshot: {
-		viewportSize: {
-			width: 60,
-			height: 200,
-		},
-		zoom: {
-			skip: true,
-		},
-	},
-});
 ROUTES.set('icon/font-awesome', {
 	snapshot: {
 		viewportSize: {


### PR DESCRIPTION
## What changed?

The `ROUTES.set('icon/basic', ...)` block was removed from `packages/tools/visual-tests/tests/sample-app.routes.js`. The basic icon sample is not theme-specific and should not generate visual snapshots. This is a test infrastructure cleanup with no impact on any component's functionality or API.

## Linked issues

No linked issues.

## Type of change

- [x] 🔧 Internal (no release note needed)

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `icon/basic`-Route wurde aus den Visual-Test-Routes entfernt, da das Basis-Icon-Sample keine theme-spezifischen Snapshots erzeugen sollte.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/tests/sample-app.routes.js` — `icon/basic`-Route entfernt

</details>