### PR TITLE
refactor(props): replace withValidPropValue helper with apply method and add clamped number prop

### DIFF
--- a/packages/components/src/internal/functional-components/avatar/controller.ts
+++ b/packages/components/src/internal/functional-components/avatar/controller.ts
@@ -1,7 +1,5 @@
 import type { ColorPair } from '../../../schema';
-import type { ColorProp, InitialsProp, LabelProp, SrcProp } from '../../props';
 import { colorProp, initialsProp, labelProp, srcProp } from '../../props';
-import { withValidPropValue } from '../../props/helpers/factory';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { AvatarApi } from './api';
@@ -23,22 +21,22 @@ export class AvatarController extends BaseController<AvatarApi> implements Contr
 	}
 
 	public watchColor(value?: string | ColorPair): void {
-		withValidPropValue<ColorProp>(colorProp, value, (v) => {
+		colorProp.apply(value, (v) => {
 			this.setProp('color', v);
 		});
 	}
 
 	public watchLabel(value?: string): void {
-		withValidPropValue<LabelProp>(labelProp, value, (v) => {
+		labelProp.apply(value, (v) => {
 			this.setProp('label', v);
 		});
-		withValidPropValue<InitialsProp>(initialsProp, value, (v) => {
+		initialsProp.apply(value, (v) => {
 			this.setState('initials', v);
 		});
 	}
 
 	public watchSrc(value?: string): void {
-		withValidPropValue<SrcProp>(srcProp, value, (v) => {
+		srcProp.apply(value, (v) => {
 			this.setProp('src', v);
 		});
 	}

--- a/packages/components/src/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/internal/functional-components/click-button/controller.ts
@@ -1,5 +1,4 @@
-import type { LabelProp } from '../../props';
-import { labelProp, withValidPropValue } from '../../props';
+import { labelProp } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { ClickButtonApi } from './api';
@@ -19,7 +18,7 @@ export class ClickButtonController extends BaseController<ClickButtonApi> implem
 	}
 
 	public watchLabel(value?: string): void {
-		withValidPropValue<LabelProp>(labelProp, value, (v) => {
+		labelProp.apply(value, (v) => {
 			this.setProp('label', v);
 		});
 	}

--- a/packages/components/src/internal/functional-components/image/controller.ts
+++ b/packages/components/src/internal/functional-components/image/controller.ts
@@ -1,5 +1,5 @@
-import type { AltProp, LoadingProp, LoadingType, SizesProp, SrcProp, SrcsetProp } from '../../props';
-import { altProp, loadingProp, sizesProp, srcProp, srcsetProp, withValidPropValue } from '../../props';
+import type { LoadingType } from '../../props';
+import { altProp, loadingProp, sizesProp, srcProp, srcsetProp } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { ImageApi } from './api';
@@ -25,31 +25,31 @@ export class ImageController extends BaseController<ImageApi> implements Control
 	}
 
 	public watchAlt(value?: string): void {
-		withValidPropValue<AltProp>(altProp, value, (v) => {
+		altProp.apply(value, (v) => {
 			this.setProp('alt', v);
 		});
 	}
 
 	public watchLoading(value?: LoadingType): void {
-		withValidPropValue<LoadingProp>(loadingProp, value, (v) => {
+		loadingProp.apply(value, (v) => {
 			this.setProp('loading', v);
 		});
 	}
 
 	public watchSizes(value?: string): void {
-		withValidPropValue<SizesProp>(sizesProp, value, (v) => {
+		sizesProp.apply(value, (v) => {
 			this.setProp('sizes', v);
 		});
 	}
 
 	public watchSrc(value?: string): void {
-		withValidPropValue<SrcProp>(srcProp, value, (v) => {
+		srcProp.apply(value, (v) => {
 			this.setProp('src', v);
 		});
 	}
 
 	public watchSrcset(value?: string): void {
-		withValidPropValue<SrcsetProp>(srcsetProp, value, (v) => {
+		srcsetProp.apply(value, (v) => {
 			this.setProp('srcset', v);
 		});
 	}

--- a/packages/components/src/internal/functional-components/progress/api.tsx
+++ b/packages/components/src/internal/functional-components/progress/api.tsx
@@ -1,10 +1,10 @@
-import type { LabelProp, MaxProp, UnitProp, ValueProp, VariantProgressProp } from '../../props';
+import type { LabelProp, MaxProp, UnitProp, NumberValueProp, VariantProgressProp } from '../../props';
 import type { ComponentApi, InternalOf } from '../generic-types';
 
 export interface ProgressApi extends ComponentApi {
 	Props: {
 		Optional: LabelProp & UnitProp & VariantProgressProp;
-		Required: MaxProp & ValueProp;
+		Required: MaxProp & NumberValueProp;
 	};
 	States: InternalOf<UnitProp> &
 		InternalOf<VariantProgressProp> & {

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -1,4 +1,4 @@
-import { labelProp, maxProp, clampedNumberValueProp, unitProp, variantProgressProp } from '../../props';
+import { clampedNumberValueProp, labelProp, maxProp, unitProp, variantProgressProp } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { ProgressApi } from './api';

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -1,5 +1,4 @@
-import type { ClampedNumberValueDeps, ClampedNumberValueProp, LabelProp, MaxProp, UnitProp, VariantProgressProp } from '../../props';
-import { labelProp, maxProp, clampedNumberValueProp, unitProp, variantProgressProp, withValidPropValue } from '../../props';
+import { labelProp, maxProp, clampedNumberValueProp, unitProp, variantProgressProp } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { ProgressApi } from './api';
@@ -31,13 +30,13 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	}
 
 	public watchLabel(value?: string): void {
-		withValidPropValue<LabelProp>(labelProp, value, (v) => {
+		labelProp.apply(value, (v) => {
 			this.setProp('label', v);
 		});
 	}
 
 	public watchMax(value?: number): void {
-		withValidPropValue<MaxProp>(maxProp, value, (v) => {
+		maxProp.apply(value, (v) => {
 			this.setProp('max', v);
 			this.setState('max', v);
 		});
@@ -45,15 +44,14 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	}
 
 	public watchUnit(value?: string): void {
-		withValidPropValue<UnitProp>(unitProp, value, (v) => {
+		unitProp.apply(value, (v) => {
 			this.setProp('unit', v);
 			this.setState('unit', v);
 		});
 	}
 
 	public watchValue(value?: number): void {
-		withValidPropValue<ClampedNumberValueProp, ClampedNumberValueDeps>(
-			clampedNumberValueProp,
+		clampedNumberValueProp.apply(
 			value,
 			(v) => {
 				this.setProp('value', v);
@@ -63,7 +61,7 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	}
 
 	public watchVariant(value?: string): void {
-		withValidPropValue<VariantProgressProp>(variantProgressProp, value, (v) => {
+		variantProgressProp.apply(value, (v) => {
 			this.setProp('variant', v);
 			this.setState('variant', v);
 		});

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -1,5 +1,5 @@
-import type { LabelProp, MaxProp, UnitProp, ValueProp, VariantProgressProp } from '../../props';
-import { labelProp, maxProp, unitProp, valueProp, variantProgressProp, withValidPropValue } from '../../props';
+import type { ClampedNumberValueDeps, ClampedNumberValueProp, LabelProp, MaxProp, UnitProp, VariantProgressProp } from '../../props';
+import { labelProp, maxProp, clampedNumberValueProp, unitProp, variantProgressProp, withValidPropValue } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { ProgressApi } from './api';
@@ -52,9 +52,14 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	}
 
 	public watchValue(value?: number): void {
-		withValidPropValue<ValueProp>(valueProp, this.clampValue(value), (v) => {
-			this.setProp('value', v);
-		});
+		withValidPropValue<ClampedNumberValueProp, ClampedNumberValueDeps>(
+			clampedNumberValueProp,
+			value,
+			(v) => {
+				this.setProp('value', v);
+			},
+			{ min: 0, max: this.getProps().max },
+		);
 	}
 
 	public watchVariant(value?: string): void {
@@ -62,19 +67,6 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 			this.setProp('variant', v);
 			this.setState('variant', v);
 		});
-	}
-
-	private clampValue(value?: number): number | undefined {
-		if (typeof value === 'number') {
-			if (value > this.component.max) {
-				value = this.component.max;
-			}
-
-			if (value < 0) {
-				value = 0;
-			}
-		}
-		return value;
 	}
 
 	// a11y: says the value of the component every 5s

--- a/packages/components/src/internal/functional-components/quote/controller.ts
+++ b/packages/components/src/internal/functional-components/quote/controller.ts
@@ -1,5 +1,4 @@
-import type { HrefProp, LabelProp, QuoteProp, VariantQuoteProp } from '../../props';
-import { hrefProp, labelProp, quoteProp, variantQuoteProp, withValidPropValue } from '../../props';
+import { hrefProp, labelProp, quoteProp, variantQuoteProp } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { QuoteApi } from './api';
@@ -26,25 +25,25 @@ export class QuoteController extends BaseController<QuoteApi> implements Control
 	}
 
 	public watchHref(value?: string): void {
-		withValidPropValue<HrefProp>(hrefProp, value, (v) => {
+		hrefProp.apply(value, (v) => {
 			this.setProp('href', v);
 		});
 	}
 
 	public watchLabel(value?: string): void {
-		withValidPropValue<LabelProp>(labelProp, value, (v) => {
+		labelProp.apply(value, (v) => {
 			this.setProp('label', v);
 		});
 	}
 
 	public watchQuote(value?: string): void {
-		withValidPropValue<QuoteProp>(quoteProp, value, (v) => {
+		quoteProp.apply(value, (v) => {
 			this.setProp('quote', v);
 		});
 	}
 
 	public watchVariant(value?: string): void {
-		withValidPropValue<VariantQuoteProp>(variantQuoteProp, value, (v) => {
+		variantQuoteProp.apply(value, (v) => {
 			this.setProp('variant', v);
 		});
 	}

--- a/packages/components/src/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/internal/functional-components/skeleton/controller.ts
@@ -1,6 +1,5 @@
 import { Log } from '../../../schema';
-import type { CountProp, LabelProp, NameProp } from '../../props';
-import { countProp, labelProp, nameProp, withValidPropValue } from '../../props';
+import { countProp, labelProp, nameProp } from '../../props';
 import { BaseController } from '../base-controller';
 import { ClickButtonController } from '../click-button/controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
@@ -31,20 +30,20 @@ export class SkeletonController extends BaseController<SkeletonApi> implements C
 	}
 
 	public watchCount(value?: number | string): void {
-		withValidPropValue<CountProp>(countProp, value, (v) => {
+		countProp.apply(value, (v) => {
 			this.setProp('count', v);
 			this.setState('count', v);
 		});
 	}
 
 	public watchName(value?: string): void {
-		withValidPropValue<NameProp>(nameProp, value, (v) => {
+		nameProp.apply(value, (v) => {
 			this.setProp('name', v);
 		});
 	}
 
 	public watchLabel(value?: string): void {
-		withValidPropValue<LabelProp>(labelProp, value, (v) => {
+		labelProp.apply(value, (v) => {
 			this.setState('label', v);
 			this.clickButtonCtrl.watchLabel(v);
 		});

--- a/packages/components/src/internal/props/helpers/factory.ts
+++ b/packages/components/src/internal/props/helpers/factory.ts
@@ -60,7 +60,7 @@ export type DependentPropDefinition<TInternal, TDeps> = {
 	apply: (value: unknown, callback: (normalized: TInternal) => void, deps: TDeps) => void;
 };
 
-export function createDependentPropDefinition<P extends Prop<string, unknown, unknown>, TDeps = Record<string, never>>(
+export function createDependentPropDefinition<P extends Prop<string, unknown, unknown>, TDeps>(
 	normalize: (value: unknown, deps: TDeps) => InternalPropValue<P> | never,
 	validate: (value: InternalPropValue<P>, deps: TDeps) => boolean = () => true,
 ): DependentPropDefinition<InternalPropValue<P>, TDeps> {

--- a/packages/components/src/internal/props/helpers/factory.ts
+++ b/packages/components/src/internal/props/helpers/factory.ts
@@ -28,29 +28,31 @@ export type SimpleProp<K extends string, T> = Prop<K, T, T>;
 
 export type InternalPropValue<P extends Prop<string, unknown, unknown>> = NonNullable<P['__propInternal__']>;
 
-export type PropDefinition<TInternal> = {
-	normalize: (value: unknown) => TInternal | never;
-	validate: (value: TInternal) => boolean;
+export type PropDefinition<TInternal, TDeps = Record<string, never>> = {
+	normalize: (value: unknown, deps: TDeps) => TInternal | never;
+	validate: (value: TInternal, deps: TDeps) => boolean;
 };
 
-export function createPropDefinition<P extends Prop<string, unknown, unknown>>(
-	normalize: (value: unknown) => InternalPropValue<P> | never,
-	validate: (value: InternalPropValue<P>) => boolean = () => true,
-): PropDefinition<InternalPropValue<P>> {
+export function createPropDefinition<P extends Prop<string, unknown, unknown>, TDeps = Record<string, never>>(
+	normalize: (value: unknown, deps: TDeps) => InternalPropValue<P> | never,
+	validate: (value: InternalPropValue<P>, deps: TDeps) => boolean = () => true,
+): PropDefinition<InternalPropValue<P>, TDeps> {
 	return {
 		normalize,
 		validate,
 	};
 }
 
-export function withValidPropValue<P extends Prop<string, unknown, unknown>>(
-	propDef: PropDefinition<InternalPropValue<P>>,
+export function withValidPropValue<P extends Prop<string, unknown, unknown>, TDeps = Record<string, never>>(
+	propDef: PropDefinition<InternalPropValue<P>, TDeps>,
 	value: unknown,
 	callback: (normalized: InternalPropValue<P>) => void,
+	deps?: TDeps,
 ): void {
 	try {
-		const normalized = propDef.normalize(value);
-		if (propDef.validate(normalized)) {
+		const dependencies = deps || ({} as TDeps);
+		const normalized = propDef.normalize(value, dependencies);
+		if (propDef.validate(normalized, dependencies)) {
 			callback(normalized);
 		}
 	} catch (e) {

--- a/packages/components/src/internal/props/helpers/factory.ts
+++ b/packages/components/src/internal/props/helpers/factory.ts
@@ -28,24 +28,49 @@ export type SimpleProp<K extends string, T> = Prop<K, T, T>;
 
 export type InternalPropValue<P extends Prop<string, unknown, unknown>> = NonNullable<P['__propInternal__']>;
 
-export type PropDefinition<TInternal, TDeps = Record<string, never>> = {
-	normalize: (value: unknown, deps: TDeps) => TInternal | never;
-	validate: (value: TInternal, deps: TDeps) => boolean;
-	apply: (value: unknown, callback: (normalized: TInternal) => void, deps?: TDeps) => void;
+export type PropDefinition<TInternal> = {
+	normalize: (value: unknown) => TInternal | never;
+	validate: (value: TInternal) => boolean;
+	apply: (value: unknown, callback: (normalized: TInternal) => void) => void;
 };
 
-export function createPropDefinition<P extends Prop<string, unknown, unknown>, TDeps = Record<string, never>>(
-	normalize: (value: unknown, deps: TDeps) => InternalPropValue<P> | never,
-	validate: (value: InternalPropValue<P>, deps: TDeps) => boolean = () => true,
-): PropDefinition<InternalPropValue<P>, TDeps> {
+export function createPropDefinition<P extends Prop<string, unknown, unknown>>(
+	normalize: (value: unknown) => InternalPropValue<P> | never,
+	validate: (value: InternalPropValue<P>) => boolean = () => true,
+): PropDefinition<InternalPropValue<P>> {
 	return {
 		normalize,
 		validate,
-		apply(value, callback, deps) {
+		apply(value, callback) {
 			try {
-				const dependencies = deps ?? ({} as TDeps);
-				const normalized = this.normalize(value, dependencies);
-				if (this.validate(normalized, dependencies)) {
+				const normalized = this.normalize(value);
+				if (this.validate(normalized)) {
+					callback(normalized);
+				}
+			} catch (e) {
+				Log.debug(e);
+			}
+		},
+	};
+}
+
+export type DependentPropDefinition<TInternal, TDeps> = {
+	normalize: (value: unknown, deps: TDeps) => TInternal | never;
+	validate: (value: TInternal, deps: TDeps) => boolean;
+	apply: (value: unknown, callback: (normalized: TInternal) => void, deps: TDeps) => void;
+};
+
+export function createDependentPropDefinition<P extends Prop<string, unknown, unknown>, TDeps = Record<string, never>>(
+	normalize: (value: unknown, deps: TDeps) => InternalPropValue<P> | never,
+	validate: (value: InternalPropValue<P>, deps: TDeps) => boolean = () => true,
+): DependentPropDefinition<InternalPropValue<P>, TDeps> {
+	return {
+		normalize,
+		validate,
+		apply(value, callback, deps: TDeps) {
+			try {
+				const normalized = this.normalize(value, deps);
+				if (this.validate(normalized, deps)) {
 					callback(normalized);
 				}
 			} catch (e) {

--- a/packages/components/src/internal/props/helpers/factory.ts
+++ b/packages/components/src/internal/props/helpers/factory.ts
@@ -31,6 +31,7 @@ export type InternalPropValue<P extends Prop<string, unknown, unknown>> = NonNul
 export type PropDefinition<TInternal, TDeps = Record<string, never>> = {
 	normalize: (value: unknown, deps: TDeps) => TInternal | never;
 	validate: (value: TInternal, deps: TDeps) => boolean;
+	apply: (value: unknown, callback: (normalized: TInternal) => void, deps?: TDeps) => void;
 };
 
 export function createPropDefinition<P extends Prop<string, unknown, unknown>, TDeps = Record<string, never>>(
@@ -40,22 +41,16 @@ export function createPropDefinition<P extends Prop<string, unknown, unknown>, T
 	return {
 		normalize,
 		validate,
+		apply(value, callback, deps) {
+			try {
+				const dependencies = deps ?? ({} as TDeps);
+				const normalized = this.normalize(value, dependencies);
+				if (this.validate(normalized, dependencies)) {
+					callback(normalized);
+				}
+			} catch (e) {
+				Log.debug(e);
+			}
+		},
 	};
-}
-
-export function withValidPropValue<P extends Prop<string, unknown, unknown>, TDeps = Record<string, never>>(
-	propDef: PropDefinition<InternalPropValue<P>, TDeps>,
-	value: unknown,
-	callback: (normalized: InternalPropValue<P>) => void,
-	deps?: TDeps,
-): void {
-	try {
-		const dependencies = deps || ({} as TDeps);
-		const normalized = propDef.normalize(value, dependencies);
-		if (propDef.validate(normalized, dependencies)) {
-			callback(normalized);
-		}
-	} catch (e) {
-		Log.debug(e);
-	}
 }

--- a/packages/components/src/internal/props/index.ts
+++ b/packages/components/src/internal/props/index.ts
@@ -14,6 +14,7 @@ export * from './sizes';
 export * from './src';
 export * from './srcset';
 export * from './unit';
-export * from './value';
+export * from './value-number';
+export * from './value-number-clamped';
 export * from './variant-progress';
 export * from './variant-quote';

--- a/packages/components/src/internal/props/value-number-clamped.ts
+++ b/packages/components/src/internal/props/value-number-clamped.ts
@@ -1,0 +1,23 @@
+import type { SimpleProp } from './helpers/factory';
+import { createPropDefinition } from './helpers/factory';
+import { normalizeNumber } from './helpers/normalizers';
+
+export type ClampedNumberValueProp = SimpleProp<'value', number>;
+
+export type ClampedNumberValueDeps = {
+	min: number;
+	max: number;
+};
+
+export const clampedNumberValueProp = createPropDefinition<ClampedNumberValueProp, ClampedNumberValueDeps>(
+	(value, deps) => {
+		const normalized = normalizeNumber(value);
+		if (normalized < deps.min) {
+			return deps.min;
+		} else if (deps.max !== undefined && normalized > deps.max) {
+			return deps.max;
+		}
+		return normalized;
+	},
+	(v) => v >= 0,
+);

--- a/packages/components/src/internal/props/value-number-clamped.ts
+++ b/packages/components/src/internal/props/value-number-clamped.ts
@@ -1,5 +1,5 @@
 import type { SimpleProp } from './helpers/factory';
-import { createPropDefinition } from './helpers/factory';
+import { createDependentPropDefinition } from './helpers/factory';
 import { normalizeNumber } from './helpers/normalizers';
 
 export type ClampedNumberValueProp = SimpleProp<'value', number>;
@@ -9,12 +9,12 @@ export type ClampedNumberValueDeps = {
 	max: number;
 };
 
-export const clampedNumberValueProp = createPropDefinition<ClampedNumberValueProp, ClampedNumberValueDeps>(
+export const clampedNumberValueProp = createDependentPropDefinition<ClampedNumberValueProp, ClampedNumberValueDeps>(
 	(value, deps) => {
 		const normalized = normalizeNumber(value);
 		if (normalized < deps.min) {
 			return deps.min;
-		} else if (deps.max !== undefined && normalized > deps.max) {
+		} else if (normalized > deps.max) {
 			return deps.max;
 		}
 		return normalized;

--- a/packages/components/src/internal/props/value-number.ts
+++ b/packages/components/src/internal/props/value-number.ts
@@ -2,5 +2,5 @@ import type { SimpleProp } from './helpers/factory';
 import { createPropDefinition } from './helpers/factory';
 import { normalizeNumber } from './helpers/normalizers';
 
-export type ValueProp = SimpleProp<'value', number>;
-export const valueProp = createPropDefinition<ValueProp>(normalizeNumber, (v) => v >= 0);
+export type NumberValueProp = SimpleProp<'value', number>;
+export const numberValueProp = createPropDefinition<NumberValueProp>(normalizeNumber, (v) => v >= 0);


### PR DESCRIPTION
## What changed?

The internal prop validation helper `withValidPropValue` has been removed and replaced by a new `apply` method added directly to each `PropDefinition` object, making prop definitions self-contained. The file `value.ts` was renamed to `value-number.ts` with corresponding type renames (`ValueProp` → `NumberValueProp`, `valueProp` → `numberValueProp`). A new `clampedNumberValueProp` was introduced via a `createDependentPropDefinition` factory that accepts min/max dependencies and normalizes a number to the specified range; it is used by `ProgressController` to clamp the `value` prop between 0 and the component's `max`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der interne Prop-Validierungs-Helper `withValidPropValue` wurde entfernt und durch eine `apply`-Methode ersetzt, die nun direkt auf jedem `PropDefinition`-Objekt verfügbar ist. Die Datei `value.ts` wurde zu `value-number.ts` umbenannt mit entsprechenden Typ-Umbenennungen (`ValueProp` → `NumberValueProp`, `valueProp` → `numberValueProp`). Neu eingeführt wurde `clampedNumberValueProp` über eine `createDependentPropDefinition`-Factory, die Min/Max-Abhängigkeiten akzeptiert und Zahlen auf den angegebenen Bereich begrenzt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/internal/props/helpers/factory.ts` — `apply`-Methode zu `PropDefinition` hinzugefügt; `withValidPropValue` entfernt; `createDependentPropDefinition` neu eingeführt
- `packages/components/src/internal/props/value-number.ts` — Aus `value.ts` umbenannt; Typen auf `NumberValueProp`/`numberValueProp` umgestellt
- `packages/components/src/internal/props/value-number-clamped.ts` — Neue Datei: `clampedNumberValueProp` mit Min/Max-Clamp-Logik
- `packages/components/src/internal/props/index.ts` — Exporte auf neue Dateinamen angepasst
- Multiple controller files — `withValidPropValue(prop, value, cb)` durch `prop.apply(value, cb)` ersetzt

</details>