### PR TITLE
fix: active tab not identifiable in forced-colors / high-contrast mode (#10213)

### DIFF
--- a/packages/components/src/components/tabs/style.scss
+++ b/packages/components/src/components/tabs/style.scss
@@ -52,6 +52,13 @@
 				border-bottom-color: transparent;
 				display: block;
 				border-bottom-style: solid;
+
+				@media (forced-colors: active) {
+					&.selected {
+						outline: 3px solid Highlight;
+						outline-offset: -3px;
+					}
+				}
 			}
 		}
 

--- a/packages/components/src/components/tabs/style.scss
+++ b/packages/components/src/components/tabs/style.scss
@@ -57,6 +57,10 @@
 					&.selected {
 						outline: 3px solid Highlight;
 						outline-offset: -3px;
+
+						&:focus-visible {
+							outline-style: dashed;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## What changed?

The `KolTabs` component was not visually identifiable in Windows High Contrast / forced-colors mode because color-based active-tab indicators (box shadows, CSS custom property colors) are stripped or neutralized by the browser in that mode. A `@media (forced-colors: active)` block was added to `packages/components/src/components/tabs/style.scss`, adding `outline: 3px solid Highlight; outline-offset: -3px` on `.selected` tab buttons. `Highlight` is the CSS system color semantically defined for selected interactive elements (WCAG 1.4.11). The rule is placed in the component base layer (`@layer kol-component`) so all themes benefit automatically; individual themes can still override it in their own `@layer kol-theme-component`.

## Linked issues

- Closes #10213 — active tab not identifiable in forced-colors / high-contrast mode

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `KolTabs`-Komponente war im Windows High Contrast / Forced-Colors-Modus nicht erkennbar, da farbbasierte Aktiv-Tab-Indikatoren (Box-Shadows, CSS-Custom-Properties) vom Browser in diesem Modus entfernt oder neutralisiert werden. In `tabs/style.scss` wurde ein `@media (forced-colors: active)`-Block ergänzt, der auf `.selected`-Tab-Buttons einen Outline-Indikator (`outline: 3px solid Highlight; outline-offset: -3px`) setzt. `Highlight` ist die systemsemantische CSS-Farbe für ausgewählte interaktive Elemente (WCAG 1.4.11). Die Regel liegt im `@layer kol-component` und kommt allen Themes automatisch zugute.

### Verknüpfte Tickets

- Schließt #10213 — Aktiver Tab im Forced-Colors-/High-Contrast-Modus nicht erkennbar

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tabs/style.scss` — `@media (forced-colors: active)`-Block mit Outline-Indikator für ausgewählte Tabs hinzugefügt

</details>