### PR TITLE
fix: prevent KolAlert close event from bubbling to KolDialog onClose (#9541)

### DIFF
--- a/packages/components/src/components/dialog/component.tsx
+++ b/packages/components/src/components/dialog/component.tsx
@@ -46,7 +46,12 @@ export class KolDialogWc implements DialogAPI {
 		}
 	};
 
-	private handleNativeCloseEvent() {
+	private handleNativeCloseEvent(event: Event) {
+		// Ignore close events that bubble up from child components (e.g. KolAlert).
+		// Only react when the dialog element itself is the event origin.
+		if (event.target !== this.refDialog) {
+			return;
+		}
 		this.state._on?.onClose?.();
 		if (this.host) {
 			dispatchDomEvent(this.host, KolEvent.close);

--- a/packages/components/src/components/dialog/component.tsx
+++ b/packages/components/src/components/dialog/component.tsx
@@ -52,7 +52,9 @@ export class KolDialogWc implements DialogAPI {
 		if (event.target !== this.refDialog) {
 			return;
 		}
-		this.state._on?.onClose?.();
+		if (typeof this.state._on?.onClose === 'function') {
+			this.state._on.onClose();
+		}
 		if (this.host) {
 			dispatchDomEvent(this.host, KolEvent.close);
 		}

--- a/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
+++ b/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
@@ -1,0 +1,40 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolCardWc } from '../../card/component';
+import { KolDialogWc } from '../component';
+
+describe('kol-dialog-wc onClose event propagation', () => {
+	it('does not call onClose when a child dispatches a bubbling close event', async () => {
+		const onClose = jest.fn();
+
+		const page = await newSpecPage({
+			components: [KolDialogWc, KolCardWc],
+			template: () => <kol-dialog-wc _label="Test" _variant="blank" _on={{ onClose }} />,
+		});
+		await page.waitForChanges();
+
+		// Dispatch a 'close' event from a child element (simulates KolAlert closer).
+		const child = document.createElement('div');
+		page.root?.appendChild(child);
+		child.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true, cancelable: true }));
+
+		expect(onClose).not.toHaveBeenCalled();
+	});
+
+	it('calls onClose when the native dialog element fires a close event', async () => {
+		const onClose = jest.fn();
+
+		const page = await newSpecPage({
+			components: [KolDialogWc, KolCardWc],
+			template: () => <kol-dialog-wc _label="Test" _variant="blank" _on={{ onClose }} />,
+		});
+		await page.waitForChanges();
+
+		// Dispatch a 'close' event from the dialog element itself (simulates native dialog close).
+		const dialog = page.root?.querySelector('dialog');
+		dialog?.dispatchEvent(new Event('close', { bubbles: false }));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
+++ b/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
@@ -41,16 +41,4 @@ describe('kol-dialog-wc onClose event propagation', () => {
 
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
-
-	it('does not throw when onClose is set to boolean true', async () => {
-		const page = await newSpecPage({
-			components: [KolDialogWc, KolCardWc],
-			// onClose: true is a valid value per validateOn (line 179 in component.tsx)
-			template: () => <kol-dialog-wc _label="Test" _variant="blank" _on={{ onClose: true }} />,
-		});
-		await page.waitForChanges();
-
-		const dialog = page.root?.querySelector('dialog');
-		expect(() => dialog?.dispatchEvent(new Event('close', { bubbles: false }))).not.toThrow();
-	});
 });

--- a/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
+++ b/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
@@ -37,4 +37,16 @@ describe('kol-dialog-wc onClose event propagation', () => {
 
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});
+
+	it('does not throw when onClose is set to boolean true', async () => {
+		const page = await newSpecPage({
+			components: [KolDialogWc, KolCardWc],
+			// onClose: true is a valid value per validateOn (line 179 in component.tsx)
+			template: () => <kol-dialog-wc _label="Test" _variant="blank" _on={{ onClose: true }} />,
+		});
+		await page.waitForChanges();
+
+		const dialog = page.root?.querySelector('dialog');
+		expect(() => dialog?.dispatchEvent(new Event('close', { bubbles: false }))).not.toThrow();
+	});
 });

--- a/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
+++ b/packages/components/src/components/dialog/test/on-close-propagation.spec.tsx
@@ -14,9 +14,12 @@ describe('kol-dialog-wc onClose event propagation', () => {
 		});
 		await page.waitForChanges();
 
-		// Dispatch a 'close' event from a child element (simulates KolAlert closer).
+		// The child must be inside the <dialog> so the event actually bubbles through it,
+		// accurately simulating a KolAlert closer click inside an open dialog.
+		const dialog = page.root?.querySelector('dialog');
+		expect(dialog).not.toBeNull();
 		const child = document.createElement('div');
-		page.root?.appendChild(child);
+		dialog!.appendChild(child);
 		child.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true, cancelable: true }));
 
 		expect(onClose).not.toHaveBeenCalled();
@@ -31,9 +34,10 @@ describe('kol-dialog-wc onClose event propagation', () => {
 		});
 		await page.waitForChanges();
 
-		// Dispatch a 'close' event from the dialog element itself (simulates native dialog close).
+		// Assert dialog is present so a missing element causes an explicit failure.
 		const dialog = page.root?.querySelector('dialog');
-		dialog?.dispatchEvent(new Event('close', { bubbles: false }));
+		expect(dialog).not.toBeNull();
+		dialog!.dispatchEvent(new Event('close', { bubbles: false }));
 
 		expect(onClose).toHaveBeenCalledTimes(1);
 	});

--- a/packages/samples/react/src/components/dialog/routes.ts
+++ b/packages/samples/react/src/components/dialog/routes.ts
@@ -1,8 +1,10 @@
 import type { Routes } from '../../shares/types';
 import { DialogBasic } from './basic';
+import { DialogWithAlert } from './with-alert';
 
 export const DIALOG_ROUTES: Routes = {
 	dialog: {
 		basic: DialogBasic,
+		'with-alert': DialogWithAlert,
 	},
 };

--- a/packages/samples/react/src/components/dialog/with-alert.tsx
+++ b/packages/samples/react/src/components/dialog/with-alert.tsx
@@ -1,0 +1,75 @@
+import type { FC } from 'react';
+import React, { useRef, useState } from 'react';
+
+import { KolAlert, KolButton, KolDialog } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+/**
+ * Demonstrates that closing a KolAlert inside a KolDialog does NOT trigger
+ * the dialog's onClose callback (regression test for issue #9541).
+ */
+export const DialogWithAlert: FC = () => {
+	const dialogRef = useRef<HTMLKolDialogElement>(null);
+	const [log, setLog] = useState<string[]>([]);
+	const [showAlert, setShowAlert] = useState(true);
+
+	const appendLog = (msg: string) => setLog((prev) => [...prev, `${new Date().toLocaleTimeString()} – ${msg}`]);
+
+	const onOpenDialog = {
+		onClick: () => {
+			setShowAlert(true);
+			dialogRef.current?.showModal();
+		},
+	};
+
+	const onDialogClose = () => {
+		appendLog('Dialog onClose fired');
+	};
+
+	const onAlertClose = () => {
+		appendLog('Alert onClose fired');
+		setShowAlert(false);
+	};
+
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					Closing the <strong>KolAlert</strong> inside the dialog must <em>not</em> trigger the dialog&apos;s <code>onClose</code> callback. Only closing the
+					dialog itself (via the card closer or <code>close()</code>) should fire that callback.
+				</p>
+				<p>
+					Watch the event log below: after clicking the alert closer you should see <em>only</em> &quot;Alert onClose fired&quot;, not &quot;Dialog onClose
+					fired&quot;.
+				</p>
+			</SampleDescription>
+
+			<div className="grid gap-4">
+				<div>
+					<KolButton _label="Open dialog with alert" _on={onOpenDialog} />
+					<KolDialog ref={dialogRef} _label="Dialog with KolAlert inside" _variant="card" _width="40%" _on={{ onClose: onDialogClose }}>
+						<div className="p-4">
+							{showAlert && (
+								<KolAlert _label="Closeable alert" _type="info" _variant="card" _hasCloser _on={{ onClose: onAlertClose }}>
+									Close this alert – the dialog must stay open and its onClose must NOT fire.
+								</KolAlert>
+							)}
+							{!showAlert && <p>Alert was closed. The dialog is still open – correct behaviour!</p>}
+						</div>
+					</KolDialog>
+				</div>
+
+				{log.length > 0 && (
+					<div>
+						<strong>Event log:</strong>
+						<ul>
+							{log.map((entry, i) => (
+								<li key={i}>{entry}</li>
+							))}
+						</ul>
+					</div>
+				)}
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
## What changed?

`KolAlertWc` dispatches a custom `close` event with `bubbles: true` and `composed: true` whenever its closer button is clicked. Because `KolDialogWc` renders a native `<dialog>` element and attaches an `onClose` listener, this bubbling event from a `KolAlert` nested inside a `KolDialog` was incorrectly intercepted by the dialog's listener — triggering the dialog's `onClose` callback even though the dialog itself was not being closed. The fix adds an `event.target` guard in `KolDialogWc.handleNativeCloseEvent`: the method now returns early if the event did not originate from the dialog element itself, ensuring only genuine native dialog-close events invoke the `onClose` callback. New unit tests covering both the ignored-bubbled-event and the handled-native-event cases were added, along with a React sample page at `/#/dialog/with-alert`.

## Linked issues

- Closes #9541 — KolAlert close event bubbles to KolDialog onClose

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolAlertWc` sendet beim Klick auf den Schließen-Button ein `close`-Ereignis mit `bubbles: true` und `composed: true`. Da `KolDialogWc` ein natives `<dialog>`-Element rendert und einen `onClose`-Listener anhängt, wurde dieses bubbelnde Ereignis einer `KolAlert` innerhalb eines `KolDialog` fälschlicherweise vom Dialog-Listener abgefangen — wodurch der `onClose`-Callback des Dialogs ausgelöst wurde, obwohl der Dialog selbst nicht geschlossen wurde. Die Behebung fügt einen `event.target`-Guard in `KolDialogWc.handleNativeCloseEvent` hinzu: Die Methode bricht jetzt ab, wenn das Ereignis nicht vom Dialog-Element selbst stammt. Neue Unit-Tests und eine React-Beispielseite `/#/dialog/with-alert` wurden ergänzt.

### Verknüpfte Tickets

- Schließt #9541 — KolAlert-close-Ereignis bubbles zu KolDialog onClose

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/dialog/component.tsx` — `event.target`-Guard in `handleNativeCloseEvent` ergänzt
- `packages/components/src/components/dialog/test/on-close-propagation.spec.tsx` — Neue Unit-Tests für beide Fälle (gebubbeltes Ereignis ignoriert / natives Ereignis behandelt)
- `packages/samples/react/src/components/dialog/with-alert.tsx` — Neue Beispielseite zur manuellen Verifikation
- `packages/samples/react/src/components/dialog/routes.ts` — Neue Route `with-alert` registriert

</details>
