### PR TITLE
chore: add TODO comments for v5 backwards-compat cleanup in input-password

### DIFF
--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -123,7 +123,8 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 
 		return {
 			ref: this.setInputRef,
-			type: (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') && this._passwordVisible ? 'text' : 'password', // TODO v5: remove `_variant === 'visibility-toggle'` backwards-compat fallback
+			// TODO v5: remove `_variant === 'visibility-toggle'` backwards-compat fallback
+			type: (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') && this._passwordVisible ? 'text' : 'password',
 			state: this.state,
 			ariaDescribedBy,
 			...this.controller.onFacade,
@@ -141,7 +142,8 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	}
 
 	private getShowPasswordButton(): VNode | null {
-		if (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') { // TODO v5: remove `_variant === 'visibility-toggle'` backwards-compat fallback
+		// TODO v5: remove `_variant === 'visibility-toggle'` backwards-compat fallback
+		if (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') {
 			return (
 				<KolIconButtonFc
 					componentName="button"

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -123,7 +123,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 
 		return {
 			ref: this.setInputRef,
-			type: (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') && this._passwordVisible ? 'text' : 'password',
+			type: (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') && this._passwordVisible ? 'text' : 'password', // TODO v5: remove `_variant === 'visibility-toggle'` backwards-compat fallback
 			state: this.state,
 			ariaDescribedBy,
 			...this.controller.onFacade,
@@ -141,7 +141,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	}
 
 	private getShowPasswordButton(): VNode | null {
-		if (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') {
+		if (this.state._visibilityToggle || this.state._variant === 'visibility-toggle') { // TODO v5: remove `_variant === 'visibility-toggle'` backwards-compat fallback
 			return (
 				<KolIconButtonFc
 					componentName="button"


### PR DESCRIPTION
## What changed?

Two TODO comments were added to `packages/components/src/components/input-password/shadow.tsx` to mark backwards-compatibility code that should be cleaned up in v5. Both comments are placed adjacent to the dual-condition checks `this.state._visibilityToggle || this.state._variant === 'visibility-toggle'` — one at line 126 (affecting the `type` attribute of the input) and one at line 144 (guarding the `getShowPasswordButton()` return logic). These comments document the technical debt of supporting both the deprecated `_variant === 'visibility-toggle'` property and the newer `_visibilityToggle` property simultaneously.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Zwei TODO-Kommentare wurden in `packages/components/src/components/input-password/shadow.tsx` hinzugefügt, um Rückwärtskompatibilitätscode zu markieren, der in v5 bereinigt werden soll. Beide Kommentare befinden sich neben den Doppelbedingungsprüfungen `this.state._visibilityToggle || this.state._variant === 'visibility-toggle'` — einer in der Logik für das `type`-Attribut des Eingabefeldes und einer in der Methode `getShowPasswordButton()`. Diese Kommentare dokumentieren die technische Schuld der gleichzeitigen Unterstützung der veralteten Eigenschaft `_variant === 'visibility-toggle'` und der neueren Eigenschaft `_visibilityToggle`.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/components/input-password/shadow.tsx` — Zwei TODO-Kommentare für v5-Cleanup der Rückwärtskompatibilität hinzugefügt.

</details>