### PR TITLE
fix: combobox/single select panel z-index

### DIFF
--- a/packages/components/src/components/@shared/_input-container.mixin.scss
+++ b/packages/components/src/components/@shared/_input-container.mixin.scss
@@ -6,6 +6,7 @@
 		width: 100%;
 		min-width: var(--a11y-min-size);
 		min-height: var(--a11y-min-size);
+		position: relative;
 
 		align-items: center;
 		grid-template-columns: 1fr;
@@ -17,6 +18,7 @@
 
 		&__container {
 			position: relative;
+			z-index: 1;
 		}
 
 		&__adornment {

--- a/packages/components/src/components/@shared/_input-container.mixin.scss
+++ b/packages/components/src/components/@shared/_input-container.mixin.scss
@@ -3,10 +3,10 @@
 		$root: &;
 		background-color: transparent;
 		display: grid;
+		position: relative;
 		width: 100%;
 		min-width: var(--a11y-min-size);
 		min-height: var(--a11y-min-size);
-		position: relative;
 
 		align-items: center;
 		grid-template-columns: 1fr;

--- a/packages/samples/react/src/scenarios/z-index.tsx
+++ b/packages/samples/react/src/scenarios/z-index.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import React, { useEffect, useRef } from 'react';
 
-import { KolButton, KolCombobox, KolDialog, KolPopoverButton } from '@public-ui/react-v19';
+import { KolButton, KolCombobox, KolDialog, KolInputNumber, KolPopoverButton } from '@public-ui/react-v19';
 import { useSearchParams } from 'react-router';
 import { SampleDescription } from '../components/SampleDescription';
 
@@ -42,6 +42,7 @@ export const ZIndexScenario: FC = () => {
 							</div>
 						</KolPopoverButton>
 						<KolCombobox _label="With string array in html" _suggestions="['Herr','Frau','Firma']" _value="Herr" _hideLabel />
+						<KolInputNumber _label="Amount" />
 					</KolDialog>
 				</div>
 			</div>

--- a/packages/themes/bwst/src/mixins/input-text.scss
+++ b/packages/themes/bwst/src/mixins/input-text.scss
@@ -13,7 +13,6 @@
 	}
 
 	.kol-input-container {
-		position: relative;
 		padding: 0;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;

--- a/packages/themes/bwst/src/mixins/select.scss
+++ b/packages/themes/bwst/src/mixins/select.scss
@@ -36,7 +36,6 @@
 	}
 
 	.kol-input-container:has(:not(.kol-select[multiple])) {
-		position: relative;
 		padding: 0;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;

--- a/packages/themes/default/src/mixins/input-text.scss
+++ b/packages/themes/default/src/mixins/input-text.scss
@@ -13,7 +13,6 @@
 	}
 
 	.kol-input-container {
-		position: relative;
 		padding: 0;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;
@@ -45,11 +44,6 @@
 
 		&:has(&__adornment--end &__icon + &__smart-button) .#{$clickable-classname} {
 			padding-right: to-rem(76);
-		}
-
-		&__container {
-			position: relative;
-			z-index: 1;
 		}
 	}
 }

--- a/packages/themes/default/src/mixins/select.scss
+++ b/packages/themes/default/src/mixins/select.scss
@@ -36,7 +36,6 @@
 	}
 
 	.kol-input-container:not(:has(.kol-select[multiple])) {
-		position: relative;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;
 

--- a/packages/themes/desy/src/components/input-file.scss
+++ b/packages/themes/desy/src/components/input-file.scss
@@ -10,7 +10,6 @@
 	}
 
 	.kol-input-container {
-		position: relative;
 		padding: 0;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;

--- a/packages/themes/desy/src/mixins/kol-input-text.scss
+++ b/packages/themes/desy/src/mixins/kol-input-text.scss
@@ -12,7 +12,6 @@
 	}
 
 	.kol-input-container {
-		position: relative;
 		padding: 0;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;

--- a/packages/themes/ecl/src/ecl-ec/mixins/input-text.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/input-text.scss
@@ -20,7 +20,6 @@
 	}
 
 	.kol-input-container {
-		position: relative;
 		padding: 0;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;

--- a/packages/themes/ecl/src/ecl-ec/mixins/select.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/select.scss
@@ -35,7 +35,6 @@
 	}
 
 	.kol-input-container:has(:not(.kol-select[multiple])) {
-		position: relative;
 		padding: 0;
 		gap: 0;
 		grid-template-columns: auto max-content min-content;

--- a/packages/themes/kern/src/mixins/_input-core.mixin.scss
+++ b/packages/themes/kern/src/mixins/_input-core.mixin.scss
@@ -37,7 +37,6 @@
 	.kol-input-container {
 		background: var(--kern-color-form-input-background);
 		border-radius: var(--kern-metric-border-radius-small) var(--kern-metric-border-radius-small) 0 0;
-		position: relative;
 		padding: 0 var(--kern-metric-space-default);
 		gap: 0;
 		border: none;


### PR DESCRIPTION
## What changed?

The shared `_input-container.mixin.scss` mixin was updated to add `position: relative` to the root element and `z-index: 1` to the `__container` child, establishing a proper stacking context that prevents the dropdown panels of `KolCombobox` and single-select inputs from rendering beneath adjacent elements. As a result, the now-redundant `position: relative` declarations that several theme SCSS files (bwst, default, desy, ecl, kern) had been adding locally were removed — the stacking context is now managed exclusively by the shared mixin. A `KolInputNumber` component was also added to the z-index test scenario in `packages/samples/react` to validate the fix.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Das gemeinsame Mixin `_input-container.mixin.scss` wurde aktualisiert: Am Root-Element wurde `position: relative` hinzugefügt und am `__container`-Kind-Element `z-index: 1`, um einen korrekten Stacking-Kontext herzustellen. Dieser verhindert, dass Dropdown-Panels von `KolCombobox` und Single-Select-Inputs unter benachbarten Elementen gerendert werden. Die nun redundanten `position: relative`-Deklarationen wurden aus den Theme-SCSS-Dateien (bwst, default, desy, ecl, kern) entfernt, da der Stacking-Kontext jetzt ausschließlich im gemeinsamen Mixin verwaltet wird. Außerdem wurde eine `KolInputNumber`-Komponente zum Z-Index-Testszenario hinzugefügt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/@shared/_input-container.mixin.scss` — `position: relative` am Root und `z-index: 1` am `__container` hinzugefügt
- `packages/themes/bwst/src/mixins/input-text.scss` — redundante `position: relative` entfernt
- `packages/themes/bwst/src/mixins/select.scss` — redundante `position: relative` entfernt
- `packages/themes/default/src/mixins/input-text.scss` — redundante `position: relative` und lokalen `z-index`-Block entfernt
- `packages/themes/default/src/mixins/select.scss` — redundante `position: relative` entfernt
- `packages/themes/desy/src/components/input-file.scss` — redundante `position: relative` entfernt
- `packages/themes/desy/src/mixins/kol-input-text.scss` — redundante `position: relative` entfernt
- `packages/themes/ecl/src/ecl-ec/mixins/input-text.scss` — redundante `position: relative` entfernt
- `packages/themes/ecl/src/ecl-ec/mixins/select.scss` — redundante `position: relative` entfernt
- `packages/themes/kern/src/mixins/_input-core.mixin.scss` — redundante `position: relative` entfernt
- `packages/samples/react/src/scenarios/z-index.tsx` — `KolInputNumber` zum Testszenario hinzugefügt

</details>