### PR TITLE
fix: single select clear button space key

### DIFF
--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -478,6 +478,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 			case 'NumpadEnter': {
 				if (this.clearButtonFocused) {
 					this.clearSelection();
+					event.preventDefault();
 				} else if (this._isOpen) {
 					if (this.selectFocusedOption()) {
 						this.refInput?.focus();


### PR DESCRIPTION
## What changed?

In the `KolSingleSelect` component, pressing the Space key while the clear button was focused correctly triggered the clear action but also caused the browser to scroll the page downward, because the browser's default behavior for Space on a non-`<button>` interactive element (scrolling) was not suppressed. A single `event.preventDefault()` call was added inside the `Space`/`NumpadEnter` keyboard handler branch that handles the focused clear button state. This ensures that clearing the selection via the Space key no longer produces unwanted page scrolling as a side effect, while the clear action itself continues to function correctly.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In der Komponente `KolSingleSelect` wurde ein Fehler behoben, bei dem das Drücken der Leertaste auf dem Löschen-Button zwar die Auswahl korrekt zurücksetzte, aber gleichzeitig die Seite nach unten scrollte. Im Tastatur-Handler für die `Space`/`NumpadEnter`-Taste wurde ein `event.preventDefault()`-Aufruf ergänzt, der das Standard-Browser-Verhalten (Seite scrollen) unterdrückt, sobald der Löschen-Button fokussiert ist.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/single-select/shadow.tsx` — `event.preventDefault()` im Space-Key-Handler des Löschen-Buttons ergänzt

</details>
