### PR TITLE
perf: optimize overlay z-index management logic

### DIFF
--- a/packages/components/src/utils/overlay.ts
+++ b/packages/components/src/utils/overlay.ts
@@ -18,12 +18,14 @@ export function showOverlay(overlay: HTMLElement): void {
 	// Ensure the overlay is at the end of the set to maintain the invariant:
 	// all overlays have z-index 999 except the last one (z-index 1000).
 	const last = [...VISIBLE_OVERLAYS].at(-1);
-	if (last && last !== overlay) {
-		last.style.setProperty('z-index', '999');
+	if (last !== overlay) {
+		if (last) {
+			last.style.setProperty('z-index', '999');
+		}
+		VISIBLE_OVERLAYS.delete(overlay);
+		VISIBLE_OVERLAYS.add(overlay);
+		overlay.style.setProperty('z-index', '1000');
 	}
-	VISIBLE_OVERLAYS.delete(overlay);
-	VISIBLE_OVERLAYS.add(overlay);
-	overlay.style.setProperty('z-index', '1000');
 }
 
 /**
@@ -34,7 +36,8 @@ export function showOverlay(overlay: HTMLElement): void {
  * @param overlay Get the overlay element reference
  */
 export function hideOverlay(overlay: HTMLElement): void {
-	if (VISIBLE_OVERLAYS.delete(overlay) && VISIBLE_OVERLAYS.size > 0) {
-		[...VISIBLE_OVERLAYS].at(-1)?.style.setProperty('z-index', '1000');
+	const overlays = [...VISIBLE_OVERLAYS];
+	if (VISIBLE_OVERLAYS.delete(overlay) && overlays.at(-1) === overlay && overlays.length > 1) {
+		overlays.at(-2)?.style.setProperty('z-index', '1000');
 	}
 }

--- a/packages/components/src/utils/overlay.ts
+++ b/packages/components/src/utils/overlay.ts
@@ -8,6 +8,12 @@
 const VISIBLE_OVERLAYS: Set<HTMLElement> = new Set();
 
 /**
+ * Cached reference to the top-most overlay (z-index 1000).
+ * Maintained by showOverlay and hideOverlay to avoid repeated set iterations.
+ */
+let lastOverlay: HTMLElement | null = null;
+
+/**
  * This function is used to add an overlay to the visible overlay list.
  * All overlays in the list will have a z-index of 999, except the last
  * one, which will have a z-index of 1000.
@@ -17,14 +23,14 @@ const VISIBLE_OVERLAYS: Set<HTMLElement> = new Set();
 export function showOverlay(overlay: HTMLElement): void {
 	// Ensure the overlay is at the end of the set to maintain the invariant:
 	// all overlays have z-index 999 except the last one (z-index 1000).
-	const last = [...VISIBLE_OVERLAYS].at(-1);
-	if (last !== overlay) {
-		if (last) {
-			last.style.setProperty('z-index', '999');
+	if (lastOverlay !== overlay) {
+		if (lastOverlay) {
+			lastOverlay.style.setProperty('z-index', '999');
 		}
 		VISIBLE_OVERLAYS.delete(overlay);
 		VISIBLE_OVERLAYS.add(overlay);
 		overlay.style.setProperty('z-index', '1000');
+		lastOverlay = overlay;
 	}
 }
 
@@ -36,8 +42,18 @@ export function showOverlay(overlay: HTMLElement): void {
  * @param overlay Get the overlay element reference
  */
 export function hideOverlay(overlay: HTMLElement): void {
-	const overlays = [...VISIBLE_OVERLAYS];
-	if (VISIBLE_OVERLAYS.delete(overlay) && overlays.at(-1) === overlay && overlays.length > 1) {
-		overlays.at(-2)?.style.setProperty('z-index', '1000');
+	if (!VISIBLE_OVERLAYS.delete(overlay)) {
+		return;
+	}
+
+	if (lastOverlay === overlay) {
+		// Find the new last overlay
+		lastOverlay = null;
+		for (const el of VISIBLE_OVERLAYS) {
+			lastOverlay = el;
+		}
+		if (lastOverlay) {
+			lastOverlay.style.setProperty('z-index', '1000');
+		}
 	}
 }

--- a/packages/components/src/utils/overlay.ts
+++ b/packages/components/src/utils/overlay.ts
@@ -15,8 +15,13 @@ const VISIBLE_OVERLAYS: Set<HTMLElement> = new Set();
  * @param overlay Get the overlay element reference
  */
 export function showOverlay(overlay: HTMLElement): void {
-	// Only the current last overlay needs to be demoted — all others are already at 999.
-	[...VISIBLE_OVERLAYS].at(-1)?.style.setProperty('z-index', '999');
+	// Ensure the overlay is at the end of the set to maintain the invariant:
+	// all overlays have z-index 999 except the last one (z-index 1000).
+	const last = [...VISIBLE_OVERLAYS].at(-1);
+	if (last && last !== overlay) {
+		last.style.setProperty('z-index', '999');
+	}
+	VISIBLE_OVERLAYS.delete(overlay);
 	VISIBLE_OVERLAYS.add(overlay);
 	overlay.style.setProperty('z-index', '1000');
 }
@@ -29,9 +34,7 @@ export function showOverlay(overlay: HTMLElement): void {
  * @param overlay Get the overlay element reference
  */
 export function hideOverlay(overlay: HTMLElement): void {
-	const wasLast = [...VISIBLE_OVERLAYS].at(-1) === overlay;
-	VISIBLE_OVERLAYS.delete(overlay);
-	if (wasLast && VISIBLE_OVERLAYS.size > 0) {
+	if (VISIBLE_OVERLAYS.delete(overlay) && VISIBLE_OVERLAYS.size > 0) {
 		[...VISIBLE_OVERLAYS].at(-1)?.style.setProperty('z-index', '1000');
 	}
 }

--- a/packages/components/src/utils/overlay.ts
+++ b/packages/components/src/utils/overlay.ts
@@ -15,9 +15,8 @@ const VISIBLE_OVERLAYS: Set<HTMLElement> = new Set();
  * @param overlay Get the overlay element reference
  */
 export function showOverlay(overlay: HTMLElement): void {
-	VISIBLE_OVERLAYS.forEach((visibleOverlay) => {
-		visibleOverlay.style.setProperty('z-index', '999');
-	});
+	// Only the current last overlay needs to be demoted — all others are already at 999.
+	[...VISIBLE_OVERLAYS].at(-1)?.style.setProperty('z-index', '999');
 	VISIBLE_OVERLAYS.add(overlay);
 	overlay.style.setProperty('z-index', '1000');
 }
@@ -31,10 +30,5 @@ export function showOverlay(overlay: HTMLElement): void {
  */
 export function hideOverlay(overlay: HTMLElement): void {
 	VISIBLE_OVERLAYS.delete(overlay);
-	if (VISIBLE_OVERLAYS.size > 0) {
-		const last = Array.from(VISIBLE_OVERLAYS).pop();
-		if (last) {
-			last.style.setProperty('z-index', '1000');
-		}
-	}
+	[...VISIBLE_OVERLAYS].at(-1)?.style.setProperty('z-index', '1000');
 }

--- a/packages/components/src/utils/overlay.ts
+++ b/packages/components/src/utils/overlay.ts
@@ -29,6 +29,9 @@ export function showOverlay(overlay: HTMLElement): void {
  * @param overlay Get the overlay element reference
  */
 export function hideOverlay(overlay: HTMLElement): void {
+	const wasLast = [...VISIBLE_OVERLAYS].at(-1) === overlay;
 	VISIBLE_OVERLAYS.delete(overlay);
-	[...VISIBLE_OVERLAYS].at(-1)?.style.setProperty('z-index', '1000');
+	if (wasLast && VISIBLE_OVERLAYS.size > 0) {
+		[...VISIBLE_OVERLAYS].at(-1)?.style.setProperty('z-index', '1000');
+	}
 }


### PR DESCRIPTION
## What changed?

The `showOverlay` and `hideOverlay` utility functions in `packages/components/src/utils/overlay.ts` were refactored to avoid redundant iterations over the `VISIBLE_OVERLAYS` set. A new module-level `lastOverlay` variable caches the reference to the current top-most overlay (z-index 1000). In `showOverlay`, only the previous top-most overlay's z-index is reset instead of iterating over all visible overlays. In `hideOverlay`, an early return prevents unnecessary work when the element was never registered, and the new top-most overlay is located by a single pass only when the removed element was the current top. The externally observable behaviour is unchanged.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die Hilfsfunktionen `showOverlay` und `hideOverlay` in `packages/components/src/utils/overlay.ts` wurden überarbeitet, um redundante Iterationen über das `VISIBLE_OVERLAYS`-Set zu vermeiden. Eine neue modulweite Variable `lastOverlay` speichert eine Referenz auf das aktuelle oberste Overlay (z-Index 1000). In `showOverlay` wird nur noch der z-Index des vorherigen obersten Overlays zurückgesetzt, statt über alle sichtbaren Overlays zu iterieren. In `hideOverlay` verhindert ein frühes Return unnötige Arbeit, wenn das Element nie registriert war, und das neue oberste Overlay wird nur dann durch einen einmaligen Durchlauf gefunden, wenn das entfernte Element das aktuelle oberste war. Das äußerlich beobachtbare Verhalten ist unverändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/utils/overlay.ts` — Refactoring der z-Index-Verwaltung mit gecachtem `lastOverlay`-Verweis zur Vermeidung redundanter Set-Iterationen

</details>