### PR TITLE
fix(components): clear single-select without auto-select fallback

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -135,14 +135,6 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 		return event;
 	}
 
-	private getFirstEnabledOption(): Option<string> | undefined {
-		if (!Array.isArray(this._options)) {
-			return undefined;
-		}
-
-		return this._options.find((option) => !option.disabled) as Option<string> | undefined;
-	}
-
 	private clearSelection() {
 		this.isClearing = true;
 
@@ -150,14 +142,27 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			return;
 		}
 
-		const fallbackOption = this.getFirstEnabledOption();
-		if (!fallbackOption) {
-			this.isClearing = false;
-			return;
+		this._focusedOptionIndex = -1;
+		this._inputValue = '';
+		this._filteredOptions = [...this.state._options];
+
+		if (this._value !== null) {
+			this._value = null;
+
+			const inputEvent = this.createEventWithTarget('input', {
+				name: this.state._name ?? '',
+				value: null,
+			});
+			const changeEvent = this.createEventWithTarget('change', {
+				name: this.state._name ?? '',
+				value: null,
+			});
+
+			this.controller.onFacade.onInput(inputEvent, false, null);
+			this.controller.onFacade.onChange(changeEvent, null);
+			this.controller.setFormAssociatedValue(this._value);
 		}
 
-		this._focusedOptionIndex = -1;
-		this.selectOption(fallbackOption);
 		this.isClearing = false;
 	}
 
@@ -775,19 +780,10 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			return;
 		}
 
-		const fallbackOption = this.getFirstEnabledOption();
-		if (fallbackOption) {
-			this._inputValue = String(fallbackOption.label);
-			if (this._value !== fallbackOption.value) {
-				this._value = fallbackOption.value;
-				this.controller.setFormAssociatedValue(fallbackOption.value);
-			}
-		} else {
-			this._inputValue = '';
-			if (this._value !== null) {
-				this._value = null;
-				this.controller.setFormAssociatedValue(null);
-			}
+		this._inputValue = '';
+		if (this._value !== null) {
+			this._value = null;
+			this.controller.setFormAssociatedValue(null);
 		}
 	}
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -96,6 +96,9 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 				this._isOpen = false;
 			} else {
 				// Liste öffnen
+				if (this._inputValue.trim() === '') {
+					this._filteredOptions = [...this.state._options];
+				}
 				this._isOpen = true;
 				const selectedIndex = Array.isArray(this._filteredOptions) ? this._filteredOptions.findIndex((option) => option.label === this._inputValue) : -1;
 				this._focusedOptionIndex = selectedIndex >= 0 ? selectedIndex : -1;

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -108,6 +108,11 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 		if (matchingOption) {
 			this.selectOption(matchingOption as Option<string>);
+		} else if (!this._isOpen && this._value === null) {
+			const firstEnabledOption = this.state._options?.find((option) => !option.disabled) as Option<string> | undefined;
+			if (firstEnabledOption) {
+				this.selectOption(firstEnabledOption);
+			}
 		} else if (!this._isOpen && this._value) {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -141,11 +141,10 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 	}
 
 	private clearSelection() {
-		this.isClearing = true;
-
 		if (this.state._disabled) {
 			return;
 		}
+		this.isClearing = true;
 
 		this._focusedOptionIndex = -1;
 		this._inputValue = '';
@@ -786,6 +785,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 		}
 
 		this._inputValue = '';
+		this._filteredOptions = [...this.state._options];
 		if (this._value !== null) {
 			this._value = null;
 			this.controller.setFormAssociatedValue(null);

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -62,6 +62,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 	private oldValue?: StencilUnknown;
 	// so onBlur doesn't close the panel if clear button is pressed
 	private isClearing = false;
+	private skipNextBlurFallbackSelection = false;
 
 	/**
 	 * Returns the current value.
@@ -111,7 +112,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 		const matchingOption = this.state._options?.find((option) => (option.label as string)?.toLowerCase() === this._inputValue?.toLowerCase());
 		if (matchingOption) {
 			this.selectOption(matchingOption as Option<string>);
-		} else if (!this._isOpen && this._value === null) {
+		} else if (!this._isOpen && this._value === null && !this.skipNextBlurFallbackSelection) {
 			const firstEnabledOption = this.state._options?.find((option) => !option.disabled) as Option<string> | undefined;
 			if (firstEnabledOption) {
 				this.selectOption(firstEnabledOption);
@@ -120,6 +121,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			this._inputValue = this.state._options?.find((option) => (option as Option<string>).value === this._value)?.label as string;
 			this._filteredOptions = [...this.state._options];
 		}
+		this.skipNextBlurFallbackSelection = false;
 		if (event instanceof FocusEvent && event.view === window && !this.isClearing) {
 			this._isOpen = false;
 		}
@@ -148,6 +150,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			return;
 		}
 		this.isClearing = true;
+		this.skipNextBlurFallbackSelection = true;
 
 		this._focusedOptionIndex = -1;
 		this._inputValue = '';

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -94,13 +94,25 @@ test.describe(COMPONENT_NAME, () => {
 
 			await expect(input).toHaveValue(TEST_LABEL);
 			await page.waitForChanges();
-			await page.waitForTimeout(500);
 
 			const clearButton = page.getByTestId('single-select-delete');
-			await expect(clearButton).toHaveCount(1);
+			await expect(clearButton).toBeVisible();
 			await clearButton.click({ force: true });
 
 			await expect(input).toHaveValue('');
+			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', null);
+		});
+
+		test('should allow free typing after clearing the selected option', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
+			const input = page.locator('input.kol-single-select__input');
+			await input.click();
+			await page.getByRole('listbox').getByText(TEST_LABEL).click({ force: true });
+
+			await page.getByTestId('single-select-delete').click({ force: true });
+			await input.fill('Ö');
+
+			await expect(input).toHaveValue('Ö');
 			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', null);
 		});
 

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -103,7 +103,7 @@ test.describe(COMPONENT_NAME, () => {
 			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', null);
 		});
 
-		test('should allow free typing after clearing the selected option', async ({ page }) => {
+		test('should select first enabled option on blur after clearing', async ({ page }) => {
 			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
 			const input = page.locator('input.kol-single-select__input');
 			await input.click();
@@ -111,9 +111,10 @@ test.describe(COMPONENT_NAME, () => {
 
 			await page.getByTestId('single-select-delete').click({ force: true });
 			await input.fill('Ö');
+			await page.click('html', { position: { x: 0, y: 0 } });
 
-			await expect(input).toHaveValue('Ö');
-			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', null);
+			await expect(input).toHaveValue('North');
+			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', 'N');
 		});
 
 		test('should not render clear button when _hasClearButton is false', async ({ page }) => {

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -85,7 +85,7 @@ test.describe(COMPONENT_NAME, () => {
 			expect(value).toBe('W');
 		});
 
-		test('should keep an option selected when clear button is clicked', async ({ page }) => {
+		test('should clear the selection when clear button is clicked', async ({ page }) => {
 			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
 			const input = page.locator('input.kol-single-select__input');
 			await input.click();
@@ -100,8 +100,8 @@ test.describe(COMPONENT_NAME, () => {
 			await expect(clearButton).toHaveCount(1);
 			await clearButton.click({ force: true });
 
-			await expect(input).toHaveValue('North');
-			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', 'N');
+			await expect(input).toHaveValue('');
+			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', null);
 		});
 
 		test('should not render clear button when _hasClearButton is false', async ({ page }) => {

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -103,6 +103,19 @@ test.describe(COMPONENT_NAME, () => {
 			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', null);
 		});
 
+		test('should open option list again after clearing', async ({ page }) => {
+			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
+			const input = page.locator('input.kol-single-select__input');
+			await input.click();
+			await page.getByRole('listbox').getByText(TEST_LABEL).click({ force: true });
+
+			await page.getByTestId('single-select-delete').click({ force: true });
+			await input.click();
+
+			await expect(page.getByRole('listbox')).toBeVisible();
+			await expect(page.getByRole('listbox').getByText('North')).toBeVisible();
+		});
+
 		test('should select first enabled option on blur after clearing', async ({ page }) => {
 			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
 			const input = page.locator('input.kol-single-select__input');

--- a/packages/components/src/components/single-select/single-select.e2e.ts
+++ b/packages/components/src/components/single-select/single-select.e2e.ts
@@ -116,7 +116,7 @@ test.describe(COMPONENT_NAME, () => {
 			await expect(page.getByRole('listbox').getByText('North')).toBeVisible();
 		});
 
-		test('should select first enabled option on blur after clearing', async ({ page }) => {
+		test('should keep free text on first blur after clearing', async ({ page }) => {
 			await page.setContent(`<kol-single-select _label="Input" _options='${JSON.stringify(OPTIONS)}' ></kol-single-select>`);
 			const input = page.locator('input.kol-single-select__input');
 			await input.click();
@@ -126,8 +126,8 @@ test.describe(COMPONENT_NAME, () => {
 			await input.fill('Ö');
 			await page.click('html', { position: { x: 0, y: 0 } });
 
-			await expect(input).toHaveValue('North');
-			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', 'N');
+			await expect(input).toHaveValue('Ö');
+			await expect(page.locator('kol-single-select')).toHaveJSProperty('_value', null);
 		});
 
 		test('should not render clear button when _hasClearButton is false', async ({ page }) => {

--- a/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/single-select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _accessKey="V" 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -23,8 +23,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input accesskey="V" aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -33,11 +32,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -55,7 +52,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _alert=true 1`] = `
-<kol-single-select _alert="" _value="Herr">
+<kol-single-select _alert="">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -74,8 +71,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -84,11 +80,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -106,7 +100,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _disabled=true 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-form-field--disabled kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -125,8 +119,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container kol-input-container--disabled">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-single-select__input" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _disabled="" _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete" hidden=""></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--disabled kol-single-select__input" disabled="" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-custom-suggestions-toggle--disabled kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -135,11 +128,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -157,7 +148,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _hint="Hint" 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -176,8 +167,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-hint" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -186,11 +176,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -211,7 +199,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -233,8 +221,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           </div>
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -243,11 +230,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -268,7 +253,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -290,8 +275,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           </div>
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -300,11 +284,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -323,7 +305,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -343,8 +325,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
           <div class="kol-input-container__adornment kol-input-container__adornment--start"></div>
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -353,11 +334,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -378,7 +357,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
-<kol-single-select _touched="" _value="Herr">
+<kol-single-select _touched="">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-form-field--error kol-form-field--hidden-msg kol-form-field--msg-type-error kol-form-field--touched kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -397,8 +376,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container kol-input-container--error">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-error" autocapitalize="off" autocorrect="off" class="kol-input kol-input--error kol-input--touched kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -407,11 +385,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -429,7 +405,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -448,8 +424,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" aria-describedby="id-nonce-msg" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -458,11 +433,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -480,7 +453,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _readOnly=true 1`] = `
-<kol-single-select _readonly="" _value="Herr">
+<kol-single-select _readonly="">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -499,8 +472,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -509,11 +481,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -531,7 +501,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _shortKey="S" 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -553,8 +523,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" aria-keyshortcuts="S" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -563,11 +532,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -585,7 +552,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _touched=true 1`] = `
-<kol-single-select _touched="" _value="Herr">
+<kol-single-select _touched="">
   <template shadowrootmode="open">
     <div class="kol-form-field kol-form-field--touched kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -604,8 +571,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--touched kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-input--touched kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -614,11 +580,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">
@@ -636,7 +600,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
 `;
 
 exports[`kol-single-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] 1`] = `
-<kol-single-select _value="Herr">
+<kol-single-select>
   <template shadowrootmode="open">
     <div class="kol-form-field kol-single-select">
       <label class="kol-form-field__label" htmlfor="id-nonce" id="id-nonce-label">
@@ -655,8 +619,7 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
         <div class="kol-input-container">
           <div class="kol-input-container__container">
             <div class="kol-single-select__group">
-              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="Herr">
-              <kol-button-wc _hidelabel="" _icons="kolicon-cross" _label="kol-delete-selection" _variant="ghost" class="kol-single-select__delete" data-testid="single-select-delete"></kol-button-wc>
+              <input aria-autocomplete="both" aria-controls="listbox" autocapitalize="off" autocorrect="off" class="kol-input kol-single-select__input" id="id-nonce" name="field" placeholder="Hier steht ein Platzhaltertext" role="combobox" type="text" value="">
               <i aria-hidden="true" class="kol-custom-suggestions-toggle kol-icon kol-icon__icon kolicon-chevron-down" role="presentation"></i>
             </div>
             <ul class="kol-custom-suggestions-options-group" hidden="" role="listbox" style="--visible-options: 5;">
@@ -665,11 +628,9 @@ exports[`kol-single-select should render with _label="Label" _name="field" _plac
                   Frau
                 </span>
               </li>
-              <li aria-selected="true" class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
+              <li class="kol-custom-suggestions-option" data-index="1" id="option-1" role="option" tabindex="-1">
                 <span>
-                  <mark>
-                    Herr
-                  </mark>
+                  Herr
                 </span>
               </li>
               <li class="kol-custom-suggestions-option" data-index="2" id="option-2" role="option" tabindex="-1">


### PR DESCRIPTION
## Summary

Fixes the single-select component to clear its selection without automatically falling back to an auto-selected option when the value is cleared.

## Changes

- Fixed clear behaviour in `KolSingleSelect` to prevent unintended auto-selection fallback

## Testing

- Unit tests for clear/reset behaviour; manual testing

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Behebt einen Fehler in der Einfachauswahl-Komponente, bei dem beim Löschen der Auswahl automatisch ein Fallback-Wert gewählt wurde.

## Änderungen

- Lösch-Verhalten in `KolSingleSelect` korrigiert, um unbeabsichtigte Auto-Selektion zu verhindern

</details>