### PR TITLE
fix(button): prevent double form submission by stopping click event propagation

### DIFF
--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -90,6 +90,8 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 	};
 
 	private readonly onClick = (event: MouseEvent) => {
+		event.stopPropagation();
+
 		if (this.state._hideLabel) {
 			void this.hideTooltip();
 		}

--- a/packages/samples/react/src/components/button/basic.tsx
+++ b/packages/samples/react/src/components/button/basic.tsx
@@ -25,9 +25,9 @@ export const ButtonBasic: FC = () => {
 				<section className="grid gap-4">
 					<KolHeading _level={2} _label="Button Variants" />
 					<div className="flex flex-wrap gap-4">
-						<KolButton _icons="kolicon-house" _label="Primary" _variant="primary" _on={dummyEventHandler} />
-						<KolButton _icons="kolicon-kolibri" _label="Secondary" _variant="secondary" _on={dummyEventHandler} />
-						<KolButton _icons="kolicon-cogwheel" _label="Tertiary" _variant="tertiary" _on={dummyEventHandler} />
+						<KolButton _icons="kolicon-house" _label="Primary" _variant="primary" onClick={dummyClickEventHandler} />
+						<KolButton _icons="kolicon-kolibri" _label="Secondary" _variant="secondary" onClick={dummyClickEventHandler} />
+						<KolButton _icons="kolicon-cogwheel" _label="Tertiary" _variant="tertiary" onClick={dummyClickEventHandler} />
 						<KolButton _icons="kolicon-cogwheel" _label="Normal" _variant="normal" _on={dummyEventHandler} />
 						<KolButton _icons="kolicon-alert-warning" _label="Danger" _variant="danger" _on={dummyEventHandler} />
 						<KolButton _icons="kolicon-eye-closed" _label="Ghost" _variant="ghost" _on={dummyEventHandler} />

--- a/packages/samples/react/src/components/form/basic.tsx
+++ b/packages/samples/react/src/components/form/basic.tsx
@@ -1,20 +1,29 @@
-import { KolForm, KolInputText } from '@public-ui/react-v19';
+import { KolButton, KolForm, KolInputText } from '@public-ui/react-v19';
 import type { FC } from 'react';
 import React from 'react';
 import { SampleDescription } from '../SampleDescription';
 
-export const FormBasic: FC = () => (
-	<>
-		<SampleDescription>
-			<p>KolForm renders a form around the input components provided in a slot. This sample shows a basic form with three input fields.</p>
-		</SampleDescription>
+export const FormBasic: FC = () => {
+	const formEventHAndler = {
+		onSubmit: (event: any) => console.log('submitted:', event),
+	};
 
-		<KolForm className="w-full">
-			<div className="grid gap-2">
-				<KolInputText id="input1" _label="Input 1" />
-				<KolInputText id="input2" _label="Input 2" />
-				<KolInputText id="input3" _label="Input 3" />
-			</div>
-		</KolForm>
-	</>
-);
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					KolForm renders a form around the input components provided in a slot. This sample shows a basic form with three input fields and a submit button.
+				</p>
+			</SampleDescription>
+
+			<KolForm className="w-full" _on={formEventHAndler}>
+				<div className="grid gap-2">
+					<KolInputText id="input1" _label="Input 1" />
+					<KolInputText id="input2" _label="Input 2" />
+					<KolInputText id="input3" _label="Input 3" />
+					<KolButton _label="Submit" _variant="primary" _type="submit" />
+				</div>
+			</KolForm>
+		</>
+	);
+};


### PR DESCRIPTION
## What changed?

Added `event.stopPropagation()` to `KolButtonWc`'s `onClick` handler to prevent click events from bubbling up and triggering duplicate form submissions (the original "doppeltes Abschicken" issue). Updated the button basic sample to use native `onClick` for the first three button variants. Updated the form basic sample to include a submit button and an `onSubmit` handler.

## Linked issues

<!-- #123, closes #456 -->

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal change (CI, build, docs, refactor)

## Checklist

- [x] No breaking changes to public API

<details>
<summary>🇩🇪 Auf Deutsch</summary>

## Was wurde geändert?

In `KolButtonWc`'s `onClick`-Handler wurde `event.stopPropagation()` hinzugefügt, damit Click-Events nicht nach oben weiterleiten und doppelte Formular-Einsendungen auslösen (ursprüngliches „doppeltes Abschicken"-Problem). Das Button-Basic-Sample wurde aktualisiert, um für die ersten drei Button-Varianten natives `onClick` zu verwenden. Das Formular-Basic-Sample wurde um einen Absende-Button und einen `onSubmit`-Handler ergänzt.

## Verknüpfte Tickets

<!-- #123, schließt #456 -->

## Art der Änderung

- [ ] ✨ Neues Feature
- [ ] 🔼 Verbesserung
- [x] 🐛 Fehlerbehebung
- [ ] 💥 Breaking Change
- [ ] 🔧 Interne Änderung (CI, Build, Dokumentation, Refactoring)

## Geänderte Dateien

- `packages/components/src/components/button/component.tsx` — `event.stopPropagation()` in `onClick` hinzugefügt
- `packages/samples/react/src/components/button/basic.tsx` — natives `onClick` für Button-Varianten verwendet
- `packages/samples/react/src/components/form/basic.tsx` — Submit-Button und `onSubmit`-Handler hinzugefügt

</details>