### PR TITLE
ci: run dependency updater unit tests recursively

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -93,24 +93,24 @@ jobs:
         run: pnpm audit --audit-level high --production
       - name: Run build
         if: steps.verify-changed-files.outputs.changed == 'true'
-        run: pnpm build
+        run: pnpm -r build
       - name: Run format
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: pnpm format
       - name: Run lint
         if: steps.verify-changed-files.outputs.changed == 'true'
-        run: pnpm lint
+        run: pnpm -r lint
       - name: Run unit tests
         if: steps.verify-changed-files.outputs.changed == 'true'
-        run: pnpm test:unit
+        run: pnpm -r test:unit
       - name: Run e2e tests
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |
           npx playwright install chromium
-          pnpm test:e2e
+          pnpm -r test:e2e
       - name: Run unused
         if: steps.verify-changed-files.outputs.changed == 'true'
-        run: pnpm unused
+        run: pnpm -r unused
 
       - name: Update dependencies (major)
         run: pnpm ncu:major

--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -102,7 +102,7 @@ jobs:
         run: pnpm lint
       - name: Run unit tests
         if: steps.verify-changed-files.outputs.changed == 'true'
-        run: pnpm test:unit
+        run: pnpm -r test:unit
       - name: Run e2e tests
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |

--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -102,7 +102,13 @@ jobs:
         run: pnpm lint
       - name: Run unit tests
         if: steps.verify-changed-files.outputs.changed == 'true'
-        run: pnpm -r test:unit
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.['test:unit'] ? 0 : 1)"; then
+            pnpm test:unit
+          else
+            echo "No root test:unit script found; running workspace package unit tests recursively."
+            pnpm -r test:unit
+          fi
       - name: Run e2e tests
         if: steps.verify-changed-files.outputs.changed == 'true'
         run: |


### PR DESCRIPTION
## What changed?

In `.github/workflows/auto-dependency-updater.yml`, the unit test CI step was changed from `pnpm test:unit` to `pnpm -r test:unit` so that unit tests are run recursively across all workspace packages. This fixes failures on older `release/*` branches that do not have a root-level `test:unit` script. The diff also shows the same recursive update applied to `build`, `lint`, `test:e2e`, and `unused` steps (a superset of the original fix).

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `.github/workflows/auto-dependency-updater.yml` wurde der Unit-Test-Schritt von `pnpm test:unit` auf `pnpm -r test:unit` geändert, damit Tests rekursiv über alle Workspace-Pakete laufen. Dies behebt Fehler auf älteren `release/*`-Branches ohne Root-Level-`test:unit`-Skript. Der Diff umfasst auch die gleiche rekursive Aktualisierung für `build`, `lint`, `test:e2e` und `unused`.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/auto-dependency-updater.yml` — alle CI-Schritte auf `pnpm -r`-Aufrufe umgestellt

</details>