### PR TITLE
fix: sample app desy theme

### DIFF
--- a/packages/samples/react/index.html
+++ b/packages/samples/react/index.html
@@ -14,6 +14,7 @@
 		<link rel="stylesheet" href="assets/fontawesome-free/css/all.min.css" />
 		<link rel="stylesheet" href="assets/material-symbols-subset/style.css" />
 		<link rel="stylesheet" href="assets/noto-sans/noto-sans.css" />
+		<link rel="stylesheet" href="assets/desy-icons/style.css" />
 		<meta name="robots" content="noindex" />
 		<meta name="kolibri" content="dev-mode=false;experimental-mode=true;" />
 	</head>

--- a/packages/samples/react/index.html
+++ b/packages/samples/react/index.html
@@ -14,7 +14,6 @@
 		<link rel="stylesheet" href="assets/fontawesome-free/css/all.min.css" />
 		<link rel="stylesheet" href="assets/material-symbols-subset/style.css" />
 		<link rel="stylesheet" href="assets/noto-sans/noto-sans.css" />
-		<link rel="stylesheet" href="assets/desy-icons/style.css" />
 		<meta name="robots" content="noindex" />
 		<meta name="kolibri" content="dev-mode=false;experimental-mode=true;" />
 	</head>

--- a/packages/samples/react/src/react.main.tsx
+++ b/packages/samples/react/src/react.main.tsx
@@ -5,7 +5,7 @@ import { HashRouter as Router } from 'react-router-dom';
 
 import { bootstrap, KoliBriDevHelper } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/loader';
-import { BWSt, DEFAULT, ECL_EC, ECL_EU, KERN_V2 } from '@public-ui/themes';
+import { BWSt, DEFAULT, DesyV11, ECL_EC, ECL_EU, KERN_V2 } from '@public-ui/themes';
 
 import { App } from './App';
 
@@ -40,7 +40,7 @@ const getThemes = async () => {
 	}
 
 	/* List of regular sample app themes */
-	return [DEFAULT, BWSt, ECL_EC, ECL_EU, KERN_V2] as Theme[];
+	return [DEFAULT, BWSt, ECL_EC, ECL_EU, KERN_V2, DesyV11] as Theme[];
 };
 
 void (async () => {


### PR DESCRIPTION
## What changed?

The `DesyV11` theme was added to the list of available themes in the React sample application's bootstrap configuration. Previously the DESY v11 theme was missing from the sample app's theme picker despite being part of the `@public-ui/themes` package, making it unavailable for interactive testing in the sample app.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das `DesyV11`-Theme wurde der Liste der verfügbaren Themes in der Bootstrap-Konfiguration der React-Sample-App hinzugefügt. Zuvor fehlte das DESY v11-Theme im Theme-Picker der Sample-App, obwohl es im `@public-ui/themes`-Paket vorhanden ist.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/react.main.tsx` — `DesyV11` zu den importierten und registrierten Themes hinzugefügt

</details>