### PR TITLE
fix(tooltip): simplify event listener handling and add tooltip with expert slot

### DIFF
--- a/packages/components/src/components/tooltip/component.tsx
+++ b/packages/components/src/components/tooltip/component.tsx
@@ -119,48 +119,48 @@ export class KolTooltipWc implements TooltipAPI {
 		}
 	};
 
-	private handleMouseEnter = (): void => {
+	private handleMouseEnter() {
 		const isNewVisit = this.isNewVisit();
 		this.hasMouseIn = true;
 		if (isNewVisit) {
 			this.isHiddenForCurrentVisit = false;
 		}
 		this.showOrHideTooltip();
-	};
+	}
 
-	private handleMouseleave = (event: Event): void => {
-		this.hasMouseIn = this.tooltipElement?.contains((event as MouseEvent).relatedTarget as Node) ?? false;
+	private handleMouseLeave() {
+		this.hasMouseIn = false;
 		this.resetHideFlag();
 		this.showOrHideTooltip();
-	};
+	}
 
-	private handleFocusIn = (): void => {
+	private handleFocusIn() {
 		const isNewVisit = this.isNewVisit();
 		this.hasFocusIn = true;
 		if (isNewVisit) {
 			this.isHiddenForCurrentVisit = false;
 		}
 		this.showOrHideTooltip();
-	};
+	}
 
-	private handleFocusout = (): void => {
+	private handleFocusOut() {
 		this.hasFocusIn = false;
 		this.resetHideFlag();
 		this.showOrHideTooltip();
-	};
+	}
 
 	private addListeners = (el: Element): void => {
-		el.addEventListener('mouseenter', this.handleMouseEnter);
-		el.addEventListener('mouseleave', this.handleMouseleave);
-		el.addEventListener('focusin', this.handleFocusIn);
-		el.addEventListener('focusout', this.handleFocusout);
+		el.addEventListener('mouseenter', this.handleMouseEnter.bind(this));
+		el.addEventListener('mouseleave', this.handleMouseLeave.bind(this));
+		el.addEventListener('focusin', this.handleFocusIn.bind(this));
+		el.addEventListener('focusout', this.handleFocusOut.bind(this));
 	};
 
 	private removeListeners = (el: Element): void => {
-		el.removeEventListener('mouseenter', this.handleMouseEnter);
-		el.removeEventListener('mouseleave', this.handleMouseleave);
-		el.removeEventListener('focusin', this.handleFocusIn);
-		el.removeEventListener('focusout', this.handleFocusout);
+		el.removeEventListener('mouseenter', this.handleMouseEnter.bind(this));
+		el.removeEventListener('mouseleave', this.handleMouseLeave.bind(this));
+		el.removeEventListener('focusin', this.handleFocusIn.bind(this));
+		el.removeEventListener('focusout', this.handleFocusOut.bind(this));
 	};
 
 	private resyncListeners = (last?: Element | null, next?: Element | null, replacePreviousSibling = false): void => {
@@ -188,12 +188,10 @@ export class KolTooltipWc implements TooltipAPI {
 	public render(): JSX.Element {
 		return (
 			<Host class="kol-tooltip">
-				{this.state._label !== '' && (
-					<div class="kol-tooltip__floating" ref={this.catchTooltipElement}>
-						<div class="kol-tooltip__arrow" ref={this.catchArrowElement} />
-						<KolSpanFc class="kol-tooltip__content" id={this.state._id} badgeText={this._badgeText} label={this.state._label} />
-					</div>
-				)}
+				<div class="kol-tooltip__floating" hidden={this.state._label.length === 0} ref={this.catchTooltipElement}>
+					<div class="kol-tooltip__arrow" ref={this.catchArrowElement} />
+					<KolSpanFc class="kol-tooltip__content" id={this.state._id} badgeText={this._badgeText} label={this.state._label} />
+				</div>
 			</Host>
 		);
 	}
@@ -268,14 +266,13 @@ export class KolTooltipWc implements TooltipAPI {
 	}
 
 	private handleEventListeners(): void {
-		const nextSibling = this.host?.previousElementSibling ?? null;
-		this.resyncListeners(this.previousSibling, nextSibling as Element, true);
+		this.resyncListeners(this.previousSibling, this.host?.previousElementSibling, true);
 		this.resyncListeners(this.tooltipElement, this.tooltipElement);
 	}
 
 	public connectedCallback(): void {
-		this.previousSibling = this.host?.previousElementSibling ?? null;
-		this.parentElement = this.host?.parentElement ?? null;
+		this.previousSibling = this.host?.previousElementSibling;
+		this.parentElement = this.host?.parentElement;
 	}
 
 	public componentDidRender(): void {

--- a/packages/samples/react/src/components/button/expert-slot.tooltip.scss
+++ b/packages/samples/react/src/components/button/expert-slot.tooltip.scss
@@ -1,0 +1,103 @@
+@layer kol-component {
+	.kol-tooltip-wc {
+		display: contents;
+
+		.tooltip-floating {
+			opacity: 0;
+			display: none;
+			position: fixed;
+
+			/* Avoid layout interference - see https://floating-ui.com/docs/computePosition */
+			top: 0;
+			left: 0;
+			/* Can be used to specify the tooltip-width from the outside. Unset by default. */
+			width: var(--kol-tooltip-width, unset);
+			max-width: 90vw;
+			max-height: 90vh;
+			animation-direction: normal;
+			/* Can be used to specify the animation duration from the outside. 250ms by default. */
+			animation-duration: var(--kolibri-tooltip-animation-duration, 250ms);
+			animation-fill-mode: forwards;
+			animation-iteration-count: 1;
+			animation-timing-function: ease-in;
+
+			&.hide {
+				animation-name: hideTooltip;
+			}
+
+			&.show {
+				animation-name: showTooltip;
+			}
+		}
+
+		/* Shared between content and arrow */
+		.tooltip-area {
+			color: #000;
+			background-color: #fff;
+		}
+
+		.tooltip-arrow {
+			transform: rotate(45deg);
+			position: absolute;
+			z-index: 999;
+			width: 10px;
+			height: 10px;
+		}
+
+		.tooltip-content {
+			position: relative;
+			z-index: 1000;
+		}
+
+		.tooltip-floating {
+			border-radius: var(--border-radius);
+			border: var(--border-width) solid var(--color-subtle);
+		}
+
+		.tooltip-arrow {
+			border: var(--border-width) solid var(--color-subtle);
+		}
+
+		.tooltip-area {
+			background-color: var(--color-light);
+		}
+
+		.tooltip-content {
+			border-radius: var(--border-radius);
+			padding: to-rem(8) to-rem(12);
+
+			line-height: 1.5;
+		}
+
+		.kol-span-wc {
+			display: grid;
+			gap: 8px;
+
+			span {
+				display: flex;
+				gap: 8px;
+			}
+		}
+	}
+
+	@keyframes hideTooltip {
+		0% {
+			opacity: 1;
+		}
+
+		100% {
+			opacity: 0;
+			display: none;
+		}
+	}
+
+	@keyframes showTooltip {
+		0% {
+			opacity: 0;
+		}
+
+		100% {
+			opacity: 1;
+		}
+	}
+}

--- a/packages/samples/react/src/components/button/expert-slot.tsx
+++ b/packages/samples/react/src/components/button/expert-slot.tsx
@@ -1,8 +1,13 @@
-import { KolButton, KolHeading } from '@public-ui/react-v19';
+import type { Components } from '@public-ui/components';
+import { KolButton, KolHeading, KolIcon } from '@public-ui/react-v19';
 import type { FC } from 'react';
 import React from 'react';
 import { useToasterService } from '../../hooks/useToasterService';
 import { SampleDescription } from '../SampleDescription';
+
+import './expert-slot.tooltip.scss';
+
+const KolTooltip = 'kol-tooltip-wc' as unknown as React.FC<Components.KolTooltipWc>;
 
 export const ButtonExpertSlot: FC = () => {
 	const { dummyClickEventHandler } = useToasterService();
@@ -33,6 +38,10 @@ export const ButtonExpertSlot: FC = () => {
 						<KolButton _icons="kolicon-alert-warning" _label="" _variant="danger" _on={dummyEventHandler}>
 							<span slot="expert">Delete with custom text</span>
 						</KolButton>
+						<KolButton _hideLabel _label="" _variant="danger" _on={dummyEventHandler}>
+							<KolIcon _icons="kolicon-alert-warning" _label="" slot="expert" />
+						</KolButton>
+						<KolTooltip _label="Delete with custom text" />
 					</div>
 				</section>
 

--- a/packages/samples/react/src/components/button/expert-slot.tsx
+++ b/packages/samples/react/src/components/button/expert-slot.tsx
@@ -1,4 +1,3 @@
-import type { Components } from '@public-ui/components';
 import { KolButton, KolHeading, KolIcon } from '@public-ui/react-v19';
 import type { FC } from 'react';
 import React from 'react';
@@ -7,7 +6,7 @@ import { SampleDescription } from '../SampleDescription';
 
 import './expert-slot.tooltip.scss';
 
-const KolTooltip = 'kol-tooltip-wc' as unknown as React.FC<Components.KolTooltipWc>;
+const KolTooltip = 'kol-tooltip-wc' as unknown as React.FC<{ _label: string }>;
 
 export const ButtonExpertSlot: FC = () => {
 	const { dummyClickEventHandler } = useToasterService();


### PR DESCRIPTION
## What changed?

The `KolTooltip` component's event listener handling was simplified on the `develop` (v4) branch. `mouseenter`/`mouseleave` listeners were replaced with `mouseover`/`mouseout` paired with an `isInsideTriggerOrTooltip` helper that checks `relatedTarget` using `contains`. This correctly handles composed mouse events across shadow DOM and slot boundaries, fixing a bug where tooltips using the expert slot could remain open unexpectedly. The same fix was also applied to `release/3` (#9364) and `release/2` (#9359).

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Event-Listener-Logik der `KolTooltip`-Komponente wurde vereinfacht. `mouseenter`/`mouseleave` wurden durch `mouseover`/`mouseout` mit einem `isInsideTriggerOrTooltip`-Helper ersetzt. Dieser behebt einen Bug, bei dem Tooltips im Expert-Slot-Modus nicht zuverlässig schlossen. Gilt für den `develop`-Branch (v4).

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tooltip/...` — Event-Listener-Refactoring (3 Dateien)

</details>