### PR TITLE
fix(components): remove unused Fragment import from link functional component

### DIFF
--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -64,7 +64,6 @@ export class KolLink extends BaseWebComponent<LinkApi> {
 		}
 
 		if (this.host) {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			dispatchDomEvent(this.host, KolEvent.click, href);
 		}
 	};

--- a/packages/components/src/internal/functional-components/link/component.tsx
+++ b/packages/components/src/internal/functional-components/link/component.tsx
@@ -1,5 +1,5 @@
 import type { FunctionalComponent as FC } from '@stencil/core';
-import { Fragment, h } from '@stencil/core';
+import { h } from '@stencil/core';
 
 import { translate } from '../../../i18n';
 import { showExpertSlot } from '../../../schema';
@@ -54,55 +54,53 @@ export const LinkFC: FC<LinkFCProps> = (props, children) => {
 	const tooltipLabel = typeof label === 'string' && label.length > 0 ? label : typeof href === 'string' ? href : '';
 	const tooltipBadgeText = accessKey || shortKey || '';
 
-	return (
-		<>
-			<a
-				ref={refAnchor}
-				href={resolvedHref}
-				target={target || undefined}
-				rel={isExternal ? 'noopener' : undefined}
-				download={download || undefined}
-				accessKey={accessKey || undefined}
-				aria-current={ariaCurrent || undefined}
-				aria-controls={ariaControls || undefined}
-				aria-description={ariaDescription?.trim() || undefined}
-				aria-disabled={disabled ? 'true' : undefined}
-				aria-expanded={ariaExpanded || undefined}
-				aria-owns={ariaOwns || undefined}
-				aria-label={ariaLabel}
-				aria-keyshortcuts={shortKey || undefined}
-				class={clsx('kol-link', {
-					'kol-link--disabled': disabled,
-					'kol-link--external-link': isExternal,
-					'kol-link--hide-label': hideLabel,
-					[`kol-link--${variant}`]: variant !== '',
-					'kol-link--inline': inline,
-					'kol-link--standalone': !inline,
-					[customClass]: variant === 'custom' && customClass !== '',
-					[hostClass as string]: !!hostClass,
-				})}
-				onClick={onAnchorClick}
-				role={role || undefined}
-				tabIndex={disabled ? -1 : tabIndex === 0 ? undefined : tabIndex}
+	return [
+		<a
+			ref={refAnchor}
+			href={resolvedHref}
+			target={target || undefined}
+			rel={isExternal ? 'noopener' : undefined}
+			download={download || undefined}
+			accessKey={accessKey || undefined}
+			aria-current={ariaCurrent || undefined}
+			aria-controls={ariaControls || undefined}
+			aria-description={ariaDescription?.trim() || undefined}
+			aria-disabled={disabled ? 'true' : undefined}
+			aria-expanded={ariaExpanded || undefined}
+			aria-owns={ariaOwns || undefined}
+			aria-label={ariaLabel}
+			aria-keyshortcuts={shortKey || undefined}
+			class={clsx('kol-link', {
+				'kol-link--disabled': disabled,
+				'kol-link--external-link': isExternal,
+				'kol-link--hide-label': hideLabel,
+				[`kol-link--${variant}`]: variant !== '',
+				'kol-link--inline': inline,
+				'kol-link--standalone': !inline,
+				[customClass]: variant === 'custom' && customClass !== '',
+				[hostClass as string]: !!hostClass,
+			})}
+			onClick={onAnchorClick}
+			role={role || undefined}
+			tabIndex={disabled ? -1 : tabIndex === 0 ? undefined : tabIndex}
+		>
+			<SpanFC
+				class="kol-link__text"
+				badgeText={accessKey || shortKey}
+				icons={icons}
+				hideLabel={hideLabel}
+				label={hasExpertSlot ? '' : (typeof label === 'string' ? label : '') || href}
 			>
-				<SpanFC
-					class="kol-link__text"
-					badgeText={accessKey || shortKey}
-					icons={icons}
-					hideLabel={hideLabel}
-					label={hasExpertSlot ? '' : (typeof label === 'string' ? label : '') || href}
-				>
-					<slot name="expert" slot="expert">
-						{children}
-					</slot>
-				</SpanFC>
-				{isExternal && <IconFC class="kol-link__icon" label={hideLabel ? '' : translateOpenLinkInTab} icons="kolicon-link-external" aria-hidden={hideLabel} />}
-			</a>
-			{hideLabel && !hasExpertSlot && (
-				<div class="kol-link__tooltip">
-					<TooltipFC badgeText={tooltipBadgeText} label={tooltipLabel} id={tooltipId} refFloating={refTooltipFloating} />
-				</div>
-			)}
-		</>
-	);
+				<slot name="expert" slot="expert">
+					{children}
+				</slot>
+			</SpanFC>
+			{isExternal && <IconFC class="kol-link__icon" label={hideLabel ? '' : translateOpenLinkInTab} icons="kolicon-link-external" aria-hidden={hideLabel} />}
+		</a>,
+		hideLabel && !hasExpertSlot && (
+			<div class="kol-link__tooltip">
+				<TooltipFC badgeText={tooltipBadgeText} label={tooltipLabel} id={tooltipId} refFloating={refTooltipFloating} />
+			</div>
+		),
+	];
 };


### PR DESCRIPTION
### Motivation
- Remove an unused `Fragment` import from the internal link functional component so imports are minimal and no unused symbols remain.
- Ensure TypeScript/ESLint pass by avoiding JSX fragment usage without `Fragment` in scope and by removing a now-unnecessary ESLint suppression.

### Description
- Replace `import { Fragment, h } from '@stencil/core'` with `import { h } from '@stencil/core'` in `packages/components/src/internal/functional-components/link/component.tsx`.
- Replace the JSX fragment wrapper (`<>...</>`) with an adjacent node return (array of nodes) in the functional `LinkFC` so fragments are not required.
- Remove an unused `// eslint-disable-next-line @typescript-eslint/no-unsafe-argument` suppression in `packages/components/src/components/link/component.tsx` since the suppression was no longer needed.
- Modified files: `packages/components/src/internal/functional-components/link/component.tsx` and `packages/components/src/components/link/component.tsx`.

### Testing
- Ran formatting with `pnpm --filter @public-ui/components format` and fixed style issues; result: success.
- Built the components with `pnpm --filter @public-ui/components build`; result: success.
- Ran TypeScript checks with `pnpm --filter @public-ui/components lint:tsc` (`tsc --noemit`); result: success.
- Ran ESLint with `pnpm --filter @public-ui/components lint:eslint`; result: success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe92071f38832f84507332e7c97031)