### PR TITLE
chore: prove npm publish error handling in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,12 +37,15 @@ on:
 permissions:
   contents: read
   id-token: write
-  packages: write
 
 jobs:
   publish:
     if: github.repository == 'public-ui/kolibri'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
@@ -250,12 +253,13 @@ jobs:
 
       - name: Publish sample react
         run: |
-          output=$(npm publish --access restricted 2>&1) && echo "$output" || {
-            echo "$output"
-            echo "$output" | grep -qE "already exists|previously published|E409|409 Conflict" \
+          npm publish --access restricted 2>&1 | tee /tmp/npm-publish-output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          if [ $EXIT_CODE -ne 0 ]; then
+            grep -qE "already exists|previously published|E409|409 Conflict" /tmp/npm-publish-output.txt \
               && echo "⚠️ Publish skipped – package already exists" \
               || exit 1
-          }
+          fi
         working-directory: packages/samples/react
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 jobs:
   publish:
@@ -248,7 +249,13 @@ jobs:
           registry-url: https://npm.pkg.github.com
 
       - name: Publish sample react
-        run: npm publish --access restricted || echo "⚠️ Publish skipped – package already exists"
+        run: |
+          output=$(npm publish --access restricted 2>&1) && echo "$output" || {
+            echo "$output"
+            echo "$output" | grep -qE "already exists|previously published|E409|409 Conflict" \
+              && echo "⚠️ Publish skipped – package already exists" \
+              || exit 1
+          }
         working-directory: packages/samples/react
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed?

The `npm publish` step for the `packages/samples/react` package in `.github/workflows/publish.yml` was hardened to distinguish real publish failures from idempotent "already exists" errors. Previously, `|| echo` silently swallowed all errors; now the output of `npm publish` is captured via `tee`, the exit code is checked, and `grep` is used to detect error patterns (`already exists`, `previously published`, `E409`, `409 Conflict`) before deciding whether to proceed or abort with a non-zero exit code. Additionally, `packages: write` permission was explicitly added to the `publish` job to support GitHub Packages registry operations.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der `npm publish`-Schritt für das Paket `packages/samples/react` in `.github/workflows/publish.yml` wurde gehärtet, um echte Publish-Fehler von idempotenten "already exists"-Fehlern zu unterscheiden. Zuvor schluckte `|| echo` alle Fehler stillschweigend; jetzt wird die Ausgabe von `npm publish` per `tee` gespeichert, der Exit-Code geprüft und `grep` verwendet, um Fehlermuster (`already exists`, `previously published`, `E409`, `409 Conflict`) zu erkennen, bevor entschieden wird, ob weitergemacht oder mit einem Fehlercode abgebrochen wird. Außerdem wurde die `packages: write`-Berechtigung explizit zum `publish`-Job hinzugefügt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/publish.yml` — Verbessertes Fehlerhandling im npm-publish-Schritt und neue `packages: write`-Berechtigung.

</details>