### PR TITLE
ci: create draft PRs for auto-update and CVE workflows

### DIFF
--- a/.github/workflows/auto-dependency-updater.yml
+++ b/.github/workflows/auto-dependency-updater.yml
@@ -86,6 +86,7 @@ jobs:
           commit-message: 'chore: update dependencies and lock file'
           title: 'chore(${{ env.version }}): update dependencies and lock file'
           body: 'Automated dependency updates from issue #${{ env.issue }} for ${{ env.version }}.'
+          draft: true
           delete-branch: true
 
       - name: Run audit

--- a/.github/workflows/cve-overview.yml
+++ b/.github/workflows/cve-overview.yml
@@ -111,4 +111,5 @@ jobs:
           commit-message: 'chore: update CVE overview'
           title: 'chore: update CVE overview'
           body: 'Automated CVE overview update from issue #${{ env.issue }}.'
+          draft: true
           delete-branch: true


### PR DESCRIPTION
## What changed?

The auto-dependency-updater workflow (`.github/workflows/auto-dependency-updater.yml`) and the CVE-overview workflow (`.github/workflows/cve-overview.yml`) were updated to create their automated pull requests as drafts (`draft: true`) instead of immediately publishing them as ready-for-review. This gives maintainers time to inspect and adjust automated PRs before promoting them to review-ready status.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Auto-Dependency-Updater-Workflow (`.github/workflows/auto-dependency-updater.yml`) und der CVE-Übersichts-Workflow (`.github/workflows/cve-overview.yml`) wurden aktualisiert, um ihre automatisierten Pull Requests als Entwürfe (`draft: true`) zu erstellen, anstatt sie sofort als überprüfungsbereit zu veröffentlichen. Dies gibt Maintainern Zeit, automatisierte PRs zu prüfen und anzupassen, bevor sie in den Review-Status überführt werden.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/auto-dependency-updater.yml` — `draft: true` zum PR-Erstellungsschritt hinzugefügt
- `.github/workflows/cve-overview.yml` — `draft: true` zum PR-Erstellungsschritt hinzugefügt

</details>