### PR TITLE
fix: update @stencil/core dependency in sample React app

### DIFF
--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -30,6 +30,7 @@
 		"@public-ui/react-hook-form-adapter": "workspace:*",
 		"@public-ui/react-v19": "workspace:*",
 		"@public-ui/themes": "workspace:*",
+		"@stencil/core": "4.38.3",
 		"adopted-style-sheets": "1.1.9-rc.21",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
@@ -44,7 +45,6 @@
 	"devDependencies": {
 		"@eslint/js": "9.39.3",
 		"@playwright/test": "1.58.2",
-		"@stencil/core": "4.38.3",
 		"@types/node": "25.3.1",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       '@public-ui/themes':
         specifier: workspace:*
         version: link:../../themes
+      '@stencil/core':
+        specifier: 4.38.3
+        version: 4.38.3
       adopted-style-sheets:
         specifier: 1.1.9-rc.21
         version: 1.1.9-rc.21
@@ -803,9 +806,6 @@ importers:
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
-      '@stencil/core':
-        specifier: 4.38.3
-        version: 4.38.3
       '@types/node':
         specifier: 25.3.1
         version: 25.3.1


### PR DESCRIPTION
## What changed?

The `@stencil/core` dependency in the React sample app was moved from `devDependencies` to `dependencies`. This ensures the package is available at runtime in contexts where dev dependencies are not installed, fixing a missing-module error that occurred when running the sample app without dev dependencies.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `@stencil/core`-Dependency in der React-Sample-App wurde von `devDependencies` nach `dependencies` verschoben. Dies stellt sicher, dass das Paket zur Laufzeit verfügbar ist, auch wenn Dev-Dependencies nicht installiert sind.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/samples/react/package.json` — `@stencil/core` von `devDependencies` nach `dependencies` verschoben
- `pnpm-lock.yaml` — Lock-Datei aktualisiert

</details>