### PR TITLE
chore: add open-ui script for generating UI component documentation

### DIFF
--- a/packages/components/scripts/open-ui.js
+++ b/packages/components/scripts/open-ui.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const prettier = require('prettier');
+const ELEMENTS = require(path.relative(__dirname, 'custom-elements.json'));
+const TODAY = new Date();
+const OPEN_UI = {
+	$schema: '../schemas/design-system.schema.json',
+	lastUpdated: TODAY.getFullYear() + '-' + (TODAY.getMonth() + 1) + '-' + TODAY.getDate(),
+	name: 'KoliBri',
+	description:
+		'KoliBri builds directly on the web standards of the W3C (framework-agnostic), is a generic reference implementation of the WCAG standard and the BITV for accessibility and implemented as a multi-theming capable presentation layer. There is no technical reference and no data transmission functionalities. This means that KoliBri can be reused for the realization of static websites as well as dynamic web applications with different corporate designs and style guides and is therefore very interesting for open source.',
+	url: 'https://public-ui.github.io/en/',
+	version: ELEMENTS.version,
+	by: 'Informationstechnikzentrum Bund',
+	components: [],
+};
+const removeUnderscore = (str) => {
+	return str.replace(/^_/g, '');
+};
+const pascalCase = (str) => {
+	return removeUnderscore(str)
+		.replace(/-([a-z])/g, (g) => g[1].toUpperCase())
+		.replace(/^[a-z]/, (g) => g.toUpperCase());
+};
+const EXCLUDED_COMPONENTS = ['kol-skeleton', 'kol-tree-item', 'kol-version'];
+const excluded = [];
+ELEMENTS.tags.forEach((tag) => {
+	const isWc = tag.name.endsWith('-wc');
+	const isExcluded = EXCLUDED_COMPONENTS.indexOf(tag.name) !== -1;
+
+	if (isExcluded || isWc) {
+		excluded.push(tag.name);
+		return;
+	}
+
+	const clearedName = tag.name.replace('kol-', '');
+	const COMPONENT = {
+		// name: clearedName,
+		// openUIName: pascalCase(clearedName),
+		name: pascalCase(clearedName),
+		definition: tag.description,
+		url: `https://public-ui.github.io/en/docs/components/${clearedName}`,
+		anatomy: [],
+		concepts: [],
+	};
+	tag.attributes.forEach((attribute) => {
+		COMPONENT.concepts.push({
+			// name: attribute.name,
+			// openUIName: removeUnderscore(attribute.name),
+			name: removeUnderscore(attribute.name),
+			description: attribute.description,
+		});
+	});
+	OPEN_UI.components.push(COMPONENT);
+});
+
+console.log('Excluded:');
+excluded.forEach((name) => console.log(name));
+console.log('');
+console.log('Included:');
+OPEN_UI.components.forEach((c) => console.log(c.name));
+
+console.log(`# of: ${OPEN_UI.components.length}`);
+
+void (async () => {
+	const outputPath = 'open-ui.json';
+	const raw = JSON.stringify(OPEN_UI);
+	const prettierConfig = await prettier.resolveConfig(outputPath);
+	const formatted = await prettier.format(raw, { ...prettierConfig, filepath: outputPath });
+	fs.writeFileSync(outputPath, formatted);
+})();

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -6,6 +6,9 @@ import { ClickButtonFC } from '../../../../internal/functional-components/click-
 import { ClickButtonController } from '../../../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../../../internal/functional-components/generic-types';
 
+/**
+ * @internal
+ */
 @Component({
 	tag: 'kol-click-button',
 	shadow: true,

--- a/packages/components/src/components/abbr/shadow.tsx
+++ b/packages/components/src/components/abbr/shadow.tsx
@@ -5,6 +5,9 @@ import type { AbbrAPI, AbbrStates, LabelPropType } from '../../schema';
 import { validateLabel } from '../../schema';
 
 /**
+ * The **Abbr** component implements the HTML tag `abbr` with an accessible tooltip.
+ * The tooltip for the description is displayed and read aloud when the **Abbr** component is focused or hovered.
+ *
  * @slot - The abbreviation (short form).
  */
 @Component({

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -25,8 +25,11 @@ featureHint(`[KolAccordion] Anfrage nach einer KolAccordionGroup bei dem immer n
 featureHint(`[KolAccordion] Tab-Sperre des Inhalts im geschlossenen Zustand.`);
 
 /**
+ * The **Accordion** component is a collapsible menu. Clicking the header area — consisting of an icon and a heading — expands the content to reveal additional information. It is an interactive navigation element designed to present extensive content in a space-saving manner.
  *
- * @slot - Ermöglicht das Einfügen beliebigen HTML's in den Inhaltsbereich des Accordions.
+ * Accordions are used whenever content associated with a thematic heading needs to be shown or hidden. They allow more detailed information for a heading than would normally be practical, leaving it to the users to decide whether to view that information.
+ *
+ * @slot - Allows arbitrary HTML to be inserted into the content area of the accordion.
  */
 @Component({
 	tag: 'kol-accordion',

--- a/packages/components/src/components/alert/component.tsx
+++ b/packages/components/src/components/alert/component.tsx
@@ -17,7 +17,7 @@ import { watchHeadingLevel } from '../heading/validation';
 
 /**
  * @internal
- * @slot - Der Inhalt der Meldung.
+ * @slot - The content of the notification.
  */
 @Component({
 	tag: 'kol-alert-wc',

--- a/packages/components/src/components/alert/shadow.tsx
+++ b/packages/components/src/components/alert/shadow.tsx
@@ -4,7 +4,9 @@ import { KolAlertWcTag } from '../../core/component-names';
 import type { AlertProps, AlertStates, AlertTypePropType, AlertVariantPropType, HeadingLevel, KoliBriAlertEventCallbacks, LabelPropType } from '../../schema';
 
 /**
- * @slot - Der Inhalt der Meldung.
+ * The **Alert** component provides visual feedback to users. It consists of a color-coded container, a heading, content text, and an icon. The icon used and the color scheme depend on the `_type` of the alert.
+ *
+ * @slot - The content of the notification.
  */
 @Component({
 	tag: 'kol-alert',

--- a/packages/components/src/components/avatar/component.tsx
+++ b/packages/components/src/components/avatar/component.tsx
@@ -7,6 +7,9 @@ import { BaseWebComponent } from '../../internal/functional-components/base-web-
 import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type { ColorPair } from '../../schema';
 
+/**
+ * The **Avatar** component displays either a small image of the user or their initials if no image is available.
+ */
 @Component({
 	tag: 'kol-avatar',
 	shadow: true,

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -10,6 +10,10 @@ import { KolButtonWcTag } from '../../core/component-names';
 import clsx from '../../utils/clsx';
 featureHint(`[KolBadge] Optimierung des _color-Properties (rgba, rgb, hex usw.).`);
 
+/**
+ * The **Badge** component allows you to visually highlight specific information.
+ * In addition to specifying the background color and automatically calculating the text color, it also supports adding an icon and/or a different font style.
+ */
 @Component({
 	tag: 'kol-badge',
 	styleUrls: {

--- a/packages/components/src/components/breadcrumb/shadow.tsx
+++ b/packages/components/src/components/breadcrumb/shadow.tsx
@@ -9,6 +9,9 @@ import type { JSX } from '@stencil/core';
 import { KolLinkWcTag } from '../../core/component-names';
 import { IconFC } from '../../internal/functional-components/icon/component';
 
+/**
+ * The **Breadcrumb** component can be used to display the path to the current position of a web page within a hierarchical structure.
+ */
 @Component({
 	tag: 'kol-breadcrumb',
 	styleUrls: {

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -20,6 +20,19 @@ import type {
 	VariantClassNamePropType,
 } from '../../schema';
 
+/**
+ * The **ButtonLink** component is semantically a button but has the appearance of a link. All relevant properties of the Button component are adopted and extended with the design-defining properties of a link.
+ *
+ * A button can be disabled, therefore the **ButtonLink** also has the `_disabled` property. How this is styled visually is determined by the UX designer.
+ *
+ * Instead of using `_href` as with a regular link, the **ButtonLink**'s behavior is controlled via a click callback using the `_on` property.
+ *
+ * A link has the `target` property which optionally opens the link in a new window/tab. This behavior is not yet implemented.
+ *
+ * Since a link, unlike a button, is not offered in multiple variants (`primary`, `secondary`, etc.), the `_customClass` and `_variant` properties are not available.
+ *
+ * @slot expert - Custom label content, e.g. for rich text or icons.
+ */
 @Component({
 	tag: 'kol-button-link',
 	styleUrls: {

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -20,6 +20,11 @@ import type {
 	TooltipAlignPropType,
 } from '../../schema';
 
+/**
+ * The **Button** component is used to present users with action options and arrange them in a clear hierarchy. It helps users find the most important actions on a page or within a viewport and allows them to execute those actions. The button label clearly indicates which action will be triggered. Buttons allow users to confirm a change, complete steps in a task, or make decisions.
+ *
+ * @slot expert - Custom label content, e.g. for rich text or icons.
+ */
 @Component({
 	tag: 'kol-button',
 	styleUrls: {

--- a/packages/components/src/components/card/component.tsx
+++ b/packages/components/src/components/card/component.tsx
@@ -12,7 +12,8 @@ import { nonce } from '../../utils/dev.utils';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 
 /**
- * @slot - Ermöglicht das Einfügen beliebigen HTML's in den Inhaltsbereich der Card.
+ * @internal
+ * @slot - Allows arbitrary HTML to be inserted into the content area of the card.
  */
 @Component({
 	tag: 'kol-card-wc',

--- a/packages/components/src/components/card/shadow.tsx
+++ b/packages/components/src/components/card/shadow.tsx
@@ -5,7 +5,13 @@ import type { CardProps, HeadingLevel, KoliBriCardEventCallbacks, LabelPropType 
 import { KolCardWcTag } from '../../core/component-names';
 
 /**
- * @slot - Ermöglicht das Einfügen beliebigen HTML's in den Inhaltsbereich der Card.
+ * The **Card** component is ideal for visually highlighting individual sections of your website. It allows you to structure your content very easily.
+ *
+ * The **Card** component consists of a **_title area_** and a **_content area_**.
+ *
+ * The **title area** is displayed in a larger font. The **content area** is visually separated from the title area by a horizontal dividing line and is rendered in the default font.
+ *
+ * @slot - Allows arbitrary HTML to be inserted into the content area of the card.
  */
 @Component({
 	tag: 'kol-card',

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -37,7 +37,7 @@ import { nonce } from '../../utils/dev.utils';
 import { ComboboxController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-combobox',

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -7,7 +7,15 @@ import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import { watchHeadingLevel } from '../heading/validation';
 
 /**
- * @slot - Der Inhalt, der in der Detailbeschreibung angezeigt wird.
+ * The **Details** component allows additional information to be initially shown with a short introductory text,
+ * which is only fully expanded after the user clicks on an arrow icon.
+ *
+ * By default, the **Details** component is displayed as a single-line layout element consisting of an arrow icon
+ * followed by a short introductory text. The actual content is revealed below after clicking the header area. The arrow icon
+ * changes its orientation from **_right_** to **_down_**.
+ * The component can also be closed again to hide the content.
+ *
+ * @slot - The content displayed in the detail description.
  */
 @Component({
 	tag: 'kol-details',

--- a/packages/components/src/components/form/shadow.tsx
+++ b/packages/components/src/components/form/shadow.tsx
@@ -10,7 +10,9 @@ import type { ErrorListPropType, FormAPI, FormStates, KoliBriFormCallbacks, Stri
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 
 /**
- * @slot - Inhalt der Form.
+ * The **Form** component is used to wrap all input fields, correctly position the required-fields hint text, and forward the `submit` and `reset` events.
+ *
+ * @slot - The content of the form.
  */
 @Component({
 	tag: 'kol-form',

--- a/packages/components/src/components/heading/shadow.tsx
+++ b/packages/components/src/components/heading/shadow.tsx
@@ -6,8 +6,9 @@ import { validateLabelWithExpertSlot, watchString } from '../../schema';
 import { watchHeadingLevel } from './validation';
 
 /**
+ * The **Heading** component can be used wherever a heading needs to be displayed. By using the different sizes, content can be clearly structured and pages can be presented effectively and with variety. It separates styling from semantics and enables flexibility.
  *
- * @slot - Inhalt der Überschrift.
+ * @slot - The heading content.
  */
 @Component({
 	tag: 'kol-heading',

--- a/packages/components/src/components/icon/component.tsx
+++ b/packages/components/src/components/icon/component.tsx
@@ -6,6 +6,9 @@ import type { IconApi } from '../../internal/functional-components/icon/api';
 import { IconFC } from '../../internal/functional-components/icon/component';
 import { IconController } from '../../internal/functional-components/icon/controller';
 
+/**
+ * The **Icon** component allows icons from included icon fonts to be displayed at any position.
+ */
 @Component({
 	tag: 'kol-icon',
 	styleUrls: {

--- a/packages/components/src/components/image/component.tsx
+++ b/packages/components/src/components/image/component.tsx
@@ -7,6 +7,9 @@ import { ImageFC } from '../../internal/functional-components/image/component';
 import { ImageController } from '../../internal/functional-components/image/controller';
 import type { LoadingType } from '../../internal/props';
 
+/**
+ * The **Image** component renders an image with support for responsive loading via `srcset` and `sizes`, lazy loading, and accessible alternative text.
+ */
 @Component({
 	tag: 'kol-image',
 	styleUrls: {

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -38,6 +38,8 @@ import type { InputCheckboxVariantPropType } from '../../schema/props/variant-in
 import { propagateSubmitEventToForm } from '../form/controller';
 
 /**
+ * The **Checkbox** input type generates a rectangular box that can be activated and deactivated by clicking. When activated, a colored checkmark is shown inside the box.
+ *
  * @slot expert - Checkbox description.
  */
 @Component({

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -29,7 +29,9 @@ import { nonce } from '../../utils/dev.utils';
 import { InputColorController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **Color** input type creates a selection field for defining any color. The color can be entered in hexadecimal, RGB, or HSL notation. It is possible to select a color via a picker or by entering exact color values.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-color',

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -38,7 +38,9 @@ import { propagateSubmitEventToForm } from '../form/controller';
 import { InputDateController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **Date** input type creates an input field for date values. These can be specific dates as well as weeks, months, or time values.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-date',

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -38,7 +38,9 @@ import { propagateSubmitEventToForm } from '../form/controller';
 import { InputEmailController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **Email** input type creates an input field for email addresses. It supports built-in format validation, multiple addresses via the `_multiple` property, and auto-complete suggestions.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-email',

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -34,7 +34,9 @@ import { nonce } from '../../utils/dev.utils';
 import { InputFileController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **File** input type creates an input field for file uploads. One or multiple files can be selected and submitted with a form.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-file',

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -37,7 +37,9 @@ import { propagateSubmitEventToForm } from '../form/controller';
 import { InputNumberController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **Number** input type creates an input field for numeric values. Use the `_min`, `_max`, and `_step` properties to restrict the accepted value range.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-number',

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -40,7 +40,9 @@ import { propagateSubmitEventToForm } from '../form/controller';
 import { InputPasswordController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **Password** input type creates an input field for passwords. The input is masked with dot symbols.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-password',

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -35,7 +35,9 @@ import KolRadioStateWrapperFc, { type RadioStateWrapperProps } from '../../funct
 import type { OrientationPropType } from '../../schema/props/orientation';
 
 /**
- * @slot - Die Legende/Überschrift der Radiobuttons.
+ * The **InputRadio** input type consists of a collection of radio elements, providing a choice between different values. Only a single value can be selected at a time. Selected radio elements are typically represented by a filled, visually highlighted circle.
+ *
+ * @slot - The legend/heading of the radio buttons.
  */
 @Component({
 	tag: 'kol-input-radio',

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -33,7 +33,9 @@ import { propagateSubmitEventToForm } from '../form/controller';
 import { InputRangeController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabeelements.
+ * The **Range** input type creates a slider control for selecting a numeric value within a defined range. Use the `_min`, `_max`, and `_step` properties to configure the range and step size.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-range',

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -40,7 +40,9 @@ import { propagateSubmitEventToForm } from '../form/controller';
 import { InputTextController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **Text** input type creates an input field for plain text, search terms, URLs, or phone numbers.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-input-text',

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -20,6 +20,11 @@ import type {
 	TooltipAlignPropType,
 } from '../../schema';
 
+/**
+ * The **LinkButton** component is semantically a link but has the appearance of a button. All relevant properties of the Link component are adopted and extended with the design-defining properties of a button.
+ *
+ * @slot expert - Custom label content, e.g. for rich text or icons.
+ */
 @Component({
 	tag: 'kol-link-button',
 	styleUrls: {

--- a/packages/components/src/components/modal/shadow.tsx
+++ b/packages/components/src/components/modal/shadow.tsx
@@ -5,6 +5,8 @@ import type { DialogProps, KoliBriDialogEventCallbacks, LabelPropType } from '..
 import type { ModalVariantPropType } from '../../schema/props/variant/modal';
 
 /**
+ * The **Modal** component has been superseded by `kol-dialog`, which provides improved accessibility and conforms to the HTML dialog specification. It is still available in version 2 for backwards compatibility.
+ *
  * @deprecated Use `kol-dialog` instead.
  * @slot - The modal's contents.
  */

--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -56,6 +56,10 @@ const entryIsButton = (entryProps: ButtonOrLinkOrTextWithChildrenProps): entryPr
 	return (entryProps as LinkProps)._href === undefined && typeof (entryProps as ButtonWithChildrenProps)._on?.onClick === 'function';
 };
 
+/**
+ * The **Nav** component renders a group of related links or navigation elements that perform an action or display content when clicked.
+ * It provides a highly configurable vertical or horizontal navigation bar that can represent multiple levels and vary in width.
+ */
 @Component({
 	tag: 'kol-nav',
 	styleUrls: {

--- a/packages/components/src/components/pagination/component.tsx
+++ b/packages/components/src/components/pagination/component.tsx
@@ -55,6 +55,9 @@ const NUMBER_FORMATTER = new Intl.NumberFormat(userLanguage, {
 	maximumFractionDigits: 0,
 });
 
+/**
+ * @internal
+ */
 @Component({
 	tag: 'kol-pagination-wc',
 	shadow: false,

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -25,6 +25,7 @@ import { alignFloatingElements } from '../../utils/align-floating-elements';
 import clsx from '../../utils/clsx';
 
 /**
+ * @internal
  * @slot - The popover content.
  */
 @Component({

--- a/packages/components/src/components/progress/component.tsx
+++ b/packages/components/src/components/progress/component.tsx
@@ -7,6 +7,9 @@ import { ProgressFC } from '../../internal/functional-components/progress/compon
 import { ProgressController } from '../../internal/functional-components/progress/controller';
 import type { ProgressVariantType } from '../../internal/props';
 
+/**
+ * The **Progress** component visualizes the completion status of a task or process. It supports both determinate (percentage-based) and indeterminate variants.
+ */
 @Component({
 	tag: 'kol-progress',
 	styleUrls: {

--- a/packages/components/src/components/quote/component.tsx
+++ b/packages/components/src/components/quote/component.tsx
@@ -7,6 +7,9 @@ import { QuoteFC } from '../../internal/functional-components/quote/component';
 import { QuoteController } from '../../internal/functional-components/quote/controller';
 import type { QuoteVariantType } from '../../internal/props/variant-quote';
 
+/**
+ * The **Quote** component has two variants: a short inline (`inline`) and an indented block (`block`) variant. Both variants include a link to the source of the quote.
+ */
 @Component({
 	tag: 'kol-quote',
 	styleUrls: {

--- a/packages/components/src/components/select/component.tsx
+++ b/packages/components/src/components/select/component.tsx
@@ -34,7 +34,8 @@ import { propagateSubmitEventToForm } from '../form/controller';
 import { SelectController } from './controller';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * @internal
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-select-wc',

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -21,7 +21,7 @@ import type {
 import { KolSelectWcTag } from '../../core/component-names';
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-select',

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -40,7 +40,9 @@ import { nonce } from '../../utils/dev.utils';
 import { SingleSelectController } from './controller';
 
 /**
- * @slot - The input field label.
+ * The **SingleSelect** component creates a dropdown list from which exactly one predefined option can be selected.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-single-select',

--- a/packages/components/src/components/skip-nav/shadow.tsx
+++ b/packages/components/src/components/skip-nav/shadow.tsx
@@ -7,6 +7,10 @@ import { watchNavLinks } from '../nav/validation';
 
 import type { JSX } from '@stencil/core';
 import { KolLinkWcTag } from '../../core/component-names';
+
+/**
+ * The **SkipNav** component renders a hidden navigation that allows keyboard and assistive technology users to skip repetitive navigation sections and jump directly to the main content. It only becomes visible when reached via the Tab key.
+ */
 @Component({
 	tag: 'kol-skip-nav',
 	styleUrls: {

--- a/packages/components/src/components/spin/shadow.tsx
+++ b/packages/components/src/components/spin/shadow.tsx
@@ -24,6 +24,11 @@ function renderSpin(variant: SpinVariantPropType): JSX.Element {
 	}
 }
 
+/**
+ * The **Spin** component informs users about loading or processing operations being performed by the system. Progress can be communicated through a repeated animation.
+ *
+ * @slot expert - Custom content displayed when the variant is set to `none`.
+ */
 @Component({
 	tag: 'kol-spin',
 	styleUrls: {

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -23,7 +23,10 @@ import { translate } from '../../i18n';
 import clsx from '../../utils/clsx';
 
 /**
- * @slot - Ermöglicht das Einfügen beliebigen HTMLs in das dropdown.
+ * The **SplitButton** component can be used to display a two-part button. The primary button is typically used for
+ * a main action, while the secondary button opens a context menu (`Popover`) that contains additional actions.
+ *
+ * @slot - Allows arbitrary HTML to be inserted into the dropdown.
  */
 @Component({
 	tag: 'kol-split-button',

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -56,6 +56,9 @@ type SortData = {
 	direction: KoliBriSortDirection;
 };
 
+/**
+ * The **Table** component is primarily used for the clear presentation of data sets. It is designed to automatically determine all data-dependent values and render the table accordingly. This includes optional features such as column sorting and pagination.
+ */
 @Component({
 	tag: 'kol-table-stateful',
 	styleUrls: {

--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -34,6 +34,9 @@ import clsx from '../../utils/clsx';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 // https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-2/tabs.html
 
+/**
+ * The **Tabs** component is used to organize related content on the same page and navigate between them. Tabs ensure that large amounts of content can be more easily organized for users.
+ */
 @Component({
 	tag: 'kol-tabs',
 	styleUrls: {

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -50,7 +50,9 @@ const increaseTextareaHeight = (el: HTMLTextAreaElement): number => {
 };
 
 /**
- * @slot - Die Beschriftung des Eingabefeldes.
+ * The **Textarea** component provides a larger input field for content. Unlike InputText, it also allows extensive content to be entered, including line breaks.
+ *
+ * @slot - The label of the input field.
  */
 @Component({
 	tag: 'kol-textarea',

--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -12,6 +12,7 @@ const TRANSITION_TIMEOUT = 300;
 
 /**
  * @deprecated Will be removed in the next major version. For more information, please refer to: https://github.com/public-ui/kolibri/issues/8372
+ * @internal
  */
 @Component({
 	tag: 'kol-toast-container',

--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -7,6 +7,9 @@ import { validateActive, validateHref, validateLabel, validateOpen } from '../..
 import clsx from '../../utils/clsx';
 import { nonce } from '../../utils/dev.utils';
 
+/**
+ * @internal
+ */
 @Component({
 	tag: `kol-tree-item-wc`,
 	shadow: false,

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -63,21 +63,18 @@ const TAGS = [
 ];
 const EXCLUDE_TAGS = [
 	'kol-alert-wc',
-	'kol-all',
-	'kol-avatar-wc',
-	'kol-button-link-text-switch',
 	'kol-button-wc',
-	'kol-color',
-	'kol-counter',
+	'kol-card-wc',
+	'kol-click-button',
 	'kol-dialog-wc',
-	'kol-heading-wc',
-	'kol-input',
 	'kol-link-wc',
-	'kol-popover-wc',
-	'kol-span-wc',
+	'kol-pagination-wc',
+	'kol-popover-button-wc',
+	'kol-select-wc',
 	'kol-table-settings-wc',
 	'kol-table-stateless-wc',
 	'kol-tooltip-wc',
+	'kol-tree-wc',
 ];
 const BUNDLES: {
 	components: string[];


### PR DESCRIPTION
## What changed?

A new `packages/components/scripts/open-ui.js` script was added to generate a JSON representation of all public KoliBri components in the Open UI format, sourced from `custom-elements.json`. The script filters out internal components (`kol-skeleton`, `kol-tree-item`, `kol-version`, and WC variants), formats component names to PascalCase, and outputs an `open-ui.json` file. Separately, English JSDoc component descriptions were added to ~30 component `shadow.tsx` / `component.tsx` files that previously had German-only or no descriptions. Several internal-only components (`kol-click-button`, `kol-card-wc`, `kol-select-wc`, `kol-popover-button`, `kol-pagination-wc`, `kol-toast-container`, `kol-tree-item-wc`) were marked `@internal`. The Stencil `stencil.config.ts` exclusion list was updated to reflect the current set of internal components.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein neues Skript `packages/components/scripts/open-ui.js` wurde hinzugefügt, das eine JSON-Darstellung aller öffentlichen KoliBri-Komponenten im Open-UI-Format aus `custom-elements.json` generiert. Zusätzlich wurden englische JSDoc-Beschreibungen zu ~30 Komponenten-Dateien hinzugefügt, die vorher nur deutsche oder keine Beschreibungen hatten. Mehrere interne Komponenten wurden mit `@internal` markiert. Die Ausschlussliste in `stencil.config.ts` wurde aktualisiert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/scripts/open-ui.js` — Neues Skript zur Generierung von Open-UI-JSON
- 30+ `shadow.tsx`/`component.tsx`-Dateien — Englische JSDoc-Beschreibungen hinzugefügt
- `packages/components/stencil.config.ts` — Ausschlussliste für interne Komponenten aktualisiert

</details>