### PR TITLE
fix: use _on instead of onClick on KolButton sample — NOT the right fix, closing (#10243)

### DIFF
--- a/packages/samples/react/src/components/button/basic.tsx
+++ b/packages/samples/react/src/components/button/basic.tsx
@@ -25,9 +25,9 @@ export const ButtonBasic: FC = () => {
 				<section className="grid gap-4">
 					<KolHeading _level={2} _label="Button Variants" />
 					<div className="flex flex-wrap gap-4">
-						<KolButton _icons="kolicon-house" _label="Primary" _variant="primary" onClick={dummyClickEventHandler} />
-						<KolButton _icons="kolicon-kolibri" _label="Secondary" _variant="secondary" onClick={dummyClickEventHandler} />
-						<KolButton _icons="kolicon-cogwheel" _label="Tertiary" _variant="tertiary" onClick={dummyClickEventHandler} />
+						<KolButton _icons="kolicon-house" _label="Primary" _variant="primary" _on={dummyEventHandler} />
+						<KolButton _icons="kolicon-kolibri" _label="Secondary" _variant="secondary" _on={dummyEventHandler} />
+						<KolButton _icons="kolicon-cogwheel" _label="Tertiary" _variant="tertiary" _on={dummyEventHandler} />
 						<KolButton _icons="kolicon-cogwheel" _label="Normal" _variant="normal" _on={dummyEventHandler} />
 						<KolButton _icons="kolicon-alert-warning" _label="Danger" _variant="danger" _on={dummyEventHandler} />
 						<KolButton _icons="kolicon-eye-closed" _label="Ghost" _variant="ghost" _on={dummyEventHandler} />


### PR DESCRIPTION
Closes #10243

~~## What changed and why~~

**Closing this PR — it is not the correct fix.**

This PR only changed the sample file to use `_on` instead of React's native `onClick`. While that removes the NVDA "anklickbar" announcement for the sample, it does not solve the underlying problem:

**The real issue is that attaching any native framework event listener (`onClick`, `@click`, etc.) to a Web Component host element causes NVDA (via Chrome's accessibility APIs) to expose that host as "anklickbar" (clickable) — regardless of whether the actual interaction is handled by a native `<button>` inside the shadow DOM.**

KoliBri must support both `_on` and native framework events. The fix therefore needs to live in the component itself, not in consumer code or samples.

**Research needed (tracked in #10243):**
- Why does Chrome's accessibility tree expose a custom element with a click listener as interactive, even when a native `<button>` is the actual interaction target in the shadow DOM?
- Can the Stencil component prevent this (e.g. via ARIA attributes on `<Host>`, event-capturing/re-dispatching patterns, or similar)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01LptETJzbS1uvkWe5tSsFCP)_