### PR TITLE
fix(components): sync link aria-current after prop changes

### DIFF
--- a/packages/components/src/components/link/aria-current.spec.tsx
+++ b/packages/components/src/components/link/aria-current.spec.tsx
@@ -1,0 +1,49 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { setCurrentLocation } from './ariaCurrentService';
+import { KolLink } from './component';
+
+describe('kol-link aria-current', () => {
+	const getAnchor = (root?: HTMLElement): HTMLAnchorElement | null => root?.shadowRoot?.querySelector('a') ?? null;
+
+	afterEach(() => {
+		setCurrentLocation('/kolibri-test-reset');
+	});
+
+	it('updates the rendered aria-current when _ariaCurrentValue changes after initialization', async () => {
+		setCurrentLocation('/current');
+
+		const page = await newSpecPage({
+			components: [KolLink],
+			html: `<kol-link _href="/current" _label="Current"></kol-link>`,
+		});
+
+		expect(getAnchor(page.root)?.getAttribute('aria-current')).toBe('page');
+
+		(page.root as HTMLKolLinkElement)._ariaCurrentValue = 'step';
+		await page.waitForChanges();
+
+		expect(getAnchor(page.root)?.getAttribute('aria-current')).toBe('step');
+	});
+
+	it('updates and removes the rendered aria-current when _href changes after initialization', async () => {
+		setCurrentLocation('/current');
+
+		const page = await newSpecPage({
+			components: [KolLink],
+			html: `<kol-link _href="/other" _aria-current-value="location" _label="Current"></kol-link>`,
+		});
+
+		expect(getAnchor(page.root)?.hasAttribute('aria-current')).toBe(false);
+
+		(page.root as HTMLKolLinkElement)._href = '/current';
+		await page.waitForChanges();
+
+		expect(getAnchor(page.root)?.getAttribute('aria-current')).toBe('location');
+
+		(page.root as HTMLKolLinkElement)._href = '/other';
+		await page.waitForChanges();
+
+		expect(getAnchor(page.root)?.hasAttribute('aria-current')).toBe(false);
+	});
+});

--- a/packages/components/src/components/link/ariaCurrentService.ts
+++ b/packages/components/src/components/link/ariaCurrentService.ts
@@ -11,6 +11,8 @@ export const setCurrentLocation = (location: string) => {
 	});
 };
 
+export const getCurrentLocation = (): string | undefined => currentLocation;
+
 export const onLocationChange = (callback: LocationChangeCallback, eager = true): UnsubscribeFunction => {
 	if (eager && typeof currentLocation === 'string') {
 		callback(currentLocation);

--- a/packages/components/src/internal/functional-components/link/controller.ts
+++ b/packages/components/src/internal/functional-components/link/controller.ts
@@ -286,7 +286,8 @@ export class LinkController extends BaseController<LinkApi> {
 	private syncAriaCurrent(location = getCurrentLocation()): void {
 		const href = this.getRenderProp('href');
 		const ariaCurrentValue = this.getRenderProp('ariaCurrentValue');
-		this.setState('ariaCurrent', location === href ? ariaCurrentValue : '');
+		const isCurrent = typeof location === 'string' && location === href;
+		this.setState('ariaCurrent', isCurrent ? ariaCurrentValue : '');
 	}
 
 	private resolveTooltipLabel(): string {

--- a/packages/components/src/internal/functional-components/link/controller.ts
+++ b/packages/components/src/internal/functional-components/link/controller.ts
@@ -1,5 +1,5 @@
 import type { UnsubscribeFunction } from '../../../components/link/ariaCurrentService';
-import { onLocationChange } from '../../../components/link/ariaCurrentService';
+import { getCurrentLocation, onLocationChange } from '../../../components/link/ariaCurrentService';
 import { setEventTarget } from '../../../schema';
 import type { AlignPropType } from '../../../schema/props/align';
 import type { KoliBriIconsProp } from '../../../schema/types/icons';
@@ -110,15 +110,14 @@ export class LinkController extends BaseController<LinkApi> {
 		});
 
 		this.unsubscribeOnLocationChange = onLocationChange((location) => {
-			const href = this.getRenderProp('href');
-			const ariaCurrentValue = this.getRenderProp('ariaCurrentValue');
-			this.setState('ariaCurrent', location === href ? ariaCurrentValue : '');
+			this.syncAriaCurrent(location);
 		});
 	}
 
 	public watchHref(value?: string): void {
 		hrefProp.apply(value, (v) => {
 			this.setRenderProp('href', v);
+			this.syncAriaCurrent();
 		});
 	}
 
@@ -137,6 +136,7 @@ export class LinkController extends BaseController<LinkApi> {
 	public watchAriaCurrentValue(value?: string): void {
 		ariaCurrentValueProp.apply(value, (v) => {
 			this.setRenderProp('ariaCurrentValue', v);
+			this.syncAriaCurrent();
 		});
 	}
 
@@ -281,6 +281,12 @@ export class LinkController extends BaseController<LinkApi> {
 	 */
 	public getAriaCurrent(): string {
 		return this.getState('ariaCurrent');
+	}
+
+	private syncAriaCurrent(location = getCurrentLocation()): void {
+		const href = this.getRenderProp('href');
+		const ariaCurrentValue = this.getRenderProp('ariaCurrentValue');
+		this.setState('ariaCurrent', location === href ? ariaCurrentValue : '');
 	}
 
 	private resolveTooltipLabel(): string {


### PR DESCRIPTION
## What changed?

`aria-current` on link components was not being updated when `_href` or `_ariaCurrentValue` props changed after initial rendering. A `syncAriaCurrent(location?)` private method was added to `LinkController` that recomputes the `ariaCurrent` state from the current `href` and `ariaCurrentValue` props. This method is now called from `watchHref()` and `watchAriaCurrentValue()` watchers, and from the `onLocationChange` subscription (replacing the inline logic). A `getCurrentLocation()` accessor was exported from `ariaCurrentService.ts` to supply the current location to the controller. Two unit tests were added covering dynamic prop change scenarios.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das `aria-current`-Attribut von Link-Komponenten wurde nach der initialen Darstellung nicht aktualisiert, wenn sich `_href` oder `_ariaCurrentValue`-Props änderten. Eine private `syncAriaCurrent(location?)`-Methode wurde im `LinkController` ergänzt, die den `ariaCurrent`-State neu berechnet. Diese Methode wird jetzt aus den `watchHref()`- und `watchAriaCurrentValue()`-Watchern sowie aus der `onLocationChange`-Subscription aufgerufen. Ein `getCurrentLocation()`-Accessor wurde aus `ariaCurrentService.ts` exportiert. Zwei Unit-Tests wurden für dynamische Prop-Änderungen hinzugefügt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/link/ariaCurrentService.ts` — `getCurrentLocation()`-Accessor exportiert
- `packages/components/src/internal/functional-components/link/controller.ts` — `syncAriaCurrent()`-Methode hinzugefügt; `watchHref` und `watchAriaCurrentValue` aktualisiert
- `packages/components/src/components/link/aria-current.spec.tsx` — Unit-Tests für dynamische `aria-current`-Aktualisierung hinzugefügt

</details>