### PR TITLE
chore(samples): add desy-v11 theme and mark ecl-ec as stable

### DIFF
--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -15,7 +15,7 @@ jobs:
   visual-tests-snapshots:
     strategy:
       matrix:
-        package: ['test-tag-name-transformer', 'theme-default', 'theme-ecl', 'theme-kern']
+        package: ['test-tag-name-transformer', 'theme-default', 'theme-bwst', 'theme-ecl', 'theme-desy', 'theme-kern']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch

--- a/packages/samples/presentation/src/react.main.tsx
+++ b/packages/samples/presentation/src/react.main.tsx
@@ -4,7 +4,7 @@ import { HashRouter as Router } from 'react-router-dom';
 
 import { bootstrap } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/loader';
-import { BWSt, DEFAULT, ECL_EC, ECL_EU, KERN_V2, DesyV11 } from '@public-ui/themes';
+import { BWSt, DEFAULT, DesyV11, ECL_EC, ECL_EU, KERN_V2 } from '@public-ui/themes';
 
 import { App } from '@public-ui/sample-react';
 

--- a/packages/samples/presentation/src/react.main.tsx
+++ b/packages/samples/presentation/src/react.main.tsx
@@ -4,7 +4,7 @@ import { HashRouter as Router } from 'react-router-dom';
 
 import { bootstrap } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/loader';
-import { BWSt, DEFAULT, ECL_EC, ECL_EU, KERN_V2 } from '@public-ui/themes';
+import { BWSt, DEFAULT, ECL_EC, ECL_EU, KERN_V2, DesyV11 } from '@public-ui/themes';
 
 import { App } from '@public-ui/sample-react';
 
@@ -25,7 +25,7 @@ const getThemes = async () => {
 	}
 
 	/* List of regular sample app themes */
-	return [DEFAULT, BWSt, ECL_EC, ECL_EU, KERN_V2] as Theme[];
+	return [DEFAULT, BWSt, ECL_EC, ECL_EU, KERN_V2, DesyV11] as Theme[];
 };
 
 void (async () => {
@@ -85,7 +85,7 @@ void (async () => {
 								key: 'bwst',
 							},
 							{
-								name: 'European Commission (in progress)',
+								name: 'European Commission',
 								key: 'ecl-ec',
 							},
 							{

--- a/packages/samples/react/src/shares/theme.ts
+++ b/packages/samples/react/src/shares/theme.ts
@@ -18,7 +18,7 @@ export const PUBLIC_THEMES: Theme[] = [
 		key: 'bwst',
 	},
 	{
-		name: 'European Commission (in progress)',
+		name: 'European Commission',
 		key: 'ecl-ec',
 	},
 	{


### PR DESCRIPTION
## What changed?

The `DesyV11` theme was added to the presentation sample app's bootstrap configuration so it appears in the theme picker. The `theme-bwst` and `theme-desy` packages were also added to the CI visual test matrix so their snapshots are generated and validated. The `European Commission` theme was previously labelled as `European Commission (in progress)` — the "in progress" qualifier was removed from both the presentation app and the React sample app's theme list since the theme is now stable enough to be treated as generally available.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das `DesyV11`-Theme wurde zur Bootstrap-Konfiguration der Präsentations-Sample-App hinzugefügt. Die Pakete `theme-bwst` und `theme-desy` wurden in die CI-Matrix für visuelle Tests aufgenommen. Der Name des `European Commission`-Themes wurde in beiden Sample-Apps von `European Commission (in progress)` auf `European Commission` gekürzt, da das Theme nun stabil genug ist.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/visual-tests-base.yml` — `theme-bwst` und `theme-desy` zur CI-Visual-Test-Matrix hinzugefügt
- `packages/samples/presentation/src/react.main.tsx` — `DesyV11` zu den Themes hinzugefügt; `(in progress)` aus ECL-EC-Name entfernt
- `packages/samples/react/src/shares/theme.ts` — `(in progress)` aus ECL-EC-Name entfernt

</details>