### PR TITLE
perf(table): improve stateless table render performance for large data sets

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -944,18 +944,15 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 
 	private getDataWithSelectionEnabled() {
 		const keyPropertyName = this.getSelectionKeyPropertyName();
-		const disabled = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.disabledKeys).map(String));
-		return this.state._data.filter((item) => !disabled.has(String(item[keyPropertyName] as KoliBriTableSelectionKey)));
+		return this.state._data.filter((item) => !this.disabledKeysStringSet.has(String(item[keyPropertyName] as KoliBriTableSelectionKey)));
 	}
 
 	private getSelectedKeysWithoutDisabledKeys() {
-		const disabled = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.disabledKeys).map(String));
-		return KolTableStatelessWc.normalizeKeys(this.state._selection?.selectedKeys).filter((k) => !disabled.has(String(k)));
+		return KolTableStatelessWc.normalizeKeys(this.state._selection?.selectedKeys).filter((k) => !this.disabledKeysStringSet.has(String(k)));
 	}
 
 	private getSelectedKeysWithDisabledKeysOnly() {
-		const disabled = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.disabledKeys).map(String));
-		return KolTableStatelessWc.normalizeKeys(this.state._selection?.selectedKeys).filter((k) => disabled.has(String(k)));
+		return KolTableStatelessWc.normalizeKeys(this.state._selection?.selectedKeys).filter((k) => this.disabledKeysStringSet.has(String(k)));
 	}
 
 	private getRevertedSelection(selectAll: boolean) {

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -80,6 +80,13 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 	private cellsToRenderTimeouts = new Map<HTMLElement, ReturnType<typeof setTimeout>>();
 	private dataToKeyMap = new Map<KoliBriTableDataType, string>();
 
+	/** Per-render cache for the computed primary headers, keyed by header object reference. */
+	private primaryHeadersCache?: { headers: KoliBriTableHeaders; result: KoliBriTableHeaderCell[]; horizontal: boolean };
+
+	/** Per-render lookup sets for selection state to avoid O(n²) scans of the key arrays per row. */
+	private selectedKeysStringSet = new Set<string>();
+	private disabledKeysStringSet = new Set<string>();
+
 	private checkboxRefs: HTMLInputElement[] = [];
 
 	private translateSort = translate('kol-sort');
@@ -343,6 +350,9 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 	}
 
 	private updateDataToKeyMap(data: KoliBriTableDataType[]) {
+		/* Use a Set for O(1) membership checks. Using data.includes() inside the
+		 * cleanup loop below would be O(n²) and dominates rendering for large data sets. */
+		const dataSet = new Set(data);
 		data.forEach((data) => {
 			if (!this.dataToKeyMap.has(data)) {
 				this.dataToKeyMap.set(data, nonce());
@@ -351,7 +361,7 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 
 		/* Cleanup old values from map */
 		this.dataToKeyMap.forEach((_, key) => {
-			if (!data.includes(key)) {
+			if (!dataSet.has(key)) {
 				this.dataToKeyMap.delete(key);
 			}
 		});
@@ -458,6 +468,17 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 	}
 
 	private getPrimaryHeaders(headers: KoliBriTableHeaders): KoliBriTableHeaderCell[] {
+		/**
+		 * Memoize by reference: within a single render the header object is stable, so this
+		 * avoids rebuilding the primary-header array for every cell (e.g. via getActionColumnHeader),
+		 * which would otherwise be O(rows × cols × headers). The cache invalidates automatically
+		 * whenever a new header object is assigned to the state.
+		 */
+		if (this.primaryHeadersCache?.headers === headers) {
+			this.horizontal = this.primaryHeadersCache.horizontal;
+			return this.primaryHeadersCache.result;
+		}
+
 		let primaryHeaders: KoliBriTableHeaderCell[] = this.getThePrimaryHeadersWithKeyOrRenderFunction(headers.horizontal ?? []);
 
 		/**
@@ -471,6 +492,8 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 				this.horizontal = false;
 			}
 		}
+
+		this.primaryHeadersCache = { headers, result: primaryHeaders, horizontal: this.horizontal };
 		return primaryHeaders;
 	}
 
@@ -712,16 +735,9 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 		const keyProperty = firstCellData[keyPropertyName] as string | number;
 		const isMultiple = selection.multiple || selection.multiple === undefined;
 
-		const selected = (() => {
-			const v = selection?.selectedKeys;
-			const arr = v === undefined ? [] : Array.isArray(v) ? v : [v];
-			return arr.some((k) => String(k) === String(keyProperty));
-		})();
-		const disabled = (() => {
-			const v = selection?.disabledKeys;
-			const arr = v === undefined ? [] : Array.isArray(v) ? v : [v];
-			return arr.some((k) => String(k) === String(keyProperty));
-		})();
+		const keyPropertyString = String(keyProperty);
+		const selected = this.selectedKeysStringSet.has(keyPropertyString);
+		const disabled = this.disabledKeysStringSet.has(keyPropertyString);
 
 		const label = selection.label(firstCellData);
 		const props = {
@@ -912,37 +928,34 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 		return this.state._selection?.keyPropertyName ?? 'id';
 	}
 
+	private static normalizeKeys(value?: KoliBriTableSelectionKey | KoliBriTableSelectionKey[]): KoliBriTableSelectionKey[] {
+		return value === undefined ? [] : Array.isArray(value) ? value : [value];
+	}
+
+	/**
+	 * Rebuilds the per-render lookup sets for the current selection. Doing this once per render
+	 * allows O(1) membership checks per row instead of scanning the full key arrays for every row,
+	 * which would otherwise be O(rows × keys).
+	 */
+	private updateSelectionKeySets() {
+		this.selectedKeysStringSet = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.selectedKeys).map(String));
+		this.disabledKeysStringSet = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.disabledKeys).map(String));
+	}
+
 	private getDataWithSelectionEnabled() {
 		const keyPropertyName = this.getSelectionKeyPropertyName();
-		return this.state._data.filter((item) => {
-			const v = this.state._selection?.disabledKeys;
-			const arr = v === undefined ? [] : Array.isArray(v) ? v : [v];
-			return !arr.some((k) => String(k) === String(item[keyPropertyName] as KoliBriTableSelectionKey));
-		});
+		const disabled = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.disabledKeys).map(String));
+		return this.state._data.filter((item) => !disabled.has(String(item[keyPropertyName] as KoliBriTableSelectionKey)));
 	}
 
 	private getSelectedKeysWithoutDisabledKeys() {
-		const sel = (() => {
-			const v = this.state._selection?.selectedKeys;
-			return v === undefined ? [] : Array.isArray(v) ? v : [v];
-		})();
-		const dis = (() => {
-			const v = this.state._selection?.disabledKeys;
-			return v === undefined ? [] : Array.isArray(v) ? v : [v];
-		})();
-		return sel.filter((k) => !dis.some((d) => String(d) === String(k)));
+		const disabled = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.disabledKeys).map(String));
+		return KolTableStatelessWc.normalizeKeys(this.state._selection?.selectedKeys).filter((k) => !disabled.has(String(k)));
 	}
 
 	private getSelectedKeysWithDisabledKeysOnly() {
-		const sel = (() => {
-			const v = this.state._selection?.selectedKeys;
-			return v === undefined ? [] : Array.isArray(v) ? v : [v];
-		})();
-		const dis = (() => {
-			const v = this.state._selection?.disabledKeys;
-			return v === undefined ? [] : Array.isArray(v) ? v : [v];
-		})();
-		return sel.filter((k) => dis.some((d) => String(d) === String(k)));
+		const disabled = new Set(KolTableStatelessWc.normalizeKeys(this.state._selection?.disabledKeys).map(String));
+		return KolTableStatelessWc.normalizeKeys(this.state._selection?.selectedKeys).filter((k) => disabled.has(String(k)));
 	}
 
 	private getRevertedSelection(selectAll: boolean) {
@@ -1237,6 +1250,7 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 	}
 
 	public render(): JSX.Element {
+		this.updateSelectionKeySets();
 		const dataField = this.createDataField(this.state._data, this.state._headerCells);
 		this.checkboxRefs = [];
 


### PR DESCRIPTION
## What changed?

Three O(n²) performance bottlenecks in `KolTableStatelessWc` were replaced with O(n) / O(1) equivalents to address slow rendering with large data sets. First, `updateDataToKeyMap` now uses a `Set` for the cleanup membership check instead of `Array.includes()`, reducing map cleanup from O(n²) to O(n). Second, selection state lookups in `renderSelectionCell` were changed from per-row `.some()` scans over the full key arrays to O(1) `Set` lookups using `selectedKeysStringSet` and `disabledKeysStringSet` built once per `render()`. Third, `getPrimaryHeaders` was memoized by header object reference so the primary-header array is only rebuilt when the `headers` prop actually changes, instead of being recomputed for every cell. The related helpers `getDataWithSelectionEnabled`, `getSelectedKeysWithoutDisabledKeys`, and `getSelectedKeysWithDisabledKeysOnly` were refactored to use the same Set-based approach and a shared `normalizeKeys` static helper.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

> 📝 **Title corrected:** `fix(table): improve stateless table render performance for large data sets` → `perf(table): improve stateless table render performance for large data sets`
> Reason: The changes are pure performance optimizations with no bug fix — `perf` is the correct Conventional Commits type for this.

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Drei O(n²)-Engpässe in `KolTableStatelessWc` wurden durch O(n)- bzw. O(1)-Äquivalente ersetzt. 1) `updateDataToKeyMap` verwendet nun ein `Set` statt `Array.includes()` für die Bereinigungsprüfung (O(n²) → O(n)). 2) Die Selektionsstatus-Prüfung in `renderSelectionCell` wechselt von `.some()`-Scans pro Zeile zu O(1)-`Set`-Lookups (`selectedKeysStringSet`, `disabledKeysStringSet`), die einmal pro Render aufgebaut werden. 3) `getPrimaryHeaders` wird per Header-Objekt-Referenz memoized, sodass das Header-Array nur bei echten Änderungen neu aufgebaut wird. Die Hilfsmethoden für Selektionskeys wurden auf denselben `Set`-Ansatz und eine statische `normalizeKeys`-Hilfsmethode umgestellt.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/table-stateless/component.tsx` — Set-basierte Bereinigung in `updateDataToKeyMap`, per-Render-Selection-Sets, Memoization von `getPrimaryHeaders`; Refactoring der Selektions-Hilfsmethoden auf `Set`-Lookups und `normalizeKeys`

</details>