### PR TITLE
docs: update support timeline end dates for v3.x and v5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ KoliBri is always actively working on improvements, new features and future-orie
 |     0.x |   Initial    | Jul 2020 |   -    |    Dec 2021    |
 |     1.x |     LTS      | Dec 2021 |   3y   |    Dec 2024    |
 |     2.x |     LTS      | Dec 2023 |   3y   |    Dec 2026    |
-|     3.x |     STS      | Dec 2024 |  15m   |    Dec 2025    |
+|     3.x |     STS      | Dec 2024 |  15m   |    Mar 2026    |
 |     4.x |     LTS      | Dec 2025 |   3y   |    Dec 2028    |
-|     5.x |     STS      | Dec 2026 |  15m   |    Dec 2027    |
+|     5.x |     STS      | Dec 2026 |  15m   |    Mar 2028    |
 
 ```mermaid
 gantt


### PR DESCRIPTION
## What changed?

The README support lifecycle table was updated to correct the end-of-support dates for two release lines: `v3.x` (STS) moved from December 2025 to March 2026, and `v5.x` (STS) moved from December 2027 to March 2028.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Support-Lebenszyklus-Tabelle in der README wurde aktualisiert: Das Supportende von `v3.x` (STS) wurde von Dezember 2025 auf März 2026 korrigiert, und das Supportende von `v5.x` (STS) von Dezember 2027 auf März 2028.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `README.md` — Supportende-Daten für v3.x und v5.x aktualisiert

</details>