### PR TITLE
fix(table): persist settings menu changes in KolTableStateful across re-renders

### DIFF
--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -3,6 +3,7 @@ import { Component, Element, h, Host, Method, Prop, State, Watch } from '@stenci
 import { KolPaginationWcTag, KolTableStatelessWcTag } from '../../core/component-names';
 import { translate } from '../../i18n';
 import type {
+	ChangeHeaderCellsEventPayload,
 	FixedColsPropType,
 	HasSettingsMenuPropType,
 	KoliBriDataCompareFn,
@@ -104,6 +105,13 @@ export class KolTableStateful implements TableAPI {
 	private pageStartSlice = 0;
 	private pageEndSlice = 10;
 	private disableSort = false;
+
+	/**
+	 * Holds the header cells adjusted via the settings menu (visibility, width, order). Persisting
+	 * them here ensures the customisation survives re-renders triggered by sorting, pagination,
+	 * selection or data updates instead of being reset to the original `_headers`. (#10344)
+	 */
+	@State() private adjustedHeaderCells?: TableHeaderCells;
 
 	/**
 	 * Defines whether to allow multi sort.
@@ -319,6 +327,8 @@ export class KolTableStateful implements TableAPI {
 				watchValidator(this, '_headers', (value): boolean => typeof value === 'object' && value !== null, new Set(['KoliBriTableHeaders']), value, {
 					hooks: {
 						beforePatch: (nextValue: unknown) => {
+							// A new header definition invalidates any settings the user applied to the previous one.
+							this.adjustedHeaderCells = undefined;
 							const headers: KoliBriTableHeaders = nextValue as KoliBriTableHeaders;
 							const hasSortedCells = this.initializeSortFromHeaders(headers);
 							if (hasSortedCells) {
@@ -615,6 +625,35 @@ export class KolTableStateful implements TableAPI {
 		this.updateSortedData();
 	}
 
+	/**
+	 * Stores the header cells the user adjusted via the settings menu so they are reapplied on the
+	 * next render. Called from the `onChangeHeaderCells` callback of the stateless table. (#10344)
+	 */
+	private readonly handleChangeHeaderCells = (headerCells: ChangeHeaderCellsEventPayload): void => {
+		this.adjustedHeaderCells = headerCells;
+	};
+
+	/**
+	 * Builds the header cells passed to the stateless table. When the user has adjusted the columns
+	 * via the settings menu (`adjustedHeaderCells`), those horizontal cells are used as the base so
+	 * the customisation (visibility, width, order) is preserved. The current sort state is always
+	 * overlaid on top. (#10344)
+	 */
+	private buildHeaderCells(): TableHeaderCells {
+		const overlaySortState = (cell: KoliBriTableHeaderCellWithLogic) => ({
+			...cell,
+			sortDirection: this.getHeaderCellSortState(cell),
+			sortOrder: this.getHeaderCellSortOrder(cell),
+		});
+
+		const horizontalHeaders = (this.adjustedHeaderCells?.horizontal as KoliBriTableHeaderCellWithLogic[][] | undefined) ?? this.state._headers.horizontal;
+
+		return {
+			horizontal: horizontalHeaders?.map((row) => row.map(overlaySortState)) ?? [],
+			vertical: this.state._headers.vertical?.map((column) => column.map(overlaySortState)) ?? [],
+		};
+	}
+
 	public render(): JSX.Element {
 		const displayedData: KoliBriTableDataType[] = this.selectDisplayedData(
 			this.state._sortedData,
@@ -624,24 +663,7 @@ export class KolTableStateful implements TableAPI {
 		const paginationTop = this._paginationPosition === 'top' || this._paginationPosition === 'both' ? this.renderPagination('top') : null;
 		const paginationBottom = this._paginationPosition === 'bottom' || this._paginationPosition === 'both' ? this.renderPagination('bottom') : null;
 
-		const headerCells: TableHeaderCells = {
-			horizontal:
-				this.state._headers.horizontal?.map((row) =>
-					row.map((cell) => ({
-						...cell,
-						sortDirection: this.getHeaderCellSortState(cell),
-						sortOrder: this.getHeaderCellSortOrder(cell),
-					})),
-				) ?? [],
-			vertical:
-				this.state._headers.vertical?.map((column) =>
-					column.map((cell) => ({
-						...cell,
-						sortDirection: this.getHeaderCellSortState(cell),
-						sortOrder: this.getHeaderCellSortOrder(cell),
-					})),
-				) ?? [],
-		};
+		const headerCells: TableHeaderCells = this.buildHeaderCells();
 		return (
 			<Host class="kol-table-stateful">
 				{this.pageEndSlice > 0 && this.showPagination && paginationTop}
@@ -659,6 +681,9 @@ export class KolTableStateful implements TableAPI {
 						},
 						onSelectionChange: (event: Event, value: KoliBriTableSelectionKeys) => {
 							this.handleSelectionChange(event, value);
+						},
+						onChangeHeaderCells: (_event: Event, headerCells: ChangeHeaderCellsEventPayload) => {
+							this.handleChangeHeaderCells(headerCells);
 						},
 					}}
 					_selection={this.state._selection}

--- a/packages/components/src/components/table-stateful/shadow.tsx
+++ b/packages/components/src/components/table-stateful/shadow.tsx
@@ -10,6 +10,7 @@ import type {
 	KoliBriPaginationButtonCallbacks,
 	KoliBriSortDirection,
 	KoliBriTableDataType,
+	KoliBriTableHeaderCell,
 	KoliBriTableHeaderCellWithLogic,
 	KoliBriTableHeaders,
 	KoliBriTablePaginationProps,
@@ -327,9 +328,13 @@ export class KolTableStateful implements TableAPI {
 				watchValidator(this, '_headers', (value): boolean => typeof value === 'object' && value !== null, new Set(['KoliBriTableHeaders']), value, {
 					hooks: {
 						beforePatch: (nextValue: unknown) => {
-							// A new header definition invalidates any settings the user applied to the previous one.
-							this.adjustedHeaderCells = undefined;
 							const headers: KoliBriTableHeaders = nextValue as KoliBriTableHeaders;
+							// Only drop the user's settings when the column structure actually changes. A new
+							// object reference with identical keys (common with inline/non-memoized headers in
+							// React) must keep the customisation. (#10344)
+							if (this.headerKeysChanged(this.state._headers, headers)) {
+								this.adjustedHeaderCells = undefined;
+							}
 							const hasSortedCells = this.initializeSortFromHeaders(headers);
 							if (hasSortedCells) {
 								setTimeout(() => this.updateSortedData());
@@ -634,19 +639,72 @@ export class KolTableStateful implements TableAPI {
 	};
 
 	/**
+	 * Returns true if the set or order of column keys differs between two header definitions. Used to
+	 * decide whether persisted settings are still applicable to a new `_headers` value. (#10344)
+	 */
+	private headerKeysChanged(previous: KoliBriTableHeaders, next: KoliBriTableHeaders): boolean {
+		const getKeys = (headers: KoliBriTableHeaders): string[] => [
+			...(headers.horizontal?.flatMap((row) => row.map((cell) => cell?.key).filter((key): key is string => Boolean(key))) ?? []),
+			...(headers.vertical?.flatMap((column) => column.map((cell) => cell?.key).filter((key): key is string => Boolean(key))) ?? []),
+		];
+		const previousKeys = getKeys(previous);
+		const nextKeys = getKeys(next);
+		return previousKeys.length !== nextKeys.length || previousKeys.some((key, index) => key !== nextKeys[index]);
+	}
+
+	/**
+	 * Merges the user-adjusted header cells (order, visibility, width) back onto the original
+	 * `_headers` definition, matched by `key`. Logic-only fields like `compareFn` and `actions` are
+	 * always taken from the authoritative `_headers` cell, so the adjusted cells never need to carry
+	 * (or lose) them. (#10344)
+	 */
+	private mergeAdjustedHeaderCells(adjusted: KoliBriTableHeaderCell[][]): KoliBriTableHeaderCellWithLogic[][] {
+		const originalByKey = new Map<string, KoliBriTableHeaderCellWithLogic>();
+		this.state._headers.horizontal?.forEach((row) =>
+			row.forEach((cell) => {
+				if (cell?.key) {
+					originalByKey.set(cell.key, cell);
+				}
+			}),
+		);
+
+		return adjusted.map((row) =>
+			row.map((cell) => {
+				const original = cell?.key ? originalByKey.get(cell.key) : undefined;
+				if (!original) {
+					return cell as KoliBriTableHeaderCellWithLogic;
+				}
+				// Keep logic fields from the original definition, overlay only the user-adjustable settings.
+				const merged = { ...original } as KoliBriTableHeaderCellWithLogic;
+				if (cell.visible !== undefined) merged.visible = cell.visible;
+				if (cell.width !== undefined) merged.width = cell.width;
+				if (cell.hidable !== undefined) merged.hidable = cell.hidable;
+				if (cell.sortable !== undefined) merged.sortable = cell.sortable;
+				if (cell.resizable !== undefined) merged.resizable = cell.resizable;
+				return merged;
+			}),
+		);
+	}
+
+	/**
 	 * Builds the header cells passed to the stateless table. When the user has adjusted the columns
-	 * via the settings menu (`adjustedHeaderCells`), those horizontal cells are used as the base so
-	 * the customisation (visibility, width, order) is preserved. The current sort state is always
-	 * overlaid on top. (#10344)
+	 * via the settings menu (`adjustedHeaderCells`), those horizontal cells are merged onto the
+	 * original `_headers` so the customisation (visibility, width, order) is preserved. The current
+	 * sort state is always overlaid on top. (#10344)
 	 */
 	private buildHeaderCells(): TableHeaderCells {
-		const overlaySortState = (cell: KoliBriTableHeaderCellWithLogic) => ({
-			...cell,
-			sortDirection: this.getHeaderCellSortState(cell),
-			sortOrder: this.getHeaderCellSortOrder(cell),
-		});
+		const overlaySortState = (cell: KoliBriTableHeaderCellWithLogic) =>
+			cell
+				? {
+						...cell,
+						sortDirection: this.getHeaderCellSortState(cell),
+						sortOrder: this.getHeaderCellSortOrder(cell),
+					}
+				: cell;
 
-		const horizontalHeaders = (this.adjustedHeaderCells?.horizontal as KoliBriTableHeaderCellWithLogic[][] | undefined) ?? this.state._headers.horizontal;
+		const horizontalHeaders = this.adjustedHeaderCells?.horizontal
+			? this.mergeAdjustedHeaderCells(this.adjustedHeaderCells.horizontal)
+			: this.state._headers.horizontal;
 
 		return {
 			horizontal: horizontalHeaders?.map((row) => row.map(overlaySortState)) ?? [],

--- a/packages/components/src/components/table-stateful/test/settings-persistence.spec.ts
+++ b/packages/components/src/components/table-stateful/test/settings-persistence.spec.ts
@@ -13,6 +13,7 @@ type Internal = {
 	adjustedHeaderCells?: TableHeaderCells;
 	buildHeaderCells: () => TableHeaderCells;
 	handleChangeHeaderCells: (headerCells: TableHeaderCells) => void;
+	headerKeysChanged: (previous: KoliBriTableHeaders, next: KoliBriTableHeaders) => boolean;
 };
 
 const HEADERS: KoliBriTableHeaders = {
@@ -55,17 +56,47 @@ describe('KolTableStateful settings persistence (#10344)', () => {
 		expect(result.horizontal?.[0][1].visible).toBe(false);
 	});
 
-	it('overlays the current sort state on the persisted header cells', () => {
+	it('takes logic fields (compareFn) from the original headers and overlays the sort state', () => {
 		const table = new KolTableStateful() as unknown as Internal;
 		const compareFn = () => 0;
+		// Original headers carry the compareFn; the adjusted cells (from the settings menu) do not.
 		table.state._headers = { horizontal: [[{ key: 'a', label: 'A', compareFn }]] } as unknown as KoliBriTableHeaders;
-
-		table.handleChangeHeaderCells({ horizontal: [[{ key: 'a', label: 'A', width: 300, compareFn }]] } as unknown as TableHeaderCells);
+		table.handleChangeHeaderCells({ horizontal: [[{ key: 'a', label: 'A', width: 300 }]] });
 		table.sortData = [{ label: 'A', key: 'a', compareFn, direction: 'DESC' }];
 
 		const result = table.buildHeaderCells();
 
 		expect(result.horizontal?.[0][0].width).toBe(300);
+		// compareFn was recovered from _headers, so the column is still recognised as sortable.
 		expect(result.horizontal?.[0][0].sortDirection).toBe('DESC');
+	});
+
+	it('only treats a header update as structural when the column keys change', () => {
+		const table = new KolTableStateful() as unknown as Internal;
+
+		// Same keys, different labels / new reference -> not structural (settings must survive).
+		expect(
+			table.headerKeysChanged(HEADERS, {
+				horizontal: [
+					[
+						{ key: 'a', label: 'A2' },
+						{ key: 'b', label: 'B2' },
+					],
+				],
+			}),
+		).toBe(false);
+		// Removed column -> structural.
+		expect(table.headerKeysChanged(HEADERS, { horizontal: [[{ key: 'a', label: 'A' }]] })).toBe(true);
+		// Reordered keys -> structural.
+		expect(
+			table.headerKeysChanged(HEADERS, {
+				horizontal: [
+					[
+						{ key: 'b', label: 'B' },
+						{ key: 'a', label: 'A' },
+					],
+				],
+			}),
+		).toBe(true);
 	});
 });

--- a/packages/components/src/components/table-stateful/test/settings-persistence.spec.ts
+++ b/packages/components/src/components/table-stateful/test/settings-persistence.spec.ts
@@ -1,0 +1,71 @@
+import type { KoliBriTableHeaders, TableHeaderCells } from '../../../schema';
+import { KolTableStateful } from '../shadow';
+
+/**
+ * Regression tests for #10344: KolTableStateful must remember column settings (visibility, width,
+ * order) applied via the settings menu and reapply them on every render instead of resetting to the
+ * original `_headers` on sorting, pagination, selection or data updates.
+ */
+type SortDataEntry = { label: string; key: string; compareFn: () => number; direction: string };
+type Internal = {
+	state: { _headers: KoliBriTableHeaders };
+	sortData: SortDataEntry[];
+	adjustedHeaderCells?: TableHeaderCells;
+	buildHeaderCells: () => TableHeaderCells;
+	handleChangeHeaderCells: (headerCells: TableHeaderCells) => void;
+};
+
+const HEADERS: KoliBriTableHeaders = {
+	horizontal: [
+		[
+			{ key: 'a', label: 'A', visible: true, width: 100 },
+			{ key: 'b', label: 'B', visible: true, width: 100 },
+		],
+	],
+};
+
+describe('KolTableStateful settings persistence (#10344)', () => {
+	it('uses the original headers when no settings were applied', () => {
+		const table = new KolTableStateful() as unknown as Internal;
+		table.state._headers = HEADERS;
+
+		const result = table.buildHeaderCells();
+
+		expect(result.horizontal?.[0].map((cell) => cell.key)).toEqual(['a', 'b']);
+	});
+
+	it('persists adjusted header cells (reorder, hide, resize) across rebuilds', () => {
+		const table = new KolTableStateful() as unknown as Internal;
+		table.state._headers = HEADERS;
+
+		// Simulate a settings-menu change: reorder (b before a), hide column a, resize column b.
+		table.handleChangeHeaderCells({
+			horizontal: [
+				[
+					{ key: 'b', label: 'B', visible: true, width: 250 },
+					{ key: 'a', label: 'A', visible: false, width: 100 },
+				],
+			],
+		});
+
+		const result = table.buildHeaderCells();
+
+		expect(result.horizontal?.[0].map((cell) => cell.key)).toEqual(['b', 'a']);
+		expect(result.horizontal?.[0][0].width).toBe(250);
+		expect(result.horizontal?.[0][1].visible).toBe(false);
+	});
+
+	it('overlays the current sort state on the persisted header cells', () => {
+		const table = new KolTableStateful() as unknown as Internal;
+		const compareFn = () => 0;
+		table.state._headers = { horizontal: [[{ key: 'a', label: 'A', compareFn }]] } as unknown as KoliBriTableHeaders;
+
+		table.handleChangeHeaderCells({ horizontal: [[{ key: 'a', label: 'A', width: 300, compareFn }]] } as unknown as TableHeaderCells);
+		table.sortData = [{ label: 'A', key: 'a', compareFn, direction: 'DESC' }];
+
+		const result = table.buildHeaderCells();
+
+		expect(result.horizontal?.[0][0].width).toBe(300);
+		expect(result.horizontal?.[0][0].sortDirection).toBe('DESC');
+	});
+});

--- a/packages/samples/react/src/components/table/routes.ts
+++ b/packages/samples/react/src/components/table/routes.ts
@@ -19,6 +19,7 @@ import { TableSettingsColumnOptions } from './settings-column-options';
 import { TableSortData } from './sort-data';
 import { TableStatefulExport } from './stateful-export';
 import { TableStatefulResetSort } from './stateful-reset-sort';
+import { TableStatefulSettingsPersistence } from './stateful-settings-persistence';
 import { TableStatefulWithSelection } from './stateful-with-selection';
 import { TableStatefulWithSingleSelection } from './stateful-with-single-selection';
 import { TableStateless } from './stateless';
@@ -51,6 +52,7 @@ export const TABLE_ROUTES: Routes = {
 		'direction-aware-sort': TableDirectionAwareSort,
 		'stateful-export': TableStatefulExport,
 		'stateful-reset-sort': TableStatefulResetSort,
+		'stateful-settings-persistence': TableStatefulSettingsPersistence,
 		'stateful-with-selection': TableStatefulWithSelection,
 		'stateless-with-settings-menu': TableStatelessWithSettingsMenu,
 		'stateful-with-single-selection': TableStatefulWithSingleSelection,

--- a/packages/samples/react/src/components/table/stateful-settings-persistence.tsx
+++ b/packages/samples/react/src/components/table/stateful-settings-persistence.tsx
@@ -1,7 +1,7 @@
 import type { KoliBriTableDataType, KoliBriTableHeaders } from '@public-ui/components';
-import { KolTableStateful } from '@public-ui/react-v19';
+import { KolButton, KolTableStateful } from '@public-ui/react-v19';
 import type { FC } from 'react';
-import React from 'react';
+import React, { useState } from 'react';
 import { SampleDescription } from '../SampleDescription';
 
 type UserRow = {
@@ -28,7 +28,10 @@ const compareByKey =
 		return direction === 'DESC' ? -result : result;
 	};
 
-const HEADERS: KoliBriTableHeaders = {
+// Intentionally created inline on every render so the `_headers` prop receives a fresh object
+// reference each time. This mirrors the common React pattern of non-memoized headers and verifies
+// that applied settings survive parent re-renders as long as the column keys stay the same (#10344).
+const buildHeaders = (): KoliBriTableHeaders => ({
 	horizontal: [
 		[
 			{ key: 'id', label: 'ID', visible: true, width: 120 },
@@ -38,31 +41,37 @@ const HEADERS: KoliBriTableHeaders = {
 			{ key: 'status', label: 'Status', visible: true, width: 160, compareFn: compareByKey('status') },
 		],
 	],
+});
+
+export const TableStatefulSettingsPersistence: FC = () => {
+	const [renderCount, setRenderCount] = useState(0);
+
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					This example demonstrates that column settings applied via the settings menu are remembered. Open the settings menu and change a column&apos;s
+					width, visibility or order and apply. Then sort a column, switch the pagination page, select a row, or use the &quot;Force parent re-render&quot;
+					button &ndash; the customized columns must stay as you configured them and must no longer reset to their defaults (issue #10344).
+				</p>
+			</SampleDescription>
+
+			<KolButton _label={`Force parent re-render (${renderCount})`} _on={{ onClick: () => setRenderCount((count) => count + 1) }} className="block" />
+
+			<KolTableStateful
+				_label="Table that remembers settings across sorting, pagination and selection"
+				_hasSettingsMenu
+				_pagination={{ _page: 1, _pageSize: 3 }}
+				_selection={{
+					label: (row) => `Select ${(row as UserRow).name}`,
+					keyPropertyName: 'id',
+					selectedKeys: [],
+				}}
+				_headers={buildHeaders()}
+				_data={DATA}
+				className="block"
+				style={{ maxWidth: '900px' }}
+			/>
+		</>
+	);
 };
-
-export const TableStatefulSettingsPersistence: FC = () => (
-	<>
-		<SampleDescription>
-			<p>
-				This example demonstrates that column settings applied via the settings menu are remembered. Open the settings menu and change a column&apos;s width,
-				visibility or order and apply. Then sort a column, switch the pagination page or select a row &ndash; the customized columns must stay as you
-				configured them and must no longer reset to their defaults (issue #10344).
-			</p>
-		</SampleDescription>
-
-		<KolTableStateful
-			_label="Table that remembers settings across sorting, pagination and selection"
-			_hasSettingsMenu
-			_pagination={{ _page: 1, _pageSize: 3 }}
-			_selection={{
-				label: (row) => `Select ${(row as UserRow).name}`,
-				keyPropertyName: 'id',
-				selectedKeys: [],
-			}}
-			_headers={HEADERS}
-			_data={DATA}
-			className="block"
-			style={{ maxWidth: '900px' }}
-		/>
-	</>
-);

--- a/packages/samples/react/src/components/table/stateful-settings-persistence.tsx
+++ b/packages/samples/react/src/components/table/stateful-settings-persistence.tsx
@@ -50,9 +50,9 @@ export const TableStatefulSettingsPersistence: FC = () => {
 		<>
 			<SampleDescription>
 				<p>
-					This example demonstrates that column settings applied via the settings menu are remembered. Open the settings menu and change a column&apos;s
-					width, visibility or order and apply. Then sort a column, switch the pagination page, select a row, or use the &quot;Force parent re-render&quot;
-					button &ndash; the customized columns must stay as you configured them and must no longer reset to their defaults (issue #10344).
+					This example demonstrates that column settings applied via the settings menu are remembered. Open the settings menu and change a column&apos;s width,
+					visibility or order and apply. Then sort a column, switch the pagination page, select a row, or use the &quot;Force parent re-render&quot; button
+					&ndash; the customized columns must stay as you configured them and must no longer reset to their defaults (issue #10344).
 				</p>
 			</SampleDescription>
 

--- a/packages/samples/react/src/components/table/stateful-settings-persistence.tsx
+++ b/packages/samples/react/src/components/table/stateful-settings-persistence.tsx
@@ -1,0 +1,68 @@
+import type { KoliBriTableDataType, KoliBriTableHeaders } from '@public-ui/components';
+import { KolTableStateful } from '@public-ui/react-v19';
+import type { FC } from 'react';
+import React from 'react';
+import { SampleDescription } from '../SampleDescription';
+
+type UserRow = {
+	id: string;
+	name: string;
+	team: string;
+	email: string;
+	status: string;
+};
+
+const DATA: UserRow[] = [
+	{ id: 'U-001', name: 'Andrea Schmidt', team: 'Design', email: 'andrea@example.org', status: 'Active' },
+	{ id: 'U-002', name: 'Boris Klein', team: 'Engineering', email: 'boris@example.org', status: 'Active' },
+	{ id: 'U-003', name: 'Chiara Russo', team: 'Support', email: 'chiara@example.org', status: 'On leave' },
+	{ id: 'U-004', name: 'Dmitri Volkov', team: 'Engineering', email: 'dmitri@example.org', status: 'Active' },
+	{ id: 'U-005', name: 'Elena Costa', team: 'Design', email: 'elena@example.org', status: 'On leave' },
+	{ id: 'U-006', name: 'Farid Haddad', team: 'Support', email: 'farid@example.org', status: 'Active' },
+];
+
+const compareByKey =
+	(key: keyof UserRow) =>
+	(data0: KoliBriTableDataType, data1: KoliBriTableDataType, direction = 'ASC') => {
+		const result = String((data0 as UserRow)[key]).localeCompare(String((data1 as UserRow)[key]));
+		return direction === 'DESC' ? -result : result;
+	};
+
+const HEADERS: KoliBriTableHeaders = {
+	horizontal: [
+		[
+			{ key: 'id', label: 'ID', visible: true, width: 120 },
+			{ key: 'name', label: 'Name', visible: true, width: 240, compareFn: compareByKey('name') },
+			{ key: 'team', label: 'Team', visible: true, width: 200, compareFn: compareByKey('team') },
+			{ key: 'email', label: 'E-Mail', visible: true, width: 280 },
+			{ key: 'status', label: 'Status', visible: true, width: 160, compareFn: compareByKey('status') },
+		],
+	],
+};
+
+export const TableStatefulSettingsPersistence: FC = () => (
+	<>
+		<SampleDescription>
+			<p>
+				This example demonstrates that column settings applied via the settings menu are remembered. Open the settings menu and change a column&apos;s width,
+				visibility or order and apply. Then sort a column, switch the pagination page or select a row &ndash; the customized columns must stay as you
+				configured them and must no longer reset to their defaults (issue #10344).
+			</p>
+		</SampleDescription>
+
+		<KolTableStateful
+			_label="Table that remembers settings across sorting, pagination and selection"
+			_hasSettingsMenu
+			_pagination={{ _page: 1, _pageSize: 3 }}
+			_selection={{
+				label: (row) => `Select ${(row as UserRow).name}`,
+				keyPropertyName: 'id',
+				selectedKeys: [],
+			}}
+			_headers={HEADERS}
+			_data={DATA}
+			className="block"
+			style={{ maxWidth: '900px' }}
+		/>
+	</>
+);


### PR DESCRIPTION
## What changed?

`KolTableStateful` did not preserve column settings (visibility, width, order) applied via the settings menu across re-renders caused by sorting, pagination, row selection, or data updates. Two compounding bugs were at play: `onChangeHeaderCells` was never forwarded to the inner `kol-table-stateless-wc`, and every `render()` rebuilt the header cells directly from the original `_headers` prop, discarding any prior customization. The fix introduces `@State() adjustedHeaderCells` to persist the latest settings-menu changes, a `handleChangeHeaderCells` callback wired to `onChangeHeaderCells`, a `buildHeaderCells()` helper that merges persisted adjustments onto `_headers` (always taking logic fields like `compareFn` from the original definition), and a `headerKeysChanged` guard that resets persisted settings only when the actual column structure changes. A new React sample (`table/stateful-settings-persistence`) and unit tests covering the full persistence behavior were added.

## Linked issues

- Closes #10344 — KolTableStateful resets settings menu changes on re-render

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

> 📝 **Title corrected:** `fix: persist settings menu changes in stateful table (#10344)` → `fix(table): persist settings menu changes in KolTableStateful across re-renders`
> Reason: Added `(table)` scope and a more precise subject naming the component and clarifying the re-render context.

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`KolTableStateful` hat Spalteneinstellungen (Sichtbarkeit, Breite, Reihenfolge) aus dem Einstellungsmenü bei jedem Re-Render (Sortierung, Paginierung, Selektion, Datenaktualisierung) zurückgesetzt. Zwei Ursachen: `onChangeHeaderCells` wurde nie an die innere `kol-table-stateless-wc` weitergegeben, und jedes `render()` hat die Header-Zellen direkt aus `_headers` neu aufgebaut. Lösung: `@State() adjustedHeaderCells` speichert Einstellungsmenü-Änderungen, `handleChangeHeaderCells` leitet das Callback weiter, `buildHeaderCells()` führt gespeicherte Anpassungen mit `_headers` zusammen (Logikfelder wie `compareFn` werden stets aus dem Original übernommen), und `headerKeysChanged` setzt die gespeicherten Einstellungen nur bei echten Spaltenstruktur-Änderungen zurück.

### Verknüpfte Tickets

- Closes #10344 — KolTableStateful setzt Einstellungsmenü-Änderungen bei Re-Render zurück

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/table-stateful/shadow.tsx` — `@State() adjustedHeaderCells`, `handleChangeHeaderCells`, `buildHeaderCells`, `mergeAdjustedHeaderCells`, `headerKeysChanged`; Verdrahtung von `onChangeHeaderCells`
- `packages/components/src/components/table-stateful/test/settings-persistence.spec.ts` — Neue Unit-Tests für das Persistenz-Verhalten
- `packages/samples/react/src/components/table/stateful-settings-persistence.tsx` — Neue Beispielseite zur manuellen Verifikation
- `packages/samples/react/src/components/table/routes.ts` — Registriert die neue Route

</details>