### PR TITLE
fix(sample-react): persist selected theme without url parameter

### DIFF
--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -34,7 +34,7 @@ export const App: FC<Props> = ({ customThemes }) => {
 		setRegisteredThemes(allThemes);
 		return allThemes;
 	}, [customThemes]);
-	const theme: string = searchParams.get('theme') ?? themes[1].key;
+	const theme: string = searchParams.get('theme') ?? getTheme();
 
 	const getRouteList = (routes: MyRoutes, offset = '/'): string[] => {
 		let list: string[] = [];


### PR DESCRIPTION
## What changed?

Fixed theme persistence in the React sample application. The selected theme now correctly falls back to the last stored theme (via `getTheme()`) when the `theme` URL query parameter is absent. Previously, missing the URL parameter always reset the theme to the hardcoded `themes[1].key` default, bypassing the existing theme storage mechanism. The fix is a single-line change in `packages/samples/react/src/App.tsx`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Theme-Persistenz in der React-Beispielanwendung wurde korrigiert. Das ausgewählte Theme wird nun korrekt aus dem gespeicherten Wert (via `getTheme()`) geladen, wenn der `theme`-URL-Parameter fehlt. Zuvor wurde immer `themes[1].key` als Standardwert gesetzt, was die Theme-Speicherung umging. Die Änderung ist eine einzelne Zeile in `App.tsx`.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/samples/react/src/App.tsx` — Fallback von `themes[1].key` auf `getTheme()` geändert

</details>