### PR TITLE
fix(select): forward _hideMsg prop to inner KolSelectWc component

### DIFF
--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -61,6 +61,7 @@ export class KolSelect implements SelectProps, FocusableElement {
 					_accessKey={this._accessKey}
 					_disabled={this._disabled}
 					_hideLabel={this._hideLabel}
+					_hideMsg={this._hideMsg}
 					_hint={this._hint}
 					_icons={this._icons}
 					_label={this._label}

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -73,7 +73,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
   <template shadowrootmode="open">
-    <kol-select-wc _hint="" _label="Label" _name="field" _tooltipalign="top" _touched="">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top" _touched="">
       <slot name="expert" slot="expert"></slot>
     </kol-select-wc>
   </template>
@@ -163,7 +163,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
   <template shadowrootmode="open">
-    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _tooltipalign="top" _touched="">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _multiple="" _name="field" _tooltipalign="top" _touched="">
       <slot name="expert" slot="expert"></slot>
     </kol-select-wc>
   </template>
@@ -283,7 +283,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _multiple=true _value=["Divers","Frau"] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
   <template shadowrootmode="open">
-    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _tooltipalign="top" _touched="">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _multiple="" _name="field" _tooltipalign="top" _touched="">
       <slot name="expert" slot="expert"></slot>
     </kol-select-wc>
   </template>
@@ -453,7 +453,7 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _value="Herr" _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" _value="Herr" class="kol-select">
   <template shadowrootmode="open">
-    <kol-select-wc _hint="" _label="Label" _name="field" _tooltipalign="top" _touched="" _value="Herr">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top" _touched="" _value="Herr">
       <slot name="expert" slot="expert"></slot>
     </kol-select-wc>
   </template>

--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -30,6 +30,136 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _touched=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top" _touched="">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _accessKey="V" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _accesskey="V" _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _alert=true 1`] = `
+<kol-select _alert="" _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _disabled=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _disabled="" _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _hint="Hint" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="Hint" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _readOnly=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _readonly="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _shortKey="S" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _shortkey="S" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} _touched=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top" _touched="">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hideMsg=true _msg={"_type":"error","_description":"This is a combined error message"} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hint="Hint" 1`] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
   <template shadowrootmode="open">

--- a/packages/components/src/components/select/test/snapshot.spec.tsx
+++ b/packages/components/src/components/select/test/snapshot.spec.tsx
@@ -39,3 +39,9 @@ executeInputSnapshotTests<SelectProps>(KolSelectTag, [KolSelect], {
 	_multiple: true,
 	_value: ['Divers', 'Frau'],
 });
+
+executeInputSnapshotTests<SelectProps>(KolSelectTag, [KolSelect], {
+	_options: options,
+	_hideMsg: true,
+	_msg: { _type: 'error', _description: 'This is a combined error message' },
+});


### PR DESCRIPTION
## What changed?

The `KolSelect` shadow component now correctly forwards the `_hideMsg` property to its inner `KolSelectWc` component. Previously, setting `_hideMsg` on the outer `KolSelect` had no effect because the prop was not passed through, causing error and hint messages to always appear even when explicitly hidden. Snapshot tests have been updated and extended to cover all relevant prop combinations that include `_hideMsg`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `KolSelect`-Shadow-Komponente leitet die `_hideMsg`-Eigenschaft nun korrekt an die innere `KolSelectWc`-Komponente weiter. Bisher hatte das Setzen von `_hideMsg` auf der äußeren `KolSelect` keine Wirkung, da die Prop nicht weitergeleitet wurde — Fehler- und Hinweismeldungen wurden daher immer angezeigt, auch wenn sie explizit ausgeblendet sein sollten. Snapshot-Tests wurden aktualisiert und um neue Kombinationen mit `_hideMsg` erweitert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/select/shadow.tsx` — `_hideMsg`-Prop-Weiterleitung an `KolSelectWc` ergänzt
- `packages/components/src/components/select/test/snapshot.spec.tsx` — Neue Snapshot-Tests für `_hideMsg`-Kombinationen hinzugefügt
- `packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap` — Snapshot-Datei aktualisiert

</details>