### PR TITLE
fix: pin adapter peer deps to major ranges

### DIFF
--- a/packages/adapters/angular/v19/package.json
+++ b/packages/adapters/angular/v19/package.json
@@ -76,7 +76,7 @@
 		"zone.js": "0.15.1"
 	},
 	"peerDependencies": {
-		"@angular/core": "^19.2.21",
+		"@angular/core": "19.x",
 		"@public-ui/components": "workspace:*"
 	},
 	"files": [

--- a/packages/adapters/angular/v20/package.json
+++ b/packages/adapters/angular/v20/package.json
@@ -76,7 +76,7 @@
 		"zone.js": "0.15.1"
 	},
 	"peerDependencies": {
-		"@angular/core": "^20.3.20",
+		"@angular/core": "20.x",
 		"@public-ui/components": "workspace:*"
 	},
 	"files": [

--- a/packages/adapters/angular/v21/package.json
+++ b/packages/adapters/angular/v21/package.json
@@ -76,7 +76,7 @@
 		"zone.js": "0.16.2"
 	},
 	"peerDependencies": {
-		"@angular/core": "^21.2.12",
+		"@angular/core": "21.x",
 		"@public-ui/components": "workspace:*"
 	},
 	"files": [

--- a/packages/adapters/preact/package.json
+++ b/packages/adapters/preact/package.json
@@ -56,7 +56,7 @@
 	},
 	"peerDependencies": {
 		"@public-ui/react": "workspace:*",
-		"preact": ">=10.29.1"
+		"preact": "10.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/packages/adapters/react-hook-form-adapter/package.json
+++ b/packages/adapters/react-hook-form-adapter/package.json
@@ -72,8 +72,8 @@
 	"peerDependencies": {
 		"@public-ui/components": "workspace:*",
 		"@public-ui/react-v19": "workspace:*",
-		"react": "^19",
-		"react-hook-form": "^7"
+		"react": "19.x",
+		"react-hook-form": "7.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/packages/adapters/react-standalone/package.json
+++ b/packages/adapters/react-standalone/package.json
@@ -56,8 +56,8 @@
 	},
 	"peerDependencies": {
 		"@public-ui/components": "workspace:*",
-		"react": ">=16.14.0",
-		"react-dom": ">=16.14.0"
+		"react": "16.x || 17.x || 18.x",
+		"react-dom": "16.x || 17.x || 18.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/packages/adapters/react-v19/package.json
+++ b/packages/adapters/react-v19/package.json
@@ -59,8 +59,8 @@
 	},
 	"peerDependencies": {
 		"@public-ui/components": "workspace:*",
-		"react": "^19.2.6",
-		"react-dom": "^19.2.6"
+		"react": "19.x",
+		"react-dom": "19.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/packages/adapters/react/package.json
+++ b/packages/adapters/react/package.json
@@ -59,8 +59,8 @@
 	},
 	"peerDependencies": {
 		"@public-ui/components": "workspace:*",
-		"react": ">=16.14.0 <19",
-		"react-dom": ">=16.14.0 <19"
+		"react": "16.x || 17.x || 18.x",
+		"react-dom": "16.x || 17.x || 18.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/packages/adapters/solid/package.json
+++ b/packages/adapters/solid/package.json
@@ -56,7 +56,7 @@
 	},
 	"peerDependencies": {
 		"@public-ui/components": "workspace:*",
-		"solid-js": ">=1.9.12"
+		"solid-js": "1.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/packages/adapters/svelte/package.json
+++ b/packages/adapters/svelte/package.json
@@ -57,7 +57,7 @@
 	},
 	"peerDependencies": {
 		"@public-ui/components": "workspace:*",
-		"svelte": "^5.55.5"
+		"svelte": "5.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/packages/adapters/vue/package.json
+++ b/packages/adapters/vue/package.json
@@ -57,7 +57,7 @@
 	},
 	"peerDependencies": {
 		"@public-ui/components": "workspace:*",
-		"vue": "^3.5.34"
+		"vue": "3.x"
 	},
 	"sideEffects": false,
 	"type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,7 +174,7 @@ importers:
         specifier: workspace:*
         version: link:../react
       preact:
-        specifier: '>=10.29.1'
+        specifier: 10.x
         version: 10.29.1
     devDependencies:
       '@public-ui/components':
@@ -274,11 +274,11 @@ importers:
         specifier: workspace:*
         version: link:../../components
       react:
-        specifier: '>=16.14.0'
-        version: 19.1.1
+        specifier: 16.x || 17.x || 18.x
+        version: 18.3.1
       react-dom:
-        specifier: '>=16.14.0'
-        version: 19.1.1(react@19.1.1)
+        specifier: 16.x || 17.x || 18.x
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@public-ui/react':
         specifier: workspace:*


### PR DESCRIPTION
## What changed?

`peerDependencies` across all framework adapter packages were updated from open/comparative ranges (e.g., `>=16.14.0`, `^19.2.21`) to major-only `x` ranges (e.g., `16.x || 17.x || 18.x`, `19.x`). This prevents `npm-check-updates` from rewriting peer dep ranges to specific patch versions during automated dependency updates. Affected adapters: Angular v19/v20/v21, Preact, React, React v19, React standalone, React hook form adapter, Solid, Svelte, Vue. The `pnpm-lock.yaml` importer entries were updated to match the new specifier strings.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`peerDependencies` in allen Framework-Adapter-Paketen wurden von offenen/komparativen Bereichen (z.B. `>=16.14.0`, `^19.2.21`) auf Major-Only-`x`-Bereiche (z.B. `16.x || 17.x || 18.x`, `19.x`) umgestellt. Dies verhindert, dass `npm-check-updates` Peer-Dep-Bereiche bei automatisierten Dependency-Updates auf spezifische Patch-Versionen überschreibt. Betroffen: Angular v19/v20/v21, Preact, React, React v19, React Standalone, React Hook Form Adapter, Solid, Svelte, Vue.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/adapters/angular/v{19,20,21}/package.json` — `@angular/core` peerDep auf `19.x`/`20.x`/`21.x`
- `packages/adapters/preact/package.json` — `preact` auf `10.x`
- `packages/adapters/react/package.json` — `react`/`react-dom` auf `16.x || 17.x || 18.x`
- `packages/adapters/react-v19/package.json` — `react`/`react-dom` auf `19.x`
- `packages/adapters/react-standalone/package.json` — `react`/`react-dom` auf `16.x || 17.x || 18.x`
- `packages/adapters/react-hook-form-adapter/package.json` — `react` auf `19.x`, `react-hook-form` auf `7.x`
- `packages/adapters/solid/package.json` — `solid-js` auf `1.x`
- `packages/adapters/svelte/package.json` — `svelte` auf `5.x`
- `packages/adapters/vue/package.json` — `vue` auf `3.x`
- `pnpm-lock.yaml` — Lockfile-Importers angepasst

</details>