### PR TITLE
ci: deploy playwright visual test reports to GitHub Pages on PR

### DIFF
--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -7,6 +7,10 @@ concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   visual-tests-snapshots:
     strategy:
@@ -88,3 +92,53 @@ jobs:
           name: base-snapshots-${{ matrix.package }}
           path: /tmp/snapshots/${{ matrix.package }}
           if-no-files-found: ignore
+
+      - name: Determine report path
+        id: report-path
+        if: always() && github.event.pull_request.head.repo.fork == false
+        run: |
+          PACKAGE="${{ matrix.package }}"
+          if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
+            REPORT_DIR="packages/test-tag-name-transformer/playwright-report"
+          else
+            THEME_DIR="${PACKAGE#theme-}"
+            REPORT_DIR="packages/themes/${THEME_DIR}/playwright-report"
+          fi
+          echo "path=${REPORT_DIR}" >> $GITHUB_OUTPUT
+          if [ -d "${REPORT_DIR}" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy report to GitHub Pages
+        if: always() && github.event.pull_request.head.repo.fork == false && steps.report-path.outputs.exists == 'true'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: ${{ steps.report-path.outputs.path }}
+          target-folder: pr-${{ github.event.pull_request.number }}/${{ matrix.package }}
+          branch: gh-pages
+          clean: false
+
+      - name: Find existing PR comment
+        if: always() && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/find-comment@v4
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- visual-test-report-${{ matrix.package }} -->'
+
+      - name: Post PR comment with report link
+        if: always() && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- visual-test-report-${{ matrix.package }} -->
+            ## Visual Test Report — `${{ matrix.package }}`
+            [Open Playwright Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/${{ matrix.package }}/)
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/visual-tests-cleanup.yml
+++ b/.github/workflows/visual-tests-cleanup.yml
@@ -1,0 +1,31 @@
+name: Visual Tests Report Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          persist-credentials: true
+
+      - name: Remove PR report directory
+        run: |
+          PR_DIR="pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PR_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$PR_DIR"
+            git commit -m "chore: remove visual test report for PR #${{ github.event.pull_request.number }}"
+            git push
+          else
+            echo "No report directory found for PR #${{ github.event.pull_request.number }}, skipping."
+          fi

--- a/packages/tools/visual-tests/playwright.config.js
+++ b/packages/tools/visual-tests/playwright.config.js
@@ -7,6 +7,7 @@ const PORT = parseInt(process.env.KOLIBRI_VISUAL_TEST_PORT || '', 10);
 const BASE_URL = `http://localhost:${PORT}`;
 
 const CWD = process.env.KOLIBRI_CWD ?? '';
+const HTML_REPORT_DIR = 'playwright-report';
 const TIMEOUT = parseInt(process.env.KOLIBRI_VISUAL_TESTS_TIMEOUT || '15000', 10);
 const EXPECT_TIMEOUT = parseInt(process.env.KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT || '5000', 10);
 const BUILD_PATH = process.env.KOLIBRI_VISUAL_TESTS_BUILD_PATH ?? '';
@@ -41,7 +42,7 @@ export default defineConfig({
 	/* Allow to override the expectation timeout for slow environments */
 	timeout: TIMEOUT,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: 'line',
+	reporter: [['line'], ['html', { open: 'never', outputFolder: path.join(CWD, HTML_REPORT_DIR) }]],
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
## What changed?

The `visual-tests-base.yml` workflow was extended to automatically deploy Playwright HTML reports to GitHub Pages under `pr-{number}/{package}/` directories and post a PR comment with a link to the report after every visual test run. The Playwright config was updated to generate HTML reports alongside the existing line reporter. A new `visual-tests-cleanup.yml` workflow was created to remove report directories from the `gh-pages` branch when a PR is closed. All new steps are guarded with `github.event.pull_request.head.repo.fork == false` to prevent failures on fork PRs. Reports are uploaded on `always()` so they are available even when tests fail.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der `visual-tests-base.yml`-Workflow wurde erweitert, um Playwright-HTML-Reports automatisch auf GitHub Pages unter `pr-{number}/{package}/` zu deployen und einen PR-Kommentar mit dem Link zum Report zu posten. Die Playwright-Konfiguration generiert jetzt HTML-Reports zusätzlich zur Zeilenausgabe. Ein neuer `visual-tests-cleanup.yml`-Workflow löscht die Report-Verzeichnisse aus dem `gh-pages`-Branch, wenn ein PR geschlossen wird.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/visual-tests-base.yml` — HTML-Report-Deployment und PR-Kommentar-Schritte hinzugefügt
- `.github/workflows/visual-tests-cleanup.yml` — Neuer Cleanup-Workflow erstellt
- `packages/tools/visual-tests/playwright.config.js` — HTML-Reporter zur Konfiguration hinzugefügt

</details>