### PR TITLE
ci(opencode-sync): enable full git history fetch

### DIFF
--- a/.github/workflows/sync-to-opencode.yml
+++ b/.github/workflows/sync-to-opencode.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ matrix.branch }}
+          fetch-depth: 0
 
       - name: Sync ${{ matrix.branch }} to OpenCoDE
         uses: public-ui/kolibri/.github/actions/opencode-sync@develop


### PR DESCRIPTION
## What changed?

The OpenCoDE sync workflow was updated to use `fetch-depth: 0` in the checkout step, enabling a full git history fetch instead of a shallow clone. This is required for the sync process to correctly handle branch history when pushing to the OpenCoDE mirror.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der OpenCoDE-Sync-Workflow wurde aktualisiert, um `fetch-depth: 0` im Checkout-Schritt zu verwenden, was einen vollständigen Git-History-Fetch anstelle eines flachen Klons ermöglicht. Dies ist erforderlich, damit der Sync-Prozess die Branch-Historie beim Spiegeln nach OpenCoDE korrekt verarbeiten kann.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/sync-to-opencode.yml` — `fetch-depth: 0` zum Checkout-Step hinzugefügt

</details>