### PR TITLE
fix(components): use hidden attribute for disabled clear buttons

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -275,9 +275,8 @@ export class KolCombobox implements ComboboxAPI {
 								_variant="ghost"
 								_disabled={isDisabled}
 								data-testid="combobox-delete"
-								class={clsx('kol-combobox__delete', {
-									'kol-combobox__delete--disabled': isDisabled,
-								})}
+								class="kol-combobox__delete"
+								hidden={isDisabled}
 								_on={{
 									onClick: () => {
 										this.clearSelection();

--- a/packages/components/src/components/combobox/style.scss
+++ b/packages/components/src/components/combobox/style.scss
@@ -26,10 +26,6 @@
 				margin-top: -2px;
 				margin-bottom: -2px;
 			}
-
-			&--disabled {
-				display: none;
-			}
 		}
 	}
 

--- a/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap
@@ -109,7 +109,7 @@ exports[`kol-combobox should render with _label="Label" _name="field" _placehold
           <div class="kol-input-container__container">
             <div class="kol-combobox__group">
               <input aria-autocomplete="both" aria-controls="listbox" aria-expanded="false" aria-labelledby="id-nonce" autocapitalize="off" autocorrect="off" class="kol-combobox__input kol-input kol-input--disabled" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _disabled="" _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-combobox__delete kol-combobox__delete--disabled" data-testid="combobox-delete"></kol-button-wc>
+              <kol-button-wc _disabled="" _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-combobox__delete" data-testid="combobox-delete" hidden=""></kol-button-wc>
               <kol-icon _icons="kolicon-chevron-down" _label="" class="kol-custom-suggestions-toggle kol-custom-suggestions-toggle--disabled"></kol-icon>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox">

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -345,9 +345,8 @@ export class KolSingleSelect implements SingleSelectAPI {
 								_variant="ghost"
 								_disabled={isDisabled}
 								data-testid="single-select-delete"
-								class={clsx('kol-single-select__delete', {
-									'kol-single-select__delete--disabled': isDisabled,
-								})}
+								class="kol-single-select__delete"
+								hidden={isDisabled}
 								_on={{
 									onClick: () => {
 										this.clearSelection();

--- a/packages/components/src/components/single-select/style.scss
+++ b/packages/components/src/components/single-select/style.scss
@@ -28,10 +28,6 @@
 				margin-top: -2px;
 				margin-bottom: -2px;
 			}
-
-			&--disabled {
-				display: none;
-			}
 		}
 
 		&__no-results-message {


### PR DESCRIPTION
## What changed?

The clear button in `KolCombobox` and `KolSingleSelect` is now hidden using the native `hidden` HTML attribute when the component is disabled, replacing the previous approach of toggling a `--disabled` CSS modifier class with `display: none`. The `kol-combobox__delete--disabled` and `kol-single-select__delete--disabled` CSS modifier rules were removed from the respective stylesheets. In the component renderers, the class-based conditional was replaced with `hidden={isDisabled}`. The combobox snapshot was updated to reflect the new rendered output.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Löschen-Button in `KolCombobox` und `KolSingleSelect` wird bei deaktiviertem Zustand jetzt über das native HTML-Attribut `hidden` ausgeblendet, anstatt über eine CSS-Modifikatorklasse. Die CSS-Regeln `kol-combobox__delete--disabled` und `kol-single-select__delete--disabled` wurden aus den Stylesheets entfernt. Im Component-Renderer wurde die klassenbasierte Bedingung durch `hidden={isDisabled}` ersetzt. Der Combobox-Snapshot wurde aktualisiert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/combobox/shadow.tsx` — `hidden`-Attribut statt CSS-Klasse
- `packages/components/src/components/single-select/shadow.tsx` — `hidden`-Attribut statt CSS-Klasse
- `packages/components/src/components/combobox/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshot-Aktualisierung

</details>