### PR TITLE
perf: remove redundant filter logic in theme rendering

### DIFF
--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -87,15 +87,15 @@ export const App: FC<Props> = ({ customThemes }) => {
 							element={
 								<div className="d-grid gap-4">
 									{themes.map((theme) => (
-											<div className="d-grid gap-2" key={theme.key}>
-												<div className="mt-4">
-													<strong>{theme.name}</strong>
-												</div>
-												<div className="my-2">
-													<ThisRoute />
-												</div>
-												<hr aria-hidden="true" />
+										<div className="d-grid gap-2" key={theme.key}>
+											<div className="mt-4">
+												<strong>{theme.name}</strong>
 											</div>
+											<div className="my-2">
+												<ThisRoute />
+											</div>
+											<hr aria-hidden="true" />
+										</div>
 									))}
 								</div>
 							}

--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -86,9 +86,7 @@ export const App: FC<Props> = ({ customThemes }) => {
 							path={`${path}/all`}
 							element={
 								<div className="d-grid gap-4">
-									{themes
-										.filter((theme) => themes.map((t) => t.key).indexOf(theme.key) >= 0)
-										.map((theme) => (
+									{themes.map((theme) => (
 											<div className="d-grid gap-2" key={theme.key}>
 												<div className="mt-4">
 													<strong>{theme.name}</strong>

--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -96,7 +96,7 @@ export const App: FC<Props> = ({ customThemes }) => {
 												</div>
 												<hr aria-hidden="true" />
 											</div>
-										))}
+									))}
 								</div>
 							}
 						/>,


### PR DESCRIPTION
## What changed?

In `packages/samples/react/src/App.tsx`, a redundant `.filter()` call was removed from the theme rendering loop. The original filter checked whether each theme's key existed in the same themes array it was iterating over — a condition that is always true, making the filter a no-op. The code was simplified to a direct `.map()` call with identical output and slightly reduced computational overhead.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/samples/react/src/App.tsx` wurde ein redundanter `.filter()`-Aufruf aus der Theme-Rendering-Schleife entfernt. Der ursprüngliche Filter prüfte, ob jeder Theme-Schlüssel in dem selben Array existiert, über das iteriert wurde — eine Bedingung, die immer wahr ist. Der Code wurde zu einem direkten `.map()`-Aufruf vereinfacht, der identische Ausgabe mit leicht reduziertem Rechenaufwand erzeugt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/App.tsx` — redundanter `.filter()`-Aufruf aus Theme-Rendering-Schleife entfernt

</details>