### PR TITLE
fix(components): keep select shadow focus unchanged; ensure single-select waits one frame

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -71,7 +71,12 @@ export class KolSingleSelect implements SingleSelectAPI {
 	 */
 	@Method()
 	public async focus() {
-		return Promise.resolve(this.refInput?.focus());
+		return new Promise<void>((resolve) => {
+			requestAnimationFrame(() => {
+				this.refInput?.focus();
+				resolve();
+			});
+		});
 	}
 
 	/**


### PR DESCRIPTION
## What changed?

The `kol-select` shadow wrapper's `focus()` method was reverted to delegate directly with `Promise.resolve(this.selectWcRef?.focus())` instead of adding an extra `requestAnimationFrame` layer — because the internal `kol-select-wc` already waits one frame before calling the native `focus()`, which would otherwise cause a double-frame delay. The `kol-single-select` shadow wrapper retains its `requestAnimationFrame`-based `focus()` implementation so the underlying input is focused on the next render frame.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `focus()`-Methode des `kol-select`-Shadow-Wrappers wurde zurückgesetzt auf `Promise.resolve(this.selectWcRef?.focus())`, um eine doppelte Frame-Verzögerung zu vermeiden, da `kol-select-wc` intern bereits einen Frame wartet. Der `kol-single-select`-Shadow-Wrapper behält die `requestAnimationFrame`-basierte Implementierung bei.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/select/shadow.tsx` — Revert zu direktem `focus()`-Aufruf ohne `requestAnimationFrame`
- `packages/components/src/components/single-select/shadow.tsx` — Beibehaltung des `requestAnimationFrame`-Musters

</details>