### PR TITLE
fix: netlify deployments (variant b)

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -13,13 +13,6 @@ on:
         required: false
         default: ''
 
-permissions:
-  attestations: write
-  contents: read
-  id-token: write
-  issues: write
-  pull-requests: write
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -36,7 +29,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        id: pnpm-install
         with:
           version: 10
 

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -1,0 +1,26 @@
+name: Netlify Draft-Deploy
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: true
+
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    # Skip this job when the base clone URL may be different from the head clone URL.
+    if: github.event.pull_request.head.repo.fork == false
+    uses: ./.github/workflows/deploy-netlify.yml
+    secrets: inherit
+    with:
+      environment: preview

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -14,9 +14,15 @@ concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  attestations: write
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-netlify.yml
+    secrets: inherit
     with:
       environment: production
       alias: ${{ github.ref_name }}


### PR DESCRIPTION
## What changed?

The Netlify deployment GitHub Actions configuration was restructured: the `permissions` block and `secrets: inherit` were moved from the reusable `deploy-netlify.yml` workflow into the caller workflows (`draft-deploy.yml` and `test-deploy.yml`) to fix deployment failures caused by missing secrets or insufficient permissions in the reusable workflow context. A new `draft-deploy.yml` caller workflow was introduced alongside the existing `test-deploy.yml`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die GitHub Actions-Konfiguration für Netlify-Deployments wurde umstrukturiert: Der `permissions`-Block und `secrets: inherit` wurden aus dem wiederverwendbaren `deploy-netlify.yml`-Workflow in die aufrufenden Workflows (`draft-deploy.yml` und `test-deploy.yml`) verschoben, um Deployment-Fehler durch fehlende Secrets oder unzureichende Berechtigungen im Kontext des wiederverwendbaren Workflows zu beheben. Ein neuer `draft-deploy.yml`-Caller-Workflow wurde eingeführt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `.github/workflows/deploy-netlify.yml` — `permissions`-Block und `id: pnpm-install` entfernt
- `.github/workflows/draft-deploy.yml` — Neuer Caller-Workflow mit `permissions`-Block und `secrets: inherit`
- `.github/workflows/test-deploy.yml` — `permissions`-Block und `secrets: inherit` hinzugefügt

</details>