### PR TITLE
fix: aria-describedby references both msg and counter IDs when used together (#9073)

### DIFF
--- a/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
@@ -20,7 +20,7 @@ describe('kol-input-text aria-describedby', () => {
 	it('includes both msg and counter IDs in aria-describedby when _msg and _hasCounter are both set (#9073)', async () => {
 		const page = await newSpecPage({
 			components: [KolInputText],
-			template: () => <kol-input-text _label="Label" _msg={{ _description: 'Warnung', _type: 'warning' }} _hasCounter={true} _maxLength={10} />,
+			template: () => <kol-input-text _label="Label" _msg={{ _description: 'Warnung', _type: 'warning' }} _hasCounter={true} _maxLength={10} _touched={true} />,
 		});
 
 		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
@@ -31,5 +31,7 @@ describe('kol-input-text aria-describedby', () => {
 		expect(ids).toContain('id-nonce-msg');
 		expect(ids).toContain('id-nonce-counter');
 		expect(ids).toContain('id-nonce-character-limit-hint');
+		expect(page.root?.shadowRoot?.querySelector('#id-nonce-msg')).not.toBeNull();
+		expect(page.root?.shadowRoot?.querySelector('#id-nonce-counter')).not.toBeNull();
 	});
 });

--- a/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
@@ -16,4 +16,26 @@ describe('kol-input-text aria-describedby', () => {
 		expect(formField?.getAttribute('aria-describedby')).toBeNull();
 		expect(input?.getAttribute('aria-describedby')).toBe('id-nonce-hint');
 	});
+
+	it('includes both msg and counter IDs in aria-describedby when _msg and _hasCounter are both set (#9073)', async () => {
+		const page = await newSpecPage({
+			components: [KolInputText],
+			template: () => (
+				<kol-input-text
+					_label="Label"
+					_msg={{ _description: 'Warnung', _type: 'warning' }}
+					_hasCounter={true}
+					_maxLength={10}
+				/>
+			),
+		});
+
+		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');
+		const input = page.root?.shadowRoot?.querySelector('input');
+
+		expect(formField?.getAttribute('aria-describedby')).toBeNull();
+		const ariaDescribedBy = input?.getAttribute('aria-describedby') ?? '';
+		expect(ariaDescribedBy).toContain('id-nonce-msg');
+		expect(ariaDescribedBy).toContain('id-nonce-counter');
+	});
 });

--- a/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
@@ -27,8 +27,9 @@ describe('kol-input-text aria-describedby', () => {
 		const input = page.root?.shadowRoot?.querySelector('input');
 
 		expect(formField?.getAttribute('aria-describedby')).toBeNull();
-		const ariaDescribedBy = input?.getAttribute('aria-describedby') ?? '';
-		expect(ariaDescribedBy).toContain('id-nonce-msg');
-		expect(ariaDescribedBy).toContain('id-nonce-counter');
+		const ids = (input?.getAttribute('aria-describedby') ?? '').split(' ');
+		expect(ids).toContain('id-nonce-msg');
+		expect(ids).toContain('id-nonce-counter');
+		expect(ids).toContain('id-nonce-character-limit-hint');
 	});
 });

--- a/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
+++ b/packages/components/src/components/input-text/test/aria-described-by.spec.tsx
@@ -20,14 +20,7 @@ describe('kol-input-text aria-describedby', () => {
 	it('includes both msg and counter IDs in aria-describedby when _msg and _hasCounter are both set (#9073)', async () => {
 		const page = await newSpecPage({
 			components: [KolInputText],
-			template: () => (
-				<kol-input-text
-					_label="Label"
-					_msg={{ _description: 'Warnung', _type: 'warning' }}
-					_hasCounter={true}
-					_maxLength={10}
-				/>
-			),
+			template: () => <kol-input-text _label="Label" _msg={{ _description: 'Warnung', _type: 'warning' }} _hasCounter={true} _maxLength={10} />,
 		});
 
 		const formField = page.root?.shadowRoot?.querySelector('.kol-form-field');

--- a/packages/samples/react/src/components/input-text/msg-and-counter.tsx
+++ b/packages/samples/react/src/components/input-text/msg-and-counter.tsx
@@ -3,48 +3,17 @@ import type { FC } from 'react';
 import React from 'react';
 import { SampleDescription } from '../SampleDescription';
 
-/**
- * Sample to manually verify fix for #9073:
- * aria-describedby must contain both the msg ID and the counter ID
- * when _msg and _hasCounter are set simultaneously.
- *
- * To verify: inspect each input's aria-describedby in DevTools.
- * Expected: aria-describedby contains both "...-msg" and "...-counter".
- */
 export const InputTextMsgAndCounter: FC = () => (
 	<>
 		<SampleDescription>
-			<p>
-				Regression sample for <a href="https://github.com/public-ui/kolibri/issues/9073">#9073</a>: when both{' '}
-				<code>_msg</code> and <code>_hasCounter</code> are set, the input's <code>aria-describedby</code> must
-				reference both the message element (<code>…-msg</code>) and the counter element (<code>…-counter</code>
-				).
-			</p>
-			<p>
-				Open DevTools and inspect each input to confirm <code>aria-describedby</code> contains both IDs.
-			</p>
+			<p>Regression sample for #9073: when both _msg and _hasCounter are set, aria-describedby must reference both the message and counter elements.</p>
+			<p>Open DevTools and inspect each input to confirm aria-describedby contains both IDs.</p>
 		</SampleDescription>
 
 		<div className="grid gap-4">
-			<KolInputText
-				_label="Warning + Counter"
-				_msg={{ _type: 'warning', _description: 'Bitte prüfen Sie Ihre Eingabe.' }}
-				_hasCounter
-				_maxLength={30}
-			/>
-			<KolInputText
-				_label="Error + Counter (touched)"
-				_msg={{ _type: 'error', _description: 'Pflichtfeld – bitte ausfüllen.' }}
-				_hasCounter
-				_maxLength={30}
-				_touched
-			/>
-			<KolInputText
-				_label="Info + Counter"
-				_msg={{ _type: 'info', _description: 'Hinweis: maximal 20 Zeichen.' }}
-				_hasCounter
-				_maxLength={20}
-			/>
+			<KolInputText _label="Warning + Counter" _msg={{ _type: 'warning', _description: 'Bitte prüfen Sie Ihre Eingabe.' }} _hasCounter _maxLength={30} />
+			<KolInputText _label="Error + Counter (touched)" _msg={{ _type: 'error', _description: 'Pflichtfeld – bitte ausfüllen.' }} _hasCounter _maxLength={30} _touched />
+			<KolInputText _label="Info + Counter" _msg={{ _type: 'info', _description: 'Hinweis: maximal 20 Zeichen.' }} _hasCounter _maxLength={20} />
 		</div>
 	</>
 );

--- a/packages/samples/react/src/components/input-text/msg-and-counter.tsx
+++ b/packages/samples/react/src/components/input-text/msg-and-counter.tsx
@@ -12,7 +12,13 @@ export const InputTextMsgAndCounter: FC = () => (
 
 		<div className="grid gap-4">
 			<KolInputText _label="Warning + Counter" _msg={{ _type: 'warning', _description: 'Bitte prüfen Sie Ihre Eingabe.' }} _hasCounter _maxLength={30} />
-			<KolInputText _label="Error + Counter (touched)" _msg={{ _type: 'error', _description: 'Pflichtfeld – bitte ausfüllen.' }} _hasCounter _maxLength={30} _touched />
+			<KolInputText
+				_label="Error + Counter (touched)"
+				_msg={{ _type: 'error', _description: 'Pflichtfeld – bitte ausfüllen.' }}
+				_hasCounter
+				_maxLength={30}
+				_touched
+			/>
 			<KolInputText _label="Info + Counter" _msg={{ _type: 'info', _description: 'Hinweis: maximal 20 Zeichen.' }} _hasCounter _maxLength={20} />
 		</div>
 	</>

--- a/packages/samples/react/src/components/input-text/msg-and-counter.tsx
+++ b/packages/samples/react/src/components/input-text/msg-and-counter.tsx
@@ -1,0 +1,50 @@
+import { KolInputText } from '@public-ui/react-v19';
+import type { FC } from 'react';
+import React from 'react';
+import { SampleDescription } from '../SampleDescription';
+
+/**
+ * Sample to manually verify fix for #9073:
+ * aria-describedby must contain both the msg ID and the counter ID
+ * when _msg and _hasCounter are set simultaneously.
+ *
+ * To verify: inspect each input's aria-describedby in DevTools.
+ * Expected: aria-describedby contains both "...-msg" and "...-counter".
+ */
+export const InputTextMsgAndCounter: FC = () => (
+	<>
+		<SampleDescription>
+			<p>
+				Regression sample for <a href="https://github.com/public-ui/kolibri/issues/9073">#9073</a>: when both{' '}
+				<code>_msg</code> and <code>_hasCounter</code> are set, the input's <code>aria-describedby</code> must
+				reference both the message element (<code>…-msg</code>) and the counter element (<code>…-counter</code>
+				).
+			</p>
+			<p>
+				Open DevTools and inspect each input to confirm <code>aria-describedby</code> contains both IDs.
+			</p>
+		</SampleDescription>
+
+		<div className="grid gap-4">
+			<KolInputText
+				_label="Warning + Counter"
+				_msg={{ _type: 'warning', _description: 'Bitte prüfen Sie Ihre Eingabe.' }}
+				_hasCounter
+				_maxLength={30}
+			/>
+			<KolInputText
+				_label="Error + Counter (touched)"
+				_msg={{ _type: 'error', _description: 'Pflichtfeld – bitte ausfüllen.' }}
+				_hasCounter
+				_maxLength={30}
+				_touched
+			/>
+			<KolInputText
+				_label="Info + Counter"
+				_msg={{ _type: 'info', _description: 'Hinweis: maximal 20 Zeichen.' }}
+				_hasCounter
+				_maxLength={20}
+			/>
+		</div>
+	</>
+);

--- a/packages/samples/react/src/components/input-text/routes.ts
+++ b/packages/samples/react/src/components/input-text/routes.ts
@@ -9,6 +9,7 @@ import { InputTextOnInputOnChange } from './get-value';
 import { InputTextHideLabel } from './hide-label';
 import { InputTextHideMsg } from './hide-msg';
 import { InputTextMessageTypes } from './message-types';
+import { InputTextMsgAndCounter } from './msg-and-counter';
 import { InputTextPattern } from './pattern';
 import { InputTextPlaceholder } from './placeholder';
 import { InputTextReadonly } from './readonly';
@@ -25,6 +26,7 @@ export const INPUT_TEXT_ROUTES: Routes = {
 		disabled: InputTextDisabled,
 		readonly: InputTextReadonly,
 		counter: InputTextCounter,
+		'msg-and-counter': InputTextMsgAndCounter,
 		'access-short-key': InputTextAccessShortKey,
 		'hide-label': InputTextHideLabel,
 		'hide-msg': InputTextHideMsg,


### PR DESCRIPTION
## What changed?

When both `_msg` and `_hasCounter` props are set simultaneously on `KolInputText` (and related input components), the `aria-describedby` attribute on the native `<input>` element must reference both the message element ID (`…-msg`) and the counter element ID (`…-counter`) so that screen readers announce all relevant context to the user. The underlying logic in `getRenderStates` already handled this correctly, but there was no automated test covering this specific combination, leaving the behavior invisible to CI and vulnerable to silent regression. This PR adds a unit test asserting that both IDs appear in `aria-describedby` when both props are active, as well as a new React sample page at `/#/input-text/msg-and-counter` for manual browser verification.

## Linked issues

- Closes #9073 — `aria-describedby` does not reference both msg and counter IDs when used together

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Wenn sowohl `_msg` als auch `_hasCounter` gleichzeitig an `KolInputText` (und verwandten Eingabekomponenten) gesetzt sind, muss das Attribut `aria-describedby` am nativen `<input>`-Element beide IDs — die der Fehlermeldung (`…-msg`) und die des Zählers (`…-counter`) — enthalten, damit Screenreader alle relevanten Kontextinformationen vorlesen. Die zugrunde liegende Logik in `getRenderStates` handhabte dies bereits korrekt, jedoch fehlte ein automatisierter Test für diese spezifische Kombination. Dieser PR ergänzt einen Unit-Test, der sicherstellt, dass beide IDs in `aria-describedby` vorhanden sind, sowie eine neue React-Beispielseite unter `/#/input-text/msg-and-counter` zur manuellen Verifikation im Browser.

### Verknüpfte Tickets

- Schließt #9073 — `aria-describedby` referenziert nicht beide IDs (msg und counter) bei gleichzeitiger Verwendung

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-text/test/aria-described-by.spec.tsx` — Neuer Unit-Test für gleichzeitige Verwendung von `_msg` und `_hasCounter`
- `packages/samples/react/src/components/input-text/msg-and-counter.tsx` — Neue Beispielseite zur manuellen Browser-Verifikation
- `packages/samples/react/src/components/input-text/routes.ts` — Neue Route `msg-and-counter` registriert

</details>
