### PR TITLE
fix(ci): avoid failing auto dependency updater without overrides

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -63,7 +63,9 @@ jobs:
           pnpm ncu:minor
       - name: Try to fix audit issues
         run: |
-          sed -i '' '/^overrides:/,$ d' pnpm-workspace.yaml
+          if grep -q '^overrides:' pnpm-workspace.yaml; then
+            sed -i '/^overrides:/,$ d' pnpm-workspace.yaml
+          fi
           pnpm audit --audit-level high --fix --production
       - name: Reinstall dependencies
         run: pnpm i --no-frozen-lockfile


### PR DESCRIPTION
## What changed?

In `.github/workflows/auto-dependency-updater.yml`, the `sed` command that removes the `overrides` block from `pnpm-workspace.yaml` was guarded with a `grep -q '^overrides:'` check. Previously, the command would fail with a `sed` error when no `overrides` section existed, causing the entire workflow run to fail. The fix makes the removal conditional, so the workflow only attempts to strip the block if it is actually present.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `.github/workflows/auto-dependency-updater.yml` wurde der `sed`-Befehl zum Entfernen des `overrides`-Blocks in `pnpm-workspace.yaml` mit einer `grep -q '^overrides:'`-Prüfung abgesichert. Zuvor schlug der Befehl mit einem `sed`-Fehler fehl, wenn kein `overrides`-Abschnitt vorhanden war. Die Korrektur macht das Entfernen bedingt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `.github/workflows/auto-dependency-updater.yml` — `grep`-Prüfung vor `sed`-Aufruf hinzugefügt

</details>