### PR TITLE
fix: update password variant migration to use string values for visibility toggle

### DIFF
--- a/packages/components/src/components/input-number/input-number.e2e.ts
+++ b/packages/components/src/components/input-number/input-number.e2e.ts
@@ -4,6 +4,7 @@ import { test } from '@stencil/playwright';
 import { testInputCallbacksAndEvents, testInputValueReflection } from '../../e2e';
 import { testInputMessage } from '../../e2e/input-msg';
 import type { FillAction } from '../../e2e/utils/FillAction';
+import { setContentWithRetry } from '../../e2e/utils/setContentWithRetry';
 import type { NumberString } from '../../schema';
 
 const COMPONENT_NAME = 'kol-input-number';
@@ -111,7 +112,7 @@ test.describe(COMPONENT_NAME, () => {
 		});
 
 		test('HTML: should handle undefined type correctly', async ({ page }) => {
-			await page.setContent('<kol-input-number _label="Number input"></kol-input-number>');
+			await setContentWithRetry(page, '<kol-input-number _label="Number input"></kol-input-number>');
 			await setInitialValue(page, undefined);
 
 			const getValueResult = await getCurrentValue(page);
@@ -130,7 +131,7 @@ test.describe(COMPONENT_NAME, () => {
 				<script type="module">
 					import React from 'https://esm.sh/react';
 					import { createRoot } from 'https://esm.sh/react-dom/client';
-					
+
 					// Create a simple wrapper that renders a kol-input-number
 					const root = createRoot(document.getElementById('root'));
 					const element = React.createElement('kol-input-number', {
@@ -278,7 +279,7 @@ test.describe(COMPONENT_NAME, () => {
 				<script type="module">
 					import React from 'https://esm.sh/react';
 					import { createRoot } from 'https://esm.sh/react-dom/client';
-					
+
 					const root = createRoot(document.getElementById('root'));
 					const element = React.createElement('kol-input-number', {
 						_label: 'Number input',

--- a/packages/components/src/e2e/input-msg.ts
+++ b/packages/components/src/e2e/input-msg.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
 import type { MsgPropType, Stringified } from '../schema';
+import { setContentWithRetry } from './utils/setContentWithRetry';
 
 const testInputMessage = <ElementType extends { _msg?: Stringified<MsgPropType>; _touched?: boolean } & HTMLElement>(componentName: string) => {
 	test.describe('Input messages', () => {
@@ -26,11 +27,10 @@ const testInputMessage = <ElementType extends { _msg?: Stringified<MsgPropType>;
 		});
 
 		test('should display and hide message based on _msg value', async ({ page }) => {
-			await page.setContent(`<${componentName}
-					_label="Input"
-					_msg="{'_description': 'An error message', '_type': 'error'}"
-					_touched
-				></${componentName}>`);
+			await setContentWithRetry(
+				page,
+				`<${componentName} _label="Input" _msg="{'_description': 'An error message', '_type': 'error'}" _touched></${componentName}>`,
+			);
 			const alert = page.getByTestId('alert');
 
 			await expect(alert).toBeVisible();

--- a/packages/components/src/e2e/utils/setContentWithRetry.ts
+++ b/packages/components/src/e2e/utils/setContentWithRetry.ts
@@ -1,0 +1,16 @@
+import type { E2EPage } from '@stencil/playwright';
+
+const setContentWithRetry = async (page: Pick<E2EPage, 'setContent' | 'waitForTimeout'>, html: string) => {
+	try {
+		await page.setContent(html);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!message.includes('page.waitForFunction: Timeout')) {
+			throw error;
+		}
+		await page.waitForTimeout(250);
+		await page.setContent(html);
+	}
+};
+
+export { setContentWithRetry };

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/AbstractMapPropertyValueToBooleanTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/AbstractMapPropertyValueToBooleanTask.ts
@@ -1,0 +1,160 @@
+import fs from 'fs';
+
+import { COMPONENT_FILE_EXTENSIONS, CUSTOM_ELEMENT_FILE_EXTENSIONS, MARKUP_EXTENSIONS } from '../../../../types';
+import {
+	filterFilesByExt,
+	isPropertyKebabCaseRegExp,
+	isTagKebabCaseRegExp,
+	kebabToCamelCase,
+	kebabToCapitalCase,
+	logAndCreateError,
+	MODIFIED_FILES,
+} from '../../../shares/reuse';
+import { AbstractTask, TaskOptions } from '../../abstract-task';
+
+export type BooleanMappingResult = 'false' | 'remove' | 'true';
+
+export type BooleanPropertyValueMapping = {
+	fromValue: string;
+	result: BooleanMappingResult;
+};
+
+export type BareSourceResult = BooleanMappingResult;
+
+export abstract class AbstractMapPropertyValueToBooleanTask extends AbstractTask {
+	private readonly componentTagRegExp: RegExp;
+	private readonly customElementTagRegExp: RegExp;
+	private readonly sourcePropertyCamelCase: string;
+	private readonly tagCapitalCase: string;
+	private readonly targetPropertyCamelCase: string;
+
+	protected constructor(
+		identifier: string,
+		title: string,
+		private readonly tag: string,
+		private readonly sourceProperty: string,
+		private readonly targetProperty: string,
+		private readonly mappings: BooleanPropertyValueMapping[],
+		versionRange: string,
+		dependentTasks: AbstractTask[] = [],
+		private readonly preserveExistingTarget = false,
+		private readonly bareSourceResult?: BareSourceResult,
+		options: TaskOptions = {},
+	) {
+		super(identifier, title, MARKUP_EXTENSIONS, versionRange, dependentTasks, options);
+
+		if (!isTagKebabCaseRegExp.test(tag)) {
+			throw logAndCreateError(`Tag "${tag}" is not in kebab case.`);
+		}
+		if (!isPropertyKebabCaseRegExp.test(sourceProperty)) {
+			throw logAndCreateError(`Source property "${sourceProperty}" is not in kebab case.`);
+		}
+		if (!isPropertyKebabCaseRegExp.test(targetProperty)) {
+			throw logAndCreateError(`Target property "${targetProperty}" is not in kebab case.`);
+		}
+
+		this.sourcePropertyCamelCase = kebabToCamelCase(sourceProperty);
+		this.targetPropertyCamelCase = kebabToCamelCase(targetProperty);
+		this.tagCapitalCase = kebabToCapitalCase(tag);
+		this.componentTagRegExp = new RegExp(`<${this.tagCapitalCase}[^>]*${this.sourcePropertyCamelCase}[^>]*>`, 'g');
+		this.customElementTagRegExp = new RegExp(`<${this.tag}[^>]*${this.sourceProperty}[^>]*>`, 'g');
+	}
+
+	public run(baseDir: string): void {
+		this.transpileComponentFiles(baseDir);
+		this.transpileCustomElementFiles(baseDir);
+	}
+
+	private transpileComponentFiles(baseDir: string): void {
+		filterFilesByExt(baseDir, COMPONENT_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(this.componentTagRegExp, (componentTag) => this.rewriteTag(componentTag, true));
+			if (newContent !== content) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+
+	private transpileCustomElementFiles(baseDir: string): void {
+		filterFilesByExt(baseDir, CUSTOM_ELEMENT_FILE_EXTENSIONS).forEach((file) => {
+			const content = fs.readFileSync(file, 'utf8');
+			const newContent = content.replace(this.customElementTagRegExp, (componentTag) => this.rewriteTag(componentTag, false));
+			if (newContent !== content) {
+				MODIFIED_FILES.add(file);
+				fs.writeFileSync(file, newContent);
+			}
+		});
+	}
+
+	private rewriteTag(componentTag: string, isComponent: boolean): string {
+		const sourcePropertyName = isComponent ? this.sourcePropertyCamelCase : this.sourceProperty;
+		const targetPropertyName = isComponent ? this.targetPropertyCamelCase : this.targetProperty;
+
+		for (const mapping of this.mappings) {
+			const sourceValueRegExp = this.getSourceValueRegExp(sourcePropertyName, mapping.fromValue, isComponent);
+			if (!sourceValueRegExp.test(componentTag)) {
+				continue;
+			}
+
+			if (this.preserveExistingTarget && this.hasTargetProperty(componentTag, targetPropertyName)) {
+				return componentTag.replace(sourceValueRegExp, '');
+			}
+
+			if (mapping.result === 'remove') {
+				return componentTag.replace(sourceValueRegExp, '');
+			}
+
+			const replacement = this.getBooleanReplacement(targetPropertyName, mapping.result, isComponent);
+			return componentTag.replace(sourceValueRegExp, replacement);
+		}
+
+		if (this.bareSourceResult !== undefined) {
+			const bareSourceRegExp = this.getBareSourceRegExp(sourcePropertyName);
+			if (bareSourceRegExp.test(componentTag)) {
+				if (this.preserveExistingTarget && this.hasTargetProperty(componentTag, targetPropertyName)) {
+					return componentTag.replace(bareSourceRegExp, '');
+				}
+
+				if (this.bareSourceResult === 'remove') {
+					return componentTag.replace(bareSourceRegExp, '');
+				}
+
+				const replacement = this.getBooleanReplacement(targetPropertyName, this.bareSourceResult, isComponent);
+				return componentTag.replace(bareSourceRegExp, replacement);
+			}
+		}
+
+		return componentTag;
+	}
+
+	private hasTargetProperty(componentTag: string, targetPropertyName: string): boolean {
+		const targetRegExp = new RegExp(`\\s${targetPropertyName}(?:\\s*=\\s*(?:\\{[^\\}]+\\}|["'][^"']+["']))?(?=[\\s/>])`);
+		return targetRegExp.test(componentTag);
+	}
+
+	private getSourceValueRegExp(sourcePropertyName: string, fromValue: string, isComponent: boolean): RegExp {
+		const escapedValue = this.escapeRegExp(fromValue);
+		if (isComponent) {
+			const quotedValue = `\\{\\s*(?:"${escapedValue}"|'${escapedValue}')\\s*\\}|(?:"${escapedValue}"|'${escapedValue}')`;
+			const booleanLiteral = fromValue === 'true' || fromValue === 'false' ? `|\\{\\s*${escapedValue}\\s*\\}` : '';
+			return new RegExp(`\\s${sourcePropertyName}\\s*=\\s*(?:${quotedValue}${booleanLiteral})`);
+		}
+		return new RegExp(`\\s${sourcePropertyName}\\s*=\\s*["']${escapedValue}["']`);
+	}
+
+	private getBareSourceRegExp(sourcePropertyName: string): RegExp {
+		return new RegExp(`\\s${sourcePropertyName}(?!\\s*=)(?=[\\s/>])`);
+	}
+
+	private getBooleanReplacement(targetPropertyName: string, result: Exclude<BooleanMappingResult, 'remove'>, isComponent: boolean): string {
+		if (isComponent) {
+			return ` ${targetPropertyName}={${result}}`;
+		}
+		return ` ${targetPropertyName}="${result}"`;
+	}
+
+	private escapeRegExp(input: string): string {
+		return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/clear-button.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/clear-button.ts
@@ -1,53 +1,37 @@
-import fs from 'fs';
-
-import { MARKUP_EXTENSIONS } from '../../../../types';
-import { filterFilesByExt, MODIFIED_FILES } from '../../../shares/reuse';
 import { AbstractTask } from '../../abstract-task';
+import { AbstractMapPropertyValueToBooleanTask, BooleanPropertyValueMapping } from '../common/AbstractMapPropertyValueToBooleanTask';
 
-export class RenameClearButtonPropTask extends AbstractTask {
-	private constructor(identifier: string, versionRange: string) {
-		super(identifier, 'Rename _hide-clear-button to _has-clear-button', MARKUP_EXTENSIONS, versionRange);
+export class RenameClearButtonPropTask extends AbstractMapPropertyValueToBooleanTask {
+	public static readonly supportedTags = ['kol-combobox', 'kol-single-select'] as const;
+	private static readonly mappings: BooleanPropertyValueMapping[] = [
+		{ fromValue: 'false', result: 'true' },
+		{ fromValue: 'true', result: 'false' },
+	];
+
+	private constructor(identifier: string, tag: (typeof RenameClearButtonPropTask.supportedTags)[number], versionRange: string) {
+		super(
+			identifier,
+			`Rename _hide-clear-button to _has-clear-button for "${tag}"`,
+			tag,
+			'_hide-clear-button',
+			'_has-clear-button',
+			RenameClearButtonPropTask.mappings,
+			versionRange,
+			[],
+			false,
+			'false',
+		);
 	}
 
-	public static getInstance(versionRange: string): RenameClearButtonPropTask {
-		const identifier = 'rename-clear-button-prop';
+	public static getInstance(versionRange: string, tag: (typeof RenameClearButtonPropTask.supportedTags)[number] = 'kol-combobox'): RenameClearButtonPropTask {
+		const identifier = `rename-clear-button-prop-${tag}`;
 		if (!this.instances.has(identifier)) {
-			this.instances.set(identifier, new RenameClearButtonPropTask(identifier, versionRange));
+			this.instances.set(identifier, new RenameClearButtonPropTask(identifier, tag, versionRange));
 		}
 		return this.instances.get(identifier) as RenameClearButtonPropTask;
 	}
-
-	public run(baseDir: string): void {
-		filterFilesByExt(baseDir, MARKUP_EXTENSIONS).forEach((file) => {
-			const content = fs.readFileSync(file, 'utf8');
-			const newContent = content
-				.replace(/_hide-clear-button\s*=\s*"(true|false)"/g, (_match, value: string) => {
-					return `_has-clear-button="${value === 'true' ? 'false' : 'true'}"`;
-				})
-				.replace(/_hide-clear-button\s*=\s*'(true|false)'/g, (_match, value: string) => {
-					return `_has-clear-button='${value === 'true' ? 'false' : 'true'}'`;
-				})
-				.replace(/_hide-clear-button\s*=\s*\{\s*(true|false)\s*\}/g, (_match, value: string) => {
-					return `_has-clear-button={${value === 'true' ? 'false' : 'true'}}`;
-				})
-				.replace(/_hideClearButton\s*=\s*"(true|false)"/g, (_match, value: string) => {
-					return `_hasClearButton="${value === 'true' ? 'false' : 'true'}"`;
-				})
-				.replace(/_hideClearButton\s*=\s*'(true|false)'/g, (_match, value: string) => {
-					return `_hasClearButton='${value === 'true' ? 'false' : 'true'}'`;
-				})
-				.replace(/_hideClearButton\s*=\s*\{\s*(true|false)\s*\}/g, (_match, value: string) => {
-					return `_hasClearButton={${value === 'true' ? 'false' : 'true'}}`;
-				})
-				.replace(/_hide-clear-button(?=[\s/>])/g, '_has-clear-button="false"')
-				.replace(/_hideClearButton(?=[\s/>])/g, '_hasClearButton={false}');
-
-			if (content !== newContent) {
-				fs.writeFileSync(file, newContent);
-				MODIFIED_FILES.add(file);
-			}
-		});
-	}
 }
 
-export const RenameClearButtonPropTasks: AbstractTask[] = [RenameClearButtonPropTask.getInstance('^4')];
+export const RenameClearButtonPropTasks: AbstractTask[] = RenameClearButtonPropTask.supportedTags.map((tag) =>
+	RenameClearButtonPropTask.getInstance('^4', tag),
+);

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts
@@ -1,22 +1,23 @@
-import fs from 'fs';
-
-import { COMPONENT_FILE_EXTENSIONS, CUSTOM_ELEMENT_FILE_EXTENSIONS, MARKUP_EXTENSIONS } from '../../../../types';
-import { filterFilesByExt, kebabToCapitalCase, MODIFIED_FILES } from '../../../shares/reuse';
 import { AbstractTask, TaskOptions } from '../../abstract-task';
+import { AbstractMapPropertyValueToBooleanTask, BooleanPropertyValueMapping } from '../common/AbstractMapPropertyValueToBooleanTask';
 
-class MapVariantStandaloneToInlineTask extends AbstractTask {
-	private readonly tagCapitalCase: string;
-	private readonly variantStandaloneRegExp = /\s_variant\s*=\s*(\{["'`]standalone["'`]\}|["'`]standalone["'`])/;
+class MapVariantStandaloneToInlineTask extends AbstractMapPropertyValueToBooleanTask {
+	private static readonly mappings: BooleanPropertyValueMapping[] = [{ fromValue: 'standalone', result: 'false' }];
 
-	private constructor(
-		identifier: string,
-		private readonly tag: string,
-		versionRange: string,
-		dependentTasks?: AbstractTask[],
-		options?: TaskOptions,
-	) {
-		super(identifier, `Map "_variant=standalone" to "_inline" for "${tag}"`, MARKUP_EXTENSIONS, versionRange, dependentTasks, options);
-		this.tagCapitalCase = kebabToCapitalCase(tag);
+	private constructor(identifier: string, tag: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions) {
+		super(
+			identifier,
+			`Map "_variant=standalone" to "_inline" for "${tag}"`,
+			tag,
+			'_variant',
+			'_inline',
+			MapVariantStandaloneToInlineTask.mappings,
+			versionRange,
+			dependentTasks,
+			true,
+			undefined,
+			options,
+		);
 	}
 
 	public static getInstance(tag: string, versionRange: string, dependentTasks?: AbstractTask[], options?: TaskOptions): MapVariantStandaloneToInlineTask {
@@ -25,50 +26,6 @@ class MapVariantStandaloneToInlineTask extends AbstractTask {
 			this.instances.set(identifier, new MapVariantStandaloneToInlineTask(identifier, tag, versionRange, dependentTasks, options));
 		}
 		return this.instances.get(identifier) as MapVariantStandaloneToInlineTask;
-	}
-
-	public run(baseDir: string): void {
-		this.transpileComponentFiles(baseDir);
-		this.transpileCustomElementFiles(baseDir);
-	}
-
-	private transpileComponentFiles(baseDir: string): void {
-		const tagRegExp = new RegExp(`<${this.tagCapitalCase}[^>]*_variant[^>]*>`, 'g');
-
-		filterFilesByExt(baseDir, COMPONENT_FILE_EXTENSIONS).forEach((file) => {
-			const content = fs.readFileSync(file, 'utf8');
-			const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, true));
-			if (content !== newContent) {
-				MODIFIED_FILES.add(file);
-				fs.writeFileSync(file, newContent);
-			}
-		});
-	}
-
-	private transpileCustomElementFiles(baseDir: string): void {
-		const tagRegExp = new RegExp(`<${this.tag}[^>]*_variant[^>]*>`, 'g');
-
-		filterFilesByExt(baseDir, CUSTOM_ELEMENT_FILE_EXTENSIONS).forEach((file) => {
-			const content = fs.readFileSync(file, 'utf8');
-			const newContent = content.replace(tagRegExp, (componentTag) => this.rewriteTag(componentTag, false));
-			if (content !== newContent) {
-				MODIFIED_FILES.add(file);
-				fs.writeFileSync(file, newContent);
-			}
-		});
-	}
-
-	private rewriteTag(componentTag: string, isComponent: boolean): string {
-		if (!this.variantStandaloneRegExp.test(componentTag)) {
-			return componentTag;
-		}
-
-		const inlineReplacement = isComponent ? ' _inline={false}' : ' _inline="false"';
-		if (/\s_inline\s*=/.test(componentTag)) {
-			return componentTag.replace(this.variantStandaloneRegExp, '');
-		}
-
-		return componentTag.replace(this.variantStandaloneRegExp, inlineReplacement);
 	}
 }
 

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/password-variant.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/password-variant.ts
@@ -1,36 +1,41 @@
 import { AbstractTask } from '../../abstract-task';
+import { AbstractMapPropertyValueToBooleanTask, BooleanPropertyValueMapping } from '../common/AbstractMapPropertyValueToBooleanTask';
 import { RemovePropertyNameTask } from '../common/RemovePropertyNameTask';
 import { RenamePropertyNameTask } from '../common/RenamePropertyNameTask';
-import { UpdatePropertyValueTask } from '../common/UpdatePropertyValueTask';
 
 const RenameVariantPropTask: AbstractTask = RenamePropertyNameTask.getInstance('kol-input-password', '_variant', '_visibility-toggle', '^4');
 
-const UpdateVisibilityToggleValueTrue: AbstractTask = UpdatePropertyValueTask.getInstance(
-	'kol-input-password',
-	'_visibility-toggle',
-	'visibility-toggle',
-	'true',
-	'^4',
-	[RenameVariantPropTask],
-);
+class MapVisibilityToggleTask extends AbstractMapPropertyValueToBooleanTask {
+	private static readonly mappings: BooleanPropertyValueMapping[] = [
+		{ fromValue: 'default', result: 'remove' },
+		{ fromValue: 'visibility-toggle', result: 'true' },
+	];
 
-const UpdateVisibilityToggleValueFalse: AbstractTask = UpdatePropertyValueTask.getInstance(
-	'kol-input-password',
-	'_visibility-toggle',
-	'default',
-	'false',
-	'^4',
-	[RenameVariantPropTask],
-);
+	private constructor(identifier: string, versionRange: string, dependentTasks: AbstractTask[] = []) {
+		super(
+			identifier,
+			'Map password variant values to visibility-toggle boolean semantics',
+			'kol-input-password',
+			'_visibility-toggle',
+			'_visibility-toggle',
+			MapVisibilityToggleTask.mappings,
+			versionRange,
+			dependentTasks,
+			false,
+		);
+	}
 
-export const RemoveVariantPropTask: AbstractTask = RemovePropertyNameTask.getInstance('kol-input-password', '_variant', '^4', [
-	UpdateVisibilityToggleValueTrue,
-	UpdateVisibilityToggleValueFalse,
-]);
+	public static getInstance(versionRange: string, dependentTasks: AbstractTask[] = []): MapVisibilityToggleTask {
+		const identifier = 'kol-input-password-map-variant-to-visibility-toggle';
+		if (!this.instances.has(identifier)) {
+			this.instances.set(identifier, new MapVisibilityToggleTask(identifier, versionRange, dependentTasks));
+		}
+		return this.instances.get(identifier) as MapVisibilityToggleTask;
+	}
+}
 
-export const RenamePasswordVariantToVisibilityToggleTasks: AbstractTask[] = [
-	RenameVariantPropTask,
-	UpdateVisibilityToggleValueTrue,
-	UpdateVisibilityToggleValueFalse,
-	RemoveVariantPropTask,
-];
+const MapVisibilityToggle: AbstractTask = MapVisibilityToggleTask.getInstance('^4', [RenameVariantPropTask]);
+
+const RemoveVariantPropTask: AbstractTask = RemovePropertyNameTask.getInstance('kol-input-password', '_variant', '^4', [MapVisibilityToggle]);
+
+export const RenamePasswordVariantToVisibilityToggleTasks: AbstractTask[] = [RenameVariantPropTask, MapVisibilityToggle, RemoveVariantPropTask];

--- a/packages/tools/kolibri-cli/test/clear-button-migration.spec.ts
+++ b/packages/tools/kolibri-cli/test/clear-button-migration.spec.ts
@@ -1,42 +1,54 @@
-import assert from 'node:assert';
 import fs from 'fs';
+import assert from 'node:assert';
 import os from 'os';
 import path from 'path';
-import { RenameClearButtonPropTask } from '../src/migrate/runner/tasks/v4/clear-button';
+import { RenameClearButtonPropTask, RenameClearButtonPropTasks } from '../src/migrate/runner/tasks/v4/clear-button';
 
 describe('RenameClearButtonPropTask', () => {
-        it('renames kebab-case attribute and inverts explicit boolean strings', () => {
-                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
-                const htmlPath = path.join(tmpDir, 'sample.html');
-                fs.writeFileSync(htmlPath, '<kol-combobox _hide-clear-button="true"></kol-combobox>');
+	it('renames kebab-case attribute and inverts explicit boolean strings', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const htmlPath = path.join(tmpDir, 'sample.html');
+		fs.writeFileSync(htmlPath, '<kol-combobox _hide-clear-button="true"></kol-combobox>');
 
-                RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
+		RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
 
-                const content = fs.readFileSync(htmlPath, 'utf8');
-                assert.ok(!content.includes('_hide-clear-button'));
-                assert.ok(content.includes('_has-clear-button="false"'));
-        });
+		const content = fs.readFileSync(htmlPath, 'utf8');
+		assert.ok(!content.includes('_hide-clear-button'));
+		assert.ok(content.includes('_has-clear-button="false"'));
+	});
 
-        it('renames camelCase prop and inverts JSX boolean props', () => {
-                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
-                const tsxPath = path.join(tmpDir, 'sample.tsx');
-                fs.writeFileSync(tsxPath, '<KolCombobox _hideClearButton={false} />');
+	it('renames single-select clear-button attribute and inverts explicit boolean strings', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const htmlPath = path.join(tmpDir, 'single-select.html');
+		fs.writeFileSync(htmlPath, '<kol-single-select _hide-clear-button="false"></kol-single-select>');
 
-                RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
+		RenameClearButtonPropTasks.forEach((task) => task.run(tmpDir));
 
-                const content = fs.readFileSync(tsxPath, 'utf8');
-                assert.ok(!content.includes('_hideClearButton'));
-                assert.ok(content.includes('_hasClearButton={true}'));
-        });
+		const content = fs.readFileSync(htmlPath, 'utf8');
+		assert.ok(!content.includes('_hide-clear-button'));
+		assert.ok(content.includes('_has-clear-button="true"'));
+	});
 
-        it('maps bare attributes to disabled clear buttons', () => {
-                const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
-                const tsxPath = path.join(tmpDir, 'implicit.tsx');
-                fs.writeFileSync(tsxPath, '<KolCombobox _hideClearButton />');
+	it('renames camelCase prop and inverts JSX boolean props', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const tsxPath = path.join(tmpDir, 'sample.tsx');
+		fs.writeFileSync(tsxPath, '<KolCombobox _hideClearButton={false} />');
 
-                RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
+		RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
 
-                const content = fs.readFileSync(tsxPath, 'utf8');
-                assert.ok(content.includes('_hasClearButton={false}'));
-        });
+		const content = fs.readFileSync(tsxPath, 'utf8');
+		assert.ok(!content.includes('_hideClearButton'));
+		assert.ok(content.includes('_hasClearButton={true}'));
+	});
+
+	it('maps bare attributes to disabled clear buttons', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const tsxPath = path.join(tmpDir, 'implicit.tsx');
+		fs.writeFileSync(tsxPath, '<KolCombobox _hideClearButton />');
+
+		RenameClearButtonPropTask.getInstance('^4').run(tmpDir);
+
+		const content = fs.readFileSync(tsxPath, 'utf8');
+		assert.ok(content.includes('_hasClearButton={false}'));
+	});
 });

--- a/packages/tools/kolibri-cli/test/refactor-password-input-variant-to-visibility-toggle.spec.ts
+++ b/packages/tools/kolibri-cli/test/refactor-password-input-variant-to-visibility-toggle.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import assert from 'node:assert';
 import os from 'os';
 import path from 'path';
-import { RemoveVariantPropTask } from '../src/migrate/runner/tasks/v4/password-variant';
+import { RenamePasswordVariantToVisibilityToggleTasks } from '../src/migrate/runner/tasks/v4/password-variant';
 
 describe('RefactorInputPasswordVariantToVisibilityToggle', () => {
 	it('maps kol-input-password variant visibility-toggle to visibilityToggle=true flag in component files', () => {
@@ -10,21 +10,46 @@ describe('RefactorInputPasswordVariantToVisibilityToggle', () => {
 		const tsxPath = path.join(tmpDir, 'component.tsx');
 		fs.writeFileSync(tsxPath, '<KolInputPassword _label="Password" _variant="visibility-toggle" />');
 
-		RemoveVariantPropTask.run(tmpDir);
+		RenamePasswordVariantToVisibilityToggleTasks.forEach((task) => task.run(tmpDir));
 
 		const content = fs.readFileSync(tsxPath, 'utf8');
 		assert.ok(content.includes('_visibilityToggle={true}'));
 		assert.ok(!content.includes('_variant'));
 	});
-	it('maps kol-input-password variant default to visibilityToggle=false flag in component files', () => {
+
+	it('maps kol-input-password variant visibility-toggle to custom-element true attribute in html files', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const htmlPath = path.join(tmpDir, 'component.html');
+		fs.writeFileSync(htmlPath, '<kol-input-password _label="Password" _variant="visibility-toggle"></kol-input-password>');
+
+		RenamePasswordVariantToVisibilityToggleTasks.forEach((task) => task.run(tmpDir));
+
+		const content = fs.readFileSync(htmlPath, 'utf8');
+		assert.ok(content.includes('_visibility-toggle="true"'));
+		assert.ok(!content.includes('_variant'));
+	});
+
+	it('removes kol-input-password visibilityToggle prop when variant is default in component files', () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
 		const tsxPath = path.join(tmpDir, 'component.tsx');
 		fs.writeFileSync(tsxPath, '<KolInputPassword _label="Password" _variant="default" />');
 
-		RemoveVariantPropTask.run(tmpDir);
+		RenamePasswordVariantToVisibilityToggleTasks.forEach((task) => task.run(tmpDir));
 
 		const content = fs.readFileSync(tsxPath, 'utf8');
-		assert.ok(content.includes('_visibilityToggle={false}'));
+		assert.ok(!content.includes('_visibilityToggle'));
+		assert.ok(!content.includes('_variant'));
+	});
+
+	it('removes mapped default visibility toggle in custom element files', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const htmlPath = path.join(tmpDir, 'component.html');
+		fs.writeFileSync(htmlPath, '<kol-input-password _label="Password" _variant="default"></kol-input-password>');
+
+		RenamePasswordVariantToVisibilityToggleTasks.forEach((task) => task.run(tmpDir));
+
+		const content = fs.readFileSync(htmlPath, 'utf8');
+		assert.ok(!content.includes('_visibility-toggle'));
 		assert.ok(!content.includes('_variant'));
 	});
 });


### PR DESCRIPTION
## What changed?

The `kolibri-cli` migration tooling for the `kol-input-password` component was refactored to use a new shared `AbstractMapPropertyValueToBooleanTask` base class. The `password-variant.ts` task now uses a single `MapVisibilityToggleTask` that maps `_visibility-toggle="visibility-toggle"` to `_visibility-toggle="true"` (string attribute for HTML custom elements) and removes the property when the value is `"default"`, replacing the previous two separate `UpdatePropertyValueTask` instances. The `clear-button.ts` and `link.ts` migration tasks were also refactored to use the same shared base class, removing duplicated regex-based rewrite logic. Test coverage was extended with two new cases covering HTML custom element files, and a `setContentWithRetry` utility was added to stabilise flaky E2E tests.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das Migrationswerkzeug in `kolibri-cli` für die `kol-input-password`-Komponente wurde auf eine neue gemeinsame Basisklasse `AbstractMapPropertyValueToBooleanTask` umgestellt. Die Datei `password-variant.ts` verwendet jetzt eine einzelne `MapVisibilityToggleTask`-Klasse, die `_visibility-toggle="visibility-toggle"` auf `_visibility-toggle="true"` abbildet und die Property bei `"default"` entfernt. Auch `clear-button.ts` und `link.ts` wurden auf dieselbe Basisklasse refaktoriert. Zwei neue Testfälle für HTML-Custom-Element-Dateien wurden ergänzt, und ein `setContentWithRetry`-Hilfsprogramm stabilisiert flaky E2E-Tests.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/kolibri-cli/src/migrate/runner/tasks/common/AbstractMapPropertyValueToBooleanTask.ts` — Neue gemeinsame abstrakte Basisklasse für Property-Wert-Mapping-Aufgaben
- `packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/password-variant.ts` — Umstellung auf `MapVisibilityToggleTask` mit `AbstractMapPropertyValueToBooleanTask`
- `packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/clear-button.ts` — Refactoring auf `AbstractMapPropertyValueToBooleanTask`
- `packages/tools/kolibri-cli/src/migrate/runner/tasks/v4/link.ts` — Refactoring auf `AbstractMapPropertyValueToBooleanTask`
- `packages/components/src/e2e/utils/setContentWithRetry.ts` — Neue Hilfsfunktion für stabile E2E-Tests
- `packages/tools/kolibri-cli/test/refactor-password-input-variant-to-visibility-toggle.spec.ts` — Neue Testfälle für HTML-Custom-Element-Dateien

</details>
