### PR TITLE
feat: implement table row highlighting sample

### DIFF
--- a/packages/samples/react/src/components/table/highlight-row.tsx
+++ b/packages/samples/react/src/components/table/highlight-row.tsx
@@ -83,7 +83,10 @@ export const TableHighlightRow: FC = () => {
 		const createRenderFn = (dataKey: keyof DataRow) => (el: HTMLElement, data: KoliBriTableDataType) => {
 			const rowData = data.data as DataRow;
 			if (rowData.id === highlightIndex + 1) {
-				el.innerHTML = `<strong>${String(rowData[dataKey])}</strong>`;
+				el.textContent = '';
+				const strong = document.createElement('strong');
+				strong.textContent = String(rowData[dataKey]);
+				el.appendChild(strong);
 			} else {
 				el.textContent = String(rowData[dataKey]);
 			}

--- a/packages/samples/react/src/components/table/highlight-row.tsx
+++ b/packages/samples/react/src/components/table/highlight-row.tsx
@@ -157,11 +157,7 @@ export const TableHighlightRow: FC = () => {
 		<>
 			<SampleDescription>
 				<p>
-					Performance demo: {ROWS_COUNT} rows with action buttons defined once in the column header using the refactored approach. The factory function generates
-					actions for each row on demand, eliminating redundant data and improving maintainability.
-				</p>
-				<p>
-					Actions stay type-safe with <code>ActionColumnPropType</code> (ButtonProps or LinkProps), and no custom render functions are needed.
+					In this example, the row with the index specified in the input field is highlighted by rendering its content in bold. The <code>render</code> function of each column checks if the current row's ID matches the highlight index and applies the appropriate styling.
 				</p>
 			</SampleDescription>
 

--- a/packages/samples/react/src/components/table/highlight-row.tsx
+++ b/packages/samples/react/src/components/table/highlight-row.tsx
@@ -1,0 +1,183 @@
+import type { KoliBriTableDataType, KoliBriTableHeaderCellWithLogic } from '@public-ui/components';
+import { KolInputNumber, KolTableStateful } from '@public-ui/react-v19';
+import type { FC } from 'react';
+import React from 'react';
+import { SampleDescription } from '../SampleDescription';
+
+const ROWS_COUNT = 10;
+
+type DataRow = {
+	id: number;
+	name: string;
+	email: string;
+	status: string;
+};
+
+const FIRST_NAMES = [
+	'Max',
+	'Erika',
+	'John',
+	'Jane',
+	'Peter',
+	'Anna',
+	'Michael',
+	'Sarah',
+	'Thomas',
+	'Lisa',
+	'Daniel',
+	'Maria',
+	'Christian',
+	'Laura',
+	'Stefan',
+	'Julia',
+	'Andreas',
+	'Sophie',
+	'Markus',
+	'Emma',
+];
+const LAST_NAMES = [
+	'Mustermann',
+	'Musterfrau',
+	'Doe',
+	'Smith',
+	'Schmidt',
+	'Müller',
+	'Weber',
+	'Meyer',
+	'Wagner',
+	'Becker',
+	'Fischer',
+	'Schneider',
+	'Hoffmann',
+	'Koch',
+	'Bauer',
+	'Richter',
+	'Klein',
+	'Wolf',
+	'Schröder',
+	'Neumann',
+];
+const STATUSES = ['active', 'inactive', 'pending'];
+
+const generateData = (count: number): DataRow[] => {
+	return Array.from({ length: count }, (_, i) => {
+		const firstName = FIRST_NAMES[i % FIRST_NAMES.length];
+		const lastName = LAST_NAMES[Math.floor(i / FIRST_NAMES.length) % LAST_NAMES.length];
+		const status = STATUSES[i % STATUSES.length];
+		const id = i + 1;
+
+		return {
+			id,
+			name: `${firstName} ${lastName}`,
+			email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}${id > 20 ? id : ''}@example.com`,
+			status,
+		};
+	});
+};
+
+const DATA: DataRow[] = generateData(ROWS_COUNT);
+
+export const TableHighlightRow: FC = () => {
+	const [highlightIndex, setHighlightIndex] = React.useState(2); // Index of the row to highlight (0-based)
+	const HEADERS = React.useMemo(() => {
+		const HEADERS: { horizontal: KoliBriTableHeaderCellWithLogic[][] } = {
+			horizontal: [
+				[
+					{
+						key: 'id',
+						label: 'ID',
+						textAlign: 'left',
+						width: 60,
+						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) => (data0 as unknown as DataRow).id - (data1 as unknown as DataRow).id,
+						render: (el: HTMLElement, data: KoliBriTableDataType) => {
+							const rowData = data.data as unknown as DataRow;
+							if (rowData.id === highlightIndex + 1) {
+								el.innerHTML = `<b>${rowData.id}</b>`;
+							}else {
+								el.textContent = String(rowData.id);
+							}
+						},
+						sortDirection: 'ASC',
+					},
+					{
+						key: 'name',
+						label: 'Name',
+						textAlign: 'left',
+						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) =>
+							(data0 as unknown as DataRow).name.localeCompare((data1 as unknown as DataRow).name, 'de'),
+						render: (el: HTMLElement, data: KoliBriTableDataType) => {
+							const rowData = data.data as unknown as DataRow;
+							if (rowData.id === highlightIndex + 1) {
+								el.innerHTML = `<b>${rowData.name}</b>`;
+							}else {
+								el.textContent = rowData.name;
+							}
+						},
+						sortDirection: 'ASC',
+					},
+					{
+						key: 'email',
+						label: 'E-Mail',
+						textAlign: 'left',
+						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) =>
+							(data0 as unknown as DataRow).email.localeCompare((data1 as unknown as DataRow).email, 'de'),
+						render: (el: HTMLElement, data: KoliBriTableDataType) => {
+							const rowData = data.data as unknown as DataRow;
+							if (rowData.id === highlightIndex + 1) {
+								el.innerHTML = `<b>${rowData.email}</b>`;
+							}else {
+								el.textContent = rowData.email;
+							}
+						},
+						sortDirection: 'ASC',
+					},
+					{
+						key: 'status',
+						label: 'Status',
+						textAlign: 'center',
+						width: 100,
+						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) =>
+							(data0 as unknown as DataRow).status.localeCompare((data1 as unknown as DataRow).status, 'de'),
+						render: (el: HTMLElement, data: KoliBriTableDataType) => {
+							const rowData = data.data as unknown as DataRow;
+							if (rowData.id === highlightIndex + 1) {
+								el.innerHTML = `<b>${rowData.status}</b>`;
+							}else {
+								el.textContent = rowData.status;
+							}
+						},
+						sortDirection: 'ASC',
+					}
+				],
+			],
+		};
+		return HEADERS;
+	}, [highlightIndex]);
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					Performance demo: {ROWS_COUNT} rows with action buttons defined once in the column header using the refactored approach. The factory function generates
+					actions for each row on demand, eliminating redundant data and improving maintainability.
+				</p>
+				<p>
+					Actions stay type-safe with <code>ActionColumnPropType</code> (ButtonProps or LinkProps), and no custom render functions are needed.
+				</p>
+			</SampleDescription>
+
+			<section className="w-full">
+				<KolInputNumber
+					_label="Highlight Row Index"
+					_value={highlightIndex}
+					_on={{
+						onInput: (_, value) => setHighlightIndex(value as number)
+					}}
+					_min={0}
+					_max={ROWS_COUNT - 1}
+				/>
+				<KolTableStateful _label="Benutzerverwaltung mit Hervorhebung" _headers={HEADERS} _data={DATA} className="block" />
+			</section>
+		</>
+	);
+};
+

--- a/packages/samples/react/src/components/table/highlight-row.tsx
+++ b/packages/samples/react/src/components/table/highlight-row.tsx
@@ -1,4 +1,4 @@
-import type { KoliBriTableDataType, KoliBriTableHeaderCellWithLogic } from '@public-ui/components';
+import type { KoliBriTableDataType, KoliBriTableHeaders } from '@public-ui/components';
 import { KolInputNumber, KolTableStateful } from '@public-ui/react-v19';
 import type { FC } from 'react';
 import React from 'react';
@@ -79,8 +79,29 @@ const DATA: DataRow[] = generateData(ROWS_COUNT);
 
 export const TableHighlightRow: FC = () => {
 	const [highlightIndex, setHighlightIndex] = React.useState(2); // Index of the row to highlight (0-based)
-	const HEADERS = React.useMemo(() => {
-		const HEADERS: { horizontal: KoliBriTableHeaderCellWithLogic[][] } = {
+	const headers = React.useMemo<KoliBriTableHeaders>(() => {
+		const createRenderFn = (dataKey: keyof DataRow) => (el: HTMLElement, data: KoliBriTableDataType) => {
+			const rowData = data.data as DataRow;
+			if (rowData.id === highlightIndex + 1) {
+				el.innerHTML = `<strong>${String(rowData[dataKey])}</strong>`;
+			} else {
+				el.textContent = String(rowData[dataKey]);
+			}
+		};
+
+		const createCompareFn = (key: keyof DataRow) => (data0: unknown, data1: unknown) => {
+			const val0 = (data0 as DataRow)[key];
+			const val1 = (data1 as DataRow)[key];
+			if (typeof val0 === 'number' && typeof val1 === 'number') {
+				return val0 - val1;
+			}
+			if (typeof val0 === 'string' && typeof val1 === 'string') {
+				return val0.localeCompare(val1, 'de');
+			}
+			return 0;
+		};
+
+		return {
 			horizontal: [
 				[
 					{
@@ -88,47 +109,24 @@ export const TableHighlightRow: FC = () => {
 						label: 'ID',
 						textAlign: 'left',
 						width: 60,
-						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) => (data0 as unknown as DataRow).id - (data1 as unknown as DataRow).id,
-						render: (el: HTMLElement, data: KoliBriTableDataType) => {
-							const rowData = data.data as unknown as DataRow;
-							if (rowData.id === highlightIndex + 1) {
-								el.innerHTML = `<b>${rowData.id}</b>`;
-							}else {
-								el.textContent = String(rowData.id);
-							}
-						},
+						compareFn: createCompareFn('id'),
+						render: createRenderFn('id'),
 						sortDirection: 'ASC',
 					},
 					{
 						key: 'name',
 						label: 'Name',
 						textAlign: 'left',
-						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) =>
-							(data0 as unknown as DataRow).name.localeCompare((data1 as unknown as DataRow).name, 'de'),
-						render: (el: HTMLElement, data: KoliBriTableDataType) => {
-							const rowData = data.data as unknown as DataRow;
-							if (rowData.id === highlightIndex + 1) {
-								el.innerHTML = `<b>${rowData.name}</b>`;
-							}else {
-								el.textContent = rowData.name;
-							}
-						},
+						compareFn: createCompareFn('name'),
+						render: createRenderFn('name'),
 						sortDirection: 'ASC',
 					},
 					{
 						key: 'email',
 						label: 'E-Mail',
 						textAlign: 'left',
-						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) =>
-							(data0 as unknown as DataRow).email.localeCompare((data1 as unknown as DataRow).email, 'de'),
-						render: (el: HTMLElement, data: KoliBriTableDataType) => {
-							const rowData = data.data as unknown as DataRow;
-							if (rowData.id === highlightIndex + 1) {
-								el.innerHTML = `<b>${rowData.email}</b>`;
-							}else {
-								el.textContent = rowData.email;
-							}
-						},
+						compareFn: createCompareFn('email'),
+						render: createRenderFn('email'),
 						sortDirection: 'ASC',
 					},
 					{
@@ -136,33 +134,29 @@ export const TableHighlightRow: FC = () => {
 						label: 'Status',
 						textAlign: 'center',
 						width: 100,
-						compareFn: (data0: KoliBriTableDataType, data1: KoliBriTableDataType) =>
-							(data0 as unknown as DataRow).status.localeCompare((data1 as unknown as DataRow).status, 'de'),
-						render: (el: HTMLElement, data: KoliBriTableDataType) => {
-							const rowData = data.data as unknown as DataRow;
-							if (rowData.id === highlightIndex + 1) {
-								el.innerHTML = `<b>${rowData.status}</b>`;
-							}else {
-								el.textContent = rowData.status;
-							}
-						},
+						compareFn: createCompareFn('status'),
+						render: createRenderFn('status'),
 						sortDirection: 'ASC',
-					}
+					},
 				],
 			],
-		};
-		return HEADERS;
+		} satisfies KoliBriTableHeaders;
 	}, [highlightIndex]);
+
 	return (
 		<>
 			<SampleDescription>
+				 <p>
+						This sample demonstrates how to programmatically highlight a specific row in a table. You can change the highlighted row by using the input field above the table.
+				</p>
 				<p>
-					In this example, the row with the index specified in the input field is highlighted by rendering its content in bold. The <code>render</code> function of each column checks if the current row's ID matches the highlight index and applies the appropriate styling.
+						The highlighting is achieved by using a custom <code>render</code> function for each column, which checks if the current row's ID matches the selected highlight index and applies bold styling.
 				</p>
 			</SampleDescription>
 
-			<section className="w-full">
+			<section className="flex flex-col gap-4">
 				<KolInputNumber
+					className="self-start"
 					_label="Highlight Row Index"
 					_value={highlightIndex}
 					_on={{
@@ -171,7 +165,7 @@ export const TableHighlightRow: FC = () => {
 					_min={0}
 					_max={ROWS_COUNT - 1}
 				/>
-				<KolTableStateful _label="Benutzerverwaltung mit Hervorhebung" _headers={HEADERS} _data={DATA} className="block" />
+				<KolTableStateful _label="Benutzerverwaltung mit Hervorhebung" _headers={headers} _data={DATA} className="block" />
 			</section>
 		</>
 	);

--- a/packages/samples/react/src/components/table/highlight-row.tsx
+++ b/packages/samples/react/src/components/table/highlight-row.tsx
@@ -160,7 +160,7 @@ export const TableHighlightRow: FC = () => {
 					_label="Highlight Row Index"
 					_value={highlightIndex}
 					_on={{
-						onInput: (_, value) => setHighlightIndex(value as number)
+						onInput: (_, value) => setHighlightIndex(Number(value))
 					}}
 					_min={0}
 					_max={ROWS_COUNT - 1}

--- a/packages/samples/react/src/components/table/highlight-row.tsx
+++ b/packages/samples/react/src/components/table/highlight-row.tsx
@@ -146,11 +146,13 @@ export const TableHighlightRow: FC = () => {
 	return (
 		<>
 			<SampleDescription>
-				 <p>
-						This sample demonstrates how to programmatically highlight a specific row in a table. You can change the highlighted row by using the input field above the table.
+				<p>
+					This sample demonstrates how to programmatically highlight a specific row in a table. You can change the highlighted row by using the input field
+					above the table.
 				</p>
 				<p>
-						The highlighting is achieved by using a custom <code>render</code> function for each column, which checks if the current row's ID matches the selected highlight index and applies bold styling.
+					The highlighting is achieved by using a custom <code>render</code> function for each column, which checks if the current row's ID matches the selected
+					highlight index and applies bold styling.
 				</p>
 			</SampleDescription>
 
@@ -160,7 +162,7 @@ export const TableHighlightRow: FC = () => {
 					_label="Highlight Row Index"
 					_value={highlightIndex}
 					_on={{
-						onInput: (_, value) => setHighlightIndex(Number(value))
+						onInput: (_, value) => setHighlightIndex(Number(value)),
 					}}
 					_min={0}
 					_max={ROWS_COUNT - 1}
@@ -170,4 +172,3 @@ export const TableHighlightRow: FC = () => {
 		</>
 	);
 };
-

--- a/packages/samples/react/src/components/table/routes.ts
+++ b/packages/samples/react/src/components/table/routes.ts
@@ -4,6 +4,7 @@ import { TableActionColumnPerformance } from './action-columns-performance';
 import { TableColumnAlignment } from './column-alignment';
 import { TableComplexHeaders } from './complex-headers';
 import { TableDirectionAwareSort } from './direction-aware-sort';
+import { TableHighlightRow } from './highlight-row';
 import { TableHorizontalScrollbar } from './horizontal-scrollbar';
 import { InteractiveChildElements } from './interactive-child-elements';
 import { MultiSortTable } from './multi-sort';
@@ -31,6 +32,7 @@ export const TABLE_ROUTES: Routes = {
 		'horizontal-scrollbar': TableHorizontalScrollbar,
 		'interactive-child-elements': InteractiveChildElements,
 		'multi-sort': MultiSortTable,
+		'highlight-row': TableHighlightRow,
 		'non-hidable-columns': TableNonHidableColumns,
 		'pagination-position': PaginationPosition,
 		'predefined-settings': PredefinedSettings,


### PR DESCRIPTION
## What changed?

A new `TableHighlightRow` sample was added to the React sample app demonstrating how to programmatically highlight a specific row in `KolTableStateful` using custom `render` functions on column headers. The sample renders a 10-row table and allows users to change the highlighted row index via a number input, with the selected row's cells rendered in bold.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein neues `TableHighlightRow`-Sample wurde der React-Sample-App hinzugefügt, das demonstriert, wie eine bestimmte Zeile in `KolTableStateful` mithilfe benutzerdefinierter `render`-Funktionen auf Spaltenheadern programmatisch hervorgehoben werden kann. Das Sample zeigt eine 10-Zeilen-Tabelle und erlaubt es, den Hervorhebungs-Index über ein Zahlen-Input zu ändern.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/components/table/highlight-row.tsx` — Neues Sample `TableHighlightRow` mit programmatischer Zeilenhervorhebung
- `packages/samples/react/src/components/table/routes.ts` — Neue Route `highlight-row` registriert

</details>