### PR TITLE
fix: use exact version for http-server in visual-tests

### DIFF
--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -30,7 +30,7 @@
 		"@playwright/test": "1.47.2",
 		"@public-ui/sample-react": "workspace:*",
 		"axe-playwright": "2.2.2",
-		"http-server": "^14.1.0",
+		"http-server": "14.1.0",
 		"portfinder": "1.0.38"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -919,8 +919,8 @@ importers:
         specifier: 2.2.2
         version: 2.2.2(playwright@1.58.1)
       http-server:
-        specifier: ^14.1.0
-        version: 14.1.1
+        specifier: 14.1.0
+        version: 14.1.0
       portfinder:
         specifier: 1.0.38
         version: 1.0.38
@@ -6879,8 +6879,8 @@ packages:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
 
-  http-server@14.1.1:
-    resolution: {integrity: sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==}
+  http-server@14.1.0:
+    resolution: {integrity: sha512-5lYsIcZtf6pdR8tCtzAHTWrAveo4liUlJdWc7YafwK/maPgYHs+VNP6KpCClmUnSorJrARVMXqtT055zBv11Yg==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -19625,7 +19625,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-server@14.1.1:
+  http-server@14.1.0:
     dependencies:
       basic-auth: 2.0.1
       chalk: 4.1.2


### PR DESCRIPTION
## What changed?

The `http-server` dependency in the visual-tests package was pinned to the exact version `14.1.0` instead of using the range `^14.1.0`. This prevents an accidental upgrade to `14.1.1` (or later patch versions) that may introduce unexpected behavior.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `http-server`-Dependency im visual-tests-Paket wurde auf die exakte Version `14.1.0` gepinnt statt den Bereich `^14.1.0` zu verwenden.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/package.json` — `^14.1.0` auf `14.1.0` geändert
- `pnpm-lock.yaml` — Lock-Datei auf `14.1.0` aktualisiert

</details>