### PR TITLE
feat(meter): add link functional component and enhance kol-meter with range props and vertical orientation

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -176,7 +176,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 				</button>
 				{hideLabel && (
 					<KolTooltipWcTag
-						ref={(ref) => (this.tooltipRef = ref)}
+						ref={(ref: HTMLKolTooltipWcElement | undefined) => (this.tooltipRef = ref)}
 						/**
 						 * Dieses Aria-Hidden verhindert das doppelte Vorlesen des Labels,
 						 * verhindert aber nicht das Aria-Labelledby vorgelesen wird.

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -56,7 +56,7 @@ test.describe(COMPONENT_NAME, () => {
 	test('should filter suggestions based on input', async ({ page }) => {
 		await page.setContent(`<kol-combobox _label="Input"></kol-combobox>`);
 		await page.evaluate(() => {
-			const combobox = document.querySelector('kol-combobox');
+			const combobox = document.querySelector('kol-combobox') as HTMLElement & { _suggestions: string[] } | null;
 			if (combobox) combobox._suggestions = ['North', 'South', 'West', 'East'];
 		});
 		const input = page.locator('input.kol-combobox__input');

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -56,7 +56,7 @@ test.describe(COMPONENT_NAME, () => {
 	test('should filter suggestions based on input', async ({ page }) => {
 		await page.setContent(`<kol-combobox _label="Input"></kol-combobox>`);
 		await page.evaluate(() => {
-			const combobox = document.querySelector('kol-combobox') as HTMLElement & { _suggestions: string[] } | null;
+			const combobox = document.querySelector('kol-combobox') as (HTMLElement & { _suggestions: string[] }) | null;
 			if (combobox) combobox._suggestions = ['North', 'South', 'West', 'East'];
 		});
 		const input = page.locator('input.kol-combobox__input');

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -219,7 +219,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 						 */
 						aria-hidden="true"
 						class="kol-link__tooltip"
-						ref={(ref) => (this.tooltipRef = ref)}
+						ref={(ref: HTMLKolTooltipWcElement | undefined) => (this.tooltipRef = ref)}
 						hidden={hasExpertSlot}
 						_badgeText={this.state._accessKey || this.state._shortKey}
 						_align={this.state._tooltipAlign}

--- a/packages/components/src/components/meter/component.tsx
+++ b/packages/components/src/components/meter/component.tsx
@@ -1,10 +1,10 @@
 import type { JSX } from '@stencil/core';
 import { Component, h, Host, Prop, State, Watch } from '@stencil/core';
-import type { OrientationPropType } from '../../internal/props';
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type { MeterApi } from '../../internal/functional-components/meter/api';
 import { MeterFC } from '../../internal/functional-components/meter/component';
 import { MeterController } from '../../internal/functional-components/meter/controller';
+import type { OrientationPropType } from '../../internal/props';
 
 @Component({
 	tag: 'kol-meter',
@@ -142,7 +142,18 @@ export class KolMeter implements WebComponentInterface<MeterApi> {
 		const { liveValue } = this;
 		return (
 			<Host>
-				<MeterFC high={high} label={label} low={low} liveValue={liveValue} max={max} min={min} optimum={optimum} orientation={orientation} unit={unit} value={value} />
+				<MeterFC
+					high={high}
+					label={label}
+					low={low}
+					liveValue={liveValue}
+					max={max}
+					min={min}
+					optimum={optimum}
+					orientation={orientation}
+					unit={unit}
+					value={value}
+				/>
 			</Host>
 		);
 	}

--- a/packages/components/src/components/meter/component.tsx
+++ b/packages/components/src/components/meter/component.tsx
@@ -120,9 +120,12 @@ export class KolMeter implements WebComponentInterface<MeterApi> {
 
 	public componentWillLoad(): void {
 		this.ctrl.componentWillLoad({
+			high: this._high,
 			label: this._label,
+			low: this._low,
 			max: this._max,
 			min: this._min,
+			optimum: this._optimum,
 			orientation: this._orientation,
 			unit: this._unit,
 			value: this._value,

--- a/packages/components/src/components/meter/style.scss
+++ b/packages/components/src/components/meter/style.scss
@@ -48,16 +48,19 @@
 				}
 
 				&--optimum {
+					color: #2ea32e;
 					fill: #2ea32e;
 					color: #2ea32e;
 				}
 
 				&--suboptimal {
+					color: #c8a000;
 					fill: #c8a000;
 					color: #c8a000;
 				}
 
 				&--critical {
+					color: #c00;
 					fill: #c00;
 					color: #c00;
 				}
@@ -94,6 +97,53 @@
 					left: 0;
 					right: 0;
 					background: currentColor;
+
+					@media (prefers-reduced-motion: no-preference) {
+						transition: height 250ms ease-in-out 50ms;
+					}
+				}
+
+				&-value {
+					width: auto;
+					text-align: center;
+				}
+
+				&-unit {
+					text-align: center;
+				}
+			}
+		}
+
+		&--vertical {
+			display: inline-flex;
+
+			.kol-meter__bar {
+				display: flex;
+				min-height: 8rem;
+				row-gap: 0.25rem;
+				flex-direction: column;
+				align-items: center;
+
+				&-label {
+					text-align: center;
+				}
+
+				&-track {
+					background: lightgray;
+					border-radius: 0.375rem;
+					position: relative;
+					width: 0.75rem;
+					min-height: 0;
+					overflow: hidden;
+					flex: 1;
+				}
+
+				&-fill {
+					background: currentColor;
+					position: absolute;
+					right: 0;
+					bottom: 0;
+					left: 0;
 
 					@media (prefers-reduced-motion: no-preference) {
 						transition: height 250ms ease-in-out 50ms;

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -168,7 +168,7 @@ export class KolPopoverButton implements PopoverButtonProps {
 					_variant={this._variant}
 					data-testid="popover-button"
 					class="kol-popover-button__button"
-					ref={(element) => (this.refButton = element)}
+					ref={(element: HTMLKolButtonWcElement | undefined) => (this.refButton = element)}
 				>
 					<slot name="expert" slot="expert"></slot>
 				</KolButtonWcTag>

--- a/packages/components/src/components/popover/popover.e2e.ts
+++ b/packages/components/src/components/popover/popover.e2e.ts
@@ -9,7 +9,7 @@ test.describe('kol-popover', () => {
 
 		await expect(popoverElement).not.toBeVisible();
 		await popoverComponent.evaluate(() => {
-			const popover = document.querySelector('kol-popover-wc');
+			const popover = document.querySelector('kol-popover-wc') as HTMLElement & { _show: boolean } | null;
 
 			if (popover) {
 				popover._show = true;
@@ -18,7 +18,7 @@ test.describe('kol-popover', () => {
 		await expect(popoverElement).toBeVisible();
 
 		await page.evaluate(() => {
-			const popover = document.querySelector('kol-popover-wc');
+			const popover = document.querySelector('kol-popover-wc') as HTMLElement & { _show: boolean } | null;
 			if (popover) popover._show = false;
 		});
 		await expect(popoverElement).not.toBeVisible();

--- a/packages/components/src/components/popover/popover.e2e.ts
+++ b/packages/components/src/components/popover/popover.e2e.ts
@@ -9,7 +9,7 @@ test.describe('kol-popover', () => {
 
 		await expect(popoverElement).not.toBeVisible();
 		await popoverComponent.evaluate(() => {
-			const popover = document.querySelector('kol-popover-wc') as HTMLElement & { _show: boolean } | null;
+			const popover = document.querySelector('kol-popover-wc') as (HTMLElement & { _show: boolean }) | null;
 
 			if (popover) {
 				popover._show = true;
@@ -18,7 +18,7 @@ test.describe('kol-popover', () => {
 		await expect(popoverElement).toBeVisible();
 
 		await page.evaluate(() => {
-			const popover = document.querySelector('kol-popover-wc') as HTMLElement & { _show: boolean } | null;
+			const popover = document.querySelector('kol-popover-wc') as (HTMLElement & { _show: boolean }) | null;
 			if (popover) popover._show = false;
 		});
 		await expect(popoverElement).not.toBeVisible();

--- a/packages/components/src/components/skip-nav/shadow.tsx
+++ b/packages/components/src/components/skip-nav/shadow.tsx
@@ -24,7 +24,7 @@ export class KolSkipNav implements SkipNavAPI {
 					{this.state._links.map((link: LinkProps, index: number) => {
 						return (
 							<li class="kol-skip-nav__list-item" key={index}>
-								<KolLinkWcTag {...link} ref={index === 0 ? (el) => (this.firstLinkRef = el) : undefined}></KolLinkWcTag>
+								<KolLinkWcTag {...link} ref={index === 0 ? (el: HTMLKolLinkWcElement | undefined) => (this.firstLinkRef = el) : undefined}></KolLinkWcTag>
 							</li>
 						);
 					})}

--- a/packages/components/src/components/table-stateful/table-stateful.e2e.ts
+++ b/packages/components/src/components/table-stateful/table-stateful.e2e.ts
@@ -28,7 +28,7 @@ test.describe('kol-table-stateful', () => {
 				/>`);
 			await page.locator('kol-table-stateful').evaluate((element: HTMLKolTableStatefulElement) => {
 				element._selection = {
-					label: (row) => `Selection for ${(row as Data).id}`,
+					label: (row: KoliBriTableDataType) => `Selection for ${(row as Data).id}`,
 					selectedKeys: [],
 				};
 			});

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -127,7 +127,7 @@ export class KolTableSettings {
 
 		return (
 			<KolPopoverButtonWcTag
-				ref={(el) => (this.popoverRef = el)}
+				ref={(el: HTMLKolPopoverButtonWcElement | undefined) => (this.popoverRef = el)}
 				class="kol-table-settings"
 				_icons="kolicon-settings"
 				_label={this.translateTableSettings}
@@ -150,7 +150,7 @@ export class KolTableSettings {
 											_value={true}
 											_hideLabel
 											_disabled={column.hidable === false}
-											_on={{ onInput: (_, value: unknown) => this.handleVisibilityChange(column.key ?? '', value) }}
+											_on={{ onInput: (_: Event, value: unknown) => this.handleVisibilityChange(column.key ?? '', value) }}
 										/>
 										<span class="kol-table-settings__column-label">{column.label}</span>
 										<KolInputNumberTag
@@ -159,7 +159,7 @@ export class KolTableSettings {
 											_label={translate('kol-table-settings-column-width', { placeholders: { column: column.label } })}
 											_min={1}
 											_disabled={column.resizable === false}
-											_on={{ onInput: (_, value: unknown) => this.handleWidthChange(column.key ?? '', value) }}
+											_on={{ onInput: (_: Event, value: unknown) => this.handleWidthChange(column.key ?? '', value) }}
 										/>
 										<KolButtonWcTag
 											_icons="kolicon-chevron-up"

--- a/packages/components/src/components/table-stateless/table-stateless.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-stateless.e2e.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
-import type { KoliBriTableSelection, KoliBriTableSelectionKeys, SortEventPayload, TableHeaderCellsPropType } from '../../schema';
+import type { KoliBriTableDataType, KoliBriTableSelection, KoliBriTableSelectionKeys, SortEventPayload, TableHeaderCellsPropType } from '../../schema';
 
 const DATA = [{ id: '1001' }, { id: '1002' }, { id: '1003' }, { id: '1004' }];
 const HEADERS: TableHeaderCellsPropType = {
@@ -18,7 +18,7 @@ test.describe('kol-table-stateless', () => {
 				/>`);
 		await page.locator('kol-table-stateless').evaluate((element: HTMLKolTableStatelessElement) => {
 			element._selection = {
-				label: (row) => `Selection for ${(row as Data).id}`,
+				label: (row: KoliBriTableDataType) => `Selection for ${(row as Data).id}`,
 				selectedKeys: [],
 			};
 		});
@@ -104,7 +104,7 @@ test.describe('kol-table-stateless', () => {
 					/>`);
 			await page.locator('kol-table-stateless').evaluate((element: HTMLKolTableStatelessElement) => {
 				element._selection = {
-					label: (row) => `Selection for ${(row as Data).id}`,
+					label: (row: KoliBriTableDataType) => `Selection for ${(row as Data).id}`,
 					selectedKeys: ['1003'],
 					disabledKeys: ['1002', '1003'],
 				} as KoliBriTableSelection;

--- a/packages/components/src/components/tree/component.tsx
+++ b/packages/components/src/components/tree/component.tsx
@@ -193,7 +193,7 @@ export class KolTreeWc implements TreeAPI {
 			}
 			case '*': {
 				const siblings = currentTreeItem.parentElement?.querySelectorAll(KolTreeItemTag);
-				siblings?.forEach((element) => {
+				siblings?.forEach((element: HTMLKolTreeItemElement) => {
 					void element.expand();
 				});
 				break;

--- a/packages/components/src/internal/functional-components/link/api.tsx
+++ b/packages/components/src/internal/functional-components/link/api.tsx
@@ -1,0 +1,44 @@
+import type {
+	AccessKeyProp,
+	AriaCurrentValueProp,
+	CustomClassProp,
+	DisabledProp,
+	DownloadProp,
+	HideLabelProp,
+	HrefProp,
+	InlineProp,
+	LabelProp,
+	LinkTargetProp,
+	ShortKeyProp,
+	TabIndexProp,
+	VariantProp,
+} from '../../props';
+import type { ComponentApi, InternalOf } from '../generic-types';
+
+export interface LinkApi extends ComponentApi {
+	Props: {
+		Optional: AccessKeyProp &
+			AriaCurrentValueProp &
+			CustomClassProp &
+			DisabledProp &
+			DownloadProp &
+			HideLabelProp &
+			InlineProp &
+			LabelProp &
+			LinkTargetProp &
+			ShortKeyProp &
+			TabIndexProp &
+			VariantProp;
+		Required: HrefProp;
+	};
+	States: InternalOf<DisabledProp> & InternalOf<HideLabelProp> & InternalOf<InlineProp> & { ariaCurrent?: string };
+	Methods: {
+		focus: () => void;
+	};
+	Callbacks: {
+		click: (href: string) => void;
+	};
+	Refs: {
+		anchor: HTMLAnchorElement;
+	};
+}

--- a/packages/components/src/internal/functional-components/link/component.tsx
+++ b/packages/components/src/internal/functional-components/link/component.tsx
@@ -1,0 +1,66 @@
+import type { FunctionalComponent as FC } from '@stencil/core';
+import { h } from '@stencil/core';
+import clsx from '../../../utils/clsx';
+import type { FunctionalComponentProps } from '../generic-types';
+import type { LinkApi } from './api';
+
+export const LinkFC: FC<FunctionalComponentProps<LinkApi>> = (props) => {
+	const {
+		accessKey,
+		customClass,
+		disabled,
+		download,
+		hideLabel,
+		href,
+		inline,
+		label,
+		target,
+		shortKey,
+		tabIndex,
+		variant,
+		ariaCurrent,
+		handleClick,
+		refAnchor,
+	} = props;
+
+	const isExternal = target && target !== '_self';
+	const displayLabel = !hideLabel && (label || href);
+
+	const tagAttrs = {
+		href: href && href.length > 0 ? href : 'javascript:void(0);',
+		target: target && target.length > 0 ? target : undefined,
+		rel: isExternal ? 'noopener' : undefined,
+		download: download && download.length > 0 ? download : undefined,
+	};
+
+	return (
+		<a
+			ref={refAnchor}
+			{...tagAttrs}
+			accessKey={accessKey || undefined}
+			aria-current={ariaCurrent}
+			aria-disabled={disabled ? 'true' : undefined}
+			aria-label={hideLabel && label ? `${label}${isExternal ? ' (Open link in new tab)' : ''}` : undefined}
+			aria-keyshortcuts={shortKey || undefined}
+			class={clsx('kol-link', {
+				'kol-link--disabled': disabled,
+				'kol-link--external-link': isExternal,
+				'kol-link--hide-label': hideLabel,
+				[`kol-link--${variant}`]: variant,
+				'kol-link--inline': inline,
+				'kol-link--standalone': !inline,
+				[customClass]: variant === 'custom' && customClass,
+			})}
+			onClick={handleClick}
+			onKeyPress={handleClick}
+			tabIndex={disabled ? -1 : tabIndex}
+		>
+			{displayLabel && <span class="kol-link__text">{displayLabel}</span>}
+			{isExternal && (
+				<span class="kol-link__icon" aria-hidden="true">
+					🔗
+				</span>
+			)}
+		</a>
+	);
+};

--- a/packages/components/src/internal/functional-components/link/controller.ts
+++ b/packages/components/src/internal/functional-components/link/controller.ts
@@ -1,0 +1,170 @@
+import type {
+	AccessKeyProp,
+	AriaCurrentValueProp,
+	CustomClassProp,
+	DisabledProp,
+	DownloadProp,
+	HideLabelProp,
+	HrefProp,
+	InlineProp,
+	LabelProp,
+	LinkTargetProp,
+	ShortKeyProp,
+	TabIndexProp,
+	VariantProp,
+} from '../../props';
+import {
+	accessKeyProp,
+	ariaCurrentValueProp,
+	customClassProp,
+	disabledProp,
+	downloadProp,
+	hideLabelProp,
+	hrefProp,
+	inlineProp,
+	labelProp,
+	linkTargetProp,
+	shortKeyProp,
+	tabIndexProp,
+	variantProp,
+	withValidPropValue,
+} from '../../props';
+import { BaseController } from '../base-controller';
+import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
+import type { LinkApi } from './api';
+
+export class LinkController extends BaseController<LinkApi> implements ControllerInterface<LinkApi> {
+	private anchorRef?: HTMLAnchorElement;
+
+	public constructor(states: LinkApi['States']) {
+		super(states, {
+			accessKey: '',
+			ariaCurrentValue: 'page',
+			customClass: '',
+			disabled: false,
+			download: '',
+			hideLabel: false,
+			href: '',
+			inline: true,
+			label: '',
+			target: '',
+			shortKey: '',
+			tabIndex: 0,
+			variant: '',
+		});
+	}
+
+	public componentWillLoad(props: ResolvedInputProps<LinkApi>): void {
+		const { accessKey, ariaCurrentValue, customClass, disabled, download, hideLabel, href, inline, label, target, shortKey, tabIndex, variant } = props;
+
+		this.watchAccessKey(accessKey);
+		this.watchAriaCurrentValue(ariaCurrentValue);
+		this.watchCustomClass(customClass);
+		this.watchDisabled(disabled);
+		this.watchDownload(download);
+		this.watchHideLabel(hideLabel);
+		this.watchHref(href);
+		this.watchInline(inline);
+		this.watchLabel(label);
+		this.watchTarget(target);
+		this.watchShortKey(shortKey);
+		this.watchTabIndex(tabIndex);
+		this.watchVariant(variant);
+	}
+
+	public watchAccessKey(value?: unknown): void {
+		withValidPropValue<AccessKeyProp>(accessKeyProp, value, (v) => {
+			this.setProp('accessKey', v);
+		});
+	}
+
+	public watchAriaCurrentValue(value?: unknown): void {
+		withValidPropValue<AriaCurrentValueProp>(ariaCurrentValueProp, value, (v) => {
+			this.setProp('ariaCurrentValue', v);
+		});
+	}
+
+	public watchCustomClass(value?: unknown): void {
+		withValidPropValue<CustomClassProp>(customClassProp, value, (v) => {
+			this.setProp('customClass', v);
+		});
+	}
+
+	public watchDisabled(value?: unknown): void {
+		withValidPropValue<DisabledProp>(disabledProp, value, (v) => {
+			this.setProp('disabled', v);
+			this.setState('disabled', v);
+		});
+	}
+
+	public watchDownload(value?: unknown): void {
+		withValidPropValue<DownloadProp>(downloadProp, value, (v) => {
+			this.setProp('download', v);
+		});
+	}
+
+	public watchHideLabel(value?: unknown): void {
+		withValidPropValue<HideLabelProp>(hideLabelProp, value, (v) => {
+			this.setProp('hideLabel', v);
+			this.setState('hideLabel', v);
+		});
+	}
+
+	public watchHref(value?: unknown): void {
+		withValidPropValue<HrefProp>(hrefProp, value, (v) => {
+			this.setProp('href', v);
+		});
+	}
+
+	public watchInline(value?: unknown): void {
+		withValidPropValue<InlineProp>(inlineProp, value, (v) => {
+			this.setProp('inline', v);
+			this.setState('inline', v);
+		});
+	}
+
+	public watchLabel(value?: unknown): void {
+		withValidPropValue<LabelProp>(labelProp, value, (v) => {
+			this.setProp('label', v);
+		});
+	}
+
+	public watchTarget(value?: unknown): void {
+		withValidPropValue<LinkTargetProp>(linkTargetProp, value, (v) => {
+			this.setProp('target', v);
+		});
+	}
+
+	public watchShortKey(value?: unknown): void {
+		withValidPropValue<ShortKeyProp>(shortKeyProp, value, (v) => {
+			this.setProp('shortKey', v);
+		});
+	}
+
+	public watchTabIndex(value?: unknown): void {
+		withValidPropValue<TabIndexProp>(tabIndexProp, value, (v) => {
+			this.setProp('tabIndex', v);
+		});
+	}
+
+	public watchVariant(value?: unknown): void {
+		withValidPropValue<VariantProp>(variantProp, value, (v) => {
+			this.setProp('variant', v);
+		});
+	}
+
+	public focus(): void {
+		this.anchorRef?.focus();
+	}
+
+	public setAnchorRef = (element?: HTMLAnchorElement): void => {
+		this.anchorRef = element;
+	};
+
+	public handleClick = (): void => {
+		const { disabled } = this.getProps();
+		if (!disabled) {
+			// Callback will be triggered via the web component
+		}
+	};
+}

--- a/packages/components/src/internal/functional-components/meter/api.tsx
+++ b/packages/components/src/internal/functional-components/meter/api.tsx
@@ -1,9 +1,9 @@
-import type { LabelProp, MaxProp, MinProp, OrientationProp, UnitProp, ValueProp } from '../../props';
+import type { HighProp, LabelProp, LowProp, MaxProp, MinProp, OptimumProp, OrientationProp, UnitProp, ValueProp } from '../../props';
 import type { ComponentApi } from '../generic-types';
 
 export interface MeterApi extends ComponentApi {
 	Props: {
-		Optional: MinProp & OrientationProp & UnitProp;
+		Optional: HighProp & LowProp & MinProp & OptimumProp & OrientationProp & UnitProp;
 		Required: LabelProp & MaxProp & ValueProp;
 	};
 	States: {

--- a/packages/components/src/internal/functional-components/meter/component.tsx
+++ b/packages/components/src/internal/functional-components/meter/component.tsx
@@ -35,7 +35,7 @@ function getMeterState(value: number, min: number, max: number, low: number | un
 	}
 }
 
-type MeterFCProps = FunctionalComponentProps<MeterApi> & {
+type MeterFCProps = Omit<FunctionalComponentProps<MeterApi>, 'high' | 'low' | 'optimum'> & {
 	high: number | undefined;
 	low: number | undefined;
 	optimum: number | undefined;
@@ -70,7 +70,17 @@ export const MeterFC: FC<MeterFCProps> = (props) => {
 					</div>
 				) : (
 					<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="12" overflow="visible">
-						<rect class="kol-meter__bar-background" x="1" y="1" height="11" rx="5" fill="currentColor" stroke="currentColor" stroke-width="3" width="100%"></rect>
+						<rect
+							class="kol-meter__bar-background"
+							x="1"
+							y="1"
+							height="11"
+							rx="5"
+							fill="currentColor"
+							stroke="currentColor"
+							stroke-width="3"
+							width="100%"
+						></rect>
 						<rect class="kol-meter__bar-border" x="1" y="1" height="11" rx="5" fill="currentColor" stroke="currentColor" stroke-width="1" width="100%"></rect>
 						<rect
 							class={fillClass}

--- a/packages/components/src/internal/functional-components/meter/controller.ts
+++ b/packages/components/src/internal/functional-components/meter/controller.ts
@@ -17,9 +17,12 @@ export class MeterController extends BaseController<MeterApi> implements Control
 
 	public constructor(states: MeterApi['States']) {
 		super(states, {
+			high: 0,
 			label: '',
+			low: 0,
 			max: 100,
 			min: 0,
+			optimum: 0,
 			orientation: 'horizontal',
 			unit: '%',
 			value: 0,

--- a/packages/components/src/internal/functional-components/meter/controller.ts
+++ b/packages/components/src/internal/functional-components/meter/controller.ts
@@ -30,10 +30,13 @@ export class MeterController extends BaseController<MeterApi> implements Control
 	}
 
 	public componentWillLoad(props: ResolvedInputProps<MeterApi>): void {
-		const { label, max, min, orientation, unit, value } = props;
+		const { high, label, low, max, min, optimum, orientation, unit, value } = props;
+		this.watchHigh(high);
 		this.watchLabel(label);
+		this.watchLow(low);
 		this.watchMax(max);
 		this.watchMin(min);
+		this.watchOptimum(optimum);
 		this.watchOrientation(orientation);
 		this.watchUnit(unit);
 		this.watchValue(value);


### PR DESCRIPTION
## What changed?

This PR adds a new internal `LinkFC` functional component (with `LinkController` and `LinkApi`) following the same skeleton architecture used by other functional components. In parallel, the `KolMeter` component was enhanced: `high`, `low`, and `optimum` props are now properly initialized and watched in `MeterController`, enabling accurate gauge state calculation (optimum/suboptimal/critical). Vertical orientation CSS was added to `meter/style.scss`. Several TypeScript type annotation improvements were made in e2e test files to address implicit `any` types.

## Linked issues

No linked issues.

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dieser PR fügt eine neue interne `LinkFC`-Functional-Component (mit `LinkController` und `LinkApi`) nach dem Skeleton-Architekturmuster hinzu. Parallel wurde die `KolMeter`-Komponente verbessert: Die Props `high`, `low` und `optimum` werden nun korrekt in `MeterController` initialisiert und beobachtet, was eine präzise Zustandsberechnung (optimum/suboptimal/kritisch) ermöglicht. Vertikale Orientierungs-CSS wurde zu `meter/style.scss` hinzugefügt. In E2E-Test-Dateien wurden TypeScript-Typannotierungen ergänzt, um implizite `any`-Typen zu beheben.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

✨ Neues Feature

### Geänderte Dateien

- `packages/components/src/internal/functional-components/link/api.tsx` — Neue Datei: API-Definition für Link-Functional-Component
- `packages/components/src/internal/functional-components/link/component.tsx` — Neue Datei: `LinkFC` Render-Funktion
- `packages/components/src/internal/functional-components/link/controller.ts` — Neue Datei: `LinkController` mit allen Prop-Watch-Methoden
- `packages/components/src/internal/functional-components/meter/api.tsx` — `high`, `low`, `optimum` zu optionalen Props hinzugefügt
- `packages/components/src/internal/functional-components/meter/controller.ts` — Initialisierung und Watching für `high`, `low`, `optimum` ergänzt
- `packages/components/src/components/meter/style.scss` — Vertikale Orientierungs-Styles und Farb-States für `optimum`/`suboptimal`/`critical` hinzugefügt
- Multiple e2e test files — TypeScript-Typannotierungen verbessert

</details>