### PR TITLE
fix: input password - deactivated visibility toggle always type password

### DIFF
--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -122,7 +122,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 
 		return {
 			ref: this.setInputRef,
-			type: this._variant !== 'visibility-toggle' ? 'password' : this._passwordVisible ? 'text' : 'password',
+			type: (this._variant === 'visibility-toggle' && this._passwordVisible) ? 'text' : 'password',
 			state: this.state,
 			ariaDescribedBy,
 			...this.controller.onFacade,

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -122,7 +122,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 
 		return {
 			ref: this.setInputRef,
-			type: this._passwordVisible ? 'text' : 'password',
+			type: this._variant !== 'visibility-toggle' ? 'password' : this._passwordVisible ? 'text' : 'password',
 			state: this.state,
 			ariaDescribedBy,
 			...this.controller.onFacade,


### PR DESCRIPTION
## Summary

Fixes the password input's visibility toggle: when the toggle button is deactivated, it no longer forces `type="password"`, allowing the toggle to function correctly in its active state.

## Changes

- Fixed visibility toggle logic in `KolInputPassword` to correctly handle the deactivated state

## Testing

- Manual testing of password input toggle behaviour

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Zusammenfassung

Behebt einen Fehler beim Sichtbarkeits-Toggle des Passwort-Eingabefeldes: Im deaktivierten Zustand wird `type="password"` nicht mehr erzwungen.

## Änderungen

- Toggle-Logik in `KolInputPassword` für den deaktivierten Zustand korrigiert

</details>