### PR TITLE
chore: create annotated git tags with release messages

### DIFF
--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -105,7 +105,7 @@ const run = (cmd) => execSync(cmd, { cwd: ROOT, stdio: 'inherit' });
 
 run('git add -u');
 run(`git commit -m "chore: release ${newVersion}"`);
-run(`git tag "${newVersion}"`);
+run(`git tag -a "${newVersion}" -m "chore: release ${newVersion}"`);
 
 if (!noPush) {
 	run('git push --follow-tags');


### PR DESCRIPTION
## What changed?

The version release script `scripts/version.mjs` was updated to create annotated git tags instead of lightweight tags. The `git tag` command was changed from `git tag "${newVersion}"` to `git tag -a "${newVersion}" -m "chore: release ${newVersion}"`. Annotated tags are full Git objects stored in the database with metadata (tagger identity, timestamp, and message), making them preferable for release tracking compared to lightweight tags which are merely commit references.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das Versionierungsskript `scripts/version.mjs` wurde aktualisiert, um annotierte Git-Tags statt leichtgewichtiger Tags zu erstellen. Der `git tag`-Befehl wurde von `git tag "${newVersion}"` zu `git tag -a "${newVersion}" -m "chore: release ${newVersion}"` geändert. Annotierte Tags sind vollständige Git-Objekte in der Datenbank mit Metadaten (Tagger-Identität, Zeitstempel und Nachricht), was sie für die Release-Nachverfolgung gegenüber leichtgewichtigen Tags vorzieht.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `scripts/version.mjs` — `git tag`-Befehl auf annotierte Tags (`-a -m`) umgestellt.

</details>