### PR TITLE
fix: complete v4 deprecation markers for Toast (#8372)

### DIFF
--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -6,8 +6,8 @@ import { createUniqueId } from '../../utils/dev.utils';
 
 import { KolButtonTag } from '../../core/component-names';
 import { KolToastItemFc } from '../../functional-components';
-import { Log } from '../../schema';
 import type { Toast, ToasterAPI, ToasterStates, ToastRenderFunction, ToastState } from '../../schema';
+import { Log } from '../../schema';
 
 const TRANSITION_TIMEOUT = 300;
 

--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -6,6 +6,7 @@ import { createUniqueId } from '../../utils/dev.utils';
 
 import { KolButtonTag } from '../../core/component-names';
 import { KolToastItemFc } from '../../functional-components';
+import { Log } from '../../schema';
 import type { Toast, ToasterAPI, ToasterStates, ToastRenderFunction, ToastState } from '../../schema';
 
 const TRANSITION_TIMEOUT = 300;
@@ -30,6 +31,12 @@ export class KolToastContainer implements ToasterAPI {
 
 	/* Keep track of render functions, so we call each only once. */
 	private knownRenderFunctions = new Set<ToastRenderFunction>();
+
+	public componentWillLoad(): void {
+		Log.warn(
+			'kol-toast-container is deprecated and will be removed in the next major version. Use kol-alert for inline notifications or kol-dialog for interactive messages instead. See https://github.com/public-ui/kolibri/issues/8372',
+		);
+	}
 
 	// Stencil requires async function:
 	/**

--- a/packages/components/src/functional-components/ToastItem/ToastItem.tsx
+++ b/packages/components/src/functional-components/ToastItem/ToastItem.tsx
@@ -11,6 +11,10 @@ type ToastItemProps = JSXBase.HTMLAttributes<HTMLDivElement> & {
 	onClose: () => void;
 };
 
+/**
+ * @deprecated Will be removed in the next major version together with `kol-toast-container`. See https://github.com/public-ui/kolibri/issues/8372
+ * @internal
+ */
 const ToastItemFc: FC<ToastItemProps> = ({ status, toast, onClose, ...other }) => {
 	const { type, label, description, variant } = toast;
 

--- a/packages/components/src/schema/components/toaster.ts
+++ b/packages/components/src/schema/components/toaster.ts
@@ -4,8 +4,14 @@ import type { AlertTypePropType, LabelPropType } from '../props';
 
 type ToastStatus = 'adding' | 'removing' | 'settled';
 
+/**
+ * @deprecated Will be removed in the next major version. Use `kol-alert` for inline notifications or `kol-dialog` for interactive messages instead. See https://github.com/public-ui/kolibri/issues/8372
+ */
 export type ToastRenderFunction = (nodeRef: HTMLElement, options: { close: () => void }) => void;
 
+/**
+ * @deprecated Will be removed in the next major version. Use `kol-alert` for inline notifications or `kol-dialog` for interactive messages instead. See https://github.com/public-ui/kolibri/issues/8372
+ */
 export type Toast = {
 	description?: string;
 	render?: ToastRenderFunction;
@@ -18,12 +24,18 @@ export type Toast = {
 	onClose?: () => void;
 };
 
+/**
+ * @deprecated Will be removed in the next major version. See https://github.com/public-ui/kolibri/issues/8372
+ */
 export type ToastState = {
 	toast: Toast;
 	status: ToastStatus;
 	id: string;
 };
 
+/**
+ * @deprecated Will be removed in the next major version. Use `kol-alert` for inline notifications or `kol-dialog` for interactive messages instead. See https://github.com/public-ui/kolibri/issues/8372
+ */
 export type ToasterOptions = {
 	/**
 	 * @deprecated Use `ToasterOptions.defaultVariant` when initializing the service instead.
@@ -39,6 +51,9 @@ type RequiredStates = RequiredProps & {
 };
 type OptionalStates = OptionalProps;
 
+/** @deprecated Will be removed in the next major version. See https://github.com/public-ui/kolibri/issues/8372 */
 export type ToasterProps = Generic.Element.Members<RequiredProps, OptionalProps>;
+/** @deprecated Will be removed in the next major version. See https://github.com/public-ui/kolibri/issues/8372 */
 export type ToasterStates = Generic.Element.Members<RequiredStates, OptionalStates>;
+/** @deprecated Will be removed in the next major version. See https://github.com/public-ui/kolibri/issues/8372 */
 export type ToasterAPI = Generic.Element.ComponentApi<RequiredProps, OptionalProps, RequiredStates, OptionalStates>;


### PR DESCRIPTION
## What changed?

Three source files were updated to complete the v4 deprecation markers for `kol-toast-container` and its related types. In `packages/components/src/schema/components/toaster.ts`, all seven exported types (`Toast`, `ToastState`, `ToastRenderFunction`, `ToasterOptions`, `ToasterProps`, `ToasterStates`, `ToasterAPI`) received `@deprecated` JSDoc annotations pointing to issue #8372 and the recommended alternatives (`kol-alert` / `kol-dialog`). In `packages/components/src/functional-components/ToastItem/ToastItem.tsx`, the `ToastItemFc` functional component received `@deprecated @internal` JSDoc. In `packages/components/src/components/toaster/shadow.tsx`, a `componentWillLoad()` lifecycle hook was added that calls `Log.warn()` to emit a runtime deprecation warning in the browser console whenever `kol-toast-container` is mounted.

## Linked issues

- Closes #8372 — complete v4 deprecation markers for Toast and ToastContainer

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Drei Quelldateien wurden aktualisiert, um die v4-Deprecation-Markierungen für `kol-toast-container` und die zugehörigen Typen zu vervollständigen. In `toaster.ts` erhielten alle sieben exportierten Typen `@deprecated`-JSDoc-Annotationen mit Verweis auf Issue #8372 und die empfohlenen Alternativen (`kol-alert` / `kol-dialog`). In `ToastItem.tsx` erhielt die `ToastItemFc`-Funktionskomponente `@deprecated @internal`-JSDoc. In `shadow.tsx` wurde ein `componentWillLoad()`-Lifecycle-Hook ergänzt, der via `Log.warn()` eine Laufzeit-Deprecation-Warnung in der Browser-Konsole ausgibt, sobald `kol-toast-container` eingebunden wird.

### Verknüpfte Tickets

- Schließt #8372 — vervollständigt die v4-Deprecation-Markierungen für Toast und ToastContainer

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/schema/components/toaster.ts` — `@deprecated`-JSDoc zu allen sieben exportierten Typen hinzugefügt
- `packages/components/src/functional-components/ToastItem/ToastItem.tsx` — `@deprecated @internal`-JSDoc zu `ToastItemFc` hinzugefügt
- `packages/components/src/components/toaster/shadow.tsx` — `componentWillLoad()` mit `Log.warn()` Deprecation-Warnung hinzugefügt

</details>