### PR TITLE
feat(table): disable sticky columns when fixed cols exceed container …

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -184,6 +184,7 @@ export class KolTableStateless implements TableStatelessAPI {
 	@Watch('_selection')
 	public validateSelection(value?: TableSelectionPropType): void {
 		validateTableSelection(this, value);
+		this.checkAndUpdateStickyState();
 	}
 
 	@Listen('keydown')
@@ -263,6 +264,13 @@ export class KolTableStateless implements TableStatelessAPI {
 		const startRight = this.maxCols - this._fixedCols[1];
 		for (let i = startRight; i < this.maxCols && i < primaryHeader.length; i++) {
 			totalWidth += primaryHeader[i]?.width ?? 0;
+		}
+
+		// The selection column is always position: sticky; left: 0 (CSS-hardcoded).
+		// Its width is CSS-computed and must be measured from the DOM.
+		if (this.state._selection) {
+			const selectionCell = this.tableDivElement?.querySelector<HTMLElement>('.kol-table__cell--selection');
+			totalWidth += selectionCell?.offsetWidth ?? 0;
 		}
 
 		return totalWidth;

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -43,6 +43,8 @@ import clsx from '../../utils/clsx';
 import { nonce } from '../../utils/dev.utils';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 
+const RESIZE_DEBOUNCE_DELAY = 150;
+
 /**
  * @internal
  */
@@ -241,7 +243,7 @@ export class KolTableStateless implements TableStatelessAPI {
 		clearTimeout(this.resizeDebounceTimeout);
 		this.resizeDebounceTimeout = setTimeout(() => {
 			this.checkAndUpdateStickyState();
-		}, 150);
+		}, RESIZE_DEBOUNCE_DELAY);
 	}
 
 	private checkDivElementScrollbar() {

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -78,9 +78,13 @@ export class KolTableStateless implements TableStatelessAPI {
 
 	private maxCols: number = 0;
 	private fixedOffsets: number[] = [];
+	private resizeDebounceTimeout?: ReturnType<typeof setTimeout>;
 
 	@State()
 	private tableDivElementHasScrollbar = false;
+
+	@State()
+	private stickyColsDisabled = false;
 
 	/**
 	 * Store previous value to allow change detection by value-comparison
@@ -150,6 +154,7 @@ export class KolTableStateless implements TableStatelessAPI {
 	@Watch('_fixedCols')
 	public validateFixedCols(value?: FixedColsPropType) {
 		validateFixedCols(this, value);
+		this.checkAndUpdateStickyState();
 	}
 
 	@Watch('_headerCells')
@@ -208,9 +213,10 @@ export class KolTableStateless implements TableStatelessAPI {
 
 	public componentDidLoad() {
 		if (this.tableDivElement && ResizeObserver) {
-			this.tableDivElementResizeObserver = new ResizeObserver(this.checkDivElementScrollbar.bind(this));
+			this.tableDivElementResizeObserver = new ResizeObserver(this.handleResize.bind(this));
 			this.tableDivElementResizeObserver.observe(this.tableDivElement);
 		}
+		this.checkAndUpdateStickyState();
 	}
 
 	@Listen('changeheadercells')
@@ -226,12 +232,50 @@ export class KolTableStateless implements TableStatelessAPI {
 
 	public disconnectedCallback() {
 		this.tableDivElementResizeObserver?.disconnect();
+		clearTimeout(this.resizeDebounceTimeout);
+	}
+
+	private handleResize() {
+		this.checkDivElementScrollbar();
+		clearTimeout(this.resizeDebounceTimeout);
+		this.resizeDebounceTimeout = setTimeout(() => {
+			this.checkAndUpdateStickyState();
+		}, 150);
 	}
 
 	private checkDivElementScrollbar() {
 		if (this.tableDivElement) {
 			this.tableDivElementHasScrollbar = this.tableDivElement.scrollWidth > this.tableDivElement.clientWidth;
 		}
+	}
+
+	private calculateFixedColsWidth(): number {
+		if (!this._fixedCols) return 0;
+		const primaryHeader = this.getPrimaryHeaders(this.state._headerCells);
+		let totalWidth = 0;
+
+		// Sum widths of left-fixed columns
+		for (let i = 0; i < this._fixedCols[0] && i < primaryHeader.length; i++) {
+			totalWidth += primaryHeader[i]?.width ?? 0;
+		}
+
+		// Sum widths of right-fixed columns
+		const startRight = this.maxCols - this._fixedCols[1];
+		for (let i = startRight; i < this.maxCols && i < primaryHeader.length; i++) {
+			totalWidth += primaryHeader[i]?.width ?? 0;
+		}
+
+		return totalWidth;
+	}
+
+	private checkAndUpdateStickyState() {
+		if (!this.tableDivElement || !this._fixedCols) {
+			this.stickyColsDisabled = false;
+			return;
+		}
+		const containerWidth = this.tableDivElement.clientWidth;
+		const fixedColsWidth = this.calculateFixedColsWidth();
+		this.stickyColsDisabled = fixedColsWidth > 0 && fixedColsWidth >= containerWidth;
 	}
 
 	private updateDataToKeyMap(data: KoliBriTableDataType[]) {
@@ -508,7 +552,7 @@ export class KolTableStateless implements TableStatelessAPI {
 	}
 
 	private isFixedCol(index: number | undefined): 'left' | 'right' | undefined {
-		if (!this._fixedCols || index === undefined) {
+		if (!this._fixedCols || index === undefined || this.stickyColsDisabled) {
 			return undefined;
 		}
 		if (index < this._fixedCols[0]) {


### PR DESCRIPTION
## What changed?

`KolTableStateless` now automatically disables sticky column positioning when the combined width of all fixed (left + right) columns is greater than or equal to the container width. A new `stickyColsDisabled` state is toggled by a `checkAndUpdateStickyState()` method that compares `calculateFixedColsWidth()` against `tableDivElement.clientWidth`. The `ResizeObserver` callback was updated to call this check with a 150 ms debounce, preventing recalculation on every pixel of resize. The debounce timer is properly cleared in `disconnectedCallback`. When sticky is disabled, `isFixedCol()` returns `undefined`, removing all sticky CSS classes and inline offsets — preventing the table from becoming unusable on narrow viewports.

## Linked issues

- Closes #9740 — sticky columns unusable when fixed cols fill/exceed container width

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolTableStateless` deaktiviert Sticky-Column-Positioning automatisch, wenn die Summe der Breiten aller fixierten Spalten die Container-Breite erreicht oder überschreitet. Ein neuer `stickyColsDisabled`-State wird über `checkAndUpdateStickyState()` gesteuert, das via 150ms-debounceden `ResizeObserver` ausgelöst wird. Bei deaktiviertem Sticky entfernt `isFixedCol()` alle Sticky-CSS-Klassen und Inline-Offsets.

### Verknüpfte Tickets

- Schließt #9740 — Sticky-Spalten unbrauchbar bei kleinen Containern

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/table-stateless/component.tsx` — `stickyColsDisabled`-State, `checkAndUpdateStickyState`, `calculateFixedColsWidth`, Debounce-Handler

</details>