### PR TITLE
chore(components): decouple kolicons asset generation

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -68,6 +68,7 @@
 		"wcag"
 	],
 	"scripts": {
+		"assets:kolicons": "pnpm --filter @public-ui/icons build",
 		"build": "pnpm build:light",
 		"build:light": "mkdir doc && cross-env NODE_ENV=production stencil build --docs --prod && node scripts/autogen.doc.js && node scripts/vaadin.js && pnpm format -w",
 		"clear": "rimraf -g dist doc www ../adapters/angular/v19/src ../adapters/angular/v20/src ../adapters/angular/v21/src ../adapters/hydrate/dist ../adapters/react/src ../adapters/react-v19/src ../adapters/solid/src ../adapters/vaadin/*.java ../adapters/vue/src assets/kolicons",
@@ -85,9 +86,9 @@
 		"test:update:unit": "pnpm test:unit -u",
 		"test:watch": "cross-env NODE_ENV=test stencil test --spec --watchAll",
 		"postinstall": "node ./postinstall.js",
-		"prebuild:light": "pnpm clear && pnpm pretest:e2e",
+		"prebuild:light": "pnpm clear && pnpm assets:kolicons",
 		"prepack": "pnpm build && rimraf dist/collection dist/kolibri/assets/@leanup dist/types/assets/@leanup && node scripts/minify.js",
-		"pretest:e2e": "pnpm --filter @public-ui/icons build",
+		"pretest:e2e": "pnpm assets:kolicons",
 		"xunused": "knip"
 	},
 	"dependencies": {


### PR DESCRIPTION
## What changed?

A dedicated `assets:kolicons` script was added to `packages/components/package.json` that invokes `pnpm --filter @public-ui/icons build`. The `prebuild:light` script was updated to call `assets:kolicons` directly instead of delegating through `pretest:e2e`, and `pretest:e2e` was updated to invoke `assets:kolicons` as well. This decouples icon asset generation from the E2E test lifecycle so it can be triggered explicitly without being semantically tied to test preparation.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ein dediziertes `assets:kolicons`-Skript wurde in `packages/components/package.json` hinzugefügt, das `pnpm --filter @public-ui/icons build` aufruft. Das `prebuild:light`-Skript delegiert nun an `assets:kolicons` statt an `pretest:e2e`, und `pretest:e2e` ruft ebenfalls `assets:kolicons` auf. Damit wird die Icon-Asset-Generierung vom E2E-Test-Lifecycle entkoppelt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/package.json` — `assets:kolicons`-Skript hinzugefügt; `prebuild:light` und `pretest:e2e` auf neues Skript umgestellt

</details>