### PR TITLE
feat: reset props to default when removed from outside

### DIFF
--- a/packages/components/src/components/progress/test/default-values.spec.tsx
+++ b/packages/components/src/components/progress/test/default-values.spec.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from '@jest/globals';
+import { newSpecPage } from '@stencil/core/testing';
+import type { KolProgress } from '../component';
+import { KolProgress as KolProgressComponent } from '../component';
+
+describe('kol-progress default values', () => {
+	it('should apply default values when properties are set to undefined', async () => {
+		const page = await newSpecPage({
+			components: [KolProgressComponent],
+			html: `<kol-progress _label="Test" _variant="cycle" _max="100" _value="50"></kol-progress>`,
+		});
+
+		const instance = page.rootInstance as KolProgress;
+
+		// Verify initial values are set correctly
+		expect(instance._label).toBe('Test');
+		expect(instance._variant).toBe('cycle');
+		expect(instance._max).toBe(100);
+		expect(instance._value).toBe(50);
+
+		// Verify controlled values match the set props
+		let props = instance['ctrl'].getProps();
+		expect(props.variant).toBe('cycle');
+		expect(props.label).toBe('Test');
+		expect(props.max).toBe(100);
+		expect(props.unit).toBe('%'); // default unit
+
+		// Set variant to undefined - should apply default 'bar'
+		instance._variant = undefined;
+		await page.waitForChanges();
+
+		props = instance['ctrl'].getProps();
+		expect(props.variant).toBe('bar');
+
+		// Set it back to cycle
+		instance._variant = 'cycle';
+		await page.waitForChanges();
+
+		props = instance['ctrl'].getProps();
+		expect(props.variant).toBe('cycle');
+
+		// Set label to undefined - should apply default ''
+		instance._label = undefined;
+		await page.waitForChanges();
+
+		props = instance['ctrl'].getProps();
+		expect(props.label).toBe('');
+
+		// Set unit to undefined - should apply default '%'
+		instance._unit = undefined;
+		await page.waitForChanges();
+
+		props = instance['ctrl'].getProps();
+		expect(props.unit).toBe('%');
+
+		// Set max and verify value constraints are reapplied
+		instance._max = 42;
+		instance._value = 100; // more than new max
+		await page.waitForChanges();
+
+		props = instance['ctrl'].getProps();
+		expect(props.max).toBe(42);
+		expect(props.value).toBe(42); // clamped to new max
+	});
+
+	it('should restore cycle variant when set back from another variant', async () => {
+		const page = await newSpecPage({
+			components: [KolProgressComponent],
+			html: `<kol-progress _label="Test" _variant="cycle" _max="100" _value="42"></kol-progress>`,
+		});
+
+		const instance = page.rootInstance as KolProgress;
+		let props = instance['ctrl'].getProps();
+
+		// Verify initial cycle variant
+		expect(props.variant).toBe('cycle');
+
+		// Change to bar variant
+		instance._variant = 'bar';
+		await page.waitForChanges();
+
+		props = instance['ctrl'].getProps();
+		expect(props.variant).toBe('bar');
+
+		// Set back by removing attribute (undefined)
+		instance._variant = undefined;
+		await page.waitForChanges();
+
+		props = instance['ctrl'].getProps();
+		expect(props.variant).toBe('bar'); // defaults to 'bar' not 'cycle'
+	});
+});

--- a/packages/components/src/internal/functional-components/avatar/controller.ts
+++ b/packages/components/src/internal/functional-components/avatar/controller.ts
@@ -5,14 +5,6 @@ import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { AvatarApi } from './api';
 
 export class AvatarController extends BaseController<AvatarApi> implements ControllerInterface<AvatarApi> {
-	public constructor(states: AvatarApi['States']) {
-		super(states, {
-			color: { backgroundColor: '#d3d3d3', foregroundColor: '#3f3f3f' },
-			label: '',
-			src: '',
-		});
-	}
-
 	public componentWillLoad(props: ResolvedInputProps<AvatarApi>): void {
 		const { color, label, src } = props;
 		this.watchColor(color);
@@ -21,23 +13,42 @@ export class AvatarController extends BaseController<AvatarApi> implements Contr
 	}
 
 	public watchColor(value?: string | ColorPair): void {
-		colorProp.apply(value, (v) => {
-			this.setProp('color', v);
-		});
+		colorProp.apply(
+			value,
+			(v) => {
+				this.setProp('color', v);
+			},
+			{
+				backgroundColor: '#d3d3d3',
+				foregroundColor: '#3f3f3f',
+			},
+		);
 	}
 
 	public watchLabel(value?: string): void {
-		labelProp.apply(value, (v) => {
-			this.setProp('label', v);
-		});
-		initialsProp.apply(value, (v) => {
-			this.setState('initials', v);
-		});
+		labelProp.apply(
+			value,
+			(v) => {
+				this.setProp('label', v);
+			},
+			'',
+		);
+		initialsProp.apply(
+			value,
+			(v) => {
+				this.setState('initials', v);
+			},
+			'',
+		);
 	}
 
 	public watchSrc(value?: string): void {
-		srcProp.apply(value, (v) => {
-			this.setProp('src', v);
-		});
+		srcProp.apply(
+			value,
+			(v) => {
+				this.setProp('src', v);
+			},
+			'',
+		);
 	}
 }

--- a/packages/components/src/internal/functional-components/base-controller.ts
+++ b/packages/components/src/internal/functional-components/base-controller.ts
@@ -3,17 +3,16 @@ import type { ComponentApi, InternalOf, ResolvedProps, StrictFields } from './ge
 type InternalStates<Api extends ComponentApi> = InternalOf<NonNullable<Api['States']>>;
 
 export abstract class BaseController<Api extends ComponentApi> {
-	public constructor(
-		protected readonly component: InternalStates<Api>,
-		private readonly props: StrictFields<ResolvedProps<Api>>,
-	) {}
+	private readonly props: Partial<StrictFields<ResolvedProps<Api>>> = {};
+
+	public constructor(protected readonly component: InternalStates<Api> = {} as InternalStates<Api>) {}
 
 	protected setProp<K extends keyof ResolvedProps<Api>>(key: K, value: StrictFields<ResolvedProps<Api>>[K]): void {
 		this.props[key] = value;
 	}
 
 	public getProps(): StrictFields<ResolvedProps<Api>> {
-		return this.props;
+		return this.props as StrictFields<ResolvedProps<Api>>;
 	}
 
 	protected setState<K extends keyof InternalStates<Api>>(key: K, value: InternalStates<Api>[K]): void {

--- a/packages/components/src/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/internal/functional-components/click-button/controller.ts
@@ -6,21 +6,19 @@ import type { ClickButtonApi } from './api';
 export class ClickButtonController extends BaseController<ClickButtonApi> implements ControllerInterface<ClickButtonApi> {
 	private buttonRef?: HTMLButtonElement;
 
-	public constructor(states: ClickButtonApi['States'] = {}) {
-		super(states, {
-			label: '',
-		});
-	}
-
 	public componentWillLoad(props: ResolvedInputProps<ClickButtonApi>): void {
 		const { label } = props;
 		this.watchLabel(label);
 	}
 
 	public watchLabel(value?: string): void {
-		labelProp.apply(value, (v) => {
-			this.setProp('label', v);
-		});
+		labelProp.apply(
+			value,
+			(v) => {
+				this.setProp('label', v);
+			},
+			'',
+		);
 	}
 
 	public handleClick = (): void => {

--- a/packages/components/src/internal/functional-components/image/controller.ts
+++ b/packages/components/src/internal/functional-components/image/controller.ts
@@ -5,16 +5,6 @@ import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { ImageApi } from './api';
 
 export class ImageController extends BaseController<ImageApi> implements ControllerInterface<ImageApi> {
-	public constructor(states: ImageApi['States'] = {}) {
-		super(states, {
-			alt: '',
-			loading: 'lazy',
-			sizes: '',
-			src: '',
-			srcset: '',
-		});
-	}
-
 	public componentWillLoad(props: ResolvedInputProps<ImageApi>): void {
 		const { alt, loading, sizes, src, srcset } = props;
 		this.watchAlt(alt);
@@ -25,32 +15,52 @@ export class ImageController extends BaseController<ImageApi> implements Control
 	}
 
 	public watchAlt(value?: string): void {
-		altProp.apply(value, (v) => {
-			this.setProp('alt', v);
-		});
+		altProp.apply(
+			value,
+			(v) => {
+				this.setProp('alt', v);
+			},
+			'',
+		);
 	}
 
 	public watchLoading(value?: LoadingType): void {
-		loadingProp.apply(value, (v) => {
-			this.setProp('loading', v);
-		});
+		loadingProp.apply(
+			value,
+			(v) => {
+				this.setProp('loading', v);
+			},
+			'lazy',
+		);
 	}
 
 	public watchSizes(value?: string): void {
-		sizesProp.apply(value, (v) => {
-			this.setProp('sizes', v);
-		});
+		sizesProp.apply(
+			value,
+			(v) => {
+				this.setProp('sizes', v);
+			},
+			'',
+		);
 	}
 
 	public watchSrc(value?: string): void {
-		srcProp.apply(value, (v) => {
-			this.setProp('src', v);
-		});
+		srcProp.apply(
+			value,
+			(v) => {
+				this.setProp('src', v);
+			},
+			'',
+		);
 	}
 
 	public watchSrcset(value?: string): void {
-		srcsetProp.apply(value, (v) => {
-			this.setProp('srcset', v);
-		});
+		srcsetProp.apply(
+			value,
+			(v) => {
+				this.setProp('srcset', v);
+			},
+			'',
+		);
 	}
 }

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -6,16 +6,6 @@ import type { ProgressApi } from './api';
 export class ProgressController extends BaseController<ProgressApi> implements ControllerInterface<ProgressApi> {
 	private interval?: ReturnType<typeof setInterval>;
 
-	public constructor(states: ProgressApi['States']) {
-		super(states, {
-			label: '',
-			max: 100,
-			unit: '%',
-			value: 0,
-			variant: 'bar',
-		});
-	}
-
 	public componentWillLoad(props: ResolvedInputProps<ProgressApi>): void {
 		const { label, max, unit, value, variant } = props;
 		this.watchLabel(label);
@@ -30,24 +20,42 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	}
 
 	public watchLabel(value?: string): void {
-		labelProp.apply(value, (v) => {
-			this.setProp('label', v);
-		});
+		labelProp.apply(
+			value,
+			(v) => {
+				this.setProp('label', v);
+			},
+			'',
+		);
 	}
 
 	public watchMax(value?: number): void {
-		maxProp.apply(value, (v) => {
-			this.setProp('max', v);
-			this.setState('max', v);
-		});
-		this.watchValue(this.getProps().value);
+		maxProp.apply(
+			value,
+			(v) => {
+				this.setProp('max', v);
+				/**
+				 * ARCHITECTURE NOTE: Why ... we have a inner stable max prop.
+				 */
+				this.setState('max', v);
+			},
+			100,
+		);
+		const currentValue = this.getProps().value;
+		if (currentValue !== undefined) {
+			this.watchValue(currentValue);
+		}
 	}
 
 	public watchUnit(value?: string): void {
-		unitProp.apply(value, (v) => {
-			this.setProp('unit', v);
-			this.setState('unit', v);
-		});
+		unitProp.apply(
+			value,
+			(v) => {
+				this.setProp('unit', v);
+				this.setState('unit', v);
+			},
+			'%',
+		);
 	}
 
 	public watchValue(value?: number): void {
@@ -57,14 +65,19 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 				this.setProp('value', v);
 			},
 			{ min: 0, max: this.getProps().max },
+			0,
 		);
 	}
 
 	public watchVariant(value?: string): void {
-		variantProgressProp.apply(value, (v) => {
-			this.setProp('variant', v);
-			this.setState('variant', v);
-		});
+		variantProgressProp.apply(
+			value,
+			(v) => {
+				this.setProp('variant', v);
+				this.setState('variant', v);
+			},
+			'bar',
+		);
 	}
 
 	// a11y: says the value of the component every 5s

--- a/packages/components/src/internal/functional-components/quote/controller.ts
+++ b/packages/components/src/internal/functional-components/quote/controller.ts
@@ -4,18 +4,6 @@ import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
 import type { QuoteApi } from './api';
 
 export class QuoteController extends BaseController<QuoteApi> implements ControllerInterface<QuoteApi> {
-	public constructor() {
-		super(
-			{},
-			{
-				href: '',
-				label: '',
-				quote: '',
-				variant: 'inline',
-			},
-		);
-	}
-
 	public componentWillLoad(props: ResolvedInputProps<QuoteApi>): void {
 		const { href, label, quote, variant } = props;
 		this.watchHref(href);
@@ -25,26 +13,42 @@ export class QuoteController extends BaseController<QuoteApi> implements Control
 	}
 
 	public watchHref(value?: string): void {
-		hrefProp.apply(value, (v) => {
-			this.setProp('href', v);
-		});
+		hrefProp.apply(
+			value,
+			(v) => {
+				this.setProp('href', v);
+			},
+			'',
+		);
 	}
 
 	public watchLabel(value?: string): void {
-		labelProp.apply(value, (v) => {
-			this.setProp('label', v);
-		});
+		labelProp.apply(
+			value,
+			(v) => {
+				this.setProp('label', v);
+			},
+			'',
+		);
 	}
 
 	public watchQuote(value?: string): void {
-		quoteProp.apply(value, (v) => {
-			this.setProp('quote', v);
-		});
+		quoteProp.apply(
+			value,
+			(v) => {
+				this.setProp('quote', v);
+			},
+			'',
+		);
 	}
 
 	public watchVariant(value?: string): void {
-		variantQuoteProp.apply(value, (v) => {
-			this.setProp('variant', v);
-		});
+		variantQuoteProp.apply(
+			value,
+			(v) => {
+				this.setProp('variant', v);
+			},
+			'inline',
+		);
 	}
 }

--- a/packages/components/src/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/internal/functional-components/skeleton/controller.ts
@@ -1,5 +1,5 @@
 import { Log } from '../../../schema';
-import { countProp, labelProp, nameProp } from '../../props';
+import { countProp, nameProp } from '../../props';
 import { BaseController } from '../base-controller';
 import { ClickButtonController } from '../click-button/controller';
 import type { ControllerInterface, ResolvedInputProps } from '../generic-types';
@@ -10,10 +10,7 @@ export class SkeletonController extends BaseController<SkeletonApi> implements C
 	private intervalId?: ReturnType<typeof setTimeout>;
 
 	public constructor(states: SkeletonApi['States']) {
-		super(states, {
-			count: 0,
-			name: '',
-		});
+		super(states);
 
 		this.clickButtonCtrl = new ClickButtonController({});
 		this.startLoadedEventInterval();
@@ -23,30 +20,30 @@ export class SkeletonController extends BaseController<SkeletonApi> implements C
 		const { count, name } = props;
 		this.watchCount(count);
 		this.watchName(name);
-		this.watchLabel(this.component.label);
 		this.clickButtonCtrl.componentWillLoad({
 			label: this.component.label,
 		});
 	}
 
 	public watchCount(value?: number | string): void {
-		countProp.apply(value, (v) => {
-			this.setProp('count', v);
-			this.setState('count', v);
-		});
+		countProp.apply(
+			value,
+			(v) => {
+				this.setProp('count', v);
+				this.setState('count', v);
+			},
+			0,
+		);
 	}
 
 	public watchName(value?: string): void {
-		nameProp.apply(value, (v) => {
-			this.setProp('name', v);
-		});
-	}
-
-	public watchLabel(value?: string): void {
-		labelProp.apply(value, (v) => {
-			this.setState('label', v);
-			this.clickButtonCtrl.watchLabel(v);
-		});
+		nameProp.apply(
+			value,
+			(v) => {
+				this.setProp('name', v);
+			},
+			'',
+		);
 	}
 
 	public toggle(): void {

--- a/packages/components/src/internal/props/helpers/factory.ts
+++ b/packages/components/src/internal/props/helpers/factory.ts
@@ -31,7 +31,7 @@ export type InternalPropValue<P extends Prop<string, unknown, unknown>> = NonNul
 export type PropDefinition<TInternal> = {
 	normalize: (value: unknown) => TInternal | never;
 	validate: (value: TInternal) => boolean;
-	apply: (value: unknown, callback: (normalized: TInternal) => void) => void;
+	apply: (value: unknown, callback: (normalized: TInternal) => void, defaultValue: TInternal) => void;
 };
 
 export function createPropDefinition<P extends Prop<string, unknown, unknown>>(
@@ -41,7 +41,13 @@ export function createPropDefinition<P extends Prop<string, unknown, unknown>>(
 	return {
 		normalize,
 		validate,
-		apply(value, callback) {
+		apply(value, callback, defaultValue) {
+			if (value === undefined || value === null) {
+				if (defaultValue !== undefined) {
+					callback(defaultValue);
+				}
+				return;
+			}
 			try {
 				const normalized = this.normalize(value);
 				if (this.validate(normalized)) {
@@ -57,7 +63,7 @@ export function createPropDefinition<P extends Prop<string, unknown, unknown>>(
 export type DependentPropDefinition<TInternal, TDeps> = {
 	normalize: (value: unknown, deps: TDeps) => TInternal | never;
 	validate: (value: TInternal, deps: TDeps) => boolean;
-	apply: (value: unknown, callback: (normalized: TInternal) => void, deps: TDeps) => void;
+	apply: (value: unknown, callback: (normalized: TInternal) => void, deps: TDeps, defaultValue: TInternal) => void;
 };
 
 export function createDependentPropDefinition<P extends Prop<string, unknown, unknown>, TDeps>(
@@ -67,7 +73,13 @@ export function createDependentPropDefinition<P extends Prop<string, unknown, un
 	return {
 		normalize,
 		validate,
-		apply(value, callback, deps: TDeps) {
+		apply(value, callback, deps: TDeps, defaultValue) {
+			if (value === undefined || value === null) {
+				if (defaultValue !== undefined) {
+					callback(defaultValue);
+				}
+				return;
+			}
 			try {
 				const normalized = this.normalize(value, deps);
 				if (this.validate(normalized, deps)) {


### PR DESCRIPTION
## What changed?

`PropDefinition.apply()` and `DependentPropDefinition.apply()` in `props/helpers/factory.ts` gained a new `defaultValue` parameter. When the incoming value is `undefined` or `null`, the `defaultValue` is now passed directly to the callback instead of silently skipping the call. This means skeleton-architecture components correctly reset to their declared default state when an optional `@Prop()` attribute is removed from outside (e.g. in a reactive framework). All skeleton controllers (`AvatarController`, `ClickButtonController`, `ImageController`, `ProgressController`, `QuoteController`, `SkeletonController`) were updated to pass their known default values to each `apply()` call instead of encoding them in their constructors. The explicit default-props objects in controller constructors were removed. A comprehensive integration test (`progress/test/default-values.spec.tsx`) was added to verify the reset behavior.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`PropDefinition.apply()` erhält einen neuen `defaultValue`-Parameter. Bei `undefined`/`null` wird jetzt `callback(defaultValue)` aufgerufen statt nichts zu tun. Alle Skeleton-Controller wurden aktualisiert, um Standardwerte via `apply()` statt via Konstruktor-Defaults zu übergeben. Ein neuer Integrationstest prüft das Reset-Verhalten von `KolProgress`.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/internal/props/helpers/factory.ts` — `defaultValue`-Parameter in `apply()` hinzugefügt
- `packages/components/src/internal/functional-components/base-controller.ts` — Konstruktor vereinfacht
- 5 Controller-Dateien (avatar, click-button, image, progress, quote, skeleton) — Default-Werte aus Konstruktor in `apply()`-Aufrufe verschoben
- `packages/components/src/components/progress/test/default-values.spec.tsx` — Neuer Test

</details>