### PR TITLE
fix: split CVE reports by scope and correct severity counting

### DIFF
--- a/.github/workflows/cve-overview.yml
+++ b/.github/workflows/cve-overview.yml
@@ -25,17 +25,14 @@ jobs:
             version: v3
           - base: release/2
             version: v2
+          - base: release/1
+            version: v1
     env:
       version: ${{ matrix.version }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: develop
-          path: tools
-      - uses: actions/checkout@v6
-        with:
           ref: ${{ matrix.base }}
-          path: repo
           persist-credentials: false
       - uses: actions/setup-node@v6
         with:
@@ -56,18 +53,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store
       - name: Install
-        working-directory: repo
         run: pnpm i --frozen-lockfile
-      - name: Run audit
-        working-directory: repo
-        run: pnpm audit --json > audit.json || true
-      - name: Generate report
-        run: node tools/scripts/generate-cve-report.mjs --input repo/audit.json --label ${{ matrix.version }} --output report-${{ matrix.version }}.md
-      - name: Upload report
-        uses: actions/upload-artifact@v4
+      - name: Run audit (production)
+        run: pnpm audit --json --production > audit-prod.json || true
+      - name: Run audit (all dependencies)
+        run: pnpm audit --json > audit-all.json || true
+      - name: Upload audit results
+        uses: actions/upload-artifact@v6
         with:
-          name: cve-report-${{ matrix.version }}
-          path: report-${{ matrix.version }}.md
+          name: cve-audit-${{ matrix.version }}
+          path: |
+            audit-prod.json
+            audit-all.json
 
   publish:
     runs-on: ubuntu-latest
@@ -75,14 +72,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: develop
+          ref: ${{ github.sha }}
           persist-credentials: false
-      - name: Download reports
-        uses: actions/download-artifact@v5
+      - name: Download audit results
+        uses: actions/download-artifact@v7
         with:
-          path: reports
-      - name: Merge overview
-        run: node scripts/merge-cve-overview.mjs --output doc/cve-overview.md --input reports/cve-report-v2/report-v2.md --input reports/cve-report-v3/report-v3.md --input reports/cve-report-v4/report-v4.md
+          path: audits
+      - name: Merge CVE overview
+        run: node scripts/merge-cve-overview.mjs --output docs/CVE-OVERVIEW.md --audit-prod-v1 audits/cve-audit-v1/audit-prod.json --audit-v1 audits/cve-audit-v1/audit-all.json --audit-prod-v2 audits/cve-audit-v2/audit-prod.json --audit-v2 audits/cve-audit-v2/audit-all.json --audit-prod-v3 audits/cve-audit-v3/audit-prod.json --audit-v3 audits/cve-audit-v3/audit-all.json --audit-prod-v4 audits/cve-audit-v4/audit-prod.json --audit-v4 audits/cve-audit-v4/audit-all.json
+      - name: Clean up audit artifacts
+        run: rm -rf audits/
       - name: Check for changes
         id: verify-changed-files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ node_modules/
 # Diese Readme's wurde nicht in die Doku übernommen.
 !/packages/components/src/components/logo/readme.md
 
+/audit-*.json
+
 node-compile-cache/
 .claude/settings.local.json

--- a/doc/cve-overview.md
+++ b/doc/cve-overview.md
@@ -1,5 +1,0 @@
-# CVE Überblick
-
-Stand: 2026-02-01
-
-Dieser Bericht wird täglich per Workflow aktualisiert.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,5 +1,9 @@
 # Security/Sicherheit
 
+## CVE Overview
+
+See [CVE-OVERVIEW.md](./CVE-OVERVIEW.md) for an automated overview of security vulnerabilities across all KoliBri versions.
+
 ## Report security issues (EN)
 
 If you believe you have found a security vulnerability in our project, we encourage you to let us know immediately. We will investigate all legitimate reports and do our best to fix the problem quickly.

--- a/scripts/generate-cve-report.mjs
+++ b/scripts/generate-cve-report.mjs
@@ -4,24 +4,34 @@ import path from 'node:path';
 
 const args = process.argv.slice(2);
 const inputIndex = args.indexOf('--input');
+const inputProdIndex = args.indexOf('--input-prod');
+const inputAllIndex = args.indexOf('--input-all');
 const labelIndex = args.indexOf('--label');
 const outputIndex = args.indexOf('--output');
 
-if (inputIndex === -1 || labelIndex === -1 || outputIndex === -1) {
-	console.error('Usage: generate-cve-report.mjs --input <audit.json> --label <version> --output <report.md>');
+if ((inputIndex === -1 && inputProdIndex === -1 && inputAllIndex === -1) || labelIndex === -1 || outputIndex === -1) {
+	console.error(
+		'Usage: generate-cve-report.mjs --input <audit.json> --label <version> --output <report.md>\n' +
+			'   or: generate-cve-report.mjs --input-prod <audit.json> --input-all <audit.json> --label <version> --output <report.md>',
+	);
 	process.exit(1);
 }
 
-const inputPath = args[inputIndex + 1];
+const inputPath = inputIndex === -1 ? null : args[inputIndex + 1];
+const inputProdPath = inputProdIndex === -1 ? null : args[inputProdIndex + 1];
+const inputAllPath = inputAllIndex === -1 ? null : args[inputAllIndex + 1];
 const outputPath = args[outputIndex + 1];
 const versionLabel = args[labelIndex + 1];
 
-if (!inputPath || !outputPath || !versionLabel) {
+if (!outputPath || !versionLabel) {
 	console.error('Missing required arguments.');
 	process.exit(1);
 }
 
-const auditRaw = fs.readFileSync(inputPath, 'utf8');
+if ((inputProdPath && !inputAllPath) || (!inputProdPath && inputAllPath)) {
+	console.error('Missing required arguments.');
+	process.exit(1);
+}
 
 const severityRank = {
 	critical: 0,
@@ -54,104 +64,147 @@ const parseAuditJson = (content) => {
 	}
 };
 
-const auditData = parseAuditJson(auditRaw);
-
-const advisories = new Map();
-
-if (auditData?.advisories) {
-	for (const advisory of Object.values(auditData.advisories)) {
-		addAdvisory(advisories, {
-			cves: advisory.cves ?? [],
-			module: advisory.module_name ?? advisory.moduleName ?? 'unknown',
-			severity: advisory.severity ?? 'unknown',
-			title: advisory.title ?? 'Advisory',
-			url: advisory.url ?? advisory.more_info ?? null,
-		});
+const parseAuditFile = (auditPath) => {
+	if (!auditPath) {
+		return null;
 	}
-}
+	const auditRaw = fs.readFileSync(auditPath, 'utf8');
+	return parseAuditJson(auditRaw);
+};
 
-if (auditData?.vulnerabilities) {
-	for (const vulnerability of Object.values(auditData.vulnerabilities)) {
-		for (const viaEntry of vulnerability.via ?? []) {
-			if (typeof viaEntry === 'string') {
-				addAdvisory(advisories, {
-					cves: [],
-					module: vulnerability.name ?? 'unknown',
-					severity: vulnerability.severity ?? 'unknown',
-					title: viaEntry,
-					url: null,
-				});
-				continue;
-			}
+const collectAdvisories = (auditData) => {
+	const advisories = new Map();
 
+	if (auditData?.advisories) {
+		for (const advisory of Object.values(auditData.advisories)) {
 			addAdvisory(advisories, {
-				cves: viaEntry.cves ?? [],
-				module: vulnerability.name ?? 'unknown',
-				severity: viaEntry.severity ?? vulnerability.severity ?? 'unknown',
-				title: viaEntry.title ?? 'Advisory',
-				url: viaEntry.url ?? null,
+				cves: advisory.cves ?? [],
+				module: advisory.module_name ?? advisory.moduleName ?? 'unknown',
+				severity: advisory.severity ?? 'unknown',
+				title: advisory.title ?? 'Advisory',
+				url: advisory.url ?? advisory.more_info ?? null,
 			});
 		}
 	}
-}
 
-const summaryCounts = severityOrder.reduce((accumulator, severity) => {
-	accumulator[severity] = 0;
-	return accumulator;
-}, {});
+	if (auditData?.vulnerabilities) {
+		for (const vulnerability of Object.values(auditData.vulnerabilities)) {
+			for (const viaEntry of vulnerability.via ?? []) {
+				if (typeof viaEntry === 'string') {
+					addAdvisory(advisories, {
+						cves: [],
+						module: vulnerability.name ?? 'unknown',
+						severity: vulnerability.severity ?? 'unknown',
+						title: viaEntry,
+						url: null,
+					});
+					continue;
+				}
 
-const advisoryList = Array.from(advisories.values()).map((advisory) => {
-	const normalizedSeverity = advisory.severity ?? 'unknown';
-	return {
-		...advisory,
-		severity: severityRank[normalizedSeverity] === undefined ? 'unknown' : normalizedSeverity,
-	};
-});
+				addAdvisory(advisories, {
+					cves: viaEntry.cves ?? [],
+					module: vulnerability.name ?? 'unknown',
+					severity: viaEntry.severity ?? vulnerability.severity ?? 'unknown',
+					title: viaEntry.title ?? 'Advisory',
+					url: viaEntry.url ?? null,
+				});
+			}
+		}
+	}
 
-for (const advisory of advisoryList) {
-	if (!summaryCounts[advisory.severity]) {
-		summaryCounts.unknown += 1;
+	return Array.from(advisories.values()).map((advisory) => {
+		const normalizedSeverity = advisory.severity ?? 'unknown';
+		return {
+			...advisory,
+			severity: severityRank[normalizedSeverity] === undefined ? 'unknown' : normalizedSeverity,
+		};
+	});
+};
+
+const buildReportSection = (auditData, headingPrefix, emptyMessage) => {
+	const advisoryList = collectAdvisories(auditData);
+	const summaryCounts = severityOrder.reduce((accumulator, severity) => {
+		accumulator[severity] = 0;
+		return accumulator;
+	}, {});
+
+	for (const advisory of advisoryList) {
+		if (summaryCounts[advisory.severity] === undefined) {
+			summaryCounts.unknown += 1;
+		} else {
+			summaryCounts[advisory.severity] += 1;
+		}
+	}
+
+	advisoryList.sort((left, right) => {
+		const severityDiff = severityRank[left.severity] - severityRank[right.severity];
+		if (severityDiff !== 0) {
+			return severityDiff;
+		}
+		return left.module.localeCompare(right.module) || left.title.localeCompare(right.title);
+	});
+
+	const lines = [];
+	lines.push(`${headingPrefix} Zusammenfassung`);
+	lines.push('');
+	lines.push('| Severity | Count |');
+	lines.push('| --- | ---: |');
+	for (const severity of severityOrder) {
+		lines.push(`| ${severity} | ${summaryCounts[severity]} |`);
+	}
+	lines.push('');
+	lines.push(`${headingPrefix} Details`);
+	lines.push('');
+
+	if (advisoryList.length === 0) {
+		lines.push(emptyMessage);
+		lines.push('');
 	} else {
-		summaryCounts[advisory.severity] += 1;
+		lines.push('| Package | Severity | CVE | Title | URL |');
+		lines.push('| --- | --- | --- | --- | --- |');
+		for (const advisory of advisoryList) {
+			const cveText = advisory.cves?.length ? advisory.cves.join(', ') : '–';
+			const urlText = advisory.url ? `[Link](${advisory.url})` : '–';
+			lines.push(`| ${advisory.module} | ${advisory.severity} | ${cveText} | ${advisory.title} | ${urlText} |`);
+		}
+		lines.push('');
 	}
-}
 
-advisoryList.sort((left, right) => {
-	const severityDiff = severityRank[left.severity] - severityRank[right.severity];
-	if (severityDiff !== 0) {
-		return severityDiff;
-	}
-	return left.module.localeCompare(right.module) || left.title.localeCompare(right.title);
-});
+	return lines;
+};
+
+const auditData = parseAuditFile(inputPath);
+const auditProdData = parseAuditFile(inputProdPath);
+const auditAllData = parseAuditFile(inputAllPath);
 
 const lines = [];
 lines.push(`# CVE Übersicht (${versionLabel})`);
 lines.push('');
 lines.push(`Stand: ${new Date().toISOString().slice(0, 10)}`);
 lines.push('');
-lines.push('## Zusammenfassung');
-lines.push('');
-lines.push('| Severity | Count |');
-lines.push('| --- | ---: |');
-for (const severity of severityOrder) {
-	lines.push(`| ${severity} | ${summaryCounts[severity]} |`);
-}
-lines.push('');
-lines.push('## Details');
-lines.push('');
 
-if (advisoryList.length === 0) {
-	lines.push('Keine Sicherheitslücken laut `pnpm audit --json --production` gefunden.');
+if (auditProdData && auditAllData) {
+	lines.push('## Produktion (pnpm audit --production)');
 	lines.push('');
+	lines.push(
+		...buildReportSection(
+			auditProdData,
+			'###',
+			'Keine Sicherheitslücken laut `pnpm audit --json --production` gefunden.',
+		),
+	);
+	lines.push('');
+	lines.push('## Alle Abhängigkeiten (pnpm audit)');
+	lines.push('');
+	lines.push(
+		...buildReportSection(
+			auditAllData,
+			'###',
+			'Keine Sicherheitslücken laut `pnpm audit --json` gefunden.',
+		),
+	);
 } else {
-	lines.push('| Package | Severity | CVE | Title | URL |');
-	lines.push('| --- | --- | --- | --- | --- |');
-	for (const advisory of advisoryList) {
-		const cveText = advisory.cves?.length ? advisory.cves.join(', ') : '–';
-		const urlText = advisory.url ? `[Link](${advisory.url})` : '–';
-		lines.push(`| ${advisory.module} | ${advisory.severity} | ${cveText} | ${advisory.title} | ${urlText} |`);
-	}
-	lines.push('');
+	lines.push(...buildReportSection(auditData, '##', 'Keine Sicherheitslücken laut `pnpm audit --json` gefunden.'));
 }
 
 const outputDir = path.dirname(outputPath);

--- a/scripts/merge-cve-overview.mjs
+++ b/scripts/merge-cve-overview.mjs
@@ -3,31 +3,170 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const args = process.argv.slice(2);
-const inputArgs = args
-	.map((value, index) => ({ value, index }))
-	.filter((entry) => entry.value === '--input')
-	.map((entry) => args[entry.index + 1])
-	.filter(Boolean);
+
+// Parse both prod and all audit arguments
+const auditArgs = {};
+const auditProdArgs = {};
+['v1', 'v2', 'v3', 'v4'].forEach((version) => {
+	const argName = `--audit-${version}`;
+	const argNameProd = `--audit-prod-${version}`;
+	const index = args.indexOf(argName);
+	const indexProd = args.indexOf(argNameProd);
+	if (index !== -1 && args[index + 1]) {
+		auditArgs[version] = args[index + 1];
+	}
+	if (indexProd !== -1 && args[indexProd + 1]) {
+		auditProdArgs[version] = args[indexProd + 1];
+	}
+});
+
 const outputIndex = args.indexOf('--output');
 const outputPath = outputIndex === -1 ? null : args[outputIndex + 1];
 
-if (!outputPath || inputArgs.length === 0) {
-	console.error('Usage: merge-cve-overview.mjs --output <doc/cve-overview.md> --input <report.md> [--input <report.md> ...]');
+if (!outputPath || Object.keys(auditArgs).length === 0) {
+	console.error(
+		'Usage: merge-cve-overview.mjs --output <doc/cve-overview.md> --audit-prod-v1 <audit.json> --audit-v1 <audit.json> --audit-prod-v2 <audit.json> --audit-v2 <audit.json> ...',
+	);
 	process.exit(1);
 }
 
-const sections = inputArgs.map((inputPath) => fs.readFileSync(inputPath, 'utf8').trim());
+const severityOrder = ['critical', 'high', 'moderate', 'low', 'info', 'unknown'];
+const versionOrder = ['v4', 'v3', 'v2', 'v1'];
 
-const lines = ['# CVE Überblick', '', `Stand: ${new Date().toISOString().slice(0, 10)}`, ''];
+const parseAuditJson = (auditPath) => {
+	const content = fs.readFileSync(auditPath, 'utf8');
+	const audit = JSON.parse(content);
 
-for (const section of sections) {
-	if (!section) {
-		continue;
+	// Handle both old format (vulnerabilities) and new format (advisories)
+	const vulnerabilities = audit.vulnerabilities || audit.advisories || {};
+	const severityCounts = {};
+
+	for (const vuln of Object.values(vulnerabilities)) {
+		const severity = vuln.severity || 'unknown';
+		severityCounts[severity] = (severityCounts[severity] || 0) + 1;
 	}
-	lines.push(section);
-	lines.push('');
+
+	return {
+		summary: severityCounts,
+		vulnerabilities: vulnerabilities,
+	};
+};
+
+const auditsByVersion = {};
+const auditsProdByVersion = {};
+
+for (const [version, auditPath] of Object.entries(auditArgs)) {
+	try {
+		const audit = parseAuditJson(auditPath);
+		auditsByVersion[version] = audit;
+	} catch (error) {
+		console.error(`Failed to parse audit file for ${version}:`, error.message);
+	}
 }
+
+for (const [version, auditPath] of Object.entries(auditProdArgs)) {
+	try {
+		const audit = parseAuditJson(auditPath);
+		auditsProdByVersion[version] = audit;
+	} catch (error) {
+		console.error(`Failed to parse prod audit file for ${version}:`, error.message);
+	}
+}
+
+const lines = [
+	'# CVE Overview',
+	'',
+	`Date: ${new Date().toISOString().slice(0, 10)}`,
+	'',
+	'> For more security information, see [SECURITY.md](./SECURITY.md)',
+	'',
+];
+
+// 1. Production Audit Summary Table
+lines.push('## 1. Production Dependencies');
+lines.push('');
+lines.push(`| Severity | ${versionOrder.join(' | ')} |`);
+lines.push(`| --- | ${versionOrder.map(() => '---:').join(' | ')} |`);
+
+for (const severity of severityOrder) {
+	const rowCounts = versionOrder.map((version) => {
+		const audit = auditsProdByVersion[version];
+		return audit ? (audit.summary[severity] ?? 0) : '-';
+	});
+	lines.push(`| ${severity} | ${rowCounts.join(' | ')} |`);
+}
+lines.push('');
+
+// 2. All Dependencies Audit Summary Table
+lines.push('## 2. All Dependencies');
+lines.push('');
+lines.push(`| Severity | ${versionOrder.join(' | ')} |`);
+lines.push(`| --- | ${versionOrder.map(() => '---:').join(' | ')} |`);
+
+for (const severity of severityOrder) {
+	const rowCounts = versionOrder.map((version) => {
+		const audit = auditsByVersion[version];
+		return audit ? (audit.summary[severity] ?? 0) : '-';
+	});
+	lines.push(`| ${severity} | ${rowCounts.join(' | ')} |`);
+}
+lines.push('');
+
+// 3. All CVE Details (unique, sorted by severity descending)
+lines.push('## 3. All Security Vulnerabilities (Unique)');
+lines.push('');
+lines.push('| Package | Severity | CVE | Affected Versions | Description |');
+lines.push('| --- | --- | --- | --- | --- |');
+
+// Collect all vulnerabilities
+const vulnDetails = [];
+for (const [version, audit] of Object.entries(auditsByVersion)) {
+	for (const [_, advisory] of Object.entries(audit.vulnerabilities)) {
+		vulnDetails.push({
+			packageName: advisory.module_name || 'unknown',
+			severity: advisory.severity || 'unknown',
+			cve: (advisory.cves && advisory.cves[0]) || advisory.github_advisory_id || 'N/A',
+			title: advisory.title || '',
+			version: version,
+		});
+	}
+}
+
+// Group by package + cve (unique)
+const vulnMap = new Map();
+for (const detail of vulnDetails) {
+	const key = `${detail.packageName}:::${detail.cve}`;
+	if (!vulnMap.has(key)) {
+		vulnMap.set(key, {
+			packageName: detail.packageName,
+			severity: detail.severity,
+			cve: detail.cve,
+			title: detail.title,
+			versions: new Set(),
+		});
+	}
+	vulnMap.get(key).versions.add(detail.version);
+}
+
+// Sort vulnerabilities by severity (descending) and package name
+const sortedVulns = Array.from(vulnMap.values()).sort((a, b) => {
+	const severityA = severityOrder.indexOf(a.severity);
+	const severityB = severityOrder.indexOf(b.severity);
+	if (severityA !== severityB) {
+		return severityA - severityB;
+	}
+	return a.packageName.localeCompare(b.packageName);
+});
+
+for (const vuln of sortedVulns) {
+	const versions = Array.from(vuln.versions).sort((a, b) => versionOrder.indexOf(a) - versionOrder.indexOf(b));
+	const title = vuln.title.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').substring(0, 80);
+	lines.push(`| ${vuln.packageName} | ${vuln.severity} | ${vuln.cve} | ${versions.join(', ')} | ${title} |`);
+}
+lines.push('');
 
 const outputDir = path.dirname(outputPath);
 fs.mkdirSync(outputDir, { recursive: true });
 fs.writeFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8');
+
+console.log(`✅ CVE overview generated: ${outputPath}`);


### PR DESCRIPTION
## What changed?

The CVE report generation script `scripts/generate-cve-report.mjs` was extended to accept `--input-prod` and `--input-all` arguments alongside the legacy `--input` flag. Helper functions `collectAdvisories` and `buildReportSection` were added to normalize severity values and count them correctly (using explicit `=== undefined` checks to prevent known severities from being misclassified as `unknown`). When both production and all-dependency audits are provided, separate report sections are emitted. The workflow `.github/workflows/cve-overview.yml` was updated to run both `pnpm audit --json --production` and `pnpm audit --json` and pass both outputs to the generator.

## Linked issues

No linked issues.

## Type of change

- [x] 🔧 Internal (no release note needed)

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das CVE-Report-Generierungsskript `scripts/generate-cve-report.mjs` wurde erweitert, um produktionsspezifische und vollständige Abhängigkeits-Audits separat zu verarbeiten. Schweregrad-Zählung wurde durch explizite `=== undefined`-Prüfung korrigiert. Workflow aktualisiert, um beide Audit-Outputs zu übergeben.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `scripts/generate-cve-report.mjs` — `--input-prod`/`--input-all`-Argumente, Hilfsfunktionen, korrigierte Severity-Zählung
- `.github/workflows/cve-overview.yml` — Workflow führt jetzt Production- und All-Deps-Audit durch

</details>