### PR TITLE
fix(components): type link web component interface

### DIFF
--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stencil/core';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
+import type { WebComponentInterface } from '../../internal/functional-components/generic-types';
 import type { LinkApi } from '../../internal/functional-components/link/api';
 import { LinkFC } from '../../internal/functional-components/link/component';
 import { LinkController } from '../../internal/functional-components/link/controller';
@@ -23,7 +24,7 @@ import { dispatchDomEvent, KolEvent } from '../../utils/events';
 	},
 	shadow: true,
 })
-export class KolLink extends BaseWebComponent<LinkApi> {
+export class KolLink extends BaseWebComponent<LinkApi> implements WebComponentInterface<LinkApi> {
 	@Element() private readonly host?: HTMLKolLinkElement;
 
 	private readonly ctrl = new LinkController(this.stateAccess);

--- a/packages/components/src/internal/functional-components/link/controller.ts
+++ b/packages/components/src/internal/functional-components/link/controller.ts
@@ -3,6 +3,7 @@ import { getCurrentLocation, onLocationChange } from '../../../components/link/a
 import { setEventTarget } from '../../../schema';
 import type { AlignPropType } from '../../../schema/props/align';
 import type { KoliBriIconsProp } from '../../../schema/types/icons';
+import type { AriaCurrentValuePropType } from '../../props';
 import {
 	accessKeyProp,
 	ariaControlsProp,
@@ -335,7 +336,7 @@ export function initLinkControllerFromProps(ctrl: LinkController, props: { _href
 		shortKey: props['_shortKey'] as string | undefined,
 		tooltipAlign: props['_tooltipAlign'] as AlignPropType | undefined,
 		ariaControls: props['_ariaControls'] as string | undefined,
-		ariaCurrentValue: props['_ariaCurrentValue'] as string | undefined,
+		ariaCurrentValue: props['_ariaCurrentValue'] as AriaCurrentValuePropType | undefined,
 		ariaDescription: props['_ariaDescription'] as string | undefined,
 		ariaExpanded: props['_ariaExpanded'] as boolean | undefined,
 		ariaOwns: props['_ariaOwns'] as string | undefined,

--- a/packages/components/src/internal/props/aria-current-value.ts
+++ b/packages/components/src/internal/props/aria-current-value.ts
@@ -4,7 +4,8 @@ import { normalizeString } from './helpers/normalizers';
 
 const ARIA_CURRENT_VALUE_OPTIONS = ['date', 'location', 'page', 'step', 'time', 'true', 'false'] as const;
 
-export type AriaCurrentValueProp = SimpleProp<'ariaCurrentValue', string>;
+export type AriaCurrentValuePropType = (typeof ARIA_CURRENT_VALUE_OPTIONS)[number];
+export type AriaCurrentValueProp = SimpleProp<'ariaCurrentValue', AriaCurrentValuePropType>;
 export const ariaCurrentValueProp = createPropDefinition<AriaCurrentValueProp>(
 	'ariaCurrentValue',
 	'page',
@@ -12,7 +13,7 @@ export const ariaCurrentValueProp = createPropDefinition<AriaCurrentValueProp>(
 		if (value === undefined || value === null || value === '') return 'page';
 		const str = normalizeString(value);
 		if ((ARIA_CURRENT_VALUE_OPTIONS as readonly string[]).includes(str)) {
-			return str;
+			return str as AriaCurrentValuePropType;
 		}
 		throw new Error(`Invalid ariaCurrentValue: ${str}`);
 	},


### PR DESCRIPTION
## What changed?

`KolLink` in `packages/components/src/components/link/component.tsx` was updated to explicitly implement `WebComponentInterface<LinkApi>`, enforcing the shared functional-component API contract at the TypeScript level. The `ariaCurrentValue` type was narrowed from `string` to the stricter `AriaCurrentValuePropType` union in both `aria-current-value.ts` and `controller.ts`. An obsolete `eslint-disable` comment was removed. No runtime behavior changes; this is a type-safety alignment across the link component hierarchy.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolLink` in `packages/components/src/components/link/component.tsx` implementiert nun explizit `WebComponentInterface<LinkApi>`. Der Typ `ariaCurrentValue` wurde von `string` auf den strengeren `AriaCurrentValuePropType`-Union-Typ in `aria-current-value.ts` und `controller.ts` verengt. Ein veraltetes `eslint-disable`-Kommentar wurde entfernt. Keine Laufzeit-Verhaltensänderungen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/link/component.tsx` — `WebComponentInterface<LinkApi>`-Implementierung hinzugefügt; `eslint-disable`-Kommentar entfernt
- `packages/components/src/internal/functional-components/link/controller.ts` — `ariaCurrentValue` auf `AriaCurrentValuePropType` eingeschränkt
- `packages/components/src/internal/props/aria-current-value.ts` — `AriaCurrentValuePropType`-Typ exportiert; `AriaCurrentValueProp` darauf basierend

</details>