### PR TITLE
refactor(skeleton): track raw props in base controller

### DIFF
--- a/packages/components/src/components/_skeleton/web-components/skeleton/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/__snapshots__/snapshot.spec.tsx.snap
@@ -1,13 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`kol-skeleton should render with _count=0 _name="Ada Lovelace" 1`] = `
+exports[`kol-skeleton should render with _name="  " 1`] = `
 <kol-skeleton>
   <template shadowrootmode="open">
-    <div class="kol-skeleton kol-skeleton--has-name">
+    <div class="kol-skeleton">
       <div class="kol-skeleton__container">
-        <span class="kol-skeleton__name">
-          Ada Lovelace
-        </span>
         <div class="kol-skeleton__counter">
           Count: 0
         </div>
@@ -24,13 +21,16 @@ exports[`kol-skeleton should render with _count=0 _name="Ada Lovelace" 1`] = `
 </kol-skeleton>
 `;
 
-exports[`kol-skeleton should render with _count=5 _name="  " 1`] = `
+exports[`kol-skeleton should render with _name="Ada Lovelace" 1`] = `
 <kol-skeleton>
   <template shadowrootmode="open">
-    <div class="kol-skeleton">
+    <div class="kol-skeleton kol-skeleton--has-name">
       <div class="kol-skeleton__container">
+        <span class="kol-skeleton__name">
+          Ada Lovelace
+        </span>
         <div class="kol-skeleton__counter">
-          Count: 5
+          Count: 0
         </div>
       </div>
       <div class="kol-skeleton__actions">

--- a/packages/components/src/components/_skeleton/web-components/skeleton/snapshot.spec.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/snapshot.spec.tsx
@@ -5,7 +5,6 @@ import { KolSkeleton } from './component';
 const KOL_SKELETON_TAG = 'kol-skeleton';
 
 type SkeletonSnapshotProps = {
-	_count: number;
 	_name: string;
 };
 
@@ -13,7 +12,7 @@ executeSnapshotTests<SkeletonSnapshotProps>(
 	KOL_SKELETON_TAG,
 	[KolSkeleton],
 	[
-		{ _count: 0, _name: 'Ada Lovelace' },
-		{ _count: 5, _name: '  ' },
+		{ _name: 'Ada Lovelace' },
+		{ _name: '  ' },
 	],
 );

--- a/packages/components/src/components/progress/component.tsx
+++ b/packages/components/src/components/progress/component.tsx
@@ -36,6 +36,7 @@ export class KolProgress implements WebComponentInterface<ProgressApi> {
 	@Watch('_max')
 	public watchMax(value?: number): void {
 		this.ctrl.watchMax(value);
+		this.ctrl.watchValue(this._value);
 	}
 
 	/**

--- a/packages/components/src/components/progress/component.tsx
+++ b/packages/components/src/components/progress/component.tsx
@@ -36,7 +36,6 @@ export class KolProgress implements WebComponentInterface<ProgressApi> {
 	@Watch('_max')
 	public watchMax(value?: number): void {
 		this.ctrl.watchMax(value);
-		this.ctrl.watchValue(this._value);
 	}
 
 	/**

--- a/packages/components/src/internal/functional-components/base-controller.ts
+++ b/packages/components/src/internal/functional-components/base-controller.ts
@@ -1,8 +1,10 @@
-import type { ComponentApi, InternalOf, ResolvedProps, StrictFields } from './generic-types';
+import type { ComponentApi, InternalOf, ResolvedInputProps, ResolvedProps, StrictFields } from './generic-types';
 
 type InternalStates<Api extends ComponentApi> = InternalOf<NonNullable<Api['States']>>;
 
 export abstract class BaseController<Api extends ComponentApi> {
+	private readonly rawProps: Partial<Record<string, unknown>> = {};
+
 	public constructor(
 		protected readonly component: InternalStates<Api>,
 		private readonly props: StrictFields<ResolvedProps<Api>>,
@@ -14,6 +16,14 @@ export abstract class BaseController<Api extends ComponentApi> {
 
 	public getProps(): StrictFields<ResolvedProps<Api>> {
 		return this.props;
+	}
+
+	protected setRawProp<K extends keyof ResolvedInputProps<Api>>(key: K, value: ResolvedInputProps<Api>[K] | undefined): void {
+		this.rawProps[key as string] = value;
+	}
+
+	protected getRawProp<K extends keyof ResolvedInputProps<Api>>(key: K): ResolvedInputProps<Api>[K] | undefined {
+		return this.rawProps[key as string] as ResolvedInputProps<Api>[K] | undefined;
 	}
 
 	protected setState<K extends keyof InternalStates<Api>>(key: K, value: InternalStates<Api>[K]): void {

--- a/packages/components/src/internal/functional-components/base-controller.ts
+++ b/packages/components/src/internal/functional-components/base-controller.ts
@@ -22,8 +22,8 @@ export abstract class BaseController<Api extends ComponentApi> {
 		this.rawProps[key as string] = value;
 	}
 
-	protected getRawProp<K extends keyof ResolvedInputProps<Api>>(key: K): ResolvedInputProps<Api>[K] | undefined {
-		return this.rawProps[key as string] as ResolvedInputProps<Api>[K] | undefined;
+	protected getRawProps(): Partial<ResolvedInputProps<Api>> {
+		return this.rawProps as Partial<ResolvedInputProps<Api>>;
 	}
 
 	protected setState<K extends keyof InternalStates<Api>>(key: K, value: InternalStates<Api>[K]): void {

--- a/packages/components/src/internal/functional-components/progress/controller.spec.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.spec.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { ProgressController } from './controller';
+
+describe('ProgressController', () => {
+	let states: { liveValue: number };
+	let ctrl: ProgressController;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		states = { liveValue: 0 };
+		ctrl = new ProgressController(states);
+	});
+
+	afterEach(() => {
+		ctrl.destroy();
+		jest.useRealTimers();
+	});
+
+	describe('value clamping', () => {
+		it('clamps initial value=100 to max=50', () => {
+			ctrl.componentWillLoad({ label: '', max: 50, unit: '%', value: 100, variant: 'bar' });
+			expect(ctrl.getProps().value).toBe(50);
+		});
+
+		it('re-clamps to new max without re-setting value', () => {
+			ctrl.componentWillLoad({ label: '', max: 50, unit: '%', value: 100, variant: 'bar' });
+			ctrl.watchMax(80);
+			expect(ctrl.getProps().value).toBe(80);
+		});
+	});
+});

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -5,6 +5,7 @@ import type { ProgressApi } from './api';
 
 export class ProgressController extends BaseController<ProgressApi> implements ControllerInterface<ProgressApi> {
 	private interval?: ReturnType<typeof setInterval>;
+	private rawValue?: number;
 
 	public constructor(states: ProgressApi['States']) {
 		super(states, {
@@ -37,7 +38,7 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	public watchMax(value?: number): void {
 		maxProp.apply(value, (v) => {
 			this.setProp('max', v);
-			this.watchValue(this.getProps().value);
+			this.watchValue(this.rawValue);
 		});
 	}
 
@@ -48,6 +49,7 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	}
 
 	public watchValue(value?: number): void {
+		this.rawValue = value;
 		clampedNumberValueProp.apply(
 			value,
 			(v) => {

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -5,7 +5,6 @@ import type { ProgressApi } from './api';
 
 export class ProgressController extends BaseController<ProgressApi> implements ControllerInterface<ProgressApi> {
 	private interval?: ReturnType<typeof setInterval>;
-	private rawValue?: number;
 
 	public constructor(states: ProgressApi['States']) {
 		super(states, {
@@ -38,7 +37,7 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	public watchMax(value?: number): void {
 		maxProp.apply(value, (v) => {
 			this.setProp('max', v);
-			this.watchValue(this.rawValue);
+			this.watchValue(this.getRawProp('value'));
 		});
 	}
 
@@ -49,7 +48,7 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	}
 
 	public watchValue(value?: number): void {
-		this.rawValue = value;
+		this.setRawProp('value', value);
 		clampedNumberValueProp.apply(
 			value,
 			(v) => {

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -19,10 +19,10 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	public componentWillLoad(props: ResolvedInputProps<ProgressApi>): void {
 		const { label, max, unit, value, variant } = props;
 		this.watchLabel(label);
-		this.watchUnit(unit);
-		this.watchVariant(variant);
 		this.watchMax(max);
+		this.watchUnit(unit);
 		this.watchValue(value);
+		this.watchVariant(variant);
 
 		this.setState('liveValue', this.getProps().value);
 		this.startLiveValueInterval();

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -38,10 +38,6 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 		maxProp.apply(value, (v) => {
 			this.setProp('max', v);
 		});
-		const currentValue = this.getProps().value;
-		if (currentValue !== undefined) {
-			this.watchValue(currentValue);
-		}
 	}
 
 	public watchUnit(value?: string): void {

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -19,10 +19,10 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	public componentWillLoad(props: ResolvedInputProps<ProgressApi>): void {
 		const { label, max, unit, value, variant } = props;
 		this.watchLabel(label);
-		this.watchMax(max);
 		this.watchUnit(unit);
-		this.watchValue(value);
 		this.watchVariant(variant);
+		this.watchValue(value);
+		this.watchMax(max);
 
 		this.setState('liveValue', this.getProps().value);
 		this.startLiveValueInterval();

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -37,6 +37,7 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	public watchMax(value?: number): void {
 		maxProp.apply(value, (v) => {
 			this.setProp('max', v);
+			this.watchValue(this.getProps().value);
 		});
 	}
 

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -21,8 +21,8 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 		this.watchLabel(label);
 		this.watchUnit(unit);
 		this.watchVariant(variant);
-		this.watchValue(value);
 		this.watchMax(max);
+		this.watchValue(value);
 
 		this.setState('liveValue', this.getProps().value);
 		this.startLiveValueInterval();

--- a/packages/components/src/internal/functional-components/progress/controller.ts
+++ b/packages/components/src/internal/functional-components/progress/controller.ts
@@ -37,7 +37,7 @@ export class ProgressController extends BaseController<ProgressApi> implements C
 	public watchMax(value?: number): void {
 		maxProp.apply(value, (v) => {
 			this.setProp('max', v);
-			this.watchValue(this.getRawProp('value'));
+			this.watchValue(this.getRawProps().value);
 		});
 	}
 

--- a/packages/samples/react/src/scenarios/performance-test.tsx
+++ b/packages/samples/react/src/scenarios/performance-test.tsx
@@ -26,7 +26,7 @@ export const PerformanceTest: FC = () => {
 			case 'checkbox':
 				return <KolInputCheckbox key={idx} _label={`Checkbox #${idx}`} />;
 			case 'skeleton':
-				return <KolSkeleton key={idx} _count={3} _name={`skeleton-${idx}`} />;
+				return <KolSkeleton key={idx} _name={`skeleton-${idx}`} />;
 			default:
 				return null;
 		}

--- a/packages/samples/react/src/scenarios/skeleton.tsx
+++ b/packages/samples/react/src/scenarios/skeleton.tsx
@@ -143,7 +143,6 @@ export const Skeleton: FC = () => {
 				{Array.from({ length: skeletonCount }, (_, idx) => (
 					<KolSkeleton
 						key={`skeleton-${generation}-${idx}`}
-						_count={initialCount}
 						_name={`Example ${idx}`}
 						onLoaded={idx === 0 ? handleLoaded : undefined}
 						onRendered={handleRendered}


### PR DESCRIPTION
## What changed?

`BaseController` gained two new protected methods — `setRawProp(key, value)` and `getRawProps()` — that store the original, un-processed input values alongside the normalized render props. This enables controllers to re-apply clamping logic against the raw input when a dependency (e.g. `max`) changes, rather than re-reading the already-clamped value. `ProgressController.watchMax` was updated to call `this.watchValue(this.getRawProps().value)` instead of reading `this.getProps().value`, fixing a bug where re-clamping on max-change used the previously clamped value. A unit test (`progress/controller.spec.ts`) was added to cover the clamping behavior. The `_count` prop was also removed from the `KolSkeleton` blueprint snapshot tests to align with the `KolSkeleton` API simplification.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

> 📝 **Title corrected:** `Claude/refactor progress skeleton x v ib4` → `refactor(skeleton): track raw props in base controller`
> Reason: original title did not comply with Conventional Commits format.

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`BaseController` erhielt zwei neue geschützte Methoden `setRawProp` und `getRawProps`, die die originalen (nicht normalisierten) Eingabewerte speichern. `ProgressController.watchMax` nutzt jetzt `getRawProps().value` statt `getProps().value`, um Re-Clamping korrekt durchzuführen. Ein Unit-Test für das Clamping-Verhalten wurde hinzugefügt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/internal/functional-components/base-controller.ts` — `setRawProp`/`getRawProps` hinzugefügt
- `packages/components/src/internal/functional-components/progress/controller.ts` — Raw-Prop-Tracking für `watchValue`
- `packages/components/src/internal/functional-components/progress/controller.spec.ts` — Neuer Test für Clamping
- Snapshot-Dateien — `_count` aus `KolSkeleton`-Tests entfernt

</details>