### PR TITLE
refactor(span): migrate SpanApi props to prop-definition factory

### DIFF
--- a/packages/components/src/internal/functional-components/span/api.tsx
+++ b/packages/components/src/internal/functional-components/span/api.tsx
@@ -1,15 +1,11 @@
-import type { SimpleProp } from '../../../internal/props/helpers/factory';
-import type { BadgeTextPropType, HideLabelPropType, KoliBriIconsProp, LabelWithExpertSlotPropType } from '../../../schema';
-import type { ComponentApi } from '../generic-types';
+import { allowMarkdownProp, badgeTextProp, hideLabelProp } from '../../../internal/props';
+import { labelProp } from '../../../internal/props/label';
+import { spanIconsProp } from '../../../internal/props/span-icons';
+import type { ApiFromConfig, PropsConfigShape } from '../generic-types';
 
-export interface SpanApi extends ComponentApi {
-	Props: {
-		Required: {
-			label: LabelWithExpertSlotPropType;
-		};
-		Optional: SimpleProp<'allowMarkdown', boolean> &
-			SimpleProp<'badgeText', BadgeTextPropType> &
-			SimpleProp<'hideLabel', HideLabelPropType> &
-			SimpleProp<'icons', KoliBriIconsProp>;
-	};
-}
+export const spanPropsConfig = {
+	required: [labelProp],
+	optional: [allowMarkdownProp, badgeTextProp, hideLabelProp, spanIconsProp],
+} as const satisfies PropsConfigShape;
+
+export type SpanApi = ApiFromConfig<typeof spanPropsConfig>;

--- a/packages/components/src/internal/functional-components/span/component.tsx
+++ b/packages/components/src/internal/functional-components/span/component.tsx
@@ -72,13 +72,15 @@ function renderLabel(label: string, hideLabel: boolean, allowMarkdown: boolean |
 }
 
 export const SpanFC: FC<
-	Omit<FunctionalComponentProps<SpanApi>, 'badgeText' | 'hideLabel' | 'icons' | 'allowMarkdown'> & {
-		badgeText?: string | undefined;
-		hideLabel?: boolean | undefined;
-		icons?: KoliBriIconsProp | undefined;
-		allowMarkdown?: boolean | undefined;
+	Omit<FunctionalComponentProps<SpanApi>, 'allowMarkdown' | 'badgeText' | 'hideLabel' | 'icons'> & {
+		allowMarkdown?: boolean;
+		badgeText?: string;
+		hideLabel?: boolean;
+		icons?: KoliBriIconsProp;
 	}
-> = ({ class: classNames, label, hideLabel = false, badgeText, icons, allowMarkdown, ...htmlAttributes }, children) => {
+> = (props, children) => {
+	const { allowMarkdown, badgeText, class: classNames, hideLabel = false, icons, label, ...htmlAttributes } = props;
+
 	let top: NormalizedIcon = null;
 	let left: NormalizedIcon = null;
 	let right: NormalizedIcon = null;

--- a/packages/components/src/internal/props/allow-markdown.ts
+++ b/packages/components/src/internal/props/allow-markdown.ts
@@ -1,0 +1,20 @@
+import type { SimpleProp } from './helpers/factory';
+import { createPropDefinition } from './helpers/factory';
+import { normalizeBoolean } from './helpers/normalizers';
+
+/**
+ * Allow Markdown prop for rendering markdown content
+ *
+ * Description:
+ * Specifies whether the label content should be interpreted and rendered as Markdown.
+ * When enabled, the label will be parsed as Markdown and rendered as HTML.
+ *
+ * Usage:
+ * - Default: false (label is rendered as plain text)
+ * - When true: label content is parsed as Markdown
+ * - Only affects text rendering, not interactive elements
+ *
+ * @see https://www.markdownguide.org/
+ */
+export type AllowMarkdownProp = SimpleProp<'allowMarkdown', boolean>;
+export const allowMarkdownProp = createPropDefinition<AllowMarkdownProp>('allowMarkdown', false, normalizeBoolean);

--- a/packages/components/src/internal/props/badge-text.ts
+++ b/packages/components/src/internal/props/badge-text.ts
@@ -1,0 +1,22 @@
+import type { SimpleProp } from './helpers/factory';
+import { createPropDefinition } from './helpers/factory';
+import { normalizeString } from './helpers/normalizers';
+
+/**
+ * Badge Text prop for highlighting text in labels
+ *
+ * Description:
+ * Specifies text to be underlined and highlighted as a badge within the label.
+ * This is useful for highlighting keyboard shortcuts or other important text portions.
+ *
+ * Usage:
+ * - Default: empty string (no badge highlighting)
+ * - When set: the specified text will be underlined in the label
+ * - Case-sensitive matching (tries uppercase/lowercase variations if exact match not found)
+ *
+ * Accessibility:
+ * - Underlined text must have sufficient contrast (WCAG 1.4.11)
+ * - Badge text should complement, not replace, other text alternatives
+ */
+export type BadgeTextProp = SimpleProp<'badgeText', string>;
+export const badgeTextProp = createPropDefinition<BadgeTextProp>('badgeText', '', normalizeString);

--- a/packages/components/src/internal/props/hide-label.ts
+++ b/packages/components/src/internal/props/hide-label.ts
@@ -1,0 +1,22 @@
+import type { SimpleProp } from './helpers/factory';
+import { createPropDefinition } from './helpers/factory';
+import { normalizeBoolean } from './helpers/normalizers';
+
+/**
+ * Hide Label prop for controlling label visibility
+ *
+ * Description:
+ * Specifies whether the label should be visually hidden.
+ * When enabled, the label is not displayed but remains accessible to screen readers.
+ *
+ * Usage (according to WCAG 2.1 and WAI-ARIA):
+ * - Default: false (label is visible)
+ * - When true: label is hidden visually but remains available to assistive technologies (WCAG 1.3.1)
+ * - The label content is still used for accessibility purposes
+ * - Expert slot becomes visible when label is hidden
+ *
+ * @see https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html
+ * @see https://www.a11yproject.com/posts/how-to-hide-content/
+ */
+export type HideLabelProp = SimpleProp<'hideLabel', boolean>;
+export const hideLabelProp = createPropDefinition<HideLabelProp>('hideLabel', false, normalizeBoolean);

--- a/packages/components/src/internal/props/index.ts
+++ b/packages/components/src/internal/props/index.ts
@@ -1,6 +1,9 @@
+export * from './allow-markdown';
 export * from './alt';
+export * from './badge-text';
 export * from './color';
 export * from './helpers/factory';
+export * from './hide-label';
 export * from './href';
 export * from './icons';
 export * from './label';
@@ -10,6 +13,7 @@ export * from './name';
 export * from './quote';
 export * from './show';
 export * from './sizes';
+export * from './span-icons';
 export * from './src';
 export * from './srcset';
 export * from './unit';

--- a/packages/components/src/internal/props/span-icons.ts
+++ b/packages/components/src/internal/props/span-icons.ts
@@ -1,0 +1,51 @@
+import type { KoliBriIconsProp } from '../../schema/types';
+import type { SimpleProp } from './helpers/factory';
+import { createPropDefinition } from './helpers/factory';
+import { normalizeObject, normalizeString } from './helpers/normalizers';
+
+/**
+ * Icons prop for multi-directional icon display
+ *
+ * Description:
+ * Specifies icons to display in one or more directions (top, right, bottom, left).
+ * Can accept either a single icon class or an object with directional icon specifications.
+ *
+ * Usage:
+ * - String: A single icon class name (displayed on the left by default)
+ * - Object: Directional icons (e.g., { top: 'icon-class', left: 'icon-class' })
+ * - Default: empty object (no icons)
+ *
+ * Accessibility:
+ * - Icons must have descriptive labels to meet WCAG 1.1.1
+ * - Use the label prop to provide text alternatives
+ * - Icons should not be the sole means of conveying information (WCAG 1.3.3)
+ *
+ * @see https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html
+ */
+export type SpanIconsProp = SimpleProp<'icons', KoliBriIconsProp>;
+
+function normalizeSpanIcons(value: unknown): KoliBriIconsProp | never {
+	if (!value || (typeof value === 'string' && value === '')) {
+		return {};
+	}
+	// If it's a string, return it as-is
+	if (typeof value === 'string') {
+		return normalizeString(value);
+	}
+	// If it's an object, normalize it
+	if (typeof value === 'object') {
+		return normalizeObject(value) as KoliBriIconsProp;
+	}
+	throw new Error(`Invalid icons: ${typeof value}`);
+}
+
+function validateSpanIcons(value: KoliBriIconsProp): boolean {
+	// String is valid if it's non-empty
+	if (typeof value === 'string') {
+		return value.length > 0;
+	}
+	// Object is always valid (even if empty)
+	return typeof value === 'object' && value !== null;
+}
+
+export const spanIconsProp = createPropDefinition<SpanIconsProp>('icons', {} as KoliBriIconsProp, normalizeSpanIcons, validateSpanIcons);


### PR DESCRIPTION
## What changed?

The `SpanApi` type definition was refactored from a manual interface (`SimpleProp<'allowMarkdown', boolean> & ...`) to the new `PropsConfigShape` / `ApiFromConfig` pattern introduced in the skeleton architecture. Four new prop-definition files were created in `packages/components/src/internal/props/`: `allow-markdown.ts`, `badge-text.ts`, `hide-label.ts`, and `span-icons.ts`. Each file defines the prop type, default value, normalizer, and optional validator via `createPropDefinition`. The `SpanFC` component was updated to destructure props from a single `props` object instead of using positional parameter destructuring. No user-facing props or rendering behavior were changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `SpanApi`-Typdefinition wurde von einer manuellen Interface-Schreibweise auf das neue `PropsConfigShape`/`ApiFromConfig`-Pattern der Skeleton-Architektur migriert. Vier neue Prop-Definitions-Dateien wurden in `packages/components/src/internal/props/` angelegt: `allow-markdown.ts`, `badge-text.ts`, `hide-label.ts` und `span-icons.ts`. Jede Datei definiert Prop-Typ, Standardwert, Normalisierer und optionalen Validator via `createPropDefinition`. Die `SpanFC`-Komponente wurde auf destrukturierendes Props-Objekt umgestellt. Keine nutzerrelevanten Props oder Rendering-Verhaltensänderungen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/internal/props/allow-markdown.ts` — Neue `AllowMarkdownProp`-Definition
- `packages/components/src/internal/props/badge-text.ts` — Neue `BadgeTextProp`-Definition
- `packages/components/src/internal/props/hide-label.ts` — Neue `HideLabelProp`-Definition
- `packages/components/src/internal/props/span-icons.ts` — Neue `SpanIconsProp`-Definition
- `packages/components/src/internal/props/index.ts` — Neue Exports hinzugefügt
- `packages/components/src/internal/functional-components/span/api.tsx` — Auf `spanPropsConfig` + `ApiFromConfig` umgestellt
- `packages/components/src/internal/functional-components/span/component.tsx` — Props-Destructuring aktualisiert

</details>