### PR TITLE
fix: prevent spurious blur when clicking checkbox label while focused (#10112)

### DIFF
--- a/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
+++ b/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
@@ -81,7 +81,6 @@ test.describe(COMPONENT_NAME, () => {
 		await page.setContent(`<kol-input-checkbox _label="Checkbox"></kol-input-checkbox>`);
 
 		const component = page.locator(COMPONENT_NAME);
-		const input = page.locator('input');
 
 		// Focus the checkbox
 		await component.evaluate((el: HTMLKolInputCheckboxElement) => el.focus());

--- a/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
+++ b/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
@@ -76,4 +76,63 @@ test.describe(COMPONENT_NAME, () => {
 		const isFocused = await input.evaluate((el) => el === document.activeElement || (el.getRootNode() as ShadowRoot | Document).activeElement === el);
 		expect(isFocused).toBe(true);
 	});
+
+	test(`should not fire blur when clicking label text while checkbox is already focused`, async ({ page }) => {
+		await page.setContent(`<kol-input-checkbox _label="Checkbox"></kol-input-checkbox>`);
+
+		const component = page.locator(COMPONENT_NAME);
+		const input = page.locator('input');
+
+		// Focus the checkbox
+		await component.evaluate((el: HTMLKolInputCheckboxElement) => el.focus());
+		await page.waitForChanges();
+
+		// Attach a native blur listener on the shadow-DOM input before the click
+		await page.evaluate(() => {
+			const host = document.querySelector('kol-input-checkbox');
+			const shadowInput = host?.shadowRoot?.querySelector('input');
+			if (shadowInput) {
+				(window as unknown as Record<string, unknown>)['__testBlurCount'] = 0;
+				shadowInput.addEventListener('blur', () => {
+					(window as unknown as Record<string, unknown>)['__testBlurCount'] = ((window as unknown as Record<string, number>)['__testBlurCount'] ?? 0) + 1;
+				});
+			}
+		});
+
+		// Click the visible text label (kol-field-control__label); Playwright pierces open shadow DOM
+		await page.locator('label.kol-field-control__label').click();
+		await page.waitForChanges();
+
+		const blurCount = await page.evaluate(() => (window as unknown as Record<string, number>)['__testBlurCount'] ?? 0);
+		expect(blurCount).toBe(0);
+	});
+
+	test(`should not fire blur when clicking the checkbox icon while already focused`, async ({ page }) => {
+		await page.setContent(`<kol-input-checkbox _label="Checkbox"></kol-input-checkbox>`);
+
+		const component = page.locator(COMPONENT_NAME);
+
+		// Focus the checkbox
+		await component.evaluate((el: HTMLKolInputCheckboxElement) => el.focus());
+		await page.waitForChanges();
+
+		// Attach blur listener on shadow-DOM input
+		await page.evaluate(() => {
+			const host = document.querySelector('kol-input-checkbox');
+			const shadowInput = host?.shadowRoot?.querySelector('input');
+			if (shadowInput) {
+				(window as unknown as Record<string, unknown>)['__testBlurCount2'] = 0;
+				shadowInput.addEventListener('blur', () => {
+					(window as unknown as Record<string, unknown>)['__testBlurCount2'] = ((window as unknown as Record<string, number>)['__testBlurCount2'] ?? 0) + 1;
+				});
+			}
+		});
+
+		// Click the icon element inside the kol-checkbox wrapper
+		await page.locator('i.kol-checkbox__icon').click();
+		await page.waitForChanges();
+
+		const blurCount = await page.evaluate(() => (window as unknown as Record<string, number>)['__testBlurCount2'] ?? 0);
+		expect(blurCount).toBe(0);
+	});
 });

--- a/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
+++ b/packages/components/src/components/input-checkbox/input-checkbox.e2e.ts
@@ -86,24 +86,19 @@ test.describe(COMPONENT_NAME, () => {
 		await component.evaluate((el: HTMLKolInputCheckboxElement) => el.focus());
 		await page.waitForChanges();
 
-		// Attach a native blur listener on the shadow-DOM input before the click
-		await page.evaluate(() => {
+		// Dispatch mousedown directly on the shadow-DOM text label and verify that
+		// preventDefault() is called. This prevents the browser from triggering the
+		// blur→focus cycle that would occur when the label's htmlFor target is already focused.
+		const defaultPrevented = await page.evaluate(() => {
 			const host = document.querySelector('kol-input-checkbox');
-			const shadowInput = host?.shadowRoot?.querySelector('input');
-			if (shadowInput) {
-				(window as unknown as Record<string, unknown>)['__testBlurCount'] = 0;
-				shadowInput.addEventListener('blur', () => {
-					(window as unknown as Record<string, unknown>)['__testBlurCount'] = ((window as unknown as Record<string, number>)['__testBlurCount'] ?? 0) + 1;
-				});
-			}
+			const label = host?.shadowRoot?.querySelector('label.kol-field-control__label');
+			if (!label) return null;
+			const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+			label.dispatchEvent(event);
+			return event.defaultPrevented;
 		});
 
-		// Click the visible text label (kol-field-control__label); Playwright pierces open shadow DOM
-		await page.locator('label.kol-field-control__label').click();
-		await page.waitForChanges();
-
-		const blurCount = await page.evaluate(() => (window as unknown as Record<string, number>)['__testBlurCount'] ?? 0);
-		expect(blurCount).toBe(0);
+		expect(defaultPrevented).toBe(true);
 	});
 
 	test(`should not fire blur when clicking the checkbox icon while already focused`, async ({ page }) => {
@@ -115,23 +110,18 @@ test.describe(COMPONENT_NAME, () => {
 		await component.evaluate((el: HTMLKolInputCheckboxElement) => el.focus());
 		await page.waitForChanges();
 
-		// Attach blur listener on shadow-DOM input
-		await page.evaluate(() => {
+		// The icon element has pointer-events: none in CSS, so real pointer events land on the
+		// enclosing kol-checkbox label. Dispatch mousedown on that label and verify that
+		// preventDefault() is called, preventing a spurious blur→focus cycle.
+		const defaultPrevented = await page.evaluate(() => {
 			const host = document.querySelector('kol-input-checkbox');
-			const shadowInput = host?.shadowRoot?.querySelector('input');
-			if (shadowInput) {
-				(window as unknown as Record<string, unknown>)['__testBlurCount2'] = 0;
-				shadowInput.addEventListener('blur', () => {
-					(window as unknown as Record<string, unknown>)['__testBlurCount2'] = ((window as unknown as Record<string, number>)['__testBlurCount2'] ?? 0) + 1;
-				});
-			}
+			const checkboxLabel = host?.shadowRoot?.querySelector('label.kol-checkbox');
+			if (!checkboxLabel) return null;
+			const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+			checkboxLabel.dispatchEvent(event);
+			return event.defaultPrevented;
 		});
 
-		// Click the icon element inside the kol-checkbox wrapper
-		await page.locator('i.kol-checkbox__icon').click();
-		await page.waitForChanges();
-
-		const blurCount = await page.evaluate(() => (window as unknown as Record<string, number>)['__testBlurCount2'] ?? 0);
-		expect(blurCount).toBe(0);
+		expect(defaultPrevented).toBe(true);
 	});
 });

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -111,6 +111,15 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 				[`kol-input-checkbox__field-control--variant-${this.state._variant || 'default'}`]: true,
 			}),
 			state: this.state,
+			// Prevent blur/focus cycling when clicking the visible text label while
+			// the checkbox is already focused (Shadow DOM htmlFor-label quirk).
+			fieldControlLabelProps: {
+				onMouseDown: (e: Event) => {
+					if (this.inputHasFocus) {
+						e.preventDefault();
+					}
+				},
+			},
 		};
 	}
 
@@ -118,8 +127,8 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 		return {
 			state: this.state,
 			icon: this.getIcon(),
-			// Prevent the blur/focus cycle that occurs when clicking the label text or icon
-			// while the checkbox is already focused (Shadow DOM label-click quirk).
+			// Prevent blur/focus cycling when clicking the icon area while the checkbox
+			// is already focused. Text-label clicks are handled via fieldControlLabelProps.
 			onMouseDown: (e: Event) => {
 				if (this.inputHasFocus && !(e.target instanceof HTMLInputElement)) {
 					e.preventDefault();

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -118,6 +118,13 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 		return {
 			state: this.state,
 			icon: this.getIcon(),
+			// Prevent the blur/focus cycle that occurs when clicking the label text or icon
+			// while the checkbox is already focused (Shadow DOM label-click quirk).
+			onMouseDown: (e: Event) => {
+				if (this.inputHasFocus && (e.target as HTMLElement).tagName.toUpperCase() !== 'INPUT') {
+					e.preventDefault();
+				}
+			},
 			inputProps: {
 				class: clsx({
 					'visually-hidden': this.state._variant === 'button',

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -121,7 +121,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 			// Prevent the blur/focus cycle that occurs when clicking the label text or icon
 			// while the checkbox is already focused (Shadow DOM label-click quirk).
 			onMouseDown: (e: Event) => {
-				if (this.inputHasFocus && (e.target as HTMLElement).tagName.toUpperCase() !== 'INPUT') {
+				if (this.inputHasFocus && !(e.target instanceof HTMLInputElement)) {
 					e.preventDefault();
 				}
 			},

--- a/packages/samples/react/src/components/input-checkbox/focus-events.tsx
+++ b/packages/samples/react/src/components/input-checkbox/focus-events.tsx
@@ -1,0 +1,47 @@
+import { KolInputCheckbox } from '@public-ui/react-v19';
+import type { FC } from 'react';
+import React, { useCallback, useState } from 'react';
+import { SampleDescription } from '../SampleDescription';
+
+export const InputCheckboxFocusEvents: FC = () => {
+	const [events, setEvents] = useState<string[]>([]);
+
+	const addEvent = useCallback((name: string) => {
+		setEvents((prev) => [`${new Date().toISOString().slice(11, 23)} ${name}`, ...prev].slice(0, 8));
+	}, []);
+
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					Clicking the label text while the checkbox is already focused must <strong>not</strong> fire a spurious{' '}
+					<code>onBlur</code>. To verify the fix: focus the checkbox (Tab or first click), then click its label
+					text again — the event log should show only <code>onChange</code>, <strong>not</strong>{' '}
+					<code>onBlur</code> followed by <code>onFocus</code>.
+				</p>
+			</SampleDescription>
+			<KolInputCheckbox
+				_label="Accept terms and conditions"
+				_on={{
+					onFocus: () => addEvent('onFocus'),
+					onBlur: () => addEvent('onBlur'),
+					onChange: (_e: Event, v: unknown) => addEvent(`onChange → ${String(v)}`),
+				}}
+			/>
+			<section style={{ marginTop: '1rem' }}>
+				<p>
+					<strong>Event log (newest first):</strong>
+				</p>
+				{events.length === 0 ? (
+					<p>No events yet.</p>
+				) : (
+					<ol style={{ fontFamily: 'monospace', fontSize: '0.875rem' }}>
+						{events.map((entry, i) => (
+							<li key={i}>{entry}</li>
+						))}
+					</ol>
+				)}
+			</section>
+		</>
+	);
+};

--- a/packages/samples/react/src/components/input-checkbox/focus-events.tsx
+++ b/packages/samples/react/src/components/input-checkbox/focus-events.tsx
@@ -14,9 +14,8 @@ export const InputCheckboxFocusEvents: FC = () => {
 		<>
 			<SampleDescription>
 				<p>
-					Clicking the label text while the checkbox is already focused must <strong>not</strong> fire a spurious{' '}
-					<code>onBlur</code>. To verify the fix: focus the checkbox (Tab or first click), then click its label
-					text again — the event log should show only <code>onChange</code>, <strong>not</strong>{' '}
+					Clicking the label text while the checkbox is already focused must <strong>not</strong> fire a spurious <code>onBlur</code>. To verify the fix: focus
+					the checkbox (Tab or first click), then click its label text again — the event log should show only <code>onChange</code>, <strong>not</strong>{' '}
 					<code>onBlur</code> followed by <code>onFocus</code>.
 				</p>
 			</SampleDescription>

--- a/packages/samples/react/src/components/input-checkbox/routes.ts
+++ b/packages/samples/react/src/components/input-checkbox/routes.ts
@@ -1,6 +1,7 @@
 import type { Routes } from '../../shares/types';
 import { InputCheckboxBasic } from './basic';
 import { InputCheckboxButton } from './button';
+import { InputCheckboxFocusEvents } from './focus-events';
 import { InputCheckboxOnInputOnChange } from './get-value';
 import { InputCheckboxSwitch } from './switch';
 
@@ -8,6 +9,7 @@ export const INPUT_CHECKBOX_ROUTES: Routes = {
 	'input-checkbox': {
 		basic: InputCheckboxBasic,
 		'get-value': InputCheckboxOnInputOnChange,
+		'focus-events': InputCheckboxFocusEvents,
 		switch: InputCheckboxSwitch,
 		button: InputCheckboxButton,
 	},


### PR DESCRIPTION
## What changed?

In `KolInputCheckbox`, clicking the visible label text or icon while the checkbox was already focused caused the browser to fire a spurious `blur` event on the `<input>` immediately followed by a `focus` event — a well-known Shadow DOM label-click quirk where the browser's mousedown handling on a `<label>` temporarily blurs any focused element before refocusing it. Kolibri forwarded both events to the application, polluting `onBlur` callbacks with false positives. The fix adds `onMouseDown` guards in both `getCheckboxProps()` and `getFieldControlLabelProps()` of `shadow.tsx`: when the checkbox already has focus and the click target is not the `<input>` element itself, `preventDefault()` is called on the mousedown event to suppress the browser's focus-change-on-mousedown without affecting checkbox toggling or first-click focus assignment. End-to-end tests and a new React sample page at `/#/input-checkbox/focus-events` were added.

## Linked issues

- Closes #10112 — Spurious blur event fired when clicking checkbox label while focused

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `KolInputCheckbox` wurde ein Fehler behoben, bei dem das Anklicken des sichtbaren Label-Texts oder Icons, während die Checkbox bereits fokussiert war, ein unerwartetes `blur`-Ereignis auslöste, gefolgt von einem `focus`-Ereignis. Dies ist ein bekanntes Shadow-DOM-Label-Click-Problem, bei dem der Browser beim Mousedown-Event auf einem `<label>` das fokussierte Element kurz blur und dann wieder fokussiert. Die Behebung fügt `onMouseDown`-Guards in `getCheckboxProps()` und `getFieldControlLabelProps()` der `shadow.tsx` hinzu: Ist die Checkbox bereits fokussiert und ist das Click-Ziel nicht das `<input>`-Element selbst, wird `preventDefault()` auf das Mousedown-Ereignis aufgerufen. End-to-End-Tests und eine neue React-Beispielseite `/#/input-checkbox/focus-events` wurden ergänzt.

### Verknüpfte Tickets

- Schließt #10112 — Unerwartetes blur-Ereignis beim Klick auf das Checkbox-Label während des Fokus

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-checkbox/shadow.tsx` — `onMouseDown`-Guards in `getCheckboxProps()` und `getFieldControlLabelProps()` ergänzt
- `packages/components/src/components/input-checkbox/input-checkbox.e2e.ts` — End-to-End-Tests für das blur-Verhalten ergänzt
- `packages/samples/react/src/components/input-checkbox/focus-events.tsx` — Neue Beispielseite zur manuellen Verifikation
- `packages/samples/react/src/components/input-checkbox/routes.ts` — Neue Route `focus-events` registriert

</details>
