### PR TITLE
chore: format CVE overview output in workflow

### DIFF
--- a/.github/workflows/cve-overview.yml
+++ b/.github/workflows/cve-overview.yml
@@ -74,12 +74,24 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: pnpm/action-setup@v4
+        id: pnpm-install
+        with:
+          version: 10
+          run_install: false
+      - name: Install
+        run: pnpm i --frozen-lockfile
       - name: Download audit results
         uses: actions/download-artifact@v7
         with:
           path: audits
       - name: Merge CVE overview
         run: node scripts/merge-cve-overview.mjs --output docs/CVE_OVERVIEW.md --audit-prod-v1 audits/cve-audit-v1/audit-prod.json --audit-v1 audits/cve-audit-v1/audit-all.json --audit-prod-v2 audits/cve-audit-v2/audit-prod.json --audit-v2 audits/cve-audit-v2/audit-all.json --audit-prod-v3 audits/cve-audit-v3/audit-prod.json --audit-v3 audits/cve-audit-v3/audit-all.json --audit-prod-v4 audits/cve-audit-v4/audit-prod.json --audit-v4 audits/cve-audit-v4/audit-all.json
+      - name: Format generated markdown
+        run: pnpm format
       - name: Clean up audit artifacts
         run: rm -rf audits/
       - name: Check for changes

--- a/docs/CVE_OVERVIEW.md
+++ b/docs/CVE_OVERVIEW.md
@@ -6,54 +6,53 @@ Date: 2026-02-09
 
 ## 1. Production Dependencies
 
-| Severity | v4 | v3 | v2 | v1 |
-| --- | ---: | ---: | ---: | ---: |
-| critical | 0 | 0 | 0 | 0 |
-| high | 0 | 0 | 0 | 1 |
-| moderate | 0 | 0 | 0 | 0 |
-| low | 0 | 0 | 0 | 0 |
-| info | 0 | 0 | 0 | 0 |
-| unknown | 0 | 0 | 0 | 0 |
+| Severity |  v4 |  v3 |  v2 |  v1 |
+| -------- | --: | --: | --: | --: |
+| critical |   0 |   0 |   0 |   0 |
+| high     |   0 |   0 |   0 |   1 |
+| moderate |   0 |   0 |   0 |   0 |
+| low      |   0 |   0 |   0 |   0 |
+| info     |   0 |   0 |   0 |   0 |
+| unknown  |   0 |   0 |   0 |   0 |
 
 ## 2. All Dependencies
 
-| Severity | v4 | v3 | v2 | v1 |
-| --- | ---: | ---: | ---: | ---: |
-| critical | 1 | 1 | 1 | 1 |
-| high | 6 | 6 | 9 | 10 |
-| moderate | 1 | 1 | 9 | 1 |
-| low | 1 | 1 | 4 | 0 |
-| info | 0 | 0 | 0 | 0 |
-| unknown | 0 | 0 | 0 | 0 |
+| Severity |  v4 |  v3 |  v2 |  v1 |
+| -------- | --: | --: | --: | --: |
+| critical |   1 |   1 |   1 |   1 |
+| high     |   6 |   6 |   9 |  10 |
+| moderate |   1 |   1 |   9 |   1 |
+| low      |   1 |   1 |   4 |   0 |
+| info     |   0 |   0 |   0 |   0 |
+| unknown  |   0 |   0 |   0 |   0 |
 
 ## 3. All Security Vulnerabilities (Unique)
 
-| Package | Severity | CVE | Affected Versions | Description |
-| --- | --- | --- | --- | --- |
-| locutus | critical | CVE-2026-25521 | v4, v3, v2, v1 | locutus is vulnerable to Prototype Pollution |
-| @angular/common | high | CVE-2025-66035 | v1 | Angular is Vulnerable to XSRF Token Leakage via Protocol-Relative URLs in Angula |
-| @angular/compiler | high | CVE-2025-66412 | v1 | Angular Stored XSS Vulnerability via SVG Animation, SVG URL and MathML Attribute |
-| @angular/compiler | high | CVE-2026-22610 | v1 | Angular has XSS Vulnerability via Unsanitized SVG Script Attributes |
-| @angular/core | high | CVE-2026-22610 | v1 | Angular has XSS Vulnerability via Unsanitized SVG Script Attributes |
-| @isaacs/brace-expansion | high | CVE-2026-25547 | v2, v1 | @isaacs/brace-expansion has Uncontrolled Resource Consumption |
-| braces | high | CVE-2024-4068 | v4, v3, v2, v1 | Uncontrolled resource consumption in braces |
-| fast-xml-parser | high | CVE-2026-25128 | v4, v3, v2 | fast-xml-parser has RangeError DoS Numeric Entities Bug |
-| lodash.pick | high | CVE-2020-8203 | v2, v1 | Prototype Pollution in lodash |
-| qs | high | CVE-2025-15284 | v4, v3, v2 | qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion |
-| semver | high | CVE-2022-25883 | v2 | semver vulnerable to Regular Expression Denial of Service |
-| tar | high | CVE-2026-23745 | v4, v3, v2, v1 | node-tar is Vulnerable to Arbitrary File Overwrite and Symlink Poisoning via Ins |
-| tar | high | CVE-2026-23950 | v4, v3, v2, v1 | Race Condition in node-tar Path Reservations via Unicode Ligature Collisions on  |
-| tar | high | CVE-2026-24842 | v4, v3, v2, v1 | node-tar Vulnerable to Arbitrary File Creation/Overwrite via Hardlink Path Trave |
-| ejs | moderate | CVE-2024-33883 | v2 | ejs lacks certain pollution protection |
-| esbuild | moderate | GHSA-67mh-4wv8-2f99 | v2 | esbuild enables any website to send any requests to the development server and r |
-| js-yaml | moderate | CVE-2025-64718 | v2 | js-yaml has prototype pollution in merge (<<) |
-| micromatch | moderate | CVE-2024-4067 | v4, v3, v2, v1 | Regular Expression Denial of Service (ReDoS) in micromatch |
-| nanoid | moderate | CVE-2024-55565 | v2 | Predictable results in nanoid generation when given non-integer values |
-| serialize-javascript | moderate | CVE-2024-11831 | v2 | Cross-site Scripting (XSS) in serialize-javascript |
-| webpack | moderate | CVE-2024-43788 | v2 | Webpack's AutoPublicPathRuntimeModule has a DOM Clobbering Gadget that leads to  |
-| webpack-dev-server | moderate | CVE-2025-30360 | v2 | webpack-dev-server users' source code may be stolen when they access a malicious |
-| webpack-dev-server | moderate | CVE-2025-30359 | v2 | webpack-dev-server users' source code may be stolen when they access a malicious |
-| diff | low | CVE-2026-24001 | v4, v3, v2 | jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch |
-| webpack | low | CVE-2025-68458 | v2 | webpack buildHttp: allowedUris allow-list bypass via URL userinfo (@) leading to |
-| webpack | low | CVE-2025-68157 | v2 | webpack buildHttp HttpUriPlugin allowedUris bypass via HTTP redirects → SSRF + c |
-
+| Package                 | Severity | CVE                 | Affected Versions | Description                                                                      |
+| ----------------------- | -------- | ------------------- | ----------------- | -------------------------------------------------------------------------------- |
+| locutus                 | critical | CVE-2026-25521      | v4, v3, v2, v1    | locutus is vulnerable to Prototype Pollution                                     |
+| @angular/common         | high     | CVE-2025-66035      | v1                | Angular is Vulnerable to XSRF Token Leakage via Protocol-Relative URLs in Angula |
+| @angular/compiler       | high     | CVE-2025-66412      | v1                | Angular Stored XSS Vulnerability via SVG Animation, SVG URL and MathML Attribute |
+| @angular/compiler       | high     | CVE-2026-22610      | v1                | Angular has XSS Vulnerability via Unsanitized SVG Script Attributes              |
+| @angular/core           | high     | CVE-2026-22610      | v1                | Angular has XSS Vulnerability via Unsanitized SVG Script Attributes              |
+| @isaacs/brace-expansion | high     | CVE-2026-25547      | v2, v1            | @isaacs/brace-expansion has Uncontrolled Resource Consumption                    |
+| braces                  | high     | CVE-2024-4068       | v4, v3, v2, v1    | Uncontrolled resource consumption in braces                                      |
+| fast-xml-parser         | high     | CVE-2026-25128      | v4, v3, v2        | fast-xml-parser has RangeError DoS Numeric Entities Bug                          |
+| lodash.pick             | high     | CVE-2020-8203       | v2, v1            | Prototype Pollution in lodash                                                    |
+| qs                      | high     | CVE-2025-15284      | v4, v3, v2        | qs's arrayLimit bypass in its bracket notation allows DoS via memory exhaustion  |
+| semver                  | high     | CVE-2022-25883      | v2                | semver vulnerable to Regular Expression Denial of Service                        |
+| tar                     | high     | CVE-2026-23745      | v4, v3, v2, v1    | node-tar is Vulnerable to Arbitrary File Overwrite and Symlink Poisoning via Ins |
+| tar                     | high     | CVE-2026-23950      | v4, v3, v2, v1    | Race Condition in node-tar Path Reservations via Unicode Ligature Collisions on  |
+| tar                     | high     | CVE-2026-24842      | v4, v3, v2, v1    | node-tar Vulnerable to Arbitrary File Creation/Overwrite via Hardlink Path Trave |
+| ejs                     | moderate | CVE-2024-33883      | v2                | ejs lacks certain pollution protection                                           |
+| esbuild                 | moderate | GHSA-67mh-4wv8-2f99 | v2                | esbuild enables any website to send any requests to the development server and r |
+| js-yaml                 | moderate | CVE-2025-64718      | v2                | js-yaml has prototype pollution in merge (<<)                                    |
+| micromatch              | moderate | CVE-2024-4067       | v4, v3, v2, v1    | Regular Expression Denial of Service (ReDoS) in micromatch                       |
+| nanoid                  | moderate | CVE-2024-55565      | v2                | Predictable results in nanoid generation when given non-integer values           |
+| serialize-javascript    | moderate | CVE-2024-11831      | v2                | Cross-site Scripting (XSS) in serialize-javascript                               |
+| webpack                 | moderate | CVE-2024-43788      | v2                | Webpack's AutoPublicPathRuntimeModule has a DOM Clobbering Gadget that leads to  |
+| webpack-dev-server      | moderate | CVE-2025-30360      | v2                | webpack-dev-server users' source code may be stolen when they access a malicious |
+| webpack-dev-server      | moderate | CVE-2025-30359      | v2                | webpack-dev-server users' source code may be stolen when they access a malicious |
+| diff                    | low      | CVE-2026-24001      | v4, v3, v2        | jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch        |
+| webpack                 | low      | CVE-2025-68458      | v2                | webpack buildHttp: allowedUris allow-list bypass via URL userinfo (@) leading to |
+| webpack                 | low      | CVE-2025-68157      | v2                | webpack buildHttp HttpUriPlugin allowedUris bypass via HTTP redirects → SSRF + c |


### PR DESCRIPTION
## What changed?

The CVE overview generation workflow (`.github/workflows/cve-overview.yml`) was updated to add Node.js and pnpm setup steps (`actions/setup-node`, `pnpm/action-setup`) and a `pnpm i --frozen-lockfile` install step before generating the CVE markdown, enabling the workflow to run Prettier for consistent formatting. A `Remove overrides before install` step was also added to the auto-dependency-updater workflow to avoid conflicts. The generated `docs/CVE_OVERVIEW.md` output format was improved for better table alignment.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der CVE-Übersichts-Workflow wurde um Node.js/pnpm-Setup-Schritte ergänzt, damit Prettier für konsistente Formatierung des generierten Markdowns ausgeführt werden kann. Ein `Remove overrides before install`-Schritt wurde zum Dependency-Updater-Workflow hinzugefügt. Die Tabellenausrichtung in `docs/CVE_OVERVIEW.md` wurde verbessert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/cve-overview.yml` — Node/pnpm-Setup und Prettier-Formatierung hinzugefügt
- `.github/workflows/auto-dependency-updater.yml` — `Remove overrides before install`-Schritt hinzugefügt

</details>