### PR TITLE
fix(combobox): select focused option with space key when dropdown is open

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -409,9 +409,6 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 						this._isOpen = false;
 						event.preventDefault();
 					}
-				} else {
-					this.toggleListbox();
-					event.preventDefault();
 				}
 				break;
 			}

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -390,19 +390,15 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 			case 'NumpadEnter': {
 				if (this.clearButtonFocused) {
 					this.clearSelection();
+					event.preventDefault();
 				} else if (this._isOpen) {
 					if (this.selectFocusedOption()) {
 						this._isOpen = false;
+						event.preventDefault();
 					}
 				} else {
 					this.toggleListbox();
-				}
-				event.preventDefault();
-				break;
-			}
-			case 'Space': {
-				if (this.clearButtonFocused) {
-					this.clearSelection();
+					event.preventDefault();
 				}
 				break;
 			}

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -385,9 +385,22 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 				this.ctaRef.el?.focus();
 				break;
 			}
-			case ' ':
 			case 'Enter':
 			case 'NumpadEnter': {
+				if (this.clearButtonFocused) {
+					this.clearSelection();
+				} else if (this._isOpen) {
+					if (this.selectFocusedOption()) {
+						this._isOpen = false;
+					}
+				} else {
+					this.toggleListbox();
+				}
+				event.preventDefault();
+				break;
+			}
+			// Space key
+			case ' ': {
 				if (this.clearButtonFocused) {
 					this.clearSelection();
 					event.preventDefault();


### PR DESCRIPTION
## What changed?

In `KolCombobox`, the space key was incorrectly grouped with `Enter` and `NumpadEnter` in the keyboard handler, causing it to trigger the same open/close code path instead of its proper selection behavior. The fix separates the space key into its own `case ' ':` branch: when the clear button is focused, it clears the selection and calls `preventDefault`; when the dropdown is open, it selects the currently focused option and closes the dropdown, also calling `preventDefault`. The previously incorrect `case 'Space':` branch (which only handled clear-button focus without `preventDefault`) was replaced entirely.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

> 📝 **Title corrected:** `fix: combobox space key` → `fix(combobox): select focused option with space key when dropdown is open`
> Reason: The original title lacked a scope and did not describe the actual bug or behavior change.

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Im `KolCombobox`-Keyboard-Handler war die Leertaste fälschlicherweise zusammen mit `Enter` und `NumpadEnter` gruppiert und löste daher denselben Code-Pfad (Dropdown öffnen/schließen) aus. Die Leertaste erhält nun einen eigenen `case ' ':`: Wenn der Lösch-Button fokussiert ist, wird die Auswahl gelöscht (mit `preventDefault`); ist das Dropdown geöffnet, wird die fokussierte Option ausgewählt und das Dropdown geschlossen. Der bisherige, nicht korrekte `case 'Space':` wurde vollständig ersetzt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/combobox/shadow.tsx` — Korrektur des Leertasten-Handlers: dedizierter `case ' ':` mit `preventDefault` und Option-Auswahl-Logik bei geöffnetem Dropdown

</details>