### PR TITLE
fix: devHint placement in searchFormElement function

### DIFF
--- a/packages/components/src/components/form/controller.ts
+++ b/packages/components/src/components/form/controller.ts
@@ -25,8 +25,10 @@ const searchFormElement = (el?: HTMLElement | ParentNode | null): HTMLElement | 
 		}
 		if (getExperimentalMode()) {
 			Log.debug(el);
-			devHint(`↑ Search form element finished.`);
 		}
+	}
+	if (getExperimentalMode()) {
+		devHint(`↑ Search form element finished.`);
 	}
 	return el;
 };


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/form/controller.ts`, the `devHint('↑ Search form element finished.')` call was moved from inside the `if (getExperimentalMode())` block within the loop body to a separate `if (getExperimentalMode())` block placed after the loop. This ensures the debug message is logged exactly once after all search form element operations complete, rather than potentially multiple times during iteration. Only affects experimental mode debug logging; no runtime behavior change for production builds.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/form/controller.ts` wurde der `devHint('↑ Search form element finished.')`-Aufruf aus dem `if (getExperimentalMode())`-Block innerhalb der Schleife in einen separaten `if (getExperimentalMode())`-Block nach der Schleife verschoben. Die Debug-Meldung wird nun genau einmal nach Abschluss aller Operationen ausgegeben statt potenziell mehrfach. Keine Auswirkung auf Production-Builds.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/form/controller.ts` — `devHint()`-Aufruf aus Schleifen-Body in Block nach der Schleife verschoben

</details>