### PR TITLE
refactor(click+focus): delegate methods with decorators for cleaner code

### DIFF
--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -1,6 +1,7 @@
 // https://codepen.io/mbxtr/pen/OJPOYg?html-preprocessor=haml
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Method, Prop, State, Watch } from '@stencil/core';
+
 import KolCollapsibleFc, { type CollapsibleProps } from '../../functional-components/Collapsible';
 import type {
 	AccordionAPI,
@@ -14,8 +15,7 @@ import type {
 } from '../../schema';
 import { featureHint, validateAccordionCallbacks, validateDisabled, validateLabel, validateOpen } from '../../schema';
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import { watchHeadingLevel } from '../heading/validation';
 
@@ -41,30 +41,24 @@ featureHint(`[KolAccordion] Tab-Sperre des Inhalts im geschlossenen Zustand.`);
 	shadow: true,
 })
 export class KolAccordion implements AccordionAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolAccordionElement;
+	@Element() protected readonly host?: HTMLKolAccordionElement;
 
 	private readonly id = createUniqueId('accordion');
-	private buttonWcRef?: HTMLKolButtonWcElement;
-
-	private readonly setButtonWcRef = (ref?: HTMLKolButtonWcElement) => {
-		this.buttonWcRef = ref;
-	};
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Triggers a click on the trigger button of the first section.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.buttonWcRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private handleOnClick = (event: MouseEvent) => {
 		this._open = !this._open;
@@ -101,7 +95,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 			class: rootClass,
 			HeadingProps: { class: `${rootClass}__heading` },
 			HeadingButtonProps: {
-				ref: this.setButtonWcRef,
+				ref: this.ctaRef,
 				class: `${rootClass}__heading-button`,
 			},
 			ContentProps: {

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -8,7 +8,7 @@ import { createUniqueId } from '../../utils/dev.utils';
 import type { JSX } from '@stencil/core';
 import { KolButtonWcTag } from '../../core/component-names';
 import clsx from '../../utils/clsx';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
 featureHint(`[KolBadge] Optimierung des _color-Properties (rgba, rgb, hex usw.).`);
 
 /**
@@ -23,20 +23,16 @@ featureHint(`[KolBadge] Optimierung des _color-Properties (rgba, rgb, hex usw.).
 	shadow: true,
 })
 export class KolBadge implements BadgeAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolBadgeElement;
+	@Element() protected readonly host?: HTMLKolBadgeElement;
 	private bgColorStr = '#000';
 	private colorStr = '#fff';
 	private readonly id = createUniqueId('badge-label');
-	private smartButtonRef?: HTMLKolButtonWcElement;
-
-	private readonly setSmartButtonRef = (ref?: HTMLKolButtonWcElement) => {
-		this.smartButtonRef = ref;
-	};
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 
 	private renderSmartButton(props: InternalButtonProps): JSX.Element {
 		return (
 			<KolButtonWcTag
-				ref={this.setSmartButtonRef}
+				ref={this.ctaRef}
 				class="kol-badge__smart-button"
 				_ariaControls={this.id}
 				_ariaDescription={props._ariaDescription}
@@ -57,9 +53,8 @@ export class KolBadge implements BadgeAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.smartButtonRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	public render(): JSX.Element {
 		const hasSmartButton = typeof this.state._smartButton === 'object' && this.state._smartButton !== null;

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -19,8 +19,7 @@ import type {
 	TooltipAlignPropType,
 	VariantClassNamePropType,
 } from '../../schema';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 
 /**
  * The **ButtonLink** component is semantically a button but has the appearance of a link. All relevant properties of the Button component are adopted and extended with the design-defining properties of a link.
@@ -43,12 +42,8 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolButtonLink implements ButtonLinkProps, FocusableElement {
-	@Element() private readonly host?: HTMLKolButtonLinkElement;
-	private buttonWcRef?: HTMLKolButtonWcElement;
-
-	private readonly setButtonWcRef = (ref?: HTMLKolButtonWcElement) => {
-		this.buttonWcRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolButtonLinkElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 
 	/**
 	 * Returns the current value.
@@ -63,22 +58,20 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.buttonWcRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	public render(): JSX.Element {
 		return (
 			<KolButtonWcTag
-				ref={this.setButtonWcRef}
+				ref={this.ctaRef}
 				_accessKey={this._accessKey}
 				_ariaControls={this._ariaControls}
 				_ariaDescription={this._ariaDescription}

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -58,8 +58,7 @@ import { TooltipController } from '../../internal/functional-components/tooltip/
 import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 import clsx from '../../utils/clsx';
-import { setClick } from '../../utils/element-click';
-import { setFocus } from '../../utils/element-focus';
+import { createCtaRef, directClick, directFocus } from '../../utils/element-interaction';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import { propagateResetEventToForm, propagateSubmitEventToForm } from '../form/controller';
 import { AssociatedInputController } from '../input-adapter-leanup/associated.controller';
@@ -72,29 +71,23 @@ import { AssociatedInputController } from '../input-adapter-leanup/associated.co
 	shadow: false,
 })
 export class KolButtonWc implements ButtonAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolButtonWcElement;
-	private buttonRef?: HTMLButtonElement;
+	@Element() protected readonly host?: HTMLKolButtonWcElement;
+	protected readonly ctaRef = createCtaRef<HTMLButtonElement>();
 	private readonly tooltipCtrl = new TooltipController(BaseWebComponent.stateLess);
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return setFocus(this.buttonRef!);
-	}
+	@directFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return setClick(this.buttonRef!);
-	}
-
-	private readonly setButtonRef = (ref?: HTMLButtonElement) => {
-		this.buttonRef = ref;
-	};
+	@directClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private readonly onClick = (event: MouseEvent) => {
 		event.stopPropagation();
@@ -103,12 +96,12 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 		if (this.state._type === 'submit') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.buttonRef,
+				ref: this.ctaRef.el,
 			});
 		} else if (this.state._type === 'reset') {
 			propagateResetEventToForm({
 				form: this.host,
-				ref: this.buttonRef,
+				ref: this.ctaRef.el,
 			});
 		} else {
 			// TODO: Static form handling
@@ -116,7 +109,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 
 			// Callback
 			if (typeof this.state._on?.onClick === 'function') {
-				setEventTarget(event, this.buttonRef);
+				setEventTarget(event, this.ctaRef.el);
 				this.state._on?.onClick(event, this.state._value);
 			}
 		}
@@ -157,7 +150,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 		return (
 			<Host>
 				<button
-					ref={this.setButtonRef}
+					ref={this.ctaRef}
 					accessKey={this.state._accessKey}
 					aria-controls={this.state._ariaControls}
 					aria-description={ariaDescription || undefined}
@@ -488,8 +481,8 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 	}
 
 	public componentDidRender(): void {
-		if (this.buttonRef) {
-			this.tooltipCtrl.syncListeners(undefined, this.buttonRef, true);
+		if (this.ctaRef.el) {
+			this.tooltipCtrl.syncListeners(undefined, this.ctaRef.el, true);
 		}
 	}
 

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -19,8 +19,7 @@ import type {
 	SyncValueBySelectorPropType,
 	TooltipAlignPropType,
 } from '../../schema';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 
 /**
  * The **Button** component is used to present users with action options and arrange them in a clear hierarchy. It helps users find the most important actions on a page or within a viewport and allows them to execute those actions. The button label clearly indicates which action will be triggered. Buttons allow users to confirm a change, complete steps in a task, or make decisions.
@@ -35,12 +34,8 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolButton implements ButtonProps, FocusableElement {
-	@Element() private readonly host?: HTMLKolButtonElement;
-	private buttonWcRef?: HTMLKolButtonWcElement;
-
-	private readonly setButtonWcRef = (ref?: HTMLKolButtonWcElement) => {
-		this.buttonWcRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolButtonElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 
 	/**
 	 * Returns the current value.
@@ -55,22 +50,20 @@ export class KolButton implements ButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.buttonWcRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	public render(): JSX.Element {
 		return (
 			<KolButtonWcTag
-				ref={this.setButtonWcRef}
+				ref={this.ctaRef}
 				_accessKey={this._accessKey}
 				_ariaControls={this._ariaControls}
 				_ariaDescription={this._ariaDescription}

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -36,8 +36,7 @@ import type {
 import type { EventDetail } from '../../schema/interfaces/EventDetail';
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { ComboboxController } from './controller';
 
 /**
@@ -51,8 +50,8 @@ import { ComboboxController } from './controller';
 	shadow: true,
 })
 export class KolCombobox implements ComboboxAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolComboboxElement;
-	private refInput?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolComboboxElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 	private refSuggestions: HTMLLIElement[] = [];
 	private _focusedOptionIndex: number = -1;
 	private readonly translateDeleteSelection = translate('kol-delete-selection');
@@ -71,24 +70,22 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.refInput!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.refInput!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private toggleListbox = () => {
 		const isDisabled = this.state._disabled === true;
 		if (isDisabled) {
 			this._isOpen = false;
 		} else {
-			this.refInput?.focus();
+			this.ctaRef.el?.focus();
 			if (this._isOpen) {
 				// Liste schließen
 				this._isOpen = false;
@@ -101,10 +98,6 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 			}
 		}
 	};
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.refInput = ref;
-	};
-
 	private selectOption(option: string) {
 		this.controller.onFacade.onInput(
 			new CustomEvent<EventDetail>('input', { bubbles: true, detail: { name: this.state._name as string, value: option } }),
@@ -118,7 +111,7 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 		this.controller.setFormAssociatedValue(option);
 		this._filteredSuggestions = [...this.state._suggestions];
 		this.state._value = option;
-		this.refInput?.focus();
+		this.ctaRef.el?.focus();
 	}
 
 	private clearSelection() {
@@ -139,7 +132,7 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 		this.controller.onFacade.onChange(new CustomEvent('change', { bubbles: true, detail }), emptyValue);
 		this.controller.setFormAssociatedValue(emptyValue);
 
-		this.refInput?.focus();
+		this.ctaRef.el?.focus();
 	}
 
 	private onInput(event: Event) {
@@ -243,7 +236,7 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 		const isDisabled = this.state._disabled === true;
 
 		return {
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			state: this.state,
 			class: 'kol-combobox__input',
 			type: 'text',
@@ -361,7 +354,7 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 			if (isOpen !== undefined) {
 				this._isOpen = isOpen;
 				if (!isOpen) {
-					this.refInput?.focus();
+					this.ctaRef.el?.focus();
 				}
 			}
 			callback?.();
@@ -382,14 +375,14 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 			case 'Tab':
 				if (this._isOpen) {
 					this._isOpen = false;
-					this.refInput?.focus();
+					this.ctaRef.el?.focus();
 				}
 				break;
 			case 'Esc':
 			case 'Escape': {
 				this._isOpen = false;
 				event.preventDefault();
-				this.refInput?.focus();
+				this.ctaRef.el?.focus();
 				break;
 			}
 			case ' ':

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -3,8 +3,7 @@ import KolCollapsibleFc, { type CollapsibleProps } from '../../functional-compon
 import type { DetailsAPI, DetailsCallbacksPropType, DetailsStates, DisabledPropType, FocusableElement, HeadingLevel, LabelPropType } from '../../schema';
 import { validateDetailsCallbacks, validateDisabled, validateLabel, validateOpen } from '../../schema';
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import { watchHeadingLevel } from '../heading/validation';
 
@@ -27,30 +26,24 @@ import { watchHeadingLevel } from '../heading/validation';
 	shadow: true,
 })
 export class KolDetails implements DetailsAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolDetailsElement;
+	@Element() protected readonly host?: HTMLKolDetailsElement;
 
 	private readonly id = createUniqueId('details');
-	private buttonWcRef?: HTMLKolButtonWcElement;
-
-	private readonly setButtonWcRef = (ref?: HTMLKolButtonWcElement) => {
-		this.buttonWcRef = ref;
-	};
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Triggers a click on the summary/toggle button.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.buttonWcRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private toggleTimeout?: ReturnType<typeof setTimeout>;
 
@@ -89,7 +82,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 			class: rootClass,
 			HeadingProps: { class: `${rootClass}__heading` },
 			HeadingButtonProps: {
-				ref: this.setButtonWcRef,
+				ref: this.ctaRef,
 				class: `${rootClass}__heading-button`,
 				_icons: 'kolicon-chevron-right',
 			},

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -27,8 +27,7 @@ import type {
 } from '../../schema';
 
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { InputCheckboxController } from './controller';
 
 import KolCheckboxStateWrapperFc, { type CheckboxStateWrapperProps } from '../../functional-component-wrappers/CheckboxStateWrapper/CheckboxStateWrapper';
@@ -52,12 +51,8 @@ import { propagateSubmitEventToForm } from '../form/controller';
 	shadow: true,
 })
 export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputCheckboxElement;
-	private inputRef?: HTMLInputElement;
-
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.inputRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolInputCheckboxElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 
 	private getModelValue(): StencilUnknown {
 		return this._checked ? this.state._value : null;
@@ -76,17 +71,15 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.inputRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.inputRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {
 		return {
@@ -138,7 +131,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 				class: clsx({
 					'visually-hidden': this.state._variant === 'button',
 				}),
-				ref: this.setInputRef,
+				ref: this.ctaRef,
 				...this.controller.onFacade,
 				onInput: this.onInput,
 				onChange: this.onChange,
@@ -430,7 +423,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.inputRef,
+				ref: this.ctaRef.el,
 			});
 		}
 	};

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -27,8 +27,7 @@ import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { InputColorController } from './controller';
 
 /**
@@ -44,13 +43,10 @@ import { InputColorController } from './controller';
 	shadow: true,
 })
 export class KolInputColor implements InputColorAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputColorElement;
-	private refInputText?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolInputColorElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 	private refInputColor?: HTMLInputElement;
 
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.refInputText = ref;
-	};
 	private readonly setColorRef = (ref?: HTMLInputElement) => {
 		this.refInputColor = ref;
 	};
@@ -68,8 +64,8 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 		const value = (event.target as HTMLInputElement).value;
 		this.state._value = value;
 
-		if (this.refInputText) {
-			this.refInputText.value = value;
+		if (this.ctaRef.el) {
+			this.ctaRef.el.value = value;
 		}
 		this.controller.onFacade.onInput(event);
 	};
@@ -91,24 +87,22 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<string | undefined> {
-		return this.refInputText?.value;
+		return this.ctaRef.el?.value;
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.refInputText!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.refInputText!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private get hasSuggestions(): boolean {
 		return Array.isArray(this.state._suggestions) && this.state._suggestions.length > 0;
@@ -139,7 +133,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	private getInputTextProps(): InputStateWrapperProps {
 		return {
 			...this.getGenericInputProps(),
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			type: 'text',
 			name: this.state._name ? `${this.state._name}-text` : undefined,
 			list: this.hasSuggestions ? createRelatedUniqueId(this.state._id, 'list') : undefined,

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -35,8 +35,7 @@ import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputDateController } from './controller';
 
@@ -53,14 +52,10 @@ import { InputDateController } from './controller';
 	shadow: true,
 })
 export class KolInputDate implements InputDateAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputDateElement;
-	private inputRef?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolInputDateElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 
 	@State() private _initialValueType: 'Date' | 'String' | null = null;
-
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.inputRef = ref;
-	};
 
 	/**
 	 * Returns the current value.
@@ -68,24 +63,22 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<string | Date | undefined | null> {
-		return this.inputRef && this.remapValue(this.inputRef?.value);
+		return this.ctaRef.el && this.remapValue(this.ctaRef.el?.value);
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.inputRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.inputRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	/**
 	 * Resets the component's value.
@@ -101,8 +94,8 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 
 		// Setting the state value might not trigger a state change and rerender if the previous value is already an empty string,
 		// which can occur during an incomplete input. Directly setting the DOM property "forces" a reset of the native element.
-		if (this.inputRef) {
-			this.inputRef.value = '';
+		if (this.ctaRef.el) {
+			this.ctaRef.el.value = '';
 		}
 	}
 
@@ -146,10 +139,10 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	};
 
 	private readonly isNativeCalendarIconFocused = (): boolean => {
-		if (!this.inputRef || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+		if (!this.ctaRef.el || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
 			return false;
 		}
-		const computedStyle = window.getComputedStyle(this.inputRef);
+		const computedStyle = window.getComputedStyle(this.ctaRef.el);
 		return computedStyle.content.includes('native-icon-focused');
 	};
 
@@ -159,7 +152,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 		if ((event.code === 'Enter' || event.code === 'NumpadEnter') && !this.isNativeCalendarIconFocused()) {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.inputRef,
+				ref: this.ctaRef.el,
 			});
 		}
 		if (this.state._readOnly && event.code === 'Space') {
@@ -180,7 +173,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 
 	private getInputProps(): InputStateWrapperProps {
 		return {
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			state: this.state,
 			...this.controller.onFacade,
 			onBlur: this.onBlur,

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -35,8 +35,7 @@ import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputEmailController } from './controller';
 
@@ -53,12 +52,8 @@ import { InputEmailController } from './controller';
 	shadow: true,
 })
 export class KolInputEmail implements InputEmailAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputEmailElement;
-	private inputRef?: HTMLInputElement;
-
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.inputRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolInputEmailElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 
 	/**
 	 * Returns the current value.
@@ -66,24 +61,22 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<string | undefined> {
-		return this.inputRef?.value;
+		return this.ctaRef.el?.value;
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.inputRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.inputRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
 		this.controller.onFacade.onKeyDown(event);
@@ -91,7 +84,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.inputRef,
+				ref: this.ctaRef.el,
 			});
 		}
 	};
@@ -117,7 +110,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 		const ariaDescribedBy = typeof this.state._maxLength === 'number' ? [createRelatedUniqueId(this.state._id, 'character-limit-hint')] : undefined; // When a character limit is defined, we provide an additional hint referenced by aria-describedby.
 
 		return {
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			state: this.state,
 			type: 'email',
 			ariaDescribedBy,

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -32,8 +32,7 @@ import KolInputContainerFc from '../../functional-component-wrappers/InputContai
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { translate } from '../../i18n';
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { InputFileController } from './controller';
 
 /**
@@ -49,15 +48,11 @@ import { InputFileController } from './controller';
 	shadow: true,
 })
 export class KolInputFile implements InputFileAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputFileElement;
-	private inputRef?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolInputFileElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 
 	private readonly translateDataBrowseText = translate('kol-data-browse-text');
 	private readonly translateFilenameText = translate('kol-filename-text');
-
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.inputRef = ref;
-	};
 
 	/**
 	 * Returns the current value.
@@ -65,24 +60,22 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<FileList | null | undefined> {
-		return this.inputRef?.files;
+		return this.ctaRef.el?.files;
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.inputRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.inputRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	/**
 	 * Resets the component's value.
@@ -94,8 +87,8 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 		this.filename = this.translateFilenameText;
 		this.hasFileSelected = false;
 
-		if (this.inputRef) {
-			this.inputRef.value = '';
+		if (this.ctaRef.el) {
+			this.ctaRef.el.value = '';
 		}
 	}
 
@@ -110,7 +103,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 
 	private getInputProps(): InputStateWrapperProps {
 		return {
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			state: this.state,
 			type: 'file',
 			accept: this.state._accept,
@@ -361,7 +354,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	}
 
 	public componentDidLoad(): void {
-		const container = this.inputRef?.parentElement?.parentElement;
+		const container = this.ctaRef.el?.parentElement?.parentElement;
 		container?.addEventListener('dragover', this.onDragOver);
 		container?.addEventListener('dragleave', this.onDragLeave);
 		container?.addEventListener('drop', this.onDrop);
@@ -369,22 +362,22 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 
 	private onDragOver = (event: DragEvent): void => {
 		event.preventDefault();
-		this.inputRef?.parentElement?.parentElement?.classList.add('kol-input-container--is-dragover');
+		this.ctaRef.el?.parentElement?.parentElement?.classList.add('kol-input-container--is-dragover');
 	};
 
 	private onDragLeave = (): void => {
-		this.inputRef?.parentElement?.parentElement?.classList.remove('kol-input-container--is-dragover');
+		this.ctaRef.el?.parentElement?.parentElement?.classList.remove('kol-input-container--is-dragover');
 	};
 
 	private onDrop = (event: DragEvent): void => {
 		event.preventDefault();
-		if (!this.inputRef) {
+		if (!this.ctaRef.el) {
 			return;
 		}
-		this.inputRef.parentElement?.parentElement?.classList.remove('kol-input-container--is-dragover');
+		this.ctaRef.el.parentElement?.parentElement?.classList.remove('kol-input-container--is-dragover');
 		if (event.dataTransfer?.files.length) {
 			const files = event.dataTransfer.files;
-			this.inputRef.files = files;
+			this.ctaRef.el.files = files;
 			this.filename = Array.from(files)
 				.map((file) => file.name)
 				.join(', ');
@@ -394,8 +387,8 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 		}
 	};
 	private onChange = (event: Event): void => {
-		if (this.inputRef instanceof HTMLInputElement && this.inputRef.type === 'file') {
-			const value = this.inputRef.files;
+		if (this.ctaRef.el instanceof HTMLInputElement && this.ctaRef.el.type === 'file') {
+			const value = this.ctaRef.el.files;
 			this.hasFileSelected = !!value?.length;
 			this.filename = value?.length
 				? Array.from(value)
@@ -409,8 +402,8 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	};
 
 	private onInput = (event: Event): void => {
-		if (this.inputRef instanceof HTMLInputElement && this.inputRef.type === 'file') {
-			const files = this.inputRef.files;
+		if (this.ctaRef.el instanceof HTMLInputElement && this.ctaRef.el.type === 'file') {
+			const files = this.ctaRef.el.files;
 			this.controller.onFacade.onInput(event, false, files);
 		}
 	};

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -34,8 +34,7 @@ import KolInputContainerFc from '../../functional-component-wrappers/InputContai
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { IconFC } from '../../internal/functional-components/icon/component';
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputNumberController } from './controller';
 
@@ -52,12 +51,8 @@ import { InputNumberController } from './controller';
 	shadow: true,
 })
 export class KolInputNumber implements InputNumberAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputNumberElement;
-	private inputRef?: HTMLInputElement;
-
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.inputRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolInputNumberElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 
 	/**
 	 * Returns the current value.
@@ -72,17 +67,15 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.inputRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.inputRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private setInitialValueType(value?: number | NumberString | null) {
 		if (this.controller.isNumberString(value)) {
@@ -109,13 +102,13 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	}
 
 	private readonly onInput = (event: InputEvent) => {
-		const newValue = this.inputRef?.value;
+		const newValue = this.ctaRef.el?.value;
 		this._value = this.remapValue(newValue === '' ? null : Number(newValue));
 		this.controller.onFacade.onInput(event, true, this._value);
 	};
 
 	private readonly onChange = (event: Event) => {
-		const newValue = this.inputRef?.value;
+		const newValue = this.ctaRef.el?.value;
 		const mappedValue = this.remapValue(newValue === '' ? null : Number(newValue));
 		this.controller.onFacade.onChange(event, mappedValue);
 	};
@@ -126,7 +119,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.inputRef,
+				ref: this.ctaRef.el,
 			});
 		}
 	};
@@ -144,7 +137,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 
 	private getInputProps(): InputStateWrapperProps {
 		return {
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			state: this.state,
 			type: 'number',
 			...this.controller.onFacade,
@@ -182,15 +175,15 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 				class="kol-input-number__step-button kol-input-number__step-button-up kol-input-container__smart-button"
 				data-testid="kol-input-number-step-up"
 				onClick={(event: MouseEvent): void => {
-					this.inputRef?.stepUp();
+					this.ctaRef.el?.stepUp();
 					// Manually trigger onInput since stepUp() doesn't fire input events
-					const newValue = this.inputRef?.value;
+					const newValue = this.ctaRef.el?.value;
 					this._value = this.remapValue(newValue === '' ? null : Number(newValue));
 					// Pass MouseEvent as Event - onInput handler accepts generic Event type
 					this.controller.onFacade.onInput(event, true, this._value);
 					// native number buttons also throw the change event on every click
 					this.controller.onFacade.onChange(event, this._value);
-					this.inputRef?.focus();
+					this.ctaRef.el?.focus();
 				}}
 				disabled={this._disabled || this._readOnly}
 			>
@@ -211,15 +204,15 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 				class="kol-input-number__step-button kol-input-number__step-button-down kol-input-container__smart-button"
 				data-testid="kol-input-number-step-down"
 				onClick={(event: MouseEvent): void => {
-					this.inputRef?.stepDown();
+					this.ctaRef.el?.stepDown();
 					// Manually trigger onInput since stepDown() doesn't fire input events
-					const newValue = this.inputRef?.value;
+					const newValue = this.ctaRef.el?.value;
 					this._value = this.remapValue(newValue === '' ? null : Number(newValue));
 					// Pass MouseEvent as Event - onInput handler accepts generic Event type
 					this.controller.onFacade.onInput(event, true, this._value);
 					// native number buttons also throw the change event on every click
 					this.controller.onFacade.onChange(event, this._value);
-					this.inputRef?.focus();
+					this.ctaRef.el?.focus();
 				}}
 				disabled={this._disabled || this._readOnly}
 			>

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -37,8 +37,7 @@ import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../funct
 import KolIconButtonFc from '../../functional-components/IconButton';
 import { translate } from '../../i18n';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputPasswordController } from './controller';
 
@@ -55,15 +54,11 @@ import { InputPasswordController } from './controller';
 	shadow: true,
 })
 export class KolInputPassword implements InputPasswordAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputPasswordElement;
-	private inputRef?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolInputPasswordElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 
 	private readonly translateHidePassword = translate('kol-hide-password');
 	private readonly translateShowPassword = translate('kol-show-password');
-
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.inputRef = ref;
-	};
 
 	/**
 	 * Returns the current value.
@@ -71,24 +66,22 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<string | undefined> {
-		return this.inputRef?.value;
+		return this.ctaRef.el?.value;
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.inputRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.inputRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private readonly onKeyDown = (event: KeyboardEvent) => {
 		this.controller.onFacade.onKeyDown(event);
@@ -96,7 +89,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.inputRef,
+				ref: this.ctaRef.el,
 			});
 		}
 	};
@@ -122,7 +115,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 		const ariaDescribedBy = typeof this.state._maxLength === 'number' ? [createRelatedUniqueId(this.state._id, 'character-limit-hint')] : undefined; // When a character limit is defined, we provide an additional hint referenced by aria-describedby.
 
 		return {
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			// TODO v5: remove `_variant === 'visibility-toggle'` backwards-compat fallback
 			type: (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') && this._passwordVisible ? 'text' : 'password',
 			state: this.state,
@@ -153,7 +146,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 					buttonVariant="ghost"
 					onClick={(): void => {
 						this._passwordVisible = !this._passwordVisible;
-						this.inputRef?.focus();
+						this.ctaRef.el?.focus();
 					}}
 					icon={`${this._passwordVisible ? 'kolicon-eye-closed' : 'kolicon-eye'}`}
 					disabled={this._disabled}

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -66,9 +66,11 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	public async click(): Promise<void> {}
 
 	private readonly setInputNumberRef = (element?: HTMLInputElement) => {
-		this.ctaRef(element);
-		if (element && !this._value && element.value) {
-			this.validateValue(parseFloat(element.value));
+		if (element) {
+			this.ctaRef(element);
+			if (!this._value && element.value) {
+				this.validateValue(parseFloat(element.value));
+			}
 		}
 	};
 

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -30,8 +30,7 @@ import KolInputContainerFc from '../../functional-component-wrappers/InputContai
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import KolSuggestionsFc from '../../functional-components/Suggestions';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputRangeController } from './controller';
 
@@ -48,32 +47,28 @@ import { InputRangeController } from './controller';
 	shadow: true,
 })
 export class KolInputRange implements InputRangeAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputRangeElement;
-	private refInputNumber?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolInputRangeElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 	private refInputRange?: HTMLInputElement;
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.refInputNumber!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.refInputNumber!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private readonly setInputNumberRef = (element?: HTMLInputElement) => {
-		if (element) {
-			this.refInputNumber = element;
-			if (!this._value && this.refInputNumber?.value) {
-				this.validateValue(parseFloat(this.refInputNumber.value));
-			}
+		this.ctaRef(element);
+		if (element && !this._value && element.value) {
+			this.validateValue(parseFloat(element.value));
 		}
 	};
 
@@ -110,8 +105,8 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<number | NumberString | undefined> {
-		if (this.refInputNumber !== undefined) {
-			const value = this.refInputNumber.value;
+		if (this.ctaRef.el !== undefined) {
+			const value = this.ctaRef.el.value;
 			const floatValue = this.getSanitizedFloatValue(value);
 			return this.remapValue(floatValue);
 		}
@@ -137,7 +132,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.refInputNumber,
+				ref: this.ctaRef.el,
 			});
 		}
 	};

--- a/packages/components/src/components/input-text/input-text.e2e.ts
+++ b/packages/components/src/components/input-text/input-text.e2e.ts
@@ -33,18 +33,18 @@ test.describe('kol-input-text', () => {
 	testInputMessage<HTMLKolInputTextElement>(COMPONENT_NAME);
 
 	test.describe('click() method', () => {
-		test('should focus input when click() method is called', async ({ page }) => {
+		test('should dispatch click on inner input when click() method is called', async ({ page }) => {
 			await page.setContent('<kol-input-text _label="Test Input" _type="text"></kol-input-text>');
 			const kolInput = page.locator('kol-input-text');
 
 			await page.waitForChanges();
 
-			// Register focus listener before calling click() to avoid race condition
-			const focusPromise = kolInput.evaluate((el: HTMLKolInputTextElement) => {
+			// Register click listener on the inner input before calling click() to avoid race conditions
+			const clickPromise = kolInput.evaluate((el: HTMLKolInputTextElement) => {
 				return new Promise<boolean>((resolve) => {
 					const input = el.shadowRoot?.querySelector('input');
 					if (input) {
-						input.addEventListener('focus', () => resolve(true), { once: true });
+						input.addEventListener('click', () => resolve(true), { once: true });
 					} else {
 						resolve(false);
 					}
@@ -62,7 +62,7 @@ test.describe('kol-input-text', () => {
 				}
 			});
 
-			await expect(focusPromise).resolves.toBe(true);
+			await expect(clickPromise).resolves.toBe(true);
 		});
 
 		test('should focus input when host is clicked directly', async ({ page }) => {

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -37,8 +37,7 @@ import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
-import { delegateFocus as delegateFocusUtil, setFocus } from '../../utils/element-focus';
-import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputTextController } from './controller';
 
@@ -112,12 +111,11 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	public async focus(): Promise<void> {}
 
 	/**
-	 * Focuses the primary interactive element inside this component.
+	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateFocusUtil(this.host!, async () => setFocus(this.ctaRef.el!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	/**
 	 * Get selection start of internal element.
@@ -131,7 +129,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 * Get selection end of internal element.
 	 */
 	@Method()
-	public async selectioconEnd() {
+	public async selectionEnd() {
 		return Promise.resolve(this.ctaRef.el?.selectionEnd);
 	}
 

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -37,8 +37,8 @@ import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
-import { createCtaRef } from '../../utils/element-interaction';
+import { delegateFocus as delegateFocusUtil, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputTextController } from './controller';
 
@@ -116,7 +116,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 */
 	@Method()
 	public async click(): Promise<void> {
-		return delegateFocus(this.host!, async () => setFocus(this.ctaRef.el!));
+		return delegateFocusUtil(this.host!, async () => setFocus(this.ctaRef.el!));
 	}
 
 	/**

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -38,6 +38,7 @@ import KolInputContainerFc from '../../functional-component-wrappers/InputContai
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
 import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputTextController } from './controller';
 
@@ -54,13 +55,9 @@ import { InputTextController } from './controller';
 	shadow: true,
 })
 export class KolInputText implements InputTextAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolInputTextElement;
-	private inputRef?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolInputTextElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 	private oldValue?: string;
-
-	private readonly setInputRef = (ref?: HTMLInputElement) => {
-		this.inputRef = ref;
-	};
 
 	private readonly onBlur = (event: FocusEvent) => {
 		this.controller.onFacade.onBlur(event);
@@ -68,7 +65,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	};
 
 	private readonly onChange = (event: Event) => {
-		const value = this.inputRef?.value;
+		const value = this.ctaRef.el?.value;
 
 		if (this.oldValue !== value) {
 			this.oldValue = value;
@@ -83,7 +80,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	};
 
 	private readonly onInput = (event: InputEvent) => {
-		this._value = this.inputRef?.value ?? '';
+		this._value = this.ctaRef.el?.value ?? '';
 		this.controller.onFacade.onInput(event);
 	};
 
@@ -93,7 +90,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 		if (event.code === 'Enter' || event.code === 'NumpadEnter') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.inputRef,
+				ref: this.ctaRef.el,
 			});
 		}
 	};
@@ -104,23 +101,22 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<string | undefined> {
-		return this.inputRef?.value;
+		return this.ctaRef.el?.value;
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.inputRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Focuses the primary interactive element inside this component.
 	 */
 	@Method()
 	public async click(): Promise<void> {
-		return delegateFocus(this.host!, async () => setFocus(this.inputRef!));
+		return delegateFocus(this.host!, async () => setFocus(this.ctaRef.el!));
 	}
 
 	/**
@@ -128,7 +124,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 */
 	@Method()
 	public async selectionStart() {
-		return Promise.resolve(this.inputRef?.selectionStart);
+		return Promise.resolve(this.ctaRef.el?.selectionStart);
 	}
 
 	/**
@@ -136,7 +132,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 */
 	@Method()
 	public async selectioconEnd() {
-		return Promise.resolve(this.inputRef?.selectionEnd);
+		return Promise.resolve(this.ctaRef.el?.selectionEnd);
 	}
 
 	/**
@@ -145,7 +141,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async setSelectionRange(selectionStart: number, selectionEnd: number, selectionDirection?: 'forward' | 'backward' | 'none') {
-		this.inputRef?.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
+		this.ctaRef.el?.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
 	}
 
 	/**
@@ -154,7 +150,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async setSelectionStart(selectionStart: number) {
-		this.inputRef?.setSelectionRange(selectionStart, selectionStart);
+		this.ctaRef.el?.setSelectionRange(selectionStart, selectionStart);
 	}
 
 	/**
@@ -164,9 +160,9 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async setRangeText(replacement: string, selectionStart?: number, selectionEnd?: number, selectMode?: 'select' | 'start' | 'end' | 'preserve') {
 		if (selectionStart && selectionEnd) {
-			this.inputRef?.setRangeText(replacement, selectionStart, selectionEnd, selectMode);
+			this.ctaRef.el?.setRangeText(replacement, selectionStart, selectionEnd, selectMode);
 		} else {
-			this.inputRef?.setRangeText(replacement);
+			this.ctaRef.el?.setRangeText(replacement);
 		}
 	}
 
@@ -186,7 +182,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 		const ariaDescribedBy = typeof this.state._maxLength === 'number' ? [createRelatedUniqueId(this.state._id, 'character-limit-hint')] : undefined; // When a character limit is defined, we provide an additional hint referenced by aria-describedby.
 
 		return {
-			ref: this.setInputRef,
+			ref: this.ctaRef,
 			state: this.state,
 			ariaDescribedBy,
 			...this.controller.onFacade,

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -157,7 +157,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async setRangeText(replacement: string, selectionStart?: number, selectionEnd?: number, selectMode?: 'select' | 'start' | 'end' | 'preserve') {
-		if (selectionStart && selectionEnd) {
+		if (selectionStart !== undefined && selectionEnd !== undefined) {
 			this.ctaRef.el?.setRangeText(replacement, selectionStart, selectionEnd, selectMode);
 		} else {
 			this.ctaRef.el?.setRangeText(replacement);

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -19,8 +19,7 @@ import type {
 	ShortKeyPropType,
 	TooltipAlignPropType,
 } from '../../schema';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 
 /**
  * The **LinkButton** component is semantically a link but has the appearance of a button. All relevant properties of the Link component are adopted and extended with the design-defining properties of a button.
@@ -35,33 +34,27 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolLinkButton implements LinkButtonProps, FocusableElement {
-	@Element() private readonly host?: HTMLKolLinkButtonElement;
-	private linkWcRef?: HTMLKolLinkWcElement;
-
-	private readonly setLinkWcRef = (ref?: HTMLKolLinkWcElement) => {
-		this.linkWcRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolLinkButtonElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolLinkWcElement>();
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.linkWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.linkWcRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	public render(): JSX.Element {
 		return (
 			<KolLinkWcTag
-				ref={this.setLinkWcRef}
+				ref={this.ctaRef}
 				_accessKey={this._accessKey}
 				_ariaCurrentValue={this._ariaCurrentValue}
 				_ariaControls={this._ariaControls}

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -55,8 +55,7 @@ import {
 	validateVariantClassName,
 } from '../../schema';
 import { validateTabIndex } from '../../schema/props/tab-index';
-import { setClick } from '../../utils/element-click';
-import { setFocus } from '../../utils/element-focus';
+import { createCtaRef, directClick, directFocus } from '../../utils/element-interaction';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import type { UnsubscribeFunction } from './ariaCurrentService';
 import { onLocationChange } from './ariaCurrentService';
@@ -76,31 +75,25 @@ import clsx from '../../utils/clsx';
 export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolLinkElement;
 
-	private anchorRef?: HTMLAnchorElement;
+	protected readonly ctaRef = createCtaRef<HTMLAnchorElement>();
 	private readonly tooltipCtrl = new TooltipController(BaseWebComponent.stateLess);
 	private unsubscribeOnLocationChange?: UnsubscribeFunction;
 
 	private readonly translateOpenLinkInTab = translate('kol-open-link-in-tab');
 
-	private readonly setAnchorRef = (ref?: HTMLAnchorElement) => {
-		this.anchorRef = ref;
-	};
-
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return setFocus(this.anchorRef!);
-	}
+	@directFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return setClick(this.anchorRef!);
-	}
+	@directClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private readonly onClick = (event: Event) => {
 		this.tooltipCtrl.hideTooltip();
@@ -109,7 +102,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 			event.preventDefault();
 		} else {
 			if (typeof this.state._on?.onClick === 'function') {
-				setEventTarget(event, this.anchorRef);
+				setEventTarget(event, this.ctaRef.el);
 				this.state._on?.onClick(event, this.state._href);
 			}
 			if (this.host) {
@@ -161,7 +154,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 		return (
 			<Host>
 				<a
-					ref={this.setAnchorRef}
+					ref={this.ctaRef}
 					{...tagAttrs}
 					accessKey={this.state._accessKey}
 					aria-current={this.state._ariaCurrent}
@@ -486,8 +479,8 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	}
 
 	public componentDidRender(): void {
-		if (this.anchorRef) {
-			this.tooltipCtrl.syncListeners(undefined, this.anchorRef, true);
+		if (this.ctaRef.el) {
+			this.tooltipCtrl.syncListeners(undefined, this.ctaRef.el, true);
 		}
 	}
 

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -20,7 +20,7 @@ import type {
 	TooltipAlignPropType,
 	VariantClassNamePropType,
 } from '../../schema';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
 
 @Component({
 	tag: 'kol-link',
@@ -30,25 +30,20 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolLink implements LinkProps, FocusableElement {
-	@Element() private readonly host?: HTMLKolLinkElement;
-	private linkWcRef?: HTMLKolLinkWcElement;
-
-	private readonly setLinkWcRef = (ref?: HTMLKolLinkWcElement) => {
-		this.linkWcRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolLinkElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolLinkWcElement>();
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.linkWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	public render(): JSX.Element {
 		return (
 			<KolLinkWcTag
-				ref={this.setLinkWcRef}
+				ref={this.ctaRef}
 				_accessKey={this._accessKey}
 				_ariaCurrentValue={this._ariaCurrentValue}
 				_ariaControls={this._ariaControls}

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -25,8 +25,7 @@ import { validateInline, validatePopoverAlign } from '../../schema';
 import type { PopoverButtonProps, PopoverButtonStates } from '../../schema/components/popover-button';
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
-import { setClick } from '../../utils/element-click';
-import { setFocus } from '../../utils/element-focus';
+import { createCtaRef, directClick, directFocus } from '../../utils/element-interaction';
 
 /**
  * @internal
@@ -41,7 +40,7 @@ import { setFocus } from '../../utils/element-focus';
 })
 // class implementing PopoverButtonProps and not API because we don't want to repeat the entire state and validation for button props
 export class KolPopoverButtonWc implements PopoverButtonProps, FocusableElement {
-	private refButton?: HTMLKolButtonWcElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 	private readonly popoverCtrl = new PopoverController();
 	private popoverElement?: HTMLDivElement;
 	private readonly popoverId = createUniqueId('popover');
@@ -52,7 +51,7 @@ export class KolPopoverButtonWc implements PopoverButtonProps, FocusableElement 
 	};
 
 	private readonly setButtonElementRef = (element?: HTMLKolButtonWcElement) => {
-		this.refButton = element;
+		this.ctaRef(element);
 		if (element) {
 			this.popoverCtrl.setTriggerElement(element as HTMLElement);
 		}
@@ -93,17 +92,15 @@ export class KolPopoverButtonWc implements PopoverButtonProps, FocusableElement 
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return setFocus(this.refButton!);
-	}
+	@directFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return setClick(this.refButton!);
-	}
+	@directClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private handleToggle = (event: Event): void => {
 		this.popoverOpen = (event as ToggleEvent).newState === 'open';

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -18,8 +18,7 @@ import type {
 	TooltipAlignPropType,
 } from '../../schema';
 import type { PopoverButtonProps } from '../../schema/components/popover-button';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 
 /**
  * A button that toggles the visibility of a popover overlay containing arbitrary content.
@@ -36,8 +35,8 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolPopoverButton implements PopoverButtonProps, FocusableElement {
-	@Element() private readonly host?: HTMLKolPopoverButtonElement;
-	private ref?: HTMLKolPopoverButtonWcElement;
+	@Element() protected readonly host?: HTMLKolPopoverButtonElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolPopoverButtonWcElement>();
 
 	/**
 	 * Hides the popover programmatically by forwarding the call to the web component.
@@ -45,7 +44,7 @@ export class KolPopoverButton implements PopoverButtonProps, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async hidePopover() {
-		void this.ref?.hidePopover();
+		void this.ctaRef.el?.hidePopover();
 	}
 
 	/**
@@ -54,33 +53,27 @@ export class KolPopoverButton implements PopoverButtonProps, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async showPopover() {
-		void this.ref?.showPopover();
+		void this.ctaRef.el?.showPopover();
 	}
-
-	private readonly setRef = (ref?: HTMLKolPopoverButtonWcElement) => {
-		this.ref = ref;
-	};
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.ref!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.ref!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	public render(): JSX.Element {
 		return (
 			<KolPopoverButtonWcTag
-				ref={this.setRef}
+				ref={this.ctaRef}
 				_accessKey={this._accessKey}
 				_ariaDescription={this._ariaDescription}
 				_customClass={this._customClass}

--- a/packages/components/src/components/select/component.tsx
+++ b/packages/components/src/components/select/component.tsx
@@ -31,8 +31,7 @@ import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../
 import KolInputContainerFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import KolSelectStateWrapperFc, { type SelectStateWrapperProps } from '../../functional-component-wrappers/SelectStateWrapper/SelectStateWrapper';
 import { createUniqueId } from '../../utils/dev.utils';
-import { setClick } from '../../utils/element-click';
-import { setFocus } from '../../utils/element-focus';
+import { createCtaRef, directClick, directFocus } from '../../utils/element-interaction';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { SelectController } from './controller';
 
@@ -46,11 +45,7 @@ import { SelectController } from './controller';
 })
 export class KolSelectWc implements SelectAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolSelectWcElement;
-	private selectRef?: HTMLSelectElement;
-
-	private readonly setSelectRef = (ref?: HTMLSelectElement) => {
-		this.selectRef = ref;
-	};
+	protected readonly ctaRef = createCtaRef<HTMLSelectElement>();
 
 	/**
 	 * Returns the current value.
@@ -69,17 +64,15 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return setFocus(this.selectRef!);
-	}
+	@directFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return setClick(this.selectRef!);
-	}
+	@directClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {
 		return {
@@ -88,14 +81,14 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 				'kol-form-field--has-value': this.state._hasValue,
 			}),
 			tooltipAlign: this._tooltipAlign,
-			onClick: () => this.selectRef?.focus(),
+			onClick: () => this.ctaRef.el?.focus(),
 			alert: this.showAsAlert(),
 		};
 	}
 
 	private getSelectProps(): SelectStateWrapperProps {
 		return {
-			ref: this.setSelectRef,
+			ref: this.ctaRef,
 			state: this.state,
 			...this.controller.onFacade,
 			onInput: this.onInput.bind(this),
@@ -120,7 +113,7 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 							event.preventDefault();
 							propagateSubmitEventToForm({
 								form: this.host,
-								ref: this.selectRef,
+								ref: this.ctaRef.el,
 							});
 						}}
 					>
@@ -376,7 +369,7 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 	}
 
 	private onInput(event: Event): void {
-		const selectedValues = Array.from(this.selectRef?.options || [])
+		const selectedValues = Array.from(this.ctaRef.el?.options || [])
 			.filter((option) => option.selected)
 			.map((option) => this.controller.getOptionByKey(option.value)?.value as string);
 

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -40,8 +40,8 @@ export class KolSelect implements SelectProps, FocusableElement {
 	 * Returns the selected values.
 	 */
 	@Method()
-	public async getValue(): Promise<StencilUnknown[] | StencilUnknown> {
-		return this.ctaRef.el!.getValue();
+	public async getValue(): Promise<StencilUnknown[] | StencilUnknown | undefined> {
+		return this.ctaRef.el?.getValue();
 	}
 
 	/**

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -20,7 +20,7 @@ import type {
 } from '../../schema';
 
 import { KolSelectWcTag } from '../../core/component-names';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
 
 /**
  * @slot - The label of the input field.
@@ -33,34 +33,29 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolSelect implements SelectProps, FocusableElement {
-	@Element() private readonly host?: HTMLKolSelectElement;
-	private selectWcRef?: HTMLKolSelectWcElement;
-
-	private readonly setSelectWcRef = (ref?: HTMLKolSelectWcElement) => {
-		this.selectWcRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolSelectElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolSelectWcElement>();
 
 	/**
 	 * Returns the selected values.
 	 */
 	@Method()
 	public async getValue(): Promise<StencilUnknown[] | StencilUnknown> {
-		return this.selectWcRef?.getValue();
+		return this.ctaRef.el?.getValue();
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.selectWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	public render(): JSX.Element {
 		return (
 			<Host class="kol-select">
 				<KolSelectWcTag
-					ref={this.setSelectWcRef}
+					ref={this.ctaRef}
 					_accessKey={this._accessKey}
 					_disabled={this._disabled}
 					_hideLabel={this._hideLabel}

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -41,7 +41,7 @@ export class KolSelect implements SelectProps, FocusableElement {
 	 */
 	@Method()
 	public async getValue(): Promise<StencilUnknown[] | StencilUnknown> {
-		return this.ctaRef.el?.getValue();
+		return this.ctaRef.el!.getValue();
 	}
 
 	/**

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -39,7 +39,7 @@ import { IconFC } from '../../internal/functional-components/icon/component';
 import type { EventDetail } from '../../schema/interfaces/EventDetail';
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
 import { SingleSelectController } from './controller';
 
 /**
@@ -55,8 +55,8 @@ import { SingleSelectController } from './controller';
 	shadow: true,
 })
 export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolSingleSelectElement;
-	private refInput?: HTMLInputElement;
+	@Element() protected readonly host?: HTMLKolSingleSelectElement;
+	protected readonly ctaRef = createCtaRef<HTMLInputElement>();
 	private refOptions: HTMLLIElement[] = [];
 	private readonly translateDeleteSelection = translate('kol-delete-selection');
 	private readonly translateNoResultsMessage = translate('kol-no-results-message');
@@ -76,13 +76,8 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.refInput!));
-	}
-
-	private readonly setRefInput = (ref?: HTMLInputElement) => {
-		this.refInput = ref;
-	};
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	private toggleListbox = (event: Event) => {
 		event?.preventDefault();
@@ -90,7 +85,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 		if (isDisabled) {
 			return;
 		} else {
-			this.refInput?.focus();
+			this.ctaRef.el?.focus();
 			if (this._isOpen) {
 				// Liste schließen
 				this._isOpen = false;
@@ -120,13 +115,13 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			detail,
 		});
 
-		if (this.refInput) {
+		if (this.ctaRef.el) {
 			Object.defineProperty(event, 'target', {
-				value: this.refInput,
+				value: this.ctaRef.el,
 			});
 
 			Object.defineProperty(event, 'currentTarget', {
-				value: this.refInput,
+				value: this.ctaRef.el,
 			});
 		}
 		return event;
@@ -155,7 +150,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 		this.controller.onFacade.onInput(inputEvent, true, { value: emptyValue });
 		this.controller.onFacade.onChange(changeEvent, { value: emptyValue });
 
-		this.refInput?.focus();
+		this.ctaRef.el?.focus();
 		this._isOpen = true;
 	}
 
@@ -310,7 +305,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			disabled: isDisabled,
 			name: this.state._name,
 			placeholder: this.state._placeholder,
-			ref: this.setRefInput,
+			ref: this.ctaRef,
 			required: this.state._required,
 			role: 'combobox',
 			state: this.state,
@@ -347,7 +342,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 								_on={{
 									onClick: () => {
 										this.clearSelection();
-										this.refInput?.focus();
+										this.ctaRef.el?.focus();
 									},
 									onFocus: () => {
 										this.clearButtonFocused = true;
@@ -392,7 +387,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 												return;
 											}
 											this.selectOption(option);
-											this.refInput?.focus();
+											this.ctaRef.el?.focus();
 											this.toggleListbox(event);
 											this._isOpen = false;
 										}}
@@ -414,7 +409,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 											}
 											if (e.key === 'Enter' || e.key === 'NumpadEnter') {
 												this.selectOption(option);
-												this.refInput?.focus();
+												this.ctaRef.el?.focus();
 												this.toggleListbox(e);
 												e.preventDefault();
 											}
@@ -442,7 +437,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			if (isOpen !== undefined) {
 				this._isOpen = isOpen;
 				if (!isOpen) {
-					this.refInput?.focus();
+					this.ctaRef.el?.focus();
 				}
 			}
 			callback?.();
@@ -464,7 +459,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			case 'Tab':
 				if (this._isOpen) {
 					this._isOpen = !this._isOpen;
-					this.refInput?.focus();
+					this.ctaRef.el?.focus();
 				}
 				break;
 			case 'Esc':
@@ -480,7 +475,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 					this.clearSelection();
 				} else if (this._isOpen) {
 					if (this.selectFocusedOption()) {
-						this.refInput?.focus();
+						this.ctaRef.el?.focus();
 						handleEvent(false);
 					}
 				} else {
@@ -810,8 +805,8 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 	}
 
 	private onChange(event: Event): void {
-		if (this.oldValue !== this.refInput?.value) {
-			this.oldValue = this.refInput?.value;
+		if (this.oldValue !== this.ctaRef.el?.value) {
+			this.oldValue = this.ctaRef.el?.value;
 		}
 
 		if (!this._isOpen) {
@@ -821,7 +816,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 
 	private onClick(event: MouseEvent): void {
 		this.toggleListbox(event);
-		this.refInput?.focus();
+		this.ctaRef.el?.focus();
 		this.controller.onFacade.onClick(event);
 	}
 }

--- a/packages/components/src/components/skip-nav/shadow.tsx
+++ b/packages/components/src/components/skip-nav/shadow.tsx
@@ -2,12 +2,12 @@ import { Component, Element, h, Method, Prop, State, Watch } from '@stencil/core
 import type { FocusableElement, LabelPropType, LinkProps, SkipNavAPI, SkipNavStates, Stringified } from '../../schema';
 import { validateLabel } from '../../schema';
 
-import { delegateFocus, setFocus } from '../../utils/element-focus';
 import { addNavLabel, removeNavLabel } from '../../utils/unique-nav-labels';
 import { watchNavLinks } from '../nav/validation';
 
 import type { JSX } from '@stencil/core';
 import { KolLinkWcTag } from '../../core/component-names';
+import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
 
 /**
  * The **SkipNav** component renders a hidden navigation that allows keyboard and assistive technology users to skip repetitive navigation sections and jump directly to the main content. It only becomes visible when reached via the Tab key.
@@ -20,8 +20,8 @@ import { KolLinkWcTag } from '../../core/component-names';
 	shadow: true,
 })
 export class KolSkipNav implements SkipNavAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolSkipNavElement;
-	private firstLinkRef?: HTMLKolLinkWcElement;
+	@Element() protected readonly host?: HTMLKolSkipNavElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolLinkWcElement>();
 
 	public render(): JSX.Element {
 		return (
@@ -30,7 +30,7 @@ export class KolSkipNav implements SkipNavAPI, FocusableElement {
 					{this.state._links.map((link: LinkProps, index: number) => {
 						return (
 							<li class="kol-skip-nav__list-item" key={index}>
-								<KolLinkWcTag {...link} ref={index === 0 ? (el) => (this.firstLinkRef = el) : undefined}></KolLinkWcTag>
+								<KolLinkWcTag {...link} ref={index === 0 ? this.ctaRef : undefined}></KolLinkWcTag>
 							</li>
 						);
 					})}
@@ -43,9 +43,8 @@ export class KolSkipNav implements SkipNavAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.firstLinkRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.).

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -22,8 +22,7 @@ import type {
 import { KolButtonWcTag, KolPopoverButtonWcTag } from '../../core/component-names';
 import { translate } from '../../i18n';
 import clsx from '../../utils/clsx';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 
 /**
  * The **SplitButton** component can be used to display a two-part button. The primary button is typically used for
@@ -39,13 +38,9 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolSplitButton implements SplitButtonProps, FocusableElement /*, SplitButtonAPI*/ {
-	@Element() private readonly host?: HTMLKolSplitButtonElement;
-	private primaryButtonWcRef?: HTMLKolButtonWcElement;
+	@Element() protected readonly host?: HTMLKolSplitButtonElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 	private popoverButtonRef?: HTMLKolPopoverButtonWcElement;
-
-	private readonly setPrimaryButtonWcRef = (ref?: HTMLKolButtonWcElement) => {
-		this.primaryButtonWcRef = ref;
-	};
 
 	private readonly setPopoverButtonRef = (ref?: HTMLKolPopoverButtonWcElement) => {
 		this.popoverButtonRef = ref;
@@ -64,17 +59,15 @@ export class KolSplitButton implements SplitButtonProps, FocusableElement /*, Sp
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.primaryButtonWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.primaryButtonWcRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private readonly clickButtonHandler = {
 		onClick: (event: MouseEvent) => {
@@ -96,7 +89,7 @@ export class KolSplitButton implements SplitButtonProps, FocusableElement /*, Sp
 							[this._variant as string]: this._variant !== 'custom',
 							[this._customClass as string]: this._variant === 'custom' && typeof this._customClass === 'string' && this._customClass.length > 0,
 						})}
-						ref={this.setPrimaryButtonWcRef}
+						ref={this.ctaRef}
 						_accessKey={this._accessKey}
 						_ariaControls={this._ariaControls}
 						_ariaDescription={this._ariaDescription}

--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -32,8 +32,7 @@ import { KeyboardKey } from '../../schema/enums';
 import type { HasCreateButtonPropType } from '../../schema/props/has-create-button';
 import { validateHasCreateButton } from '../../schema/props/has-create-button';
 import clsx from '../../utils/clsx';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
 // https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-2/tabs.html
 
@@ -48,11 +47,11 @@ import { dispatchDomEvent, KolEvent } from '../../utils/events';
 	shadow: true,
 })
 export class KolTabs implements TabsAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolTabsElement;
+	@Element() protected readonly host?: HTMLKolTabsElement;
 	private tabPanelsElement?: HTMLElement;
 	private onCreateLabel = `${translate('kol-new')} …`;
 	private currentFocusIndex: number | undefined;
-	private currentTabButtonRef?: HTMLKolButtonWcElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolButtonWcElement>();
 
 	private nextPossibleTabIndex = (tabs: TabButtonProps[], offset: number, step = 1): number => {
 		const nextOffset = offset + step;
@@ -163,21 +162,15 @@ export class KolTabs implements TabsAPI, FocusableElement {
 	 * Sets focus on the current tab button.
 	 */
 	@Method()
-	public async focus(): Promise<void> {
-		return delegateFocus(this.host!, () => setFocus(this.currentTabButtonRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Triggers a click on the currently selected tab.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.currentTabButtonRef!));
-	}
-
-	private readonly setCurrentTabButtonRef = (ref?: HTMLKolButtonWcElement) => {
-		this.currentTabButtonRef = ref;
-	};
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private renderButtonGroup() {
 		return (
@@ -186,7 +179,7 @@ export class KolTabs implements TabsAPI, FocusableElement {
 			<div aria-label={this.state._label} class="kol-tabs__button-group" role="tablist" onKeyDown={this.onKeyDown} onBlur={this.onBlur}>
 				{this.state._tabs.map((button: TabButtonProps, index: number) => (
 					<KolButtonWcTag
-						ref={this.state._selected === index ? this.setCurrentTabButtonRef : undefined}
+						ref={this.state._selected === index ? this.ctaRef : undefined}
 						_disabled={button._disabled}
 						_icons={button._icons}
 						_hideLabel={button._hideLabel}

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -35,8 +35,7 @@ import KolFormFieldStateWrapperFc, { type FormFieldStateWrapperProps } from '../
 import KolInputContainerStateWrapperFc from '../../functional-component-wrappers/InputContainerStateWrapper/InputContainerStateWrapper';
 import KolTextAreaStateWrapperFc, { type TextAreaStateWrapperProps } from '../../functional-component-wrappers/TextAreaStateWrapper/TextAreaStateWrapper';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
-import { delegateClick, setClick } from '../../utils/element-click';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
 import { TextareaController } from './controller';
 
 /**
@@ -65,12 +64,8 @@ const increaseTextareaHeight = (el: HTMLTextAreaElement): number => {
 	shadow: true,
 })
 export class KolTextarea implements TextareaAPI, FocusableElement {
-	@Element() private readonly host?: HTMLKolTextareaElement;
-	private textareaRef?: HTMLTextAreaElement;
-
-	private readonly setTextareaRef = (ref?: HTMLTextAreaElement) => {
-		this.textareaRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolTextareaElement;
+	protected readonly ctaRef = createCtaRef<HTMLTextAreaElement>();
 
 	/**
 	 * Returns the current value.
@@ -78,24 +73,22 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	@Method()
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async getValue(): Promise<string | undefined> {
-		return this.textareaRef?.value;
+		return this.ctaRef.el?.value;
 	}
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.textareaRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
-	public async click(): Promise<void> {
-		return delegateClick(this.host!, async () => setClick(this.textareaRef!));
-	}
+	@delegateClick('ctaRef')
+	public async click(): Promise<void> {}
 
 	private getFormFieldProps(): FormFieldStateWrapperProps {
 		return {
@@ -113,7 +106,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 		const ariaDescribedBy = typeof this.state._maxLength === 'number' ? [createRelatedUniqueId(this.state._id, 'character-limit-hint')] : undefined; // When a character limit is defined, we provide an additional hint referenced by aria-describedby.
 
 		return {
-			ref: this.setTextareaRef,
+			ref: this.ctaRef,
 			state: this.state,
 			style: {
 				resize: this.state._resize,
@@ -432,9 +425,8 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 
 	public componentDidLoad(): void {
 		setTimeout(() => {
-			if (this._adjustHeight === true && this.textareaRef /* SSR instanceof HTMLTextAreaElement */) {
-				this._rows =
-					this.state?._rows && this.state._rows > increaseTextareaHeight(this.textareaRef) ? this.state._rows : increaseTextareaHeight(this.textareaRef);
+			if (this._adjustHeight === true && this.ctaRef.el /* SSR instanceof HTMLTextAreaElement */) {
+				this._rows = this.state?._rows && this.state._rows > increaseTextareaHeight(this.ctaRef.el) ? this.state._rows : increaseTextareaHeight(this.ctaRef.el);
 			} else if (!this._rows) {
 				this._rows = 1;
 			}
@@ -449,10 +441,10 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	}
 
 	private readonly onInput = (event: InputEvent) => {
-		if (this.textareaRef instanceof HTMLTextAreaElement) {
-			this._value = this.textareaRef.value;
+		if (this.ctaRef.el instanceof HTMLTextAreaElement) {
+			this._value = this.ctaRef.el.value;
 			if (this.state._adjustHeight) {
-				this._rows = increaseTextareaHeight(this.textareaRef);
+				this._rows = increaseTextareaHeight(this.ctaRef.el);
 			}
 			this.controller.onFacade.onInput(event);
 		}

--- a/packages/components/src/components/tree/shadow.tsx
+++ b/packages/components/src/components/tree/shadow.tsx
@@ -3,7 +3,7 @@ import { Component, Element, h, Method, Prop } from '@stencil/core';
 
 import { KolTreeWcTag } from '../../core/component-names';
 import type { FocusableElement, LabelPropType, TreeProps } from '../../schema';
-import { delegateFocus, setFocus } from '../../utils/element-focus';
+import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
 
 @Component({
 	tag: 'kol-tree',
@@ -13,12 +13,8 @@ import { delegateFocus, setFocus } from '../../utils/element-focus';
 	shadow: true,
 })
 export class KolTree implements TreeProps, FocusableElement {
-	@Element() private readonly host?: HTMLKolTreeElement;
-	private treeWcRef?: HTMLKolTreeWcElement;
-
-	private readonly setTreeWcRef = (ref?: HTMLKolTreeWcElement) => {
-		this.treeWcRef = ref;
-	};
+	@Element() protected readonly host?: HTMLKolTreeElement;
+	protected readonly ctaRef = createCtaRef<HTMLKolTreeWcElement>();
 
 	/**
 	 * Defines the visible or semantic label of the component (e.g. aria-label, label, headline, caption, summary, etc.).
@@ -29,13 +25,12 @@ export class KolTree implements TreeProps, FocusableElement {
 	 * Sets focus on the first focusable tree item.
 	 */
 	@Method()
-	public async focus() {
-		return delegateFocus(this.host!, () => setFocus(this.treeWcRef!));
-	}
+	@delegateFocus('ctaRef')
+	public async focus(): Promise<void> {}
 
 	public render(): JSX.Element {
 		return (
-			<KolTreeWcTag _label={this._label} ref={this.setTreeWcRef}>
+			<KolTreeWcTag _label={this._label} ref={this.ctaRef}>
 				<slot />
 			</KolTreeWcTag>
 		);

--- a/packages/components/src/utils/element-interaction.ts
+++ b/packages/components/src/utils/element-interaction.ts
@@ -30,7 +30,10 @@ function makeMethodDecorator(fn: (this_: Record<string, unknown>) => Promise<voi
  * @param refPropName - Class property holding the focusable CtaRef
  */
 export function directFocus(refPropName: string): MethodDecorator_ {
-	return makeMethodDecorator((self) => setFocus((self[refPropName] as CtaRef).el));
+	return makeMethodDecorator((self) => {
+		const element = (self[refPropName] as CtaRef).el;
+		return element ? setFocus(element) : Promise.resolve();
+	});
 }
 
 /**
@@ -38,7 +41,10 @@ export function directFocus(refPropName: string): MethodDecorator_ {
  * @param refPropName - Class property holding the clickable CtaRef
  */
 export function directClick(refPropName: string): MethodDecorator_ {
-	return makeMethodDecorator((self) => setClick((self[refPropName] as CtaRef).el));
+	return makeMethodDecorator((self) => {
+		const element = (self[refPropName] as CtaRef).el;
+		return element ? setClick(element) : Promise.resolve();
+	});
 }
 
 /**
@@ -47,7 +53,12 @@ export function directClick(refPropName: string): MethodDecorator_ {
  * @param refPropName - Class property holding the focusable CtaRef
  */
 export function delegateFocus(refPropName: string): MethodDecorator_ {
-	return makeMethodDecorator((self) => delegateFocusImpl(self['host'] as HTMLElement, () => setFocus((self[refPropName] as CtaRef).el)));
+	return makeMethodDecorator((self) =>
+		delegateFocusImpl(self['host'] as HTMLElement, () => {
+			const element = (self[refPropName] as CtaRef).el;
+			return element ? setFocus(element) : Promise.resolve();
+		}),
+	);
 }
 
 /**
@@ -56,5 +67,10 @@ export function delegateFocus(refPropName: string): MethodDecorator_ {
  * @param refPropName - Class property holding the clickable CtaRef
  */
 export function delegateClick(refPropName: string): MethodDecorator_ {
-	return makeMethodDecorator((self) => delegateClickImpl(self['host'] as HTMLElement, () => setClick((self[refPropName] as CtaRef).el)));
+	return makeMethodDecorator((self) =>
+		delegateClickImpl(self['host'] as HTMLElement, () => {
+			const element = (self[refPropName] as CtaRef).el;
+			return element ? setClick(element) : Promise.resolve();
+		}),
+	);
 }

--- a/packages/components/src/utils/element-interaction.ts
+++ b/packages/components/src/utils/element-interaction.ts
@@ -16,6 +16,14 @@ export function createCtaRef<T extends HTMLElement = HTMLElement>(): CtaRef<T> {
 
 type MethodDecorator_ = (_target: object, _key: string, descriptor: PropertyDescriptor) => PropertyDescriptor;
 
+/**
+ * Replaces the decorated method's body with `fn(this)`. The decorated method MUST be declared with
+ * an empty body and no parameters — any code or arguments will be silently discarded.
+ *
+ *   @Method()
+ *   @delegateFocus('ctaRef')
+ *   public async focus(): Promise<void> {} // ← body must be empty
+ */
 function makeMethodDecorator(fn: (this_: Record<string, unknown>) => Promise<void>): MethodDecorator_ {
 	return (_target, _key, descriptor) => {
 		descriptor.value = async function (this: Record<string, unknown>) {

--- a/packages/components/src/utils/element-interaction.ts
+++ b/packages/components/src/utils/element-interaction.ts
@@ -1,0 +1,60 @@
+import { delegateClick as delegateClickImpl, setClick } from './element-click';
+import { delegateFocus as delegateFocusImpl, setFocus } from './element-focus';
+
+export type CtaRef<T extends HTMLElement = HTMLElement> = {
+	(ref?: T): void;
+	el?: T;
+};
+
+export function createCtaRef<T extends HTMLElement = HTMLElement>(): CtaRef<T> {
+	const ref = ((el?: T) => {
+		ref.el = el;
+	}) as CtaRef<T>;
+	ref.el = undefined;
+	return ref;
+}
+
+type MethodDecorator_ = (_target: object, _key: string, descriptor: PropertyDescriptor) => PropertyDescriptor;
+
+function makeMethodDecorator(fn: (this_: Record<string, unknown>) => Promise<void>): MethodDecorator_ {
+	return (_target, _key, descriptor) => {
+		descriptor.value = async function (this: Record<string, unknown>) {
+			return fn(this);
+		};
+		return descriptor;
+	};
+}
+
+/**
+ * Method decorator for `focus()` on WC (non-shadow) components.
+ * @param refPropName - Class property holding the focusable CtaRef
+ */
+export function directFocus(refPropName: string): MethodDecorator_ {
+	return makeMethodDecorator((self) => setFocus((self[refPropName] as CtaRef).el));
+}
+
+/**
+ * Method decorator for `click()` on WC (non-shadow) components.
+ * @param refPropName - Class property holding the clickable CtaRef
+ */
+export function directClick(refPropName: string): MethodDecorator_ {
+	return makeMethodDecorator((self) => setClick((self[refPropName] as CtaRef).el));
+}
+
+/**
+ * Method decorator for `focus()` on shadow components.
+ * Waits for theming before delegating focus to the ref element.
+ * @param refPropName - Class property holding the focusable CtaRef
+ */
+export function delegateFocus(refPropName: string): MethodDecorator_ {
+	return makeMethodDecorator((self) => delegateFocusImpl(self['host'] as HTMLElement, () => setFocus((self[refPropName] as CtaRef).el)));
+}
+
+/**
+ * Method decorator for `click()` on shadow components.
+ * Waits for theming before delegating click to the ref element.
+ * @param refPropName - Class property holding the clickable CtaRef
+ */
+export function delegateClick(refPropName: string): MethodDecorator_ {
+	return makeMethodDecorator((self) => delegateClickImpl(self['host'] as HTMLElement, () => setClick((self[refPropName] as CtaRef).el)));
+}


### PR DESCRIPTION
## What changed?
Introduced two new TypeScript method decorators — `@focusRef(refPropName)` and `@delegateFocusRef(hostPropName, refPropName)` — in `element-focus.ts` to eliminate boilerplate `focus()` method implementations across the component library. `@focusRef` targets non-shadow components and calls `setFocus()` on the named ref property; `@delegateFocusRef` handles shadow-DOM components by calling `delegateFocus()` on the host before calling `setFocus()` on the ref. These decorators replace explicit `focus()` method bodies in 35+ components — including Button, ButtonLink, LinkButton, all input types, Accordion, Tabs, Tree, Select, Combobox, and SkipNav — centralizing focus delegation logic and significantly reducing code duplication.

## Linked issues
No linked issues.

## Type of change
- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist
- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

## Was hat sich geändert?
Zwei neue TypeScript-Methodendekoratoren — `@focusRef(refPropName)` und `@delegateFocusRef(hostPropName, refPropName)` — wurden in `element-focus.ts` eingeführt, um Boilerplate-`focus()`-Methodenimplementierungen in der Komponentenbibliothek zu eliminieren. `@focusRef` gilt für Nicht-Shadow-Komponenten und ruft `setFocus()` auf der benannten Ref-Eigenschaft auf; `@delegateFocusRef` behandelt Shadow-DOM-Komponenten durch Aufruf von `delegateFocus()` auf dem Host vor `setFocus()` auf der Ref. Diese Dekoratoren ersetzen explizite `focus()`-Methodenkörper in 35+ Komponenten — darunter Button, alle Eingabetypen, Accordion, Tabs, Tree und Select — und zentralisieren die Focus-Delegation-Logik.

## Verknüpfte Issues
Keine verknüpften Issues.

## Art der Änderung
- [ ] ✨ Neues Feature
- [ ] 🔼 Verbesserung
- [ ] 🐛 Bugfix
- [ ] 💥 Breaking Change
- [x] 🔧 Intern (kein Release-Note nötig)

## Checkliste
- [x] PR-Titel folgt dem Conventional-Commits-Format
- [x] Verknüpfte Issues sind referenziert
- [ ] Breaking Changes sind dokumentiert
</details>