### PR TITLE
perf: extract regex pattern to constant in variant class name validation

### DIFF
--- a/packages/components/src/schema/props/variant-class-name.ts
+++ b/packages/components/src/schema/props/variant-class-name.ts
@@ -8,10 +8,8 @@ export type PropVariantClassName = {
 	variant: VariantClassNamePropType;
 };
 
-const isSafeClassName = (value: unknown) => {
-	var re = new RegExp('^[a-zA-Z][a-zA-Z0-9_-]{3,60}$');
-	return typeof value === 'string' && re.test(value);
-};
+const SAFE_CLASS_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]{3,60}$/;
+const isSafeClassName = (value: unknown) => typeof value === 'string' && SAFE_CLASS_NAME_RE.test(value);
 
 export const validateVariantClassName = (component: Generic.Element.Component, value?: VariantClassNamePropType): void => {
 	watchValidator(component, '_variant', isSafeClassName, new Set(['^[a-zA-Z][a-zA-Z0-9_-]{3,60}$']), value);

--- a/packages/components/src/schema/props/variant-class-name.ts
+++ b/packages/components/src/schema/props/variant-class-name.ts
@@ -10,7 +10,8 @@ export type PropVariantClassName = {
 
 const SAFE_CLASS_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]{3,60}$/;
 const isSafeClassName = (value: unknown) => typeof value === 'string' && SAFE_CLASS_NAME_RE.test(value);
+const SAFE_CLASS_NAME_ALLOWED = new Set([SAFE_CLASS_NAME_RE.source]);
 
 export const validateVariantClassName = (component: Generic.Element.Component, value?: VariantClassNamePropType): void => {
-	watchValidator(component, '_variant', isSafeClassName, new Set(['^[a-zA-Z][a-zA-Z0-9_-]{3,60}$']), value);
+	watchValidator(component, '_variant', isSafeClassName, SAFE_CLASS_NAME_ALLOWED, value);
 };


### PR DESCRIPTION
## What changed?

In `packages/components/src/schema/props/variant-class-name.ts`, the inline `new RegExp(...)` call inside `isSafeClassName` was replaced with a named module-level constant `SAFE_CLASS_NAME_RE`. The `isSafeClassName` function was simplified to a single-line arrow function. A pre-built `SAFE_CLASS_NAME_ALLOWED` Set constant was introduced and reused in `validateVariantClassName` to avoid recreating the Set on every call. Validation behavior and the allowed class name pattern are unchanged.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/schema/props/variant-class-name.ts` wurde der inline `new RegExp(...)`-Aufruf durch eine benannte modulweite Konstante `SAFE_CLASS_NAME_RE` ersetzt. Die Funktion `isSafeClassName` wurde zu einer einzeiligen Arrow-Function vereinfacht. Ein vorinstanziiertes `SAFE_CLASS_NAME_ALLOWED`-Set wurde als Konstante eingeführt und in `validateVariantClassName` wiederverwendet, um das wiederholte Erstellen des Sets zu vermeiden. Das Validierungsverhalten und das erlaubte Muster bleiben unverändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/schema/props/variant-class-name.ts` — Regex in Konstante `SAFE_CLASS_NAME_RE` extrahiert; `isSafeClassName` vereinfacht; `SAFE_CLASS_NAME_ALLOWED`-Set vorinstanziiert

</details>