### PR TITLE
feat(sample-react): preload sample app data and use singleton for variant lookups

### DIFF
--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
 import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
 
@@ -10,6 +10,7 @@ import { Sidebar } from './components/Sidebar';
 import { useSetCurrentLocation } from './hooks/useSetCurrentLocation';
 import { HideMenusContext } from './shares/HideMenusContext';
 import { ROUTES } from './shares/routes';
+import { sampleAppDataService } from './shares/sampleAppDataService';
 import { getTheme, getThemeName, setRegisteredThemes, setStorage, setTheme } from './shares/store';
 import { PUBLIC_THEMES, UNSTYLED_THEME } from './shares/theme';
 
@@ -35,6 +36,24 @@ export const App: FC<Props> = ({ customThemes }) => {
 		return allThemes;
 	}, [customThemes]);
 	const theme: string = searchParams.get('theme') ?? getTheme();
+	const [isSampleAppDataInitialized, setIsSampleAppDataInitialized] = useState(() => sampleAppDataService.isInitialized(themes));
+
+	useEffect(() => {
+		let isActive = true;
+		if (sampleAppDataService.isInitialized(themes)) {
+			setIsSampleAppDataInitialized(true);
+			return;
+		}
+		setIsSampleAppDataInitialized(false);
+		void sampleAppDataService.initialize(themes).then(() => {
+			if (isActive) {
+				setIsSampleAppDataInitialized(true);
+			}
+		});
+		return () => {
+			isActive = false;
+		};
+	}, [themes]);
 
 	const getRouteList = (routes: MyRoutes, offset = '/'): string[] => {
 		let list: string[] = [];
@@ -130,6 +149,16 @@ export const App: FC<Props> = ({ customThemes }) => {
 		setSearchParams({ theme: theme as string });
 		window.location.reload();
 	};
+
+	if (!isSampleAppDataInitialized) {
+		return (
+			<HideMenusContext.Provider value={hideMenus}>
+				<main className="flex flex-col items-stretch p-4" id="route-container">
+					<p>Loading data</p>
+				</main>
+			</HideMenusContext.Provider>
+		);
+	}
 
 	return (
 		<HideMenusContext.Provider value={hideMenus}>

--- a/packages/samples/react/src/components/icon/font.tsx
+++ b/packages/samples/react/src/components/icon/font.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 
 import { KolButton, KolIcon, KolInputText } from '@public-ui/react-v19';
 
@@ -7,25 +7,10 @@ import { fetchVariantData } from '../../shares/fetchVariantData';
 import { SampleDescription } from '../SampleDescription';
 
 export const IconFont: FC = () => {
-	const [iconVariants, setIconVariants] = useState<Array<string>>([]);
-	const [iconVariantsButton, setIconVariantsButton] = useState<Array<string>>([]);
-	const [iconVariantsInput, setIconVariantsInput] = useState<Array<string>>([]);
-
-	useEffect(() => {
-		const theme = document.body.dataset.theme;
-		if (!theme) {
-			return;
-		}
-		fetchVariantData(theme, 'iconVariants').then((response: string[]) => {
-			setIconVariants(response);
-		});
-		fetchVariantData(theme, 'iconVariantsButton').then((response: string[]) => {
-			setIconVariantsButton(response);
-		});
-		fetchVariantData(theme, 'iconVariantsInput').then((response: string[]) => {
-			setIconVariantsInput(response);
-		});
-	}, []);
+	const theme = document.body.dataset.theme;
+	const iconVariants = useMemo(() => (theme ? fetchVariantData(theme, 'iconVariants') : []), [theme]);
+	const iconVariantsButton = useMemo(() => (theme ? fetchVariantData(theme, 'iconVariantsButton') : []), [theme]);
+	const iconVariantsInput = useMemo(() => (theme ? fetchVariantData(theme, 'iconVariantsInput') : []), [theme]);
 
 	return (
 		<>

--- a/packages/samples/react/src/components/link/variant.tsx
+++ b/packages/samples/react/src/components/link/variant.tsx
@@ -1,59 +1,18 @@
 import type { FC } from 'react';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 
 import { KolLink } from '@public-ui/react-v19';
+import { fetchVariantData } from '../../shares/fetchVariantData';
 import { SampleDescription } from '../SampleDescription';
 
 export const LinkVariant: FC = () => {
-	const [data, setData] = useState<Array<string>>([]);
-	const [loading, setLoading] = useState<boolean>(true);
-
-	useEffect(() => {
-		const theme = document.body.dataset.theme;
-		if (!theme) {
-			setLoading(false);
-			return;
-		}
-		fetch('/assets/variants/inject-variants_' + theme + '.json')
-			.then((response) => {
-				if (response.status === 404) {
-					// No variants file for this theme is an expected state.
-					setData([]);
-					return undefined;
-				}
-				if (!response.ok) {
-					console.info('Error fetching variants: HTTP ' + response.status);
-					return undefined;
-				}
-				return response.json();
-			})
-			.then((json) => {
-				if (!json) {
-					setData([]);
-					return;
-				}
-				const linkVariants = (json as { linkVariants?: unknown }).linkVariants;
-				if (Array.isArray(linkVariants)) {
-					const variants = linkVariants.filter((item): item is string => typeof item === 'string');
-					setData(variants);
-				} else {
-					setData([]);
-				}
-			})
-			.catch((error) => {
-				console.info('No theme variant file found or file could not be parsed', error);
-				setData([]);
-			})
-			.finally(() => {
-				setLoading(false);
-			});
-	}, []);
+	const theme = document.body.dataset.theme;
+	const data = useMemo(() => (theme ? fetchVariantData(theme, 'linkVariants') : []), [theme]);
 
 	return (
 		<>
 			<SampleDescription>
 				<p>This sample shows the theme specific variants of KolLink.</p>
-				<p className={loading ? 'loading' : 'hidden'}>Loading Data</p>
 			</SampleDescription>
 
 			<div className="grid gap-4">

--- a/packages/samples/react/src/react.main.tsx
+++ b/packages/samples/react/src/react.main.tsx
@@ -8,6 +8,7 @@ import { defineCustomElements } from '@public-ui/components/loader';
 import { BWSt, DEFAULT, DesyV11, ECL_EC, ECL_EU, KERN_V2 } from '@public-ui/themes';
 
 import { App } from './App';
+import { sampleAppDataService } from './shares/sampleAppDataService';
 
 import type { Generic } from 'adopted-style-sheets';
 
@@ -44,6 +45,8 @@ const getThemes = async () => {
 };
 
 void (async () => {
+	const sampleAppDataInitialization = sampleAppDataService.initialize();
+
 	try {
 		await bootstrap(
 			await getThemes(),
@@ -128,6 +131,8 @@ void (async () => {
 	// 		append: true,
 	// 	},
 	// );
+
+	await sampleAppDataInitialization;
 
 	const htmlDivElement = document.querySelector('div#app');
 	if (htmlDivElement instanceof HTMLDivElement) {

--- a/packages/samples/react/src/shares/fetchVariantData.ts
+++ b/packages/samples/react/src/shares/fetchVariantData.ts
@@ -1,30 +1,10 @@
-export async function fetchVariantData(theme: string, variant: string): Promise<string[]> {
-	return fetch('/assets/variants/inject-variants_' + theme + '.json')
-		.then((response) => {
-			if (response.status === 404) {
-				// No variants file for this theme is an expected state.
-				return [];
-			}
-			if (!response.ok) {
-				console.info('Error fetching variants: HTTP ' + response.status);
-				return [];
-			}
-			return response.json();
-		})
-		.then((json) => {
-			if (!json) {
-				return [];
-			}
-			const data = (json as Record<string, unknown>)[variant];
-			if (Array.isArray(data)) {
-				const variants = data.filter((item): item is string => typeof item === 'string');
-				return variants;
-			} else {
-				return [];
-			}
-		})
-		.catch((error) => {
-			console.info('No theme variant file found or file could not be parsed', error);
-			return [];
-		});
+import { getThemeVariantDataKey, sampleAppDataService } from './sampleAppDataService';
+
+export function fetchVariantData(theme: string, variant: string): string[] {
+	const json = sampleAppDataService.getValue<Record<string, unknown>>(getThemeVariantDataKey(theme));
+	const data = json?.[variant];
+	if (Array.isArray(data)) {
+		return data.filter((item): item is string => typeof item === 'string');
+	}
+	return [];
 }

--- a/packages/samples/react/src/shares/sampleAppDataService.ts
+++ b/packages/samples/react/src/shares/sampleAppDataService.ts
@@ -8,7 +8,7 @@ const getDefaultThemes = (): Theme[] => [UNSTYLED_THEME, ...PUBLIC_THEMES];
 
 export const getThemeVariantDataKey = (theme: string): string => `theme-variant-data:${theme}`;
 
-const getThemeVariantDataUrl = (theme: string): string => `/assets/variants/inject-variants_${theme}.json`;
+const getThemeVariantDataUrl = (theme: string): string => `assets/variants/inject-variants_${theme}.json`;
 
 const getSampleAppDataRequests = (themes: Theme[] = getDefaultThemes()): Map<string, string> => {
 	return new Map<string, string>(themes.map(({ key }) => [getThemeVariantDataKey(key), getThemeVariantDataUrl(key)]));

--- a/packages/samples/react/src/shares/sampleAppDataService.ts
+++ b/packages/samples/react/src/shares/sampleAppDataService.ts
@@ -1,18 +1,22 @@
 import { PUBLIC_THEMES, UNSTYLED_THEME } from './theme';
 
+import type { Theme } from './theme';
+
 type JsonData = Record<string, unknown>;
+
+const getDefaultThemes = (): Theme[] => [UNSTYLED_THEME, ...PUBLIC_THEMES];
 
 export const getThemeVariantDataKey = (theme: string): string => `theme-variant-data:${theme}`;
 
 const getThemeVariantDataUrl = (theme: string): string => `/assets/variants/inject-variants_${theme}.json`;
 
-const sampleAppDataRequests = new Map<string, string>(
-	[UNSTYLED_THEME, ...PUBLIC_THEMES].map(({ key }) => [getThemeVariantDataKey(key), getThemeVariantDataUrl(key)]),
-);
+const getSampleAppDataRequests = (themes: Theme[] = getDefaultThemes()): Map<string, string> => {
+	return new Map<string, string>(themes.map(({ key }) => [getThemeVariantDataKey(key), getThemeVariantDataUrl(key)]));
+};
 
 const values = new Map<string, JsonData>();
-
-let initializePromise: Promise<void> | undefined;
+const loadPromises = new Map<string, Promise<void>>();
+const loadedKeys = new Set<string>();
 
 const fetchJsonData = async (key: string, url: string): Promise<void> => {
 	try {
@@ -34,10 +38,21 @@ const fetchJsonData = async (key: string, url: string): Promise<void> => {
 	}
 };
 
+const getLoadPromise = (key: string, url: string): Promise<void> => {
+	let loadPromise = loadPromises.get(key);
+	if (!loadPromise) {
+		loadPromise = fetchJsonData(key, url).then(() => {
+			loadedKeys.add(key);
+		});
+		loadPromises.set(key, loadPromise);
+	}
+	return loadPromise;
+};
+
 export const sampleAppDataService = {
 	getValue: <T = JsonData>(key: string): T | undefined => values.get(key) as T | undefined,
-	initialize: async (): Promise<void> => {
-		initializePromise ??= Promise.all(Array.from(sampleAppDataRequests, ([key, url]) => fetchJsonData(key, url))).then(() => undefined);
-		return initializePromise;
+	initialize: async (themes?: Theme[]): Promise<void> => {
+		await Promise.all(Array.from(getSampleAppDataRequests(themes), ([key, url]) => getLoadPromise(key, url)));
 	},
+	isInitialized: (themes?: Theme[]): boolean => Array.from(getSampleAppDataRequests(themes).keys()).every((key) => loadedKeys.has(key)),
 };

--- a/packages/samples/react/src/shares/sampleAppDataService.ts
+++ b/packages/samples/react/src/shares/sampleAppDataService.ts
@@ -1,16 +1,14 @@
+import { PUBLIC_THEMES, UNSTYLED_THEME } from './theme';
+
 type JsonData = Record<string, unknown>;
 
 export const getThemeVariantDataKey = (theme: string): string => `theme-variant-data:${theme}`;
 
-const sampleAppDataRequests = new Map<string, string>([
-	[getThemeVariantDataKey('bwst'), '/assets/variants/inject-variants_bwst.json'],
-	[getThemeVariantDataKey('default'), '/assets/variants/inject-variants_default.json'],
-	[getThemeVariantDataKey('desy-v11'), '/assets/variants/inject-variants_desy-v11.json'],
-	[getThemeVariantDataKey('ecl-ec'), '/assets/variants/inject-variants_ecl-ec.json'],
-	[getThemeVariantDataKey('ecl-eu'), '/assets/variants/inject-variants_ecl-eu.json'],
-	[getThemeVariantDataKey('kern-v2'), '/assets/variants/inject-variants_kern-v2.json'],
-	[getThemeVariantDataKey('unstyled'), '/assets/variants/inject-variants_unstyled.json'],
-]);
+const getThemeVariantDataUrl = (theme: string): string => `/assets/variants/inject-variants_${theme}.json`;
+
+const sampleAppDataRequests = new Map<string, string>(
+	[UNSTYLED_THEME, ...PUBLIC_THEMES].map(({ key }) => [getThemeVariantDataKey(key), getThemeVariantDataUrl(key)]),
+);
 
 const values = new Map<string, JsonData>();
 
@@ -24,7 +22,7 @@ const fetchJsonData = async (key: string, url: string): Promise<void> => {
 			return;
 		}
 		if (!response.ok) {
-			console.info('Error fetching sample app data: HTTP ' + response.status);
+			console.warn('Error fetching sample app data: HTTP ' + response.status);
 			return;
 		}
 		const json = (await response.json()) as unknown;
@@ -32,7 +30,7 @@ const fetchJsonData = async (key: string, url: string): Promise<void> => {
 			values.set(key, json as JsonData);
 		}
 	} catch (error) {
-		console.info('Sample app data file could not be loaded or parsed', error);
+		console.warn('Sample app data file could not be loaded or parsed', error);
 	}
 };
 

--- a/packages/samples/react/src/shares/sampleAppDataService.ts
+++ b/packages/samples/react/src/shares/sampleAppDataService.ts
@@ -1,0 +1,45 @@
+type JsonData = Record<string, unknown>;
+
+export const getThemeVariantDataKey = (theme: string): string => `theme-variant-data:${theme}`;
+
+const sampleAppDataRequests = new Map<string, string>([
+	[getThemeVariantDataKey('bwst'), '/assets/variants/inject-variants_bwst.json'],
+	[getThemeVariantDataKey('default'), '/assets/variants/inject-variants_default.json'],
+	[getThemeVariantDataKey('desy-v11'), '/assets/variants/inject-variants_desy-v11.json'],
+	[getThemeVariantDataKey('ecl-ec'), '/assets/variants/inject-variants_ecl-ec.json'],
+	[getThemeVariantDataKey('ecl-eu'), '/assets/variants/inject-variants_ecl-eu.json'],
+	[getThemeVariantDataKey('kern-v2'), '/assets/variants/inject-variants_kern-v2.json'],
+	[getThemeVariantDataKey('unstyled'), '/assets/variants/inject-variants_unstyled.json'],
+]);
+
+const values = new Map<string, JsonData>();
+
+let initializePromise: Promise<void> | undefined;
+
+const fetchJsonData = async (key: string, url: string): Promise<void> => {
+	try {
+		const response = await fetch(url);
+		if (response.status === 404) {
+			// No variants file for a theme is an expected state.
+			return;
+		}
+		if (!response.ok) {
+			console.info('Error fetching sample app data: HTTP ' + response.status);
+			return;
+		}
+		const json = (await response.json()) as unknown;
+		if (json && typeof json === 'object' && !Array.isArray(json)) {
+			values.set(key, json as JsonData);
+		}
+	} catch (error) {
+		console.info('Sample app data file could not be loaded or parsed', error);
+	}
+};
+
+export const sampleAppDataService = {
+	getValue: <T = JsonData>(key: string): T | undefined => values.get(key) as T | undefined,
+	initialize: async (): Promise<void> => {
+		initializePromise ??= Promise.all(Array.from(sampleAppDataRequests, ([key, url]) => fetchJsonData(key, url))).then(() => undefined);
+		return initializePromise;
+	},
+};


### PR DESCRIPTION
## What changed?

A singleton `sampleAppDataService` was introduced in the React sample app to preload all theme variant JSON files once at startup instead of fetching them per-component. The service maps theme identifiers to JSON URLs and loads them in parallel with `Promise.all`, tolerating 404 or malformed responses. Initialization is awaited in `react.main.tsx` before the React app renders. A shared `fetchVariantData(theme, key)` helper was added to read from the preloaded service. The `IconFont` and `LinkVariant` sample components were updated to use `useMemo + fetchVariantData` instead of their own `fetch` calls and local state.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein Singleton `sampleAppDataService` wurde in der React-Beispielanwendung eingeführt, das alle Theme-Varianten-JSON-Dateien einmalig beim Start vorlädt statt sie komponentenweise abzurufen. Die Initialisierung wird in `react.main.tsx` vor dem React-Rendering abgewartet. Ein gemeinsamer `fetchVariantData(theme, key)`-Helfer liest aus dem vorgeladenen Service. `IconFont`- und `LinkVariant`-Komponenten wurden auf `useMemo + fetchVariantData` umgestellt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/shares/sampleAppDataService.ts` — neuer Singleton-Service hinzugefügt
- `packages/samples/react/src/shares/fetchVariantData.ts` — neuer Lookup-Helfer
- `packages/samples/react/src/react.main.tsx` — Preload beim App-Start ergänzt
- `packages/samples/react/src/components/icon/font.tsx` — auf `fetchVariantData` umgestellt
- `packages/samples/react/src/components/link/variant.tsx` — auf `fetchVariantData` umgestellt

</details>