### PR TITLE
fix: table aria labelledby and settings menu

### DIFF
--- a/packages/components/src/components/@shared/_table-stateless.mixin.scss
+++ b/packages/components/src/components/@shared/_table-stateless.mixin.scss
@@ -39,6 +39,11 @@
 			text-align: start;
 		}
 
+		// table without caption but settings needs space above for the settings button
+		kol-table-settings-wc + &__scroll-container:not(:has(&__caption)) {
+			margin-top: var(--a11y-min-size);
+		}
+
 		&__sort-button {
 			.kol-button {
 				color: inherit;

--- a/packages/components/src/components/@shared/_table-stateless.mixin.scss
+++ b/packages/components/src/components/@shared/_table-stateless.mixin.scss
@@ -40,8 +40,9 @@
 		}
 
 		// table without caption but settings needs space above for the settings button
-		kol-table-settings-wc + &__scroll-container:not(:has(&__caption)) {
-			margin-top: var(--a11y-min-size);
+		kol-table-settings-wc:not(:has(~ &__scroll-container &__caption)) {
+			display: block;
+			min-height: var(--a11y-min-size);
 		}
 
 		&__sort-button {

--- a/packages/samples/react/src/components/table/aria-labelledby.tsx
+++ b/packages/samples/react/src/components/table/aria-labelledby.tsx
@@ -91,7 +91,7 @@ export const AriaLabelledby: FC = () => (
 					The <code>&lt;h2&gt;</code> above serves as the accessible label via <code>_ariaLabelledby</code>. No internal <code>&lt;caption&gt;</code> is
 					rendered.
 				</p>
-				<KolTableStateless _ariaLabelledby="caption-stateless" {...PROPS} />
+				<KolTableStateless _ariaLabelledby="caption-stateless" {...PROPS} _hasSettingsMenu />
 			</div>
 
 			<hr aria-hidden="true" className="border-0" />


### PR DESCRIPTION
## What changed?

The `_table-stateless.mixin.scss` now adds a CSS rule that ensures `kol-table-settings-wc` renders as a block element with a minimum height (`--a11y-min-size`) when the table has no visible caption element. Without this fix, the settings menu button had no reserved space and could overlap or be invisible when used alongside `_ariaLabelledby` (no internal `<caption>`). The `aria-labelledby` React sample was also updated to include `_hasSettingsMenu` so the settings-without-caption scenario is properly demonstrated and tested.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `_table-stateless.mixin.scss` wurde eine neue CSS-Regel ergänzt, die sicherstellt, dass `kol-table-settings-wc` als Block-Element mit einer Mindesthöhe (`--a11y-min-size`) dargestellt wird, wenn die Tabelle keine sichtbare Caption enthält. Ohne diesen Fix hatte der Einstellungen-Button keinen reservierten Platz und konnte bei Verwendung von `_ariaLabelledby` (ohne internes `<caption>`-Element) unsichtbar oder überlappend erscheinen. Das React-Beispiel `aria-labelledby` wurde ebenfalls aktualisiert und zeigt nun `_hasSettingsMenu`, damit dieses Szenario korrekt demonstriert wird.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/@shared/_table-stateless.mixin.scss` — Neue CSS-Regel für Settings-Button-Spacing ohne Tabellen-Caption
- `packages/samples/react/src/components/table/aria-labelledby.tsx` — `_hasSettingsMenu`-Prop zum Aria-Labelledby-Beispiel hinzugefügt

</details>