### PR TITLE
fix: split button popover alignment

### DIFF
--- a/packages/components/src/components/popover/style.scss
+++ b/packages/components/src/components/popover/style.scss
@@ -20,6 +20,7 @@
 			position: absolute;
 			min-width: max-content;
 			min-height: max-content;
+			margin: 0; // popover tags get a default margin from the browser, which interferce with our alignment
 
 			&--visible {
 				animation: 0.3s ease-in forwards fadeInOpacity;

--- a/packages/components/src/components/popover/style.scss
+++ b/packages/components/src/components/popover/style.scss
@@ -20,7 +20,7 @@
 			position: absolute;
 			min-width: max-content;
 			min-height: max-content;
-			margin: 0; // popover tags get a default margin from the browser, which interferce with our alignment
+			margin: 0; // popover tags get a default margin from the browser, which interferes with our alignment
 
 			&--visible {
 				animation: 0.3s ease-in forwards fadeInOpacity;


### PR DESCRIPTION
## What changed?

The `popover/style.scss` received a one-line fix adding `margin: 0` to the popover container element. Browser user-agent stylesheets apply a default margin to elements with the `popover` attribute, which interfered with the Floating UI–based position calculation used by `KolSplitButton`, causing the dropdown popover to appear misaligned. Setting `margin: 0` removes that browser default and restores correct alignment.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `popover/style.scss` wurde `margin: 0` auf den Popover-Container gesetzt. Browser setzen von Haus aus einen Standard-Margin auf Elemente mit dem `popover`-Attribut, was das Floating-UI-Positionierungsmodell von `KolSplitButton` störte und zu fehlerhafter Ausrichtung des Dropdowns führte. Der Fix entfernt diesen Browser-Default.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/popover/style.scss` — `margin: 0` zum Popover-Container hinzugefügt

</details>