### PR TITLE
fix(components): defer button and link focus to next frame

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -74,7 +74,12 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async kolFocus() {
-		this.buttonRef?.focus();
+		return new Promise<void>((resolve) => {
+			requestAnimationFrame(() => {
+				this.buttonRef?.focus();
+				resolve();
+			});
+		});
 	}
 
 	private readonly onClick = (event: MouseEvent) => {

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -76,7 +76,12 @@ export class KolLinkWc implements LinkWcAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async kolFocus() {
-		this.anchorRef?.focus();
+		return new Promise<void>((resolve) => {
+			requestAnimationFrame(() => {
+				this.anchorRef?.focus();
+				resolve();
+			});
+		});
 	}
 
 	private readonly onClick = (event: Event) => {


### PR DESCRIPTION
## What changed?

`kolFocus()` in `packages/components/src/components/button/component.tsx` and `packages/components/src/components/link/component.tsx` was updated to return a `Promise` and call `.focus()` inside `requestAnimationFrame`, so focus executes on the next render frame rather than synchronously. This eliminates potential timing issues where `.focus()` was called before the component's internal element was ready. Other components that already used `requestAnimationFrame` for focus were not changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`kolFocus()` in `button/component.tsx` und `link/component.tsx` wurde so aktualisiert, dass ein `Promise` zurückgegeben und `.focus()` innerhalb von `requestAnimationFrame` aufgerufen wird. Dadurch wird der Fokus im nächsten Render-Frame gesetzt und potenzielle Timing-Probleme werden vermieden.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/button/component.tsx` — `requestAnimationFrame`-basierter `kolFocus()`-Aufruf
- `packages/components/src/components/link/component.tsx` — `requestAnimationFrame`-basierter `kolFocus()`-Aufruf

</details>