### PR TITLE
refactor: focus decorator to support FocusOptions

### DIFF
--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -5,7 +5,7 @@ import type { ClickButtonApi } from '../../../../internal/functional-components/
 import { ClickButtonFC } from '../../../../internal/functional-components/click-button/component';
 import { ClickButtonController } from '../../../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../../../internal/functional-components/generic-types';
-import type { FocusFunctionOptions } from '../../../../schema';
+import type { FocusOptions } from '../../../../schema';
 
 /**
  * @internal
@@ -32,7 +32,7 @@ export class KolClickButton extends BaseWebComponent<ClickButtonApi> implements 
 	 * Focuses the interactive element of the component.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return Promise.resolve(this.ctrl.focus(options));
 	}
 

--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -6,6 +6,7 @@ import { ClickButtonFC } from '../../../../internal/functional-components/click-
 import { ClickButtonController } from '../../../../internal/functional-components/click-button/controller';
 import type { WebComponentInterface } from '../../../../internal/functional-components/generic-types';
 import type { FocusOptions } from '../../../../schema';
+import { ctrlFocus } from '../../../../utils/element-interaction';
 
 /**
  * @internal
@@ -32,8 +33,9 @@ export class KolClickButton extends BaseWebComponent<ClickButtonApi> implements 
 	 * Focuses the interactive element of the component.
 	 */
 	@Method()
+	@ctrlFocus('ctrl')
 	public async focus(options?: FocusOptions): Promise<void> {
-		return Promise.resolve(this.ctrl.focus(options));
+		void options;
 	}
 
 	public componentWillLoad(): void {

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -7,6 +7,7 @@ import { SkeletonFC } from '../../../../internal/functional-components/skeleton/
 import { SkeletonController } from '../../../../internal/functional-components/skeleton/controller';
 import type { FocusOptions } from '../../../../schema';
 import { Log } from '../../../../schema';
+import { ctrlFocus } from '../../../../utils/element-interaction';
 
 @Component({
 	tag: 'kol-skeleton',
@@ -19,8 +20,9 @@ export class KolSkeleton extends BaseWebComponent<SkeletonApi> implements WebCom
 	 * Focuses the interactive element of the component.
 	 */
 	@Method()
+	@ctrlFocus('ctrl')
 	public async focus(options?: FocusOptions): Promise<void> {
-		return Promise.resolve(this.ctrl.focus(options));
+		void options;
 	}
 
 	/**

--- a/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/skeleton/component.tsx
@@ -5,7 +5,7 @@ import type { WebComponentInterface } from '../../../../internal/functional-comp
 import type { SkeletonApi } from '../../../../internal/functional-components/skeleton/api';
 import { SkeletonFC } from '../../../../internal/functional-components/skeleton/component';
 import { SkeletonController } from '../../../../internal/functional-components/skeleton/controller';
-import type { FocusFunctionOptions } from '../../../../schema';
+import type { FocusOptions } from '../../../../schema';
 import { Log } from '../../../../schema';
 
 @Component({
@@ -19,7 +19,7 @@ export class KolSkeleton extends BaseWebComponent<SkeletonApi> implements WebCom
 	 * Focuses the interactive element of the component.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return Promise.resolve(this.ctrl.focus(options));
 	}
 

--- a/packages/components/src/components/accordion/shadow.tsx
+++ b/packages/components/src/components/accordion/shadow.tsx
@@ -8,7 +8,7 @@ import type {
 	AccordionStates,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HeadingLevel,
 	LabelPropType,
 	OpenPropType,
@@ -55,7 +55,7 @@ export class KolAccordion implements AccordionAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!, options));
 	}
 

--- a/packages/components/src/components/badge/shadow.tsx
+++ b/packages/components/src/components/badge/shadow.tsx
@@ -4,7 +4,7 @@ import type {
 	BadgeAPI,
 	BadgeStates,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	InternalButtonProps,
 	KoliBriIconsProp,
 	LabelPropType,
@@ -67,7 +67,7 @@ export class KolBadge implements BadgeAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.smartButtonRef!, options));
 	}
 

--- a/packages/components/src/components/button-link/shadow.tsx
+++ b/packages/components/src/components/button-link/shadow.tsx
@@ -9,7 +9,7 @@ import type {
 	ButtonLinkProps,
 	ButtonTypePropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	IconsPropType,
 	InlinePropType,
 	LabelWithExpertSlotPropType,
@@ -64,7 +64,7 @@ export class KolButtonLink implements ButtonLinkProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!, options));
 	}
 

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -13,7 +13,7 @@ import type {
 	CustomClassPropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	IconsPropType,
 	IdPropType,
@@ -82,7 +82,9 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 	 */
 	@Method()
 	@directFocus('ctaRef')
-	public async focus(options?: FocusFunctionOptions): Promise<void> {}
+	public async focus(options?: FocusOptions): Promise<void> {
+		void options;
+	}
 
 	/**
 	 * Clicks the primary interactive element inside this component.

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -60,8 +60,8 @@ import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 import clsx from '../../utils/clsx';
 import { setClick } from '../../utils/element-click';
-import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import { createCtaRef, directFocus } from '../../utils/element-interaction';
+import { dispatchDomEvent, KolEvent } from '../../utils/events';
 import { propagateResetEventToForm, propagateSubmitEventToForm } from '../form/controller';
 import { AssociatedInputController } from '../input-adapter-leanup/associated.controller';
 

--- a/packages/components/src/components/button/component.tsx
+++ b/packages/components/src/components/button/component.tsx
@@ -60,8 +60,8 @@ import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 import clsx from '../../utils/clsx';
 import { setClick } from '../../utils/element-click';
-import { setFocus } from '../../utils/element-focus';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
+import { createCtaRef, directFocus } from '../../utils/element-interaction';
 import { propagateResetEventToForm, propagateSubmitEventToForm } from '../form/controller';
 import { AssociatedInputController } from '../input-adapter-leanup/associated.controller';
 
@@ -74,28 +74,25 @@ import { AssociatedInputController } from '../input-adapter-leanup/associated.co
 })
 export class KolButtonWc implements ButtonAPI, FocusableElement {
 	@Element() private readonly host?: HTMLKolButtonWcElement;
-	private buttonRef?: HTMLButtonElement;
+	private readonly ctaRef = createCtaRef<HTMLButtonElement>();
 	private readonly tooltipCtrl = new TooltipController(BaseWebComponent.stateLess);
 
 	/**
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
-		return setFocus(this.buttonRef!, options);
-	}
+	@directFocus('ctaRef')
+	public async focus(options?: FocusFunctionOptions): Promise<void> {}
 
 	/**
 	 * Clicks the primary interactive element inside this component.
 	 */
 	@Method()
 	public async click(): Promise<void> {
-		return setClick(this.buttonRef!);
+		return setClick(this.ctaRef.el!);
 	}
 
-	private readonly setButtonRef = (ref?: HTMLButtonElement) => {
-		this.buttonRef = ref;
-	};
+	private readonly setButtonRef = this.ctaRef;
 
 	private readonly onClick = (event: MouseEvent) => {
 		event.stopPropagation();
@@ -104,12 +101,12 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 		if (this.state._type === 'submit') {
 			propagateSubmitEventToForm({
 				form: this.host,
-				ref: this.buttonRef,
+				ref: this.ctaRef.el,
 			});
 		} else if (this.state._type === 'reset') {
 			propagateResetEventToForm({
 				form: this.host,
-				ref: this.buttonRef,
+				ref: this.ctaRef.el,
 			});
 		} else {
 			// TODO: Static form handling
@@ -117,7 +114,7 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 
 			// Callback
 			if (typeof this.state._on?.onClick === 'function') {
-				setEventTarget(event, this.buttonRef);
+				setEventTarget(event, this.ctaRef.el);
 				this.state._on?.onClick(event, this.state._value);
 			}
 		}
@@ -489,8 +486,8 @@ export class KolButtonWc implements ButtonAPI, FocusableElement {
 	}
 
 	public componentDidRender(): void {
-		if (this.buttonRef) {
-			this.tooltipCtrl.syncListeners(undefined, this.buttonRef, true);
+		if (this.ctaRef.el) {
+			this.tooltipCtrl.syncListeners(undefined, this.ctaRef.el, true);
 		}
 	}
 

--- a/packages/components/src/components/button/shadow.tsx
+++ b/packages/components/src/components/button/shadow.tsx
@@ -11,7 +11,7 @@ import type {
 	ButtonVariantPropType,
 	CustomClassPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	IconsPropType,
 	InlinePropType,
 	LabelWithExpertSlotPropType,
@@ -56,7 +56,7 @@ export class KolButton implements ButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!, options));
 	}
 

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -15,7 +15,7 @@ import type {
 	ComboboxStates,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -71,7 +71,7 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.refInput!, options));
 	}
 

--- a/packages/components/src/components/details/shadow.tsx
+++ b/packages/components/src/components/details/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	DetailsStates,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HeadingLevel,
 	LabelPropType,
 } from '../../schema';
@@ -49,7 +49,7 @@ export class KolDetails implements DetailsAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.buttonWcRef!, options));
 	}
 

--- a/packages/components/src/components/input-checkbox/shadow.tsx
+++ b/packages/components/src/components/input-checkbox/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	CheckedPropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -77,7 +77,7 @@ export class KolInputCheckbox implements InputCheckboxAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.inputRef!, options));
 	}
 

--- a/packages/components/src/components/input-color/shadow.tsx
+++ b/packages/components/src/components/input-color/shadow.tsx
@@ -4,7 +4,7 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -98,7 +98,7 @@ export class KolInputColor implements InputColorAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.refInputText!, options));
 	}
 

--- a/packages/components/src/components/input-date/shadow.tsx
+++ b/packages/components/src/components/input-date/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -75,7 +75,7 @@ export class KolInputDate implements InputDateAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.inputRef!, options));
 	}
 

--- a/packages/components/src/components/input-email/shadow.tsx
+++ b/packages/components/src/components/input-email/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HasCounterPropType,
 	HideLabelPropType,
 	HideMsgPropType,
@@ -73,7 +73,7 @@ export class KolInputEmail implements InputEmailAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.inputRef!, options));
 	}
 

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	AcceptPropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -72,7 +72,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.inputRef!, options));
 	}
 

--- a/packages/components/src/components/input-number/shadow.tsx
+++ b/packages/components/src/components/input-number/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -72,7 +72,7 @@ export class KolInputNumber implements InputNumberAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.inputRef!, options));
 	}
 

--- a/packages/components/src/components/input-password/shadow.tsx
+++ b/packages/components/src/components/input-password/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HasCounterPropType,
 	HideLabelPropType,
 	HideMsgPropType,
@@ -78,7 +78,7 @@ export class KolInputPassword implements InputPasswordAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.inputRef!, options));
 	}
 

--- a/packages/components/src/components/input-radio/shadow.tsx
+++ b/packages/components/src/components/input-radio/shadow.tsx
@@ -5,7 +5,7 @@ import clsx from '../../utils/clsx';
 import type {
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -80,7 +80,7 @@ export class KolInputRadio implements InputRadioAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.getFocusableInput()!, options));
 	}
 

--- a/packages/components/src/components/input-range/shadow.tsx
+++ b/packages/components/src/components/input-range/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -56,7 +56,7 @@ export class KolInputRange implements InputRangeAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.refInputNumber!, options));
 	}
 

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -7,7 +7,7 @@ import type {
 	AutoCompletePropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HasCounterPropType,
 	HideLabelPropType,
 	HideMsgPropType,
@@ -111,7 +111,7 @@ export class KolInputText implements InputTextAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.inputRef!, options));
 	}
 

--- a/packages/components/src/components/link-button/shadow.tsx
+++ b/packages/components/src/components/link-button/shadow.tsx
@@ -10,7 +10,7 @@ import type {
 	CustomClassPropType,
 	DownloadPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HrefPropType,
 	IconsPropType,
 	LabelWithExpertSlotPropType,
@@ -47,7 +47,7 @@ export class KolLinkButton implements LinkButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.linkWcRef!, options));
 	}
 

--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -15,7 +15,7 @@ import type {
 	DisabledPropType,
 	DownloadPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HrefPropType,
 	InlinePropType,
@@ -91,7 +91,7 @@ export class KolLinkWc implements InternalLinkAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return setFocus(this.anchorRef!, options);
 	}
 

--- a/packages/components/src/components/link/shadow.tsx
+++ b/packages/components/src/components/link/shadow.tsx
@@ -8,7 +8,7 @@ import type {
 	AriaDescriptionPropType,
 	DownloadPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HrefPropType,
 	InlinePropType,
 	KoliBriIconsProp,
@@ -42,7 +42,7 @@ export class KolLink implements LinkProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.linkWcRef!, options));
 	}
 

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -11,7 +11,7 @@ import type {
 	ButtonVariantPropType,
 	CustomClassPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	IconsPropType,
 	IdPropType,
 	InlinePropType,
@@ -94,7 +94,7 @@ export class KolPopoverButtonWc implements PopoverButtonProps, FocusableElement 
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return setFocus(this.refButton!, options);
 	}
 

--- a/packages/components/src/components/popover-button/shadow.tsx
+++ b/packages/components/src/components/popover-button/shadow.tsx
@@ -8,7 +8,7 @@ import type {
 	ButtonVariantPropType,
 	CustomClassPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	IconsPropType,
 	InlinePropType,
 	LabelWithExpertSlotPropType,
@@ -74,7 +74,7 @@ export class KolPopoverButton implements PopoverButtonProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.ref!, options));
 	}
 

--- a/packages/components/src/components/select/component.tsx
+++ b/packages/components/src/components/select/component.tsx
@@ -5,7 +5,7 @@ import clsx from '../../utils/clsx';
 import type {
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -69,7 +69,7 @@ export class KolSelectWc implements SelectAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return setFocus(this.selectRef!, options);
 	}
 

--- a/packages/components/src/components/select/shadow.tsx
+++ b/packages/components/src/components/select/shadow.tsx
@@ -3,7 +3,7 @@ import { Component, Element, h, Host, Method, Prop } from '@stencil/core';
 
 import type {
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	IconsHorizontalPropType,
 	InputTypeOnDefault,
 	LabelWithExpertSlotPropType,
@@ -52,7 +52,7 @@ export class KolSelect implements SelectProps, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.selectWcRef!, options));
 	}
 

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -3,7 +3,7 @@ import { Component, Element, h, Listen, Method, Prop, State, Watch } from '@sten
 import type {
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HideLabelPropType,
 	HideMsgPropType,
 	HintPropType,
@@ -76,7 +76,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.refInput!, options));
 	}
 

--- a/packages/components/src/components/skip-nav/shadow.tsx
+++ b/packages/components/src/components/skip-nav/shadow.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Method, Prop, State, Watch } from '@stencil/core';
-import type { FocusableElement, FocusFunctionOptions, LabelPropType, LinkProps, SkipNavAPI, SkipNavStates, Stringified } from '../../schema';
+import type { FocusableElement, FocusOptions, LabelPropType, LinkProps, SkipNavAPI, SkipNavStates, Stringified } from '../../schema';
 import { validateLabel } from '../../schema';
 
 import { delegateFocus, setFocus } from '../../utils/element-focus';
@@ -43,7 +43,7 @@ export class KolSkipNav implements SkipNavAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.firstLinkRef!, options));
 	}
 

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -9,7 +9,7 @@ import type {
 	ButtonVariantPropType,
 	CustomClassPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	IconsPropType,
 	LabelWithExpertSlotPropType,
 	ShortKeyPropType,
@@ -65,7 +65,7 @@ export class KolSplitButton implements SplitButtonProps, FocusableElement /*, Sp
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.primaryButtonWcRef!, options));
 	}
 

--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -4,7 +4,7 @@ import type {
 	AlignPropType,
 	ButtonCallbacksPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	KoliBriTabsCallbacks,
 	LabelPropType,
 	StencilUnknown,
@@ -164,7 +164,7 @@ export class KolTabs implements TabsAPI, FocusableElement {
 	 * Sets focus on the current tab button.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		return delegateFocus(this.host!, () => setFocus(this.currentTabButtonRef!, options));
 	}
 

--- a/packages/components/src/components/textarea/shadow.tsx
+++ b/packages/components/src/components/textarea/shadow.tsx
@@ -6,7 +6,7 @@ import type {
 	AdjustHeightPropType,
 	DisabledPropType,
 	FocusableElement,
-	FocusFunctionOptions,
+	FocusOptions,
 	HasCounterPropType,
 	HideLabelPropType,
 	HideMsgPropType,
@@ -85,7 +85,7 @@ export class KolTextarea implements TextareaAPI, FocusableElement {
 	 * Sets focus on the internal element.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.textareaRef!, options));
 	}
 

--- a/packages/components/src/components/toolbar/shadow.tsx
+++ b/packages/components/src/components/toolbar/shadow.tsx
@@ -2,7 +2,7 @@ import type { JSX } from '@stencil/core';
 import { Component, Element, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
 
 import { KolButtonWcTag, KolLinkWcTag } from '../../core/component-names';
-import type { FocusableElement, FocusFunctionOptions, LabelPropType, ToolbarAPI, ToolbarItemPropType, ToolbarItemsPropType, ToolbarStates } from '../../schema';
+import type { FocusableElement, FocusOptions, LabelPropType, ToolbarAPI, ToolbarItemPropType, ToolbarItemsPropType, ToolbarStates } from '../../schema';
 import { validateLabel, validateToolbarItems } from '../../schema';
 import { KeyboardKey } from '../../schema/enums';
 import type { OrientationPropType } from '../../schema/props/orientation';
@@ -33,7 +33,7 @@ export class KolToolbar implements ToolbarAPI, FocusableElement {
 	 * Sets focus on the currently active toolbar item.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		const firstEnabledItem = this.indexToElement.get(this.currentIndex);
 		if (firstEnabledItem) {
 			return delegateFocus(this.host!, () => setFocus(firstEnabledItem, options));

--- a/packages/components/src/components/tree-item/component.tsx
+++ b/packages/components/src/components/tree-item/component.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, Host, type JSX, Method, Prop, State, Watch } fro
 
 import { KolLinkWcTag, KolTreeTag } from '../../core/component-names';
 import { IconFC } from '../../internal/functional-components/icon/component';
-import type { ActivePropType, FocusFunctionOptions, HrefPropType, LabelPropType, OpenPropType, TreeItemAPI, TreeItemStates } from '../../schema';
+import type { ActivePropType, FocusOptions, HrefPropType, LabelPropType, OpenPropType, TreeItemAPI, TreeItemStates } from '../../schema';
 import { validateActive, validateHref, validateLabel, validateOpen } from '../../schema';
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
@@ -174,7 +174,7 @@ export class KolTreeItemWc implements TreeItemAPI {
 	/**
 	 * Focuses the link element.
 	 */
-	@Method() async focus(options?: FocusFunctionOptions) {
+	@Method() async focus(options?: FocusOptions) {
 		if (this.host && this.linkElement) {
 			return Promise.resolve(this.linkElement.focus(options));
 		}

--- a/packages/components/src/components/tree-item/shadow.tsx
+++ b/packages/components/src/components/tree-item/shadow.tsx
@@ -1,7 +1,7 @@
 import { Component, h, type JSX, Method, Prop } from '@stencil/core';
 
 import { KolTreeItemWcTag } from '../../core/component-names';
-import type { FocusFunctionOptions, HrefPropType, LabelPropType, OpenPropType, TreeItemProps } from '../../schema';
+import type { FocusOptions, HrefPropType, LabelPropType, OpenPropType, TreeItemProps } from '../../schema';
 
 @Component({
 	tag: 'kol-tree-item', // keep in sync with `const TREE_ITEM_TAG_NAME`
@@ -36,7 +36,7 @@ export class KolTreeItem implements TreeItemProps {
 	/**
 	 * Focuses the link element.
 	 */
-	@Method() async focus(options?: FocusFunctionOptions) {
+	@Method() async focus(options?: FocusOptions) {
 		return Promise.resolve(this.element?.focus(options));
 	}
 

--- a/packages/components/src/components/tree/component.tsx
+++ b/packages/components/src/components/tree/component.tsx
@@ -2,7 +2,7 @@ import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
 
 import { KolTreeItemTag, KolTreeTag } from '../../core/component-names';
-import type { FocusableElement, FocusFunctionOptions, LabelPropType, TreeAPI, TreeStates } from '../../schema';
+import type { FocusableElement, FocusOptions, LabelPropType, TreeAPI, TreeStates } from '../../schema';
 import { validateLabel } from '../../schema';
 
 /**
@@ -37,7 +37,7 @@ export class KolTreeWc implements TreeAPI, FocusableElement {
 	 * Sets focus on the first focusable tree item.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions): Promise<void> {
+	public async focus(options?: FocusOptions): Promise<void> {
 		const openItems = await this.getOpenTreeItemElements();
 		await openItems?.[0]?.focus(options);
 	}

--- a/packages/components/src/components/tree/shadow.tsx
+++ b/packages/components/src/components/tree/shadow.tsx
@@ -2,7 +2,7 @@ import type { JSX } from '@stencil/core';
 import { Component, Element, h, Method, Prop } from '@stencil/core';
 
 import { KolTreeWcTag } from '../../core/component-names';
-import type { FocusableElement, FocusFunctionOptions, LabelPropType, TreeProps } from '../../schema';
+import type { FocusableElement, FocusOptions, LabelPropType, TreeProps } from '../../schema';
 import { delegateFocus, setFocus } from '../../utils/element-focus';
 
 @Component({
@@ -29,7 +29,7 @@ export class KolTree implements TreeProps, FocusableElement {
 	 * Sets focus on the first focusable tree item.
 	 */
 	@Method()
-	public async focus(options?: FocusFunctionOptions) {
+	public async focus(options?: FocusOptions) {
 		return delegateFocus(this.host!, () => setFocus(this.treeWcRef!, options));
 	}
 

--- a/packages/components/src/internal/functional-components/click-button/api.tsx
+++ b/packages/components/src/internal/functional-components/click-button/api.tsx
@@ -1,4 +1,4 @@
-import type { FocusFunctionOptions } from '../../../schema';
+import type { FocusOptions } from '../../../schema';
 import { labelProp } from '../../props';
 import type { ApiFromConfig, PropsConfigShape } from '../generic-types';
 
@@ -13,7 +13,7 @@ export type ClickButtonApi = ApiFromConfig<
 			click: () => void;
 		};
 		Methods: {
-			focus: (options?: FocusFunctionOptions) => void;
+			focus: (options?: FocusOptions) => void;
 		};
 		Refs: {
 			button: HTMLButtonElement;

--- a/packages/components/src/internal/functional-components/click-button/controller.ts
+++ b/packages/components/src/internal/functional-components/click-button/controller.ts
@@ -1,4 +1,4 @@
-import type { FocusFunctionOptions } from '../../../schema';
+import type { FocusOptions } from '../../../schema';
 import { labelProp } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps, StateAccess } from '../generic-types';
@@ -28,7 +28,7 @@ export class ClickButtonController extends BaseController<ClickButtonApi> implem
 		console.log(this, this.buttonRef, 'button clicked');
 	};
 
-	public focus(options?: FocusFunctionOptions): void {
+	public focus(options?: FocusOptions): void {
 		if (this.buttonRef) {
 			const { afterFocus, preventScroll, ...scrollOptions } = options ?? {};
 			const hasScrollOptions = Object.keys(scrollOptions).length > 0;

--- a/packages/components/src/internal/functional-components/skeleton/api.tsx
+++ b/packages/components/src/internal/functional-components/skeleton/api.tsx
@@ -1,4 +1,4 @@
-import type { FocusFunctionOptions } from '../../../schema';
+import type { FocusOptions } from '../../../schema';
 import { nameProp } from '../../props';
 import type { ApiFromConfig, PropsConfigShape } from '../generic-types';
 
@@ -20,7 +20,7 @@ export type SkeletonApi = ApiFromConfig<
 			keydown: KeyboardEvent;
 		};
 		Methods: {
-			focus: (options?: FocusFunctionOptions) => void;
+			focus: (options?: FocusOptions) => void;
 			toggle: () => void;
 		};
 		Refs: {

--- a/packages/components/src/internal/functional-components/skeleton/controller.ts
+++ b/packages/components/src/internal/functional-components/skeleton/controller.ts
@@ -1,4 +1,4 @@
-import type { FocusFunctionOptions } from '../../../schema';
+import type { FocusOptions } from '../../../schema';
 import { Log } from '../../../schema';
 import { nameProp } from '../../props';
 import { BaseController } from '../base-controller';
@@ -51,7 +51,7 @@ export class SkeletonController extends BaseController<SkeletonApi> implements C
 		this.setState('count', (this.getState?.('count') ?? 0) + 1);
 	};
 
-	public focus(options?: FocusFunctionOptions): void {
+	public focus(options?: FocusOptions): void {
 		this.clickButtonCtrl.focus(options);
 	}
 

--- a/packages/components/src/schema/interfaces/FocusableElement.ts
+++ b/packages/components/src/schema/interfaces/FocusableElement.ts
@@ -1,9 +1,12 @@
+// Alias the browser-native FocusOptions before we shadow the name with our extended type.
+type BrowserFocusOptions = FocusOptions;
+
 /**
- * Options for the {@link FocusableElement.focus} method.
- * Extends the browser's {@link ScrollIntoViewOptions} to support custom scroll behaviour.
+ * Combined focus and scroll options for the {@link FocusableElement.focus} method.
+ * Merges the browser's {@link FocusOptions} and {@link ScrollIntoViewOptions}.
  * All properties are optional to preserve backward compatibility.
  */
-export type FocusFunctionOptions = FocusOptions &
+export type FocusOptions = BrowserFocusOptions &
 	ScrollIntoViewOptions & {
 		/**
 		 * Callback invoked after the element has received focus and has been scrolled into view.
@@ -15,5 +18,5 @@ export type FocusFunctionOptions = FocusOptions &
 	};
 
 export interface FocusableElement {
-	focus(options?: FocusFunctionOptions): Promise<void>;
+	focus(options?: FocusOptions): Promise<void>;
 }

--- a/packages/components/src/schema/interfaces/FocusableElement.ts
+++ b/packages/components/src/schema/interfaces/FocusableElement.ts
@@ -1,13 +1,15 @@
-// Alias the browser-native FocusOptions before we shadow the name with our extended type.
-type BrowserFocusOptions = FocusOptions;
-
 /**
  * Combined focus and scroll options for the {@link FocusableElement.focus} method.
- * Merges the browser's {@link FocusOptions} and {@link ScrollIntoViewOptions}.
+ * Merges the browser's native focus options ({@link HTMLElement.focus}) and
+ * scroll-into-view options ({@link Element.scrollIntoView}).
  * All properties are optional to preserve backward compatibility.
  */
-export type FocusOptions = BrowserFocusOptions &
-	ScrollIntoViewOptions & {
+export type FocusOptions = {
+	/** Prevents the browser from scrolling when focus is set — scroll is then handled manually. */
+	preventScroll?: boolean;
+	/** Hints whether focus should be visible (e.g. focus ring). */
+	focusVisible?: boolean;
+} & ScrollIntoViewOptions & {
 		/**
 		 * Callback invoked after the element has received focus and has been scrolled into view.
 		 * When `behavior` is set to `'smooth'`, the callback is delayed until the element is

--- a/packages/components/src/utils/element-focus.ts
+++ b/packages/components/src/utils/element-focus.ts
@@ -1,4 +1,4 @@
-import type { FocusFunctionOptions } from '../schema';
+import type { FocusOptions } from '../schema';
 import { waitForThemed } from './element-themed';
 
 const MAX_FOCUS_ATTEMPTS = 10;
@@ -75,7 +75,7 @@ function isActiveElement(element: HTMLElement): boolean {
  * @param options - Optional scroll behaviour and completion callback
  * @see MAX_FOCUS_ATTEMPTS
  */
-export async function setFocus(element: HTMLElement, options?: FocusFunctionOptions): Promise<void> {
+export async function setFocus(element: HTMLElement, options?: FocusOptions): Promise<void> {
 	const { afterFocus, preventScroll, ...scrollOptions } = options ?? {};
 	const hasScrollOptions = Object.keys(scrollOptions).length > 0;
 	const shouldPreventScroll = preventScroll ?? (hasScrollOptions ? true : false);

--- a/packages/components/src/utils/element-interaction.ts
+++ b/packages/components/src/utils/element-interaction.ts
@@ -1,3 +1,4 @@
+import type { FocusFunctionOptions } from '../schema';
 import { delegateClick as delegateClickImpl, setClick } from './element-click';
 import { delegateFocus as delegateFocusImpl, setFocus } from './element-focus';
 
@@ -16,18 +17,19 @@ export function createCtaRef<T extends HTMLElement = HTMLElement>(): CtaRef<T> {
 
 type MethodDecorator_ = (_target: object, _key: string, descriptor: PropertyDescriptor) => PropertyDescriptor;
 
-/**
- * Replaces the decorated method's body with `fn(this)`. The decorated method MUST be declared with
- * an empty body and no parameters — any code or arguments will be silently discarded.
- *
- *   @Method()
- *   @delegateFocus('ctaRef')
- *   public async focus(): Promise<void> {} // ← body must be empty
- */
 function makeMethodDecorator(fn: (this_: Record<string, unknown>) => Promise<void>): MethodDecorator_ {
 	return (_target, _key, descriptor) => {
 		descriptor.value = async function (this: Record<string, unknown>) {
 			return fn(this);
+		};
+		return descriptor;
+	};
+}
+
+function makeFocusDecorator(fn: (this_: Record<string, unknown>, options?: FocusFunctionOptions) => Promise<void>): MethodDecorator_ {
+	return (_target, _key, descriptor) => {
+		descriptor.value = async function (this: Record<string, unknown>, options?: FocusFunctionOptions) {
+			return fn(this, options);
 		};
 		return descriptor;
 	};
@@ -38,9 +40,9 @@ function makeMethodDecorator(fn: (this_: Record<string, unknown>) => Promise<voi
  * @param refPropName - Class property holding the focusable CtaRef
  */
 export function directFocus(refPropName: string): MethodDecorator_ {
-	return makeMethodDecorator((self) => {
+	return makeFocusDecorator((self, options) => {
 		const element = (self[refPropName] as CtaRef).el;
-		return element ? setFocus(element) : Promise.resolve();
+		return element ? setFocus(element, options) : Promise.resolve();
 	});
 }
 
@@ -61,10 +63,10 @@ export function directClick(refPropName: string): MethodDecorator_ {
  * @param refPropName - Class property holding the focusable CtaRef
  */
 export function delegateFocus(refPropName: string): MethodDecorator_ {
-	return makeMethodDecorator((self) =>
+	return makeFocusDecorator((self, options) =>
 		delegateFocusImpl(self['host'] as HTMLElement, () => {
 			const element = (self[refPropName] as CtaRef).el;
-			return element ? setFocus(element) : Promise.resolve();
+			return element ? setFocus(element, options) : Promise.resolve();
 		}),
 	);
 }

--- a/packages/components/src/utils/element-interaction.ts
+++ b/packages/components/src/utils/element-interaction.ts
@@ -1,4 +1,4 @@
-import type { FocusFunctionOptions } from '../schema';
+import type { FocusOptions } from '../schema';
 import { delegateClick as delegateClickImpl, setClick } from './element-click';
 import { delegateFocus as delegateFocusImpl, setFocus } from './element-focus';
 
@@ -26,9 +26,9 @@ function makeMethodDecorator(fn: (this_: Record<string, unknown>) => Promise<voi
 	};
 }
 
-function makeFocusDecorator(fn: (this_: Record<string, unknown>, options?: FocusFunctionOptions) => Promise<void>): MethodDecorator_ {
+function makeFocusDecorator(fn: (this_: Record<string, unknown>, options?: FocusOptions) => Promise<void>): MethodDecorator_ {
 	return (_target, _key, descriptor) => {
-		descriptor.value = async function (this: Record<string, unknown>, options?: FocusFunctionOptions) {
+		descriptor.value = async function (this: Record<string, unknown>, options?: FocusOptions) {
 			return fn(this, options);
 		};
 		return descriptor;
@@ -41,7 +41,7 @@ function makeFocusDecorator(fn: (this_: Record<string, unknown>, options?: Focus
  */
 export function directFocus(refPropName: string): MethodDecorator_ {
 	return makeFocusDecorator((self, options) => {
-		const element = (self[refPropName] as CtaRef).el;
+		const element = (self[refPropName] as CtaRef | undefined)?.el;
 		return element ? setFocus(element, options) : Promise.resolve();
 	});
 }
@@ -63,12 +63,14 @@ export function directClick(refPropName: string): MethodDecorator_ {
  * @param refPropName - Class property holding the focusable CtaRef
  */
 export function delegateFocus(refPropName: string): MethodDecorator_ {
-	return makeFocusDecorator((self, options) =>
-		delegateFocusImpl(self['host'] as HTMLElement, () => {
-			const element = (self[refPropName] as CtaRef).el;
+	return makeFocusDecorator((self, options) => {
+		const host = self['host'] as HTMLElement | undefined;
+		if (!host) return Promise.resolve();
+		return delegateFocusImpl(host, () => {
+			const element = (self[refPropName] as CtaRef | undefined)?.el;
 			return element ? setFocus(element, options) : Promise.resolve();
-		}),
-	);
+		});
+	});
 }
 
 /**

--- a/packages/components/src/utils/element-interaction.ts
+++ b/packages/components/src/utils/element-interaction.ts
@@ -74,6 +74,19 @@ export function delegateFocus(refPropName: string): MethodDecorator_ {
 }
 
 /**
+ * Method decorator for `focus()` that delegates to a controller's `focus` method.
+ * Use this for components that own a controller with its own focus implementation.
+ * @param ctrlPropName - Class property holding the controller
+ */
+export function ctrlFocus(ctrlPropName: string): MethodDecorator_ {
+	return makeFocusDecorator((self, options) => {
+		const ctrl = self[ctrlPropName] as { focus?: (options?: FocusOptions) => void } | undefined;
+		ctrl?.focus?.(options);
+		return Promise.resolve();
+	});
+}
+
+/**
  * Method decorator for `click()` on shadow components.
  * Waits for theming before delegating click to the ref element.
  * @param refPropName - Class property holding the clickable CtaRef


### PR DESCRIPTION
## What changed?

The focus-related decorator infrastructure was refactored to properly thread `FocusOptions` through the entire focus method chain. A new `makeFocusDecorator` factory was introduced in `element-interaction.ts` alongside `ctrlFocus`, a new decorator that delegates focus to a controller's own `focus` method while forwarding options. The `directFocus` and `delegateFocus` decorators were updated to use `makeFocusDecorator` so that `FocusOptions` (including `preventScroll`) are no longer silently discarded. `KolButtonWc` was refactored as the first consumer: the manual `buttonRef` property was replaced with `createCtaRef()`, and the `@directFocus('ctaRef')` decorator now handles the `focus()` method body, removing its manual implementation. The `FocusFunctionOptions` type alias was renamed to `FocusOptions` across all 43 changed files, aligning the public interface with the browser's native `FocusOptions` naming.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die fokus-bezogene Decorator-Infrastruktur wurde refaktoriert, damit `FocusOptions` korrekt durch die gesamte Fokus-Methoden-Kette durchgereicht wird. In `element-interaction.ts` wurde eine neue `makeFocusDecorator`-Factory sowie `ctrlFocus` eingeführt — ein neuer Decorator, der den Fokus an die eigene `focus`-Methode eines Controllers delegiert und dabei Optionen weitergibt. Die `directFocus`- und `delegateFocus`-Decoratoren nutzen nun `makeFocusDecorator`, sodass `FocusOptions` (inkl. `preventScroll`) nicht mehr stillschweigend verworfen werden. `KolButtonWc` wurde als erster Konsument refaktoriert: Die manuelle `buttonRef`-Eigenschaft wurde durch `createCtaRef()` ersetzt, und der `@directFocus('ctaRef')`-Decorator übernimmt nun die `focus()`-Methodenimplementierung. Der Typ `FocusFunctionOptions` wurde in allen 43 geänderten Dateien zu `FocusOptions` umbenannt, um das öffentliche Interface an das native Browser-`FocusOptions`-Naming anzugleichen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/utils/element-interaction.ts` — Neue `makeFocusDecorator`-Factory und `ctrlFocus`-Decorator; `directFocus`/`delegateFocus` aktualisiert
- `packages/components/src/schema/interfaces/FocusableElement.ts` — `FocusFunctionOptions` → `FocusOptions` umbenannt; Typ-Definition überarbeitet
- `packages/components/src/utils/element-focus.ts` — `FocusFunctionOptions` → `FocusOptions` umbenannt
- `packages/components/src/components/button/component.tsx` — `buttonRef` durch `createCtaRef()` ersetzt; `@directFocus`-Decorator angewendet
- Alle weiteren Komponenten-Shadow-Dateien — Import von `FocusFunctionOptions` auf `FocusOptions` aktualisiert

</details>