### PR TITLE
chore: remove optional snapshot deletion input from update workflow

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -2,12 +2,6 @@ name: 03 - Update Snapshots
 
 on:
   workflow_dispatch:
-    inputs:
-      delete_snapshots:
-        description: 'Delete existing snapshots before update?'
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.ref }}'
@@ -61,7 +55,6 @@ jobs:
         run: pnpm --filter @public-ui/sample-react^... build
 
       - name: Purge existing snapshots
-        if: inputs.delete_snapshots == true
         run: |
           if [ "${{ matrix.type }}" = "e2e" ]; then
             find ${{ matrix.path }} -name '*.png' -path '*/snapshots/*' | grep -v 'node_modules' | xargs --no-run-if-empty rm -f
@@ -77,18 +70,10 @@ jobs:
 
       - name: Package snapshot changes
         run: |
-          if [ "${{ inputs.delete_snapshots }}" = "true" ]; then
-            # All snapshots were purged and regenerated from scratch – capture every file on disk,
-            # including those whose content is identical to HEAD (git diff would miss those).
-            find ${{ matrix.path }} \( -path '*/node_modules' -prune \) -o \( -path '*/__snapshots__/*' -o -path '*/snapshots/*' \) -type f -print \
-              | tar cf snapshots.tar -T - 2>/dev/null || tar cf snapshots.tar --files-from /dev/null
-          else
-            # Only capture files that actually changed (efficient for normal updates).
-            {
-              git diff --name-only --diff-filter=d HEAD -- ${{ matrix.path }}
-              git ls-files --others --exclude-standard -- ${{ matrix.path }}
-            } | grep -E '(__snapshots__|snapshots)/' | tar cf snapshots.tar -T - 2>/dev/null || tar cf snapshots.tar --files-from /dev/null
-          fi
+          # All snapshots were purged and regenerated from scratch – capture every file on disk,
+          # including those whose content is identical to HEAD (git diff would miss those).
+          find ${{ matrix.path }} \( -path '*/node_modules' -prune \) -o \( -path '*/__snapshots__/*' -o -path '*/snapshots/*' \) -type f -print \
+            | tar cf snapshots.tar -T - 2>/dev/null || tar cf snapshots.tar --files-from /dev/null
 
       - name: Upload snapshot artifacts
         uses: actions/upload-artifact@v7
@@ -119,8 +104,7 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
           token: ${{ steps.app-token.outputs.token }}
-      - name: Purge existing snapshots (optional)
-        if: inputs.delete_snapshots == true
+      - name: Purge existing snapshots
         run: |
           find packages -name '*.png' -path '*/snapshots/*' | grep -v 'node_modules' | xargs --no-run-if-empty rm -f
           find packages \( -path '*/node_modules' -prune \) -o -path '*/__snapshots__/*' -type f -print | xargs --no-run-if-empty rm -f


### PR DESCRIPTION
## What changed?
Simplified the snapshot update CI workflow by removing the optional `delete_snapshots` workflow dispatch input and making full snapshot purge-and-regenerate the only behavior. The "Purge existing snapshots" and "Package snapshot changes" steps now run unconditionally: all existing snapshots are deleted before test runs regenerate them from scratch, and all snapshot files on disk are captured via `find`/`tar` rather than only changed ones. The `if` condition and conditional branching logic in the workflow have been eliminated, ensuring consistent repeatable snapshot updates on every workflow run.

## Linked issues
No linked issues.

## Type of change
- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Was hat sich geändert?
Der Snapshot-Update-CI-Workflow wurde vereinfacht, indem der optionale `delete_snapshots`-Workflow-Dispatch-Input entfernt wurde und das vollständige Purge-and-Regenerate-Verhalten nun das einzige ist. Die Schritte "Purge existing snapshots" und "Package snapshot changes" laufen jetzt bedingungslos: Alle bestehenden Snapshots werden vor den Test-Runs gelöscht, die sie von Grund auf neu generieren, und alle Snapshot-Dateien auf dem Datenträger werden via `find`/`tar` erfasst statt nur geänderte. Die bedingte Verzweigungslogik im Workflow wurde eliminiert.

## Verknüpfte Issues
Keine verknüpften Issues.

## Art der Änderung
- [ ] ✨ Neues Feature
- [ ] 🔼 Verbesserung
- [ ] 🐛 Bugfix
- [ ] 💥 Breaking Change
- [x] 🔧 Intern (kein Release-Note nötig)

## Checkliste
- [x] PR-Titel folgt dem Conventional-Commits-Format
- [x] Verknüpfte Issues sind referenziert
- [ ] Breaking Changes sind dokumentiert
</details>