### PR TITLE
feat(mcp): add version resource

### DIFF
--- a/packages/tools/mcp/src/mcp.ts
+++ b/packages/tools/mcp/src/mcp.ts
@@ -69,6 +69,8 @@ const {
 	description?: string;
 };
 
+const VERSION_INFO_JSON = JSON.stringify({ name: PACKAGE_NAME, version: PACKAGE_VERSION }, null, 2);
+
 // Logging configuration
 const ENABLE_LOGGING = process.env.MCP_LOGGING === 'true' || process.env.MCP_LOGGING === '1';
 
@@ -302,7 +304,7 @@ ${PACKAGE_DESCRIPTION ?? ''}
 					{
 						uri: uri.href,
 						mimeType: 'application/json',
-						text: JSON.stringify({ name: PACKAGE_NAME, version: PACKAGE_VERSION }, null, 2),
+						text: VERSION_INFO_JSON,
 					},
 				],
 			};

--- a/packages/tools/mcp/src/mcp.ts
+++ b/packages/tools/mcp/src/mcp.ts
@@ -286,6 +286,29 @@ ${PACKAGE_DESCRIPTION ?? ''}
 		},
 	);
 
+	// Add version resource
+	server.registerResource(
+		'version',
+		new ResourceTemplate('kolibri://version', { list: undefined }),
+		{
+			title: 'KoliBri MCP Server Version',
+			description: 'Get the current version of the KoliBri MCP Server',
+		},
+		(uri) => {
+			log('resource', 'version accessed', { uri: uri.href });
+
+			return {
+				contents: [
+					{
+						uri: uri.href,
+						mimeType: 'application/json',
+						text: JSON.stringify({ name: PACKAGE_NAME, version: PACKAGE_VERSION }, null, 2),
+					},
+				],
+			};
+		},
+	);
+
 	// Add best practices resource
 	server.registerResource(
 		'best-practices',


### PR DESCRIPTION
## What changed?

A new `version` resource was added to the KoliBri MCP server, accessible at the URI `kolibri://version`. The resource returns a JSON object containing the package name and current version of the MCP server. This allows MCP clients to programmatically query which version of the KoliBri MCP server they are connected to without inspecting package files directly.

## Linked issues

No linked issues.

## Type of change

- [x] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dem KoliBri MCP-Server wurde eine neue `version`-Resource unter der URI `kolibri://version` hinzugefügt. Die Resource gibt ein JSON-Objekt mit dem Paketnamen und der aktuellen Version des MCP-Servers zurück. MCP-Clients können damit programmatisch abfragen, mit welcher Version des KoliBri MCP-Servers sie verbunden sind, ohne direkt in Paketdateien nachschauen zu müssen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

✨ Neues Feature

### Geänderte Dateien

- `packages/tools/mcp/src/mcp.ts` — Neue `version`-Resource unter `kolibri://version` registriert; gibt `{ name, version }` als JSON zurück

</details>