### PR TITLE
fix(react-hook-form-adapter): use field.disabled from controller instead of explicit disabled prop

### DIFF
--- a/packages/adapters/react-hook-form-adapter/src/index.tsx
+++ b/packages/adapters/react-hook-form-adapter/src/index.tsx
@@ -67,7 +67,6 @@ type ControllerBaseProps<TControl = Control<any>> = {
 	rules?: any;
 	defaultValue?: any;
 	shouldUnregister?: boolean;
-	disabled?: boolean;
 };
 
 // Extract component props from React component type
@@ -78,7 +77,7 @@ type ControllerComponent<P> = React.ForwardRefExoticComponent<P & ControllerBase
 
 function withController<T extends React.ComponentType<any>>(Component: T, valueProp?: string): ControllerComponent<ExtractProps<T>> {
 	const ControllerWrapper = React.forwardRef<HTMLElement, ExtractProps<T> & ControllerBaseProps<any>>((props, ref) => {
-		const { name, control, rules, defaultValue, shouldUnregister, disabled, ...componentProps } = props;
+		const { name, control, rules, defaultValue, shouldUnregister, ...componentProps } = props;
 
 		return (
 			<Controller
@@ -102,7 +101,7 @@ function withController<T extends React.ComponentType<any>>(Component: T, valueP
 						},
 						_name: name,
 						_touched: fieldState.isTouched,
-						_disabled: props._disabled || disabled || field.disabled,
+						_disabled: field.disabled, // https://react-hook-form.com/docs/useform#disabled
 						_msg: fieldState.error
 							? {
 									_type: 'error' as const,

--- a/packages/adapters/react-hook-form-adapter/src/index.tsx
+++ b/packages/adapters/react-hook-form-adapter/src/index.tsx
@@ -87,7 +87,7 @@ function withController<T extends React.ComponentType<any>>(Component: T, valueP
 				rules={rules}
 				defaultValue={defaultValue}
 				shouldUnregister={shouldUnregister}
-				disabled={disabled}
+				disabled={props._disabled}
 				render={({ field, fieldState }) => {
 					const userHandlers = (componentProps as any)._on as KolEventHandlers | undefined;
 
@@ -102,7 +102,7 @@ function withController<T extends React.ComponentType<any>>(Component: T, valueP
 						},
 						_name: name,
 						_touched: fieldState.isTouched,
-						_disabled: (componentProps as any)._disabled || disabled || field.disabled,
+						_disabled: props._disabled || disabled || field.disabled,
 						_msg: fieldState.error
 							? {
 									_type: 'error' as const,

--- a/packages/samples/react/src/scenarios/react-hook-form/disabled.tsx
+++ b/packages/samples/react/src/scenarios/react-hook-form/disabled.tsx
@@ -1,0 +1,52 @@
+import { KolInputTextController } from '@public-ui/react-hook-form-adapter';
+import { KolButton, KolForm } from '@public-ui/react-v19';
+import React, { type BaseSyntheticEvent, type FC } from 'react';
+import type { SubmitHandler } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
+
+import { SampleDescription } from '../../components/SampleDescription';
+
+interface FormData {
+	first: string;
+	second: string;
+}
+
+const defaultValues: FormData = {
+	first: '',
+	second: '',
+};
+
+export const RHFDisabled: FC = () => {
+	const { control, handleSubmit, watch } = useForm<FormData>({
+		defaultValues,
+	});
+
+	const onSubmit: SubmitHandler<FormData> = (data) => {
+		alert(JSON.stringify(data, null, 2));
+	};
+
+	return (
+		<>
+			<SampleDescription>
+				<p>This sample shows two fields of which just one can be filled. The other gets disabled.</p>
+			</SampleDescription>
+
+			<KolForm
+				className="w-full max-w-xl"
+				_on={{
+					onSubmit: (event) => {
+						void handleSubmit(onSubmit)(event as unknown as BaseSyntheticEvent);
+					},
+				}}
+			>
+				<div className="grid gap-4">
+					<KolInputTextController name="first" control={control} _label="First" _disabled={!!watch('second')} />
+
+					<KolInputTextController name="second" control={control} _label="Second" _disabled={!!watch('first')} />
+
+					<KolButton _label="Submit" _type="submit" />
+				</div>
+			</KolForm>
+		</>
+	);
+};

--- a/packages/samples/react/src/scenarios/routes.ts
+++ b/packages/samples/react/src/scenarios/routes.ts
@@ -9,6 +9,7 @@ import { InputGroupWithError } from './input-group-with-error';
 import { InputsGetValue } from './inputs-get-value';
 import { PerformanceTest } from './performance-test';
 import { RHFBasic } from './react-hook-form/basic';
+import { RHFDisabled } from './react-hook-form/disabled';
 import { SameHeightOfAllInteractiveElements } from './same-height-of-all-interactive-elements';
 import { SampleFormWithValidation } from './sample-form-with-validation';
 import { StaticForm } from './static-form';
@@ -25,6 +26,7 @@ export const SCENARIO_ROUTES: Routes = {
 		'input-group-with-error': InputGroupWithError,
 		'inputs-get-value': InputsGetValue,
 		'react-hook-form-adapter': RHFBasic,
+		'react-hook-form-adapter-disabled': RHFDisabled,
 		'same-height-of-all-interactive-elements': SameHeightOfAllInteractiveElements,
 		'static-form': StaticForm,
 		'sample-form-with-validation': SampleFormWithValidation,


### PR DESCRIPTION
## What changed?

In the `withController` higher-order component of `@public-ui/react-hook-form-adapter`, the standalone `disabled` prop was removed from the wrapper's prop destructuring. The `_disabled` state is now sourced exclusively from react-hook-form's `field.disabled` provided by the `Controller` render callback, which is the documented approach per react-hook-form's `useForm({ disabled })`. This prevents the wrapper from incorrectly intercepting or duplicating the disabled state alongside the KoliBri `_disabled` prop. This is a backport of the fix to the v3 release branch (see also #9408 for the v4 version).

## Linked issues

- Refs #9247 — form controller `disabled` state not correctly propagated

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Im Higher-Order-Component `withController` des `@public-ui/react-hook-form-adapter`-Pakets wurde die explizite `disabled`-Prop aus der Prop-Destrukturierung des Wrappers entfernt. Der `_disabled`-Zustand wird nun ausschließlich aus react-hook-forms `field.disabled` bezogen, der vom `Controller`-Render-Callback bereitgestellt wird. Dies entspricht dem dokumentierten Ansatz für `useForm({ disabled })` und verhindert, dass der Wrapper den Disabled-Zustand neben der KoliBri-`_disabled`-Prop dupliziert oder überschreibt. Dieser PR ist ein Backport des Fixes auf den v3-Release-Branch.

### Verknüpfte Tickets

- Referenziert #9247 — `disabled`-Zustand im Form-Controller wird nicht korrekt weitergegeben

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/adapters/react-hook-form-adapter/src/index.tsx` — `disabled`-Prop-Extraktion entfernt; `_disabled` wird nun nur von `field.disabled` gesetzt
- Weitere Dateien: angepasste Sample-/Test-Dateien für v3

</details>