### PR TITLE
chore(components): fix typescript type assertions for strict lint compliance

### DIFF
--- a/packages/components/src/components/input-file/input-file.e2e.ts
+++ b/packages/components/src/components/input-file/input-file.e2e.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'node:buffer';
+
 import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
 import { testInputCallbacksAndEvents } from '../../e2e';

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -505,7 +505,11 @@ export class KolTableStateful implements TableAPI {
 	}
 
 	private handleSort({ key }: SortEventPayload) {
-		const headerCell = [...(this.state._headers.horizontal || []).flat(), ...(this.state._headers.vertical || []).flat()].find((cell) => cell.key === key);
+		const allHeaders: KoliBriTableHeaderCellWithLogic[] = [
+			...((this.state._headers.horizontal ?? []) as KoliBriTableHeaderCellWithLogic[][]).flat(),
+			...((this.state._headers.vertical ?? []) as KoliBriTableHeaderCellWithLogic[][]).flat(),
+		];
+		const headerCell = allHeaders.find((cell) => cell.key === key);
 		if (headerCell) {
 			this.changeCellSort(headerCell);
 		}

--- a/packages/components/src/internal/props/helpers/normalizers.ts
+++ b/packages/components/src/internal/props/helpers/normalizers.ts
@@ -5,7 +5,7 @@ export function normalizeString(value?: unknown): string | never {
 		return value;
 	}
 	if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-		return String(value);
+		return (value as number | boolean | bigint).toString();
 	}
 	throw new Error(`Invalid string: ${value as string}`);
 }

--- a/packages/components/src/schema/props/table-header-cells.ts
+++ b/packages/components/src/schema/props/table-header-cells.ts
@@ -29,14 +29,18 @@ export const validateTableHeaderCells = (component: Generic.Element.Component, v
 			watchValidator(
 				component,
 				'_headerCells',
-				(value): boolean =>
-					typeof value === 'object' &&
-					value !== null &&
-					(value.horizontal === undefined ||
-						(Array.isArray(value.horizontal) && value.horizontal.find((headerRow) => !Array.isArray(headerRow)) === undefined)) &&
-					(value.vertical === undefined || (Array.isArray(value.vertical) && value.vertical.find((headerCol) => !Array.isArray(headerCol)) === undefined)) &&
-					[...(value.horizontal ?? []), ...(value.vertical ?? [])].flat().every((cell) => cell.width === undefined || typeof cell.width === 'number') &&
-					true,
+				(value): boolean => {
+					if (typeof value !== 'object' || value === null) return false;
+					const v = value as TableHeaderCells;
+					return (
+						(v.horizontal === undefined ||
+							(Array.isArray(v.horizontal) && v.horizontal.find((headerRow) => !Array.isArray(headerRow)) === undefined)) &&
+						(v.vertical === undefined || (Array.isArray(v.vertical) && v.vertical.find((headerCol) => !Array.isArray(headerCol)) === undefined)) &&
+						([...(v.horizontal ?? []), ...(v.vertical ?? [])] as KoliBriTableHeaderCell[][])
+							.flat()
+							.every((cell) => cell.width === undefined || typeof cell.width === 'number')
+					);
+				},
 				new Set(['TableHeaderCellsPropType']),
 				value,
 			);

--- a/packages/components/src/schema/utils/dev.utils.ts
+++ b/packages/components/src/schema/utils/dev.utils.ts
@@ -44,7 +44,7 @@ export const setRuntimeMode = (mode: Mode): void => {
 const getInitialMode = (): Mode => {
 	try {
 		// Try to get NODE_ENV, but handle cases where process is not available
-		const nodeEnv = typeof process !== 'undefined' && process.env ? process.env['NODE_ENV'] : undefined;
+		const nodeEnv: string | undefined = typeof process !== 'undefined' && process.env ? (process.env as Record<string, string | undefined>)['NODE_ENV'] : undefined;
 		if (nodeEnv && MODES.includes(nodeEnv as Mode)) {
 			return nodeEnv as Mode;
 		}

--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -66,10 +66,11 @@ const patchState = (component: Generic.Element.Component): void => {
 	 * werden.
 	 */
 	if ((component.nextState as Map<string, unknown>)?.size > 0) {
-		component.state = {
-			...component.state,
-			...Object.fromEntries(component.nextState as Map<string, unknown>),
-		};
+		const nextEntries: Record<string, unknown> = {};
+		(component.nextState as Map<string, unknown>).forEach((val, key) => {
+			nextEntries[key] = val;
+		});
+		component.state = { ...(component.state as Record<string, unknown>), ...nextEntries };
 		delete component.nextState;
 
 		component.nextHooks?.forEach((hooks, key) => {


### PR DESCRIPTION
## What changed?

Six source files in `packages/components` were updated to satisfy strict TypeScript / ESLint type-checking rules without changing runtime behavior. Key changes: `Buffer` import added to `input-file.e2e.ts`; spreaded header arrays in `table-stateful/shadow.tsx` rewritten with explicit type casts; `String(value)` replaced with `.toString()` in `normalizers.ts` for type compatibility; `table-header-cells.ts` validator refactored to use a typed intermediate variable; `process.env` access in `dev.utils.ts` typed with `Record<string, string | undefined>`; `Object.fromEntries()` in `prop.validators.ts` replaced with a typed `forEach` loop.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Sechs Quelldateien in `packages/components` wurden aktualisiert, um strenge TypeScript/ESLint-Typregeln zu erfüllen, ohne das Laufzeitverhalten zu ändern. Wesentliche Änderungen: `Buffer`-Import in `input-file.e2e.ts`; Header-Array-Spreads in `table-stateful/shadow.tsx` mit expliziten Type-Casts; `String(value)` durch `.toString()` in `normalizers.ts` ersetzt; `table-header-cells.ts`-Validator mit typisierter Variable umgeschrieben; `process.env`-Zugriff in `dev.utils.ts` typisiert; `Object.fromEntries()` in `prop.validators.ts` durch typisierte `forEach`-Schleife ersetzt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/input-file/input-file.e2e.ts` — `Buffer`-Import aus `node:buffer` hinzugefügt
- `packages/components/src/components/table-stateful/shadow.tsx` — Header-Array-Spreads mit expliziten Typ-Casts
- `packages/components/src/internal/props/helpers/normalizers.ts` — `.toString()` statt `String(value)`
- `packages/components/src/schema/props/table-header-cells.ts` — Validator mit typisierter Zwischenvariable umgeschrieben
- `packages/components/src/schema/utils/dev.utils.ts` — `process.env` mit `Record<string, string | undefined>` typisiert
- `packages/components/src/schema/utils/prop.validators.ts` — `Object.fromEntries()` durch typisierte `forEach`-Schleife ersetzt

</details>