### PR TITLE
fix(toast): add idempotency guard to close handler and clean up render functions

### DIFF
--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -73,12 +73,9 @@ export class KolToastContainer implements ToasterAPI {
 	private handleClose(toastState: ToastState) {
 		this.state = {
 			...this.state,
-			_toastStates: this.state._toastStates.map((localToastState) => {
-				if (localToastState.id === toastState.id) {
-					localToastState.status = 'removing';
-				}
-				return localToastState;
-			}),
+			_toastStates: this.state._toastStates.map((localToastState) =>
+				localToastState.id === toastState.id ? { ...localToastState, status: 'removing' } : localToastState,
+			),
 		};
 
 		setTimeout(() => {
@@ -86,6 +83,9 @@ export class KolToastContainer implements ToasterAPI {
 				...this.state,
 				_toastStates: this.state._toastStates.filter((localToastState) => localToastState.id !== toastState.id),
 			};
+			if (typeof toastState.toast.render === 'function') {
+				this.knownRenderFunctions.delete(toastState.toast.render);
+			}
 			toastState.toast.onClose?.();
 		}, TRANSITION_TIMEOUT);
 	}

--- a/packages/components/src/components/toaster/shadow.tsx
+++ b/packages/components/src/components/toaster/shadow.tsx
@@ -71,6 +71,11 @@ export class KolToastContainer implements ToasterAPI {
 	}
 
 	private handleClose(toastState: ToastState) {
+		const current = this.state._toastStates.find((t) => t.id === toastState.id);
+		if (!current || current.status === 'removing') {
+			return;
+		}
+
 		this.state = {
 			...this.state,
 			_toastStates: this.state._toastStates.map((localToastState) =>
@@ -101,6 +106,7 @@ export class KolToastContainer implements ToasterAPI {
 				...this.state,
 				_toastStates: [],
 			};
+			this.knownRenderFunctions.clear();
 		} else {
 			const toastsToClose = [...this.state._toastStates]; // Create a snapshot of the open toasts at the time closeAll has been called
 
@@ -118,6 +124,9 @@ export class KolToastContainer implements ToasterAPI {
 					_toastStates: this.state._toastStates.filter((toastState) => toastsToClose.every((toastToClose) => toastToClose.id !== toastState.id)),
 				};
 				toastsToClose.forEach((toastState) => {
+					if (typeof toastState.toast.render === 'function') {
+						this.knownRenderFunctions.delete(toastState.toast.render);
+					}
 					toastState.toast.onClose?.();
 				});
 			}, TRANSITION_TIMEOUT);


### PR DESCRIPTION
## What changed?

The `handleClose` method in `KolToastContainer` received three fixes. First, an idempotency guard was added: if the target toast is not found in the current state or already has status `'removing'`, the handler returns early, preventing double-close race conditions. Second, the state mapping was changed from mutating `localToastState.status` in-place to producing a new object via object spread, making the state update fully immutable. Third, cleanup logic was added to remove the toast's `render` function from `knownRenderFunctions` when a toast is fully removed — this applies to `handleClose`, to `closeAll` with immediate clearing, and to `closeAll` with delayed removal — preventing memory leaks when many render-function toasts are opened and closed over time.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

> 📝 **Title corrected:** `refactor(toast): close handler and clean up render functions` → `fix(toast): add idempotency guard to close handler and clean up render functions`
> Reason: The changes fix real bugs (double-close race condition, memory leak from untracked render functions) rather than being a pure refactoring — `fix` is the correct type.

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die `handleClose`-Methode von `KolToastContainer` wurde um drei Korrekturen erweitert. Erstens wurde eine Idempotenzprüfung hinzugefügt: Wenn der Toast nicht gefunden wird oder bereits den Status `'removing'` hat, bricht der Handler früh ab (verhindert Doppel-Schließ-Race-Conditions). Zweitens wird der Status nicht mehr direkt mutiert, sondern per Spread-Operator ein neues Objekt erzeugt (unveränderliches State-Update). Drittens wurde Cleanup-Logik ergänzt, die die `render`-Funktion eines Toasts aus `knownRenderFunctions` entfernt, sobald der Toast vollständig entfernt wird — verhindert Speicherlecks bei vielen Toast-Öffnungen und -Schließungen.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/toaster/shadow.tsx` — Idempotenzprüfung in `handleClose`, immutables State-Update via Spread, `knownRenderFunctions`-Cleanup bei Toast-Entfernung in `handleClose` und `closeAll`

</details>