### PR TITLE
fix: export all schema types from public API (#9430)

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -5,22 +5,7 @@ export { ToasterService } from './components/toaster/toaster';
 export { bootstrap, isInitialized, register } from './core/bootstrap';
 export * from './enums/bund';
 export * from './kolibri';
-export { KoliBri, KoliBriDevHelper } from './schema';
-export type {
-	EventValueOrEventCallback,
-	FocusableElement,
-	KoliBriTableCell,
-	KoliBriTableHeaderCell,
-	KoliBriTableHeaderCellWithLogic,
-	KoliBriTableSelection,
-	Optgroup,
-	Option,
-	RadioOption,
-	SelectOption,
-	Toast,
-	ToasterOptions,
-	W3CInputValue,
-} from './schema';
+export * from './schema';
 export { BEM } from './schema/bem-registry';
 export { KolEvent } from './utils/events';
 export { isTooltipOpen } from './utils/tooltip-open-tracking';

--- a/packages/samples/react/src/components/combobox/routes.ts
+++ b/packages/samples/react/src/components/combobox/routes.ts
@@ -2,11 +2,13 @@ import type { Routes } from '../../shares/types';
 import { ComboboxBasic } from './basic';
 import { ComboboxHtml } from './html';
 import { ComboboxLazyLoaded } from './lazy-loaded';
+import { ComboboxTypedEvents } from './typed-events';
 
 export const COMBOBOX_ROUTES: Routes = {
 	combobox: {
 		basic: ComboboxBasic,
 		html: ComboboxHtml,
 		'lazy-loaded': ComboboxLazyLoaded,
+		'typed-events': ComboboxTypedEvents,
 	},
 };

--- a/packages/samples/react/src/components/combobox/typed-events.tsx
+++ b/packages/samples/react/src/components/combobox/typed-events.tsx
@@ -14,10 +14,8 @@ import { SampleDescription } from '../SampleDescription';
 export const ComboboxTypedEvents: FC = () => {
 	const [value, setValue] = useState<string>('');
 
-	const handleChange: EventValueOrEventCallback<Event, unknown> = (_event, newValue) => {
-		if (typeof newValue === 'string') {
-			setValue(newValue);
-		}
+	const handleChange: EventValueOrEventCallback<Event, string> = (_event, newValue = '') => {
+		setValue(newValue);
 	};
 
 	return (

--- a/packages/samples/react/src/components/combobox/typed-events.tsx
+++ b/packages/samples/react/src/components/combobox/typed-events.tsx
@@ -1,8 +1,7 @@
 import type { EventValueOrEventCallback } from '@public-ui/components';
+import { KolCombobox } from '@public-ui/react-v19';
 import type { FC } from 'react';
 import React, { useState } from 'react';
-
-import { KolCombobox } from '@public-ui/react-v19';
 import { COUNTRY_SUGGESTIONS } from '../../shares/country';
 import { SampleDescription } from '../SampleDescription';
 

--- a/packages/samples/react/src/components/combobox/typed-events.tsx
+++ b/packages/samples/react/src/components/combobox/typed-events.tsx
@@ -8,8 +8,8 @@ import { SampleDescription } from '../SampleDescription';
 export const ComboboxTypedEvents: FC = () => {
 	const [value, setValue] = useState<string>('');
 
-	const handleChange: EventValueOrEventCallback<Event, string> = (_event, newValue = '') => {
-		setValue(newValue);
+	const handleChange: EventValueOrEventCallback<Event, unknown> = (_event: Event, newValue: unknown = '') => {
+		setValue(typeof newValue === 'string' ? newValue : '');
 	};
 
 	return (

--- a/packages/samples/react/src/components/combobox/typed-events.tsx
+++ b/packages/samples/react/src/components/combobox/typed-events.tsx
@@ -1,0 +1,35 @@
+import type { EventValueOrEventCallback } from '@public-ui/components';
+import type { FC } from 'react';
+import React, { useState } from 'react';
+
+import { KolCombobox } from '@public-ui/react-v19';
+import { COUNTRY_SUGGESTIONS } from '../../shares/country';
+import { SampleDescription } from '../SampleDescription';
+
+/**
+ * Demonstrates typed event callbacks imported directly from @public-ui/components.
+ * Before #9430 was fixed, EventValueOrEventCallback and other types were not
+ * importable; consumers had to define them locally or use `any`.
+ */
+export const ComboboxTypedEvents: FC = () => {
+	const [value, setValue] = useState<string>('');
+
+	const handleChange: EventValueOrEventCallback<Event, unknown> = (_event, newValue) => {
+		if (typeof newValue === 'string') {
+			setValue(newValue);
+		}
+	};
+
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					This example shows how to type event handlers using <code>EventValueOrEventCallback</code> imported directly from{' '}
+					<code>@public-ui/components</code>. The type was previously not accessible from the public API (#9430).
+				</p>
+			</SampleDescription>
+			<KolCombobox _label="Country" _suggestions={COUNTRY_SUGGESTIONS} _value={value} _on={{ onChange: handleChange }} />
+			<p>Selected value: {value || '–'}</p>
+		</>
+	);
+};

--- a/packages/samples/react/src/components/combobox/typed-events.tsx
+++ b/packages/samples/react/src/components/combobox/typed-events.tsx
@@ -5,11 +5,6 @@ import React, { useState } from 'react';
 import { COUNTRY_SUGGESTIONS } from '../../shares/country';
 import { SampleDescription } from '../SampleDescription';
 
-/**
- * Demonstrates typed event callbacks imported directly from @public-ui/components.
- * Before #9430 was fixed, EventValueOrEventCallback and other types were not
- * importable; consumers had to define them locally or use `any`.
- */
 export const ComboboxTypedEvents: FC = () => {
 	const [value, setValue] = useState<string>('');
 
@@ -20,10 +15,7 @@ export const ComboboxTypedEvents: FC = () => {
 	return (
 		<>
 			<SampleDescription>
-				<p>
-					This example shows how to type event handlers using <code>EventValueOrEventCallback</code> imported directly from{' '}
-					<code>@public-ui/components</code>. The type was previously not accessible from the public API (#9430).
-				</p>
+				<p>Demonstrates typed event callbacks using EventValueOrEventCallback, imported directly from @public-ui/components (issue #9430).</p>
 			</SampleDescription>
 			<KolCombobox _label="Country" _suggestions={COUNTRY_SUGGESTIONS} _value={value} _on={{ onChange: handleChange }} />
 			<p>Selected value: {value || '–'}</p>


### PR DESCRIPTION
Closes #9430

## What changed and why

`packages/components/src/index.ts` previously re-exported only 12 hand-picked types from the schema:

```ts
export { KoliBri, KoliBriDevHelper } from './schema';
export type {
  EventValueOrEventCallback,
  FocusableElement,
  KoliBriTableCell,
  // …9 more
} from './schema';
```

This left many publicly intended schema types unreachable from `@public-ui/components` — for example `EventCallback<E>`, `InputTypeOnDefault`, component-level API types (`ButtonProps`, `AccordionProps`, etc.), and prop types (`PropLabel`, `PropDisabled`, …).

**Fix:** Replace the curated list with a single wildcard re-export:

```ts
export * from './schema';
```

The schema's own barrel (`packages/components/src/schema/index.ts`) already filters internal symbols — `./enums` is explicitly excluded (`// export * from './enums'; // only for internal use`). All previously exported names remain available; additional types are now also exposed.

### Changed files

| File | Change |
|---|---|
| `packages/components/src/index.ts` | Replaced 15-line named-export block with `export * from './schema'` |
| `packages/samples/react/src/components/combobox/typed-events.tsx` | New demo: imports `EventValueOrEventCallback` from `@public-ui/components` and uses it to type a `KolCombobox` event handler |
| `packages/samples/react/src/components/combobox/routes.ts` | Registers the new `typed-events` demo route |

## Manual test

1. Start the React sample app (`packages/samples/react`)
2. Navigate to **combobox → typed-events**
3. The combobox renders with a typed `onChange` handler; selecting a country updates the displayed value
4. Verify (in an editor with TypeScript support) that `import type { EventValueOrEventCallback, EventCallback, InputTypeOnDefault } from '@public-ui/components'` resolves without error after building the components package

This PR addresses a contributor-reported issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhQgcY2TSRZPchcvtNFiwL)_