### PR TITLE
ci(auto-dependency-updater): move pnpm/action-setup before actions/setup-node

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -39,15 +39,15 @@ jobs:
           if grep -q '^overrides:' pnpm-workspace.yaml; then
             sed -i '/^overrides:/,$ d' pnpm-workspace.yaml
           fi
-      - uses: actions/setup-node@v6
-        with:
-          cache: 'pnpm'
-          node-version: 24
       - uses: pnpm/action-setup@v6
         id: pnpm-install
         with:
           version: 10
           run_install: false
+      - uses: actions/setup-node@v6
+        with:
+          cache: 'pnpm'
+          node-version: 24
       - name: Install
         run: pnpm i --ignore-scripts --no-frozen-lockfile
       - name: Update dependencies (minor)


### PR DESCRIPTION
## What changed?
Fixed the step ordering in the auto-dependency-updater GitHub Actions workflow so that `pnpm/action-setup@v6` runs before `actions/setup-node@v6`. The Node.js setup action reads the pnpm installation when `cache: 'pnpm'` is configured, so pnpm must already be installed at that point. The previous ordering caused potential cache resolution failures in the workflow.

## Linked issues
No linked issues.

## Type of change
- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Was hat sich geändert?
Die Schrittabfolge im auto-dependency-updater GitHub Actions Workflow wurde korrigiert, sodass `pnpm/action-setup@v6` vor `actions/setup-node@v6` ausgeführt wird. Der Node.js-Setup-Action liest die pnpm-Installation, wenn `cache: 'pnpm'` konfiguriert ist — daher muss pnpm zu diesem Zeitpunkt bereits installiert sein. Die vorherige Reihenfolge verursachte potenzielle Cache-Auflösungsfehler im Workflow.

## Verknüpfte Issues
Keine verknüpften Issues.

## Art der Änderung
- [ ] ✨ Neues Feature
- [ ] 🔼 Verbesserung
- [ ] 🐛 Bugfix
- [ ] 💥 Breaking Change
- [x] 🔧 Intern (kein Release-Note nötig)

## Checkliste
- [x] PR-Titel folgt dem Conventional-Commits-Format
- [x] Verknüpfte Issues sind referenziert
- [ ] Breaking Changes sind dokumentiert
</details>