### PR TITLE
refactor: shadow DOM traversal into reusable utility function

### DIFF
--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -298,7 +298,7 @@ export const mapStringOrBoolean2String = (value?: string | boolean): string | un
 };
 
 /**
- * Traverses the DOM including shadow roots and slotted content via BFS.
+ * Traverses the DOM including shadow roots and slotted elements via BFS.
  * `onNode` is called once per node; returning `true` stops traversal early.
  */
 const traverseShadowDom = (rootNode: ParentNode, onNode: (node: ParentNode) => boolean): void => {

--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -297,7 +297,11 @@ export const mapStringOrBoolean2String = (value?: string | boolean): string | un
 	return typeof value === 'string' ? value : mapBoolean2String(value);
 };
 
-const querySelectorShadow = <T extends Element>(selector: string, rootNode: Document | HTMLElement | ShadowRoot): T | null => {
+/**
+ * Traverses the DOM including shadow roots and slotted content via BFS.
+ * `onNode` is called once per node; returning `true` stops traversal early.
+ */
+const traverseShadowDom = (rootNode: Document | HTMLElement | ShadowRoot, onNode: (node: ParentNode) => boolean): void => {
 	const visited = new Set<Node>();
 	const queue: ParentNode[] = [rootNode];
 	let index = 0;
@@ -307,8 +311,8 @@ const querySelectorShadow = <T extends Element>(selector: string, rootNode: Docu
 			continue;
 		}
 		visited.add(current);
-		if (current instanceof Element && current.matches(selector)) {
-			return current as T;
+		if (onNode(current)) {
+			return;
 		}
 		const children = Array.from(current.children || []);
 		for (let i = 0; i < children.length; i++) {
@@ -326,41 +330,28 @@ const querySelectorShadow = <T extends Element>(selector: string, rootNode: Docu
 			}
 		}
 	}
-	return null;
+};
+
+const querySelectorShadow = <T extends Element>(selector: string, rootNode: Document | HTMLElement | ShadowRoot): T | null => {
+	let result: T | null = null;
+	traverseShadowDom(rootNode, (current) => {
+		if (current instanceof Element && current.matches(selector)) {
+			result = current as T;
+			return true;
+		}
+		return false;
+	});
+	return result;
 };
 
 const querySelectorAllShadow = <T extends Element>(selector: string, rootNode: Document | HTMLElement | ShadowRoot): T[] => {
-	const visited = new Set<Node>();
 	const results: T[] = [];
-	const resultSet = new Set<Element>();
-	const queue: ParentNode[] = [rootNode];
-	let index = 0;
-	while (index < queue.length) {
-		const current = queue[index++];
-		if (visited.has(current)) {
-			continue;
-		}
-		visited.add(current);
-		if (current instanceof Element && current.matches(selector) && !resultSet.has(current)) {
+	traverseShadowDom(rootNode, (current) => {
+		if (current instanceof Element && current.matches(selector)) {
 			results.push(current as T);
-			resultSet.add(current);
 		}
-		const children = Array.from(current.children || []);
-		for (let i = 0; i < children.length; i++) {
-			queue.push(children[i]);
-		}
-		if (current instanceof HTMLElement && current.shadowRoot) {
-			queue.push(current.shadowRoot);
-		}
-		if (current instanceof HTMLSlotElement) {
-			const assigned = current.assignedNodes({ flatten: true });
-			for (let i = 0; i < assigned.length; i++) {
-				if (assigned[i] instanceof Element) {
-					queue.push(assigned[i] as HTMLElement);
-				}
-			}
-		}
-	}
+		return false;
+	});
 	return results;
 };
 

--- a/packages/components/src/schema/utils/prop.validators.ts
+++ b/packages/components/src/schema/utils/prop.validators.ts
@@ -301,7 +301,10 @@ export const mapStringOrBoolean2String = (value?: string | boolean): string | un
  * Traverses the DOM including shadow roots and slotted content via BFS.
  * `onNode` is called once per node; returning `true` stops traversal early.
  */
-const traverseShadowDom = (rootNode: Document | HTMLElement | ShadowRoot, onNode: (node: ParentNode) => boolean): void => {
+const traverseShadowDom = (rootNode: ParentNode, onNode: (node: ParentNode) => boolean): void => {
+	if (!rootNode) {
+		return;
+	}
 	const visited = new Set<Node>();
 	const queue: ParentNode[] = [rootNode];
 	let index = 0;
@@ -332,7 +335,7 @@ const traverseShadowDom = (rootNode: Document | HTMLElement | ShadowRoot, onNode
 	}
 };
 
-const querySelectorShadow = <T extends Element>(selector: string, rootNode: Document | HTMLElement | ShadowRoot): T | null => {
+const querySelectorShadow = <T extends Element>(selector: string, rootNode: ParentNode): T | null => {
 	let result: T | null = null;
 	traverseShadowDom(rootNode, (current) => {
 		if (current instanceof Element && current.matches(selector)) {
@@ -344,7 +347,7 @@ const querySelectorShadow = <T extends Element>(selector: string, rootNode: Docu
 	return result;
 };
 
-const querySelectorAllShadow = <T extends Element>(selector: string, rootNode: Document | HTMLElement | ShadowRoot): T[] => {
+const querySelectorAllShadow = <T extends Element>(selector: string, rootNode: ParentNode): T[] => {
 	const results: T[] = [];
 	traverseShadowDom(rootNode, (current) => {
 		if (current instanceof Element && current.matches(selector)) {


### PR DESCRIPTION
## What changed?

The shared BFS (breadth-first search) traversal logic that was duplicated between `querySelectorShadow` and `querySelectorAllShadow` in `prop.validators.ts` was extracted into a new internal utility function `traverseShadowDom`. The new function accepts a `onNode` callback that is invoked for each visited node and can return `true` to abort traversal early. Both `querySelectorShadow` and `querySelectorAllShadow` now delegate their traversal to this shared primitive, reducing the file by ~20 lines and eliminating a redundant `resultSet` in the all-variant. No public API, no behavior, and no return types were changed.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die duplizierte BFS-Traversierungslogik aus `querySelectorShadow` und `querySelectorAllShadow` in `prop.validators.ts` wurde in eine neue interne Hilfsfunktion `traverseShadowDom` ausgelagert. Die neue Funktion akzeptiert einen `onNode`-Callback, der für jeden besuchten Knoten aufgerufen wird und bei Rückgabe von `true` die Traversierung abbricht. Beide Funktionen nutzen nun diesen gemeinsamen Kern, wodurch die Datei um ~20 Zeilen reduziert und ein redundantes `resultSet` entfernt wurde. Es wurden keine öffentlichen APIs, Verhalten oder Rückgabetypen geändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/schema/utils/prop.validators.ts` — BFS-DOM-Traversierungslogik in wiederverwendbare `traverseShadowDom`-Funktion extrahiert

</details>