### PR TITLE
ci: skip visual tests for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI-Pipeline
 
 on:
   pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
     paths-ignore:
       - '*.md'
       - 'docs/**'
@@ -74,6 +75,7 @@ jobs:
           name: report-e2e
 
   visual-tests:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -2,6 +2,7 @@ name: Visual Tests Snapshot Comparison
 
 on:
   pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
     paths:
       - 'packages/components/**'
       - 'packages/themes/**'
@@ -21,6 +22,7 @@ permissions:
 
 jobs:
   visual-tests-snapshots:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         package: ['test-tag-name-transformer', 'theme-default', 'theme-bwst', 'theme-ecl', 'theme-desy', 'theme-kern']


### PR DESCRIPTION
## What changed?

Two GitHub Actions workflow files were updated to skip expensive visual test jobs for draft pull requests. In `.github/workflows/ci.yml`, a `types` filter (`opened, ready_for_review, reopened, synchronize`) was added to the `pull_request` trigger, and an `if` condition was added to the `visual-tests` job so it only runs when the PR is not a draft or the event is not a pull request. In `.github/workflows/visual-tests-base.yml`, the same `types` filter was added to the trigger, and the `visual-tests-snapshots` job received an `if: github.event.pull_request.draft == false` guard.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Zwei GitHub-Actions-Workflow-Dateien wurden aktualisiert, damit aufwändige Visual-Test-Jobs bei Draft-Pull-Requests übersprungen werden. In `ci.yml` wurde ein `types`-Filter und eine `if`-Bedingung für den `visual-tests`-Job ergänzt. In `visual-tests-base.yml` wurde derselbe `types`-Filter und eine `if`-Bedingung für `visual-tests-snapshots` hinzugefügt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/ci.yml` — `types`-Filter und `if`-Bedingung für `visual-tests`-Job hinzugefügt
- `.github/workflows/visual-tests-base.yml` — `types`-Filter und `if`-Bedingung für `visual-tests-snapshots`-Job hinzugefügt

</details>