### PR TITLE
fix(components): guard drawer dialog methods in test env

### DIFF
--- a/packages/components/src/components/drawer/shadow.tsx
+++ b/packages/components/src/components/drawer/shadow.tsx
@@ -44,7 +44,7 @@ export class KolDrawer implements DrawerAPI {
 			...this.state,
 			_open: true,
 		};
-		this.dialogElement?.showModal();
+		this.dialogElement?.showModal?.();
 	}
 
 	/**
@@ -199,7 +199,7 @@ export class KolDrawer implements DrawerAPI {
 	}
 
 	private handleCloseDialog() {
-		this.dialogElement?.close();
+		this.dialogElement?.close?.();
 		this._on?.onClose?.();
 		if (this.host) {
 			dispatchDomEvent(this.host, KolEvent.close);

--- a/packages/components/src/components/drawer/shadow.tsx
+++ b/packages/components/src/components/drawer/shadow.tsx
@@ -44,7 +44,9 @@ export class KolDrawer implements DrawerAPI {
 			...this.state,
 			_open: true,
 		};
-		this.dialogElement?.showModal?.();
+		if (typeof this.dialogElement?.showModal === 'function') {
+			this.dialogElement.showModal();
+		}
 	}
 
 	/**
@@ -199,7 +201,9 @@ export class KolDrawer implements DrawerAPI {
 	}
 
 	private handleCloseDialog() {
-		this.dialogElement?.close?.();
+		if (typeof this.dialogElement?.close === 'function') {
+			this.dialogElement.close();
+		}
 		this._on?.onClose?.();
 		if (this.host) {
 			dispatchDomEvent(this.host, KolEvent.close);

--- a/packages/components/src/components/drawer/test/methods.spec.ts
+++ b/packages/components/src/components/drawer/test/methods.spec.ts
@@ -1,0 +1,19 @@
+import { KolDrawer } from '../shadow';
+
+describe('kol-drawer methods', () => {
+	it('does not throw in open when dialog showModal is unavailable', async () => {
+		const drawer = new KolDrawer();
+		(drawer as unknown as { dialogElement: object }).dialogElement = {};
+
+		await expect(drawer.open()).resolves.toBeUndefined();
+	});
+
+	it('does not throw in close flow when dialog close is unavailable', async () => {
+		const drawer = new KolDrawer();
+		(drawer as unknown as { dialogWrapperElement: HTMLElement; dialogElement: object }).dialogWrapperElement = document.createElement('div');
+		(drawer as unknown as { dialogElement: object }).dialogElement = {};
+		jest.spyOn(window, 'getComputedStyle').mockReturnValue({ animationName: 'none' } as CSSStyleDeclaration);
+
+		await expect(drawer.close()).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## What changed?

`KolDrawer` now guards the `showModal()` and `close()` calls on its internal dialog element with `typeof` function checks before invoking them. This prevents runtime errors in test environments (e.g. JSDOM) where `HTMLDialogElement` API methods are not implemented. Two unit tests were added in `packages/components/src/components/drawer/test/methods.spec.ts` that verify `open()` and `close()` complete without throwing when the dialog element does not expose these methods.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolDrawer` überprüft nun mit `typeof`-Guards, ob `showModal()` und `close()` als Funktionen auf dem internen Dialog-Element verfügbar sind, bevor sie aufgerufen werden. Das verhindert Laufzeitfehler in Testumgebungen (z. B. JSDOM), in denen die `HTMLDialogElement`-API-Methoden nicht implementiert sind. Zwei Unit-Tests in `packages/components/src/components/drawer/test/methods.spec.ts` prüfen, dass `open()` und `close()` ohne Fehler abschließen, wenn das Dialog-Element diese Methoden nicht besitzt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/drawer/shadow.tsx` — `typeof`-Guards für `showModal()` und `close()` auf dem Dialog-Element hinzugefügt
- `packages/components/src/components/drawer/test/methods.spec.ts` — Neue Unit-Tests für Drawer-Methoden in Testumgebungen ohne native Dialog-API

</details>