### PR TITLE
fix: sample all kolicons no endless loading

### DIFF
--- a/packages/samples/react/src/components/icon/all-kolicons.tsx
+++ b/packages/samples/react/src/components/icon/all-kolicons.tsx
@@ -14,7 +14,7 @@ export const IconAllKolicons: FC = () => {
 			.then((data) => {
 				setIcons(data);
 			});
-	});
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
## Summary

Fixes an infinite loading loop in the sample app's all-KolIcons page, ensuring icons load correctly.

## Changes

- Fixed the loading logic in the sample page displaying all `KolIcon` variants

## Testing

- Manual testing of the all-icons sample page

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Behebt eine Endloslade-Schleife auf der Seite „Alle KolIcons" in der Beispiel-App.

## Änderungen

- Ladelogik auf der Beispielseite für alle `KolIcon`-Varianten korrigiert

</details>