### PR TITLE
fix: resolve TypeError when invoking KoliBri MCP search/fetch tools (#9989)

### DIFF
--- a/packages/tools/mcp/src/mcp.ts
+++ b/packages/tools/mcp/src/mcp.ts
@@ -124,10 +124,6 @@ function configureServer(server: McpServer): McpServer {
 				kind: z.enum(KIND_OPTIONS).optional(),
 				limit: z.number().optional(),
 			},
-			outputSchema: {
-				query: z.string(),
-				totalResults: z.number(),
-			},
 		},
 		({ query, kind, limit }: { query?: string; kind?: string; limit?: number }) => {
 			log('tool', 'search called', { query, kind, limit });
@@ -197,11 +193,6 @@ function configureServer(server: McpServer): McpServer {
 				'Get a specific sample, specification, or documentation entry by its ID. Parameter: id (required string, e.g. "button/basic", "spec/button", or "docs/getting-started")',
 			inputSchema: {
 				id: z.string(),
-			},
-			outputSchema: {
-				id: z.string(),
-				kind: z.string(),
-				name: z.string(),
 			},
 		},
 		({ id }) => {

--- a/packages/tools/mcp/test/search-tool-invocation.test.js
+++ b/packages/tools/mcp/test/search-tool-invocation.test.js
@@ -14,6 +14,9 @@ import { createKolibriMcpServer } from '../dist/mcp.mjs';
  * invocation bypasses. Regression guard for #9989, where a `TypeError`
  * ("Cannot read properties of undefined (reading 'invoke')") was thrown when
  * the tools were invoked through the protocol.
+ *
+ * The returned `close` helper tears down both the client and the server so the
+ * test runner does not leak open transports/streams.
  */
 async function connectClient() {
 	const server = createKolibriMcpServer();
@@ -23,36 +26,53 @@ async function connectClient() {
 
 	await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
 
-	return { client, server };
+	const close = async () => {
+		await Promise.all([client.close(), server.close()]);
+	};
+
+	return { client, server, close };
 }
 
 test('search tool can be invoked via the protocol for a single-word query (#9989)', async () => {
-	const { client, server } = await connectClient();
+	const { client, close } = await connectClient();
 	try {
 		const result = await client.callTool({ name: 'search', arguments: { query: 'LinkButton' } });
 
 		assert.strictEqual(result.isError ?? false, false, 'search call should not report an error');
 		assert.ok(Array.isArray(result.content) && result.content.length > 0, 'search should return content');
 		assert.strictEqual(result.content[0].type, 'text');
+
+		// outputSchema was removed, so guard the structured-output contract explicitly.
+		assert.ok(result.structuredContent, 'search should return structuredContent');
+		assert.strictEqual(result.structuredContent.query, 'LinkButton');
+		assert.ok(Array.isArray(result.structuredContent.results), 'results should be an array');
 	} finally {
-		await server.close();
+		await close();
 	}
 });
 
 test('search tool can be invoked via the protocol with a kind filter (#9989)', async () => {
-	const { client, server } = await connectClient();
+	const { client, close } = await connectClient();
 	try {
 		const result = await client.callTool({ name: 'search', arguments: { query: 'LinkButton', kind: 'doc' } });
 
 		assert.strictEqual(result.isError ?? false, false, 'search call with kind should not report an error');
 		assert.ok(Array.isArray(result.content) && result.content.length > 0, 'search should return content');
+
+		assert.ok(result.structuredContent, 'search should return structuredContent');
+		assert.strictEqual(result.structuredContent.query, 'LinkButton');
+		assert.ok(Array.isArray(result.structuredContent.results), 'results should be an array');
+		assert.ok(
+			result.structuredContent.results.every((r) => r.kind === 'doc'),
+			'all results should match the requested kind filter',
+		);
 	} finally {
-		await server.close();
+		await close();
 	}
 });
 
 test('fetch tool can be invoked via the protocol (#9989)', async () => {
-	const { client, server } = await connectClient();
+	const { client, close } = await connectClient();
 	try {
 		// First find a real entry id via search, then fetch it.
 		const searchResult = await client.callTool({ name: 'search', arguments: { query: 'button', limit: 1 } });
@@ -63,7 +83,10 @@ test('fetch tool can be invoked via the protocol (#9989)', async () => {
 
 		assert.strictEqual(result.isError ?? false, false, 'fetch call should not report an error');
 		assert.ok(Array.isArray(result.content) && result.content.length > 0, 'fetch should return content');
+
+		assert.ok(result.structuredContent, 'fetch should return structuredContent');
+		assert.strictEqual(result.structuredContent.id, id, 'fetched entry id should match the requested id');
 	} finally {
-		await server.close();
+		await close();
 	}
 });

--- a/packages/tools/mcp/test/search-tool-invocation.test.js
+++ b/packages/tools/mcp/test/search-tool-invocation.test.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { createKolibriMcpServer } from '../dist/mcp.mjs';
+
+/**
+ * Connect a real MCP client to the KoliBri server over an in-memory transport.
+ *
+ * This exercises the full protocol-level `tools/call` path (including any
+ * structured-output validation the SDK performs), which a direct `callback()`
+ * invocation bypasses. Regression guard for #9989, where a `TypeError`
+ * ("Cannot read properties of undefined (reading 'invoke')") was thrown when
+ * the tools were invoked through the protocol.
+ */
+async function connectClient() {
+	const server = createKolibriMcpServer();
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+	const client = new Client({ name: 'test-client', version: '0.0.0' });
+
+	await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+	return { client, server };
+}
+
+test('search tool can be invoked via the protocol for a single-word query (#9989)', async () => {
+	const { client, server } = await connectClient();
+	try {
+		const result = await client.callTool({ name: 'search', arguments: { query: 'LinkButton' } });
+
+		assert.strictEqual(result.isError ?? false, false, 'search call should not report an error');
+		assert.ok(Array.isArray(result.content) && result.content.length > 0, 'search should return content');
+		assert.strictEqual(result.content[0].type, 'text');
+	} finally {
+		await server.close();
+	}
+});
+
+test('search tool can be invoked via the protocol with a kind filter (#9989)', async () => {
+	const { client, server } = await connectClient();
+	try {
+		const result = await client.callTool({ name: 'search', arguments: { query: 'LinkButton', kind: 'doc' } });
+
+		assert.strictEqual(result.isError ?? false, false, 'search call with kind should not report an error');
+		assert.ok(Array.isArray(result.content) && result.content.length > 0, 'search should return content');
+	} finally {
+		await server.close();
+	}
+});
+
+test('fetch tool can be invoked via the protocol (#9989)', async () => {
+	const { client, server } = await connectClient();
+	try {
+		// First find a real entry id via search, then fetch it.
+		const searchResult = await client.callTool({ name: 'search', arguments: { query: 'button', limit: 1 } });
+		const id = searchResult.structuredContent?.results?.[0]?.id;
+		assert.ok(id, 'expected search to return at least one result id');
+
+		const result = await client.callTool({ name: 'fetch', arguments: { id } });
+
+		assert.strictEqual(result.isError ?? false, false, 'fetch call should not report an error');
+		assert.ok(Array.isArray(result.content) && result.content.length > 0, 'fetch should return content');
+	} finally {
+		await server.close();
+	}
+});


### PR DESCRIPTION
## What changed?

The KoliBri MCP server's `search` and `fetch` tools threw a `TypeError: Cannot read properties of undefined (reading 'invoke')` on every protocol-level invocation. The root cause was that both tools were registered with an `outputSchema`, and under `@modelcontextprotocol/sdk@1.29.0` + `zod@4` this schema validation path was broken. The `search` tool's `outputSchema` was also incomplete (it declared only `query` and `totalResults` while the actual result also returns a `results` array). The fix removes the `outputSchema` declarations from both tool registrations in `packages/tools/mcp/src/mcp.ts`; `structuredContent` is still returned so clients consuming structured output continue to work. A new protocol-level integration test (`test/search-tool-invocation.test.js`) connects a real MCP client over an in-memory transport and invokes all three affected scenarios to guard against regression.

## Linked issues

- Closes #9989 — TypeError when invoking KoliBri MCP search/fetch tools

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die MCP-Tools `search` und `fetch` des KoliBri-MCP-Servers haben bei jedem protokollseitigen Aufruf einen `TypeError: Cannot read properties of undefined (reading 'invoke')` geworfen. Ursache war die Registrierung beider Tools mit einem `outputSchema`, das unter `@modelcontextprotocol/sdk@1.29.0` + `zod@4` einen fehlerhaften Validierungspfad auslöste. Das `outputSchema` von `search` war zudem unvollständig (kein `results`-Array). Lösung: Die `outputSchema`-Deklarationen wurden aus beiden Tool-Registrierungen entfernt; `structuredContent` wird weiterhin zurückgegeben. Ein neuer Integrationstest schützt gegen Regressionen.

### Verknüpfte Tickets

- Closes #9989 — TypeError beim Aufrufen der KoliBri-MCP-Such-/Fetch-Tools

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/tools/mcp/src/mcp.ts` — Entfernt `outputSchema` aus `search`- und `fetch`-Tool-Registrierungen
- `packages/tools/mcp/test/search-tool-invocation.test.js` — Neuer Protokoll-Level-Regressionstest mit In-Memory-MCP-Client (3 Szenarien)

</details>