### PR TITLE
fix(link): centralize click handling

### DIFF
--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -12,7 +12,6 @@ import type {
 	LinkTargetPropType,
 	TooltipAlignPropType,
 } from '../../schema';
-import { setEventTarget } from '../../schema';
 import { setClick } from '../../utils/element-click';
 import { setFocus } from '../../utils/element-focus';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
@@ -48,23 +47,9 @@ export class KolLink extends BaseWebComponent<LinkApi> {
 	}
 
 	private readonly handleAnchorClick = (event: MouseEvent | KeyboardEvent): void => {
-		this.ctrl.hideTooltip();
+		const { href, shouldDispatchKolEvent } = this.ctrl.handleAnchorClick(event);
 
-		if (this.ctrl.getRenderProp('disabled')) {
-			event.preventDefault();
-			return;
-		}
-
-		const href = this.ctrl.getRenderProp('href');
-		const on = this.ctrl.getRenderProp('on');
-
-		if (typeof on.onClick === 'function') {
-			setEventTarget(event, this.ctrl.getAnchorRef() as HTMLElement | undefined);
-			on.onClick(event, href);
-		}
-
-		if (this.host) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+		if (shouldDispatchKolEvent && this.host) {
 			dispatchDomEvent(this.host, KolEvent.click, href);
 		}
 	};

--- a/packages/components/src/components/link/link.e2e.ts
+++ b/packages/components/src/components/link/link.e2e.ts
@@ -40,6 +40,38 @@ test.describe('kol-link', () => {
 		});
 	});
 
+	test(`should not call onClick callback or emit click when disabled`, async ({ page }) => {
+		await page.setContent('<kol-link _href="#target" _label="Link" _disabled="true"></kol-link>');
+		const kolLink = page.locator('kol-link');
+
+		await kolLink.evaluate((element: HTMLKolLinkElement) => {
+			window.sessionStorage.setItem('kol-link-callback-count', '0');
+			window.sessionStorage.setItem('kol-link-event-count', '0');
+			element._on = {
+				onClick: () => {
+					window.sessionStorage.setItem('kol-link-callback-count', '1');
+				},
+			};
+			element.addEventListener('click', (event) => {
+				if (event instanceof CustomEvent && event.detail === '#target') {
+					window.sessionStorage.setItem('kol-link-event-count', '1');
+				}
+			});
+		});
+		await page.waitForChanges();
+
+		await page.locator('a').dispatchEvent('click');
+
+		await expect
+			.poll(async () => {
+				return await page.evaluate(() => ({
+					callbackCount: window.sessionStorage.getItem('kol-link-callback-count'),
+					eventCount: window.sessionStorage.getItem('kol-link-event-count'),
+				}));
+			})
+			.toEqual({ callbackCount: '0', eventCount: '0' });
+	});
+
 	test.skip('should hide tooltip after click until link is left and focused again', async ({ page }) => {
 		await page.setContent('<kol-link _href="#target" _label="Tooltip Link" _hide-label="true"></kol-link>');
 		const link = page.locator('a');

--- a/packages/components/src/internal/functional-components/link/controller.ts
+++ b/packages/components/src/internal/functional-components/link/controller.ts
@@ -52,6 +52,11 @@ export function createLinkStateAccess(forceRender?: () => void): StateAccess<Lin
 	};
 }
 
+export type LinkClickHandlingResult = {
+	href: string;
+	shouldDispatchKolEvent: boolean;
+};
+
 export class LinkController extends BaseController<LinkApi> {
 	private readonly tooltipCtrl = new TooltipController({ setState: () => {}, getState: () => undefined as never });
 	private anchorRef?: HTMLAnchorElement;
@@ -61,20 +66,25 @@ export class LinkController extends BaseController<LinkApi> {
 
 	/**
 	 * Handles an anchor click: hides the tooltip, prevents default when disabled,
-	 * and calls `on.onClick` when defined. Does not dispatch a KolEvent — that
-	 * responsibility belongs to the enclosing web component if needed.
+	 * calls `on.onClick` when defined, and returns whether the enclosing web
+	 * component should dispatch its `KolEvent.click` event.
 	 */
-	public readonly handleAnchorClick = (event: MouseEvent | KeyboardEvent): void => {
+	public readonly handleAnchorClick = (event: MouseEvent | KeyboardEvent): LinkClickHandlingResult => {
 		this.hideTooltip();
+		const href = this.getRenderProp('href');
+
 		if (this.getRenderProp('disabled')) {
 			event.preventDefault();
-			return;
+			return { href, shouldDispatchKolEvent: false };
 		}
+
 		const on = this.getRenderProp('on');
 		if (typeof on.onClick === 'function') {
 			setEventTarget(event, this.anchorRef as HTMLElement | undefined);
-			on.onClick(event, this.getRenderProp('href'));
+			on.onClick(event, href);
 		}
+
+		return { href, shouldDispatchKolEvent: event.defaultPrevented === false };
 	};
 
 	public constructor(stateAccess: StateAccess<LinkApi>) {


### PR DESCRIPTION
## What changed?

Click handling logic in `KolLink` was centralized into `LinkController`. The controller's `handleAnchorClick` method now returns a `LinkClickHandlingResult` object containing `{ href, shouldDispatchKolEvent }` instead of `void`. The component's `handleAnchorClick` was reduced to a thin delegation: it calls `this.ctrl.handleAnchorClick(event)` and only dispatches `KolEvent.click` when `shouldDispatchKolEvent` is true. Tooltip hiding, disabled prevention, `setEventTarget`, and `on.onClick` invocation were moved entirely to the controller, eliminating duplication between controller and component layers. An E2E test was added verifying that disabled links neither trigger the `_on.onClick` callback nor emit `KolEvent.click`.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Click-Handling-Logik in `KolLink` wurde in den `LinkController` zentralisiert. Die `handleAnchorClick`-Methode des Controllers gibt nun ein `LinkClickHandlingResult`-Objekt `{ href, shouldDispatchKolEvent }` zurück statt `void`. Die Komponente delegiert nun vollständig an den Controller und sendet `KolEvent.click` nur wenn `shouldDispatchKolEvent` true ist. Tooltip-Verbergen, Disabled-Prüfung, `setEventTarget` und `on.onClick`-Aufruf wurden vollständig in den Controller verschoben. Ein E2E-Test prüft, dass deaktivierte Links weder den `_on.onClick`-Callback auslösen noch `KolEvent.click` emittieren.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/link/component.tsx` — `handleAnchorClick` auf dünne Delegation an Controller reduziert
- `packages/components/src/internal/functional-components/link/controller.ts` — `handleAnchorClick` gibt `LinkClickHandlingResult` zurück; `setEventTarget`, `on.onClick`, `hideTooltip` und Disabled-Check verschoben
- `packages/components/src/components/link/link.e2e.ts` — E2E-Test für deaktiviertes Link-Click-Verhalten hinzugefügt

</details>