### PR TITLE
fix: prevent migration progress bar RangeError on task overflow (#10314)

### DIFF
--- a/packages/tools/kolibri-cli/src/migrate/runner/task-runner.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/task-runner.ts
@@ -18,8 +18,10 @@ const MIN_VERSION_OF_PUBLIC_UI = '1.4.2';
  */
 function displayProgressBar(current: number, total: number, title: string = ''): void {
 	const barLength = 30;
-	const percentage = total === 0 ? 0 : (current / total) * 100;
-	const filledLength = Math.round((barLength * current) / total);
+	// Clamp to 100 % so the bar stays valid even if the counter overshoots `total`
+	// (e.g. when tasks are revisited during iteration). Prevents `String.repeat(-1)`.
+	const percentage = total === 0 ? 0 : Math.min(100, (current / total) * 100);
+	const filledLength = total === 0 ? 0 : Math.min(barLength, Math.round((barLength * current) / total));
 	const emptyLength = barLength - filledLength;
 
 	const bar = chalk.green('█'.repeat(filledLength)) + chalk.gray('░'.repeat(emptyLength));
@@ -168,8 +170,13 @@ export class TaskRunner {
 		});
 		if (taskDependencies.length === 0 || taskDependencies.every((dependentTask) => dependentTask.getStatus() === 'done')) {
 			displayProgressBar(this.completedTasks, this.tasks.size, task.getTitle());
+			// Only count a task once: tasks added to the Map mid-iteration are revisited by
+			// `Map.forEach`, so without this guard `completedTasks` would climb past `tasks.size`.
+			const wasPending = task.getStatus() === 'pending';
 			this.runTask(task);
-			this.completedTasks++;
+			if (wasPending) {
+				this.completedTasks++;
+			}
 		}
 	}
 

--- a/packages/tools/kolibri-cli/src/migrate/runner/task-runner.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/task-runner.ts
@@ -168,13 +168,16 @@ export class TaskRunner {
 		taskDependencies.forEach((dependentTask) => {
 			this.dependentTaskRun(dependentTask, dependentTask.getTaskDependencies());
 		});
-		if (taskDependencies.length === 0 || taskDependencies.every((dependentTask) => dependentTask.getStatus() === 'done')) {
+		// A dependency that is excluded for the current version range ends up as `'skipped'`.
+		// Such dependencies must not block an otherwise applicable dependent task from running.
+		if (taskDependencies.length === 0 || taskDependencies.every((dependentTask) => ['done', 'skipped'].includes(dependentTask.getStatus()))) {
 			displayProgressBar(this.completedTasks, this.tasks.size, task.getTitle());
-			// Only count a task once: tasks added to the Map mid-iteration are revisited by
-			// `Map.forEach`, so without this guard `completedTasks` would climb past `tasks.size`.
+			// Only count a task once and only if it is actually part of the progress total:
+			// tasks revisited by `Map.forEach`, or dependencies excluded from `this.tasks`,
+			// would otherwise push `completedTasks` past `tasks.size`.
 			const wasPending = task.getStatus() === 'pending';
 			this.runTask(task);
-			if (wasPending) {
+			if (wasPending && this.tasks.has(task.getIdentifier())) {
 				this.completedTasks++;
 			}
 		}

--- a/packages/tools/kolibri-cli/test/task-runner.spec.ts
+++ b/packages/tools/kolibri-cli/test/task-runner.spec.ts
@@ -49,4 +49,34 @@ describe('TaskRunner', () => {
 		assert.equal(status.done, 3);
 		assert.equal(status.pending, 0);
 	});
+
+	// Regression test for https://github.com/public-ui/kolibri/issues/10314
+	// A dependency excluded for the current version range becomes `'skipped'` and is not
+	// registered in `this.tasks`. It must neither block the applicable dependent task from
+	// running nor let `completedTasks` overshoot the (registered) total.
+	it('does not overshoot completedTasks when dependencies are excluded (#10314)', () => {
+		// Version range not satisfied by the CLI version below -> task is excluded.
+		class ExcludedTask extends AbstractTask {
+			public constructor(identifier: string) {
+				super(identifier, identifier, [], '^2.0.0', []);
+			}
+
+			public run(): void {
+				// no-op
+			}
+		}
+
+		const excludedChild = new ExcludedTask('regression-excluded-child');
+		const parent = new NoopTask('regression-excluded-parent', [excludedChild]);
+
+		const runner = new TaskRunner('.', '1.3.0', '0.5.0', { migrate: { tasks: {} } });
+		runner.registerTasks([parent]);
+
+		assert.doesNotThrow(() => runner.run());
+
+		const status = runner.getStatus();
+		assert.equal(status.total, 1);
+		assert.equal(status.done, 1);
+		assert.equal(status.pending, 0);
+	});
 });

--- a/packages/tools/kolibri-cli/test/task-runner.spec.ts
+++ b/packages/tools/kolibri-cli/test/task-runner.spec.ts
@@ -1,7 +1,22 @@
 import assert from 'node:assert';
+import { AbstractTask } from '../src/migrate/runner/abstract-task';
 import { TaskRunner } from '../src/migrate/runner/task-runner';
 import { TestVersion13 } from '../src/migrate/runner/tasks/test/test-version-1.3';
 import { TestVersionZero } from '../src/migrate/runner/tasks/test/test-version-zero';
+
+/**
+ * Minimal applicable task used to build dependency graphs for the runner tests.
+ * The version range `^0` keeps it applicable for the versions used below.
+ */
+class NoopTask extends AbstractTask {
+	public constructor(identifier: string, dependencies: AbstractTask[] = []) {
+		super(identifier, identifier, [], '^0', dependencies);
+	}
+
+	public run(): void {
+		// no-op
+	}
+}
 
 describe('TaskRunner', () => {
 	it('runs applicable tasks and leaves others pending', () => {
@@ -11,6 +26,27 @@ describe('TaskRunner', () => {
 		const status = runner.getStatus();
 		assert.equal(status.total, 2);
 		assert.equal(status.done, 2);
+		assert.equal(status.pending, 0);
+	});
+
+	// Regression test for https://github.com/public-ui/kolibri/issues/10314
+	// A task whose dependencies are also top-level Map entries is visited twice by
+	// `Map.forEach`. Previously this overshot the internal `completedTasks` counter,
+	// produced a negative empty bar length and crashed with
+	// `RangeError: Invalid count value: -1` inside `String.repeat`.
+	it('does not crash when tasks are revisited during progress reporting (#10314)', () => {
+		const childA = new NoopTask('regression-child-a');
+		const childB = new NoopTask('regression-child-b');
+		const parent = new NoopTask('regression-parent', [childA, childB]);
+
+		const runner = new TaskRunner('.', '1.3.0', '0.5.0', { migrate: { tasks: {} } });
+		runner.registerTasks([parent]);
+
+		assert.doesNotThrow(() => runner.run());
+
+		const status = runner.getStatus();
+		assert.equal(status.total, 3);
+		assert.equal(status.done, 3);
 		assert.equal(status.pending, 0);
 	});
 });


### PR DESCRIPTION
## What changed?

The migration CLI's `TaskRunner` crashed with `RangeError: Invalid count value: -1` when tasks were revisited during `Map.forEach` iteration. The root cause was that `dependentTaskRun` incremented `completedTasks` on every processed task, including dependency tasks that `Map.forEach` visits a second time when they were added to the map during iteration, causing the counter to exceed `tasks.size`. `displayProgressBar` then computed a negative `emptyLength` and `'░'.repeat(-1)` threw. The fix changes `completedTasks` to increment only when the task was actually `pending` before running and is registered in `this.tasks`. Additionally, `dependentTaskRun` now treats `'skipped'` dependencies (excluded by version range) as satisfied so they no longer block applicable dependent tasks. `displayProgressBar` was hardened with `Math.min` clamps as a safety net. Two regression tests covering the Map-revisit and skipped-dependency scenarios were added.

## Linked issues

- Closes #10314 — Migration crashes with RangeError in progress bar

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der `TaskRunner` des Migrations-CLIs hat mit `RangeError: Invalid count value: -1` abgestürzt, wenn Tasks während der `Map.forEach`-Iteration erneut besucht wurden. Ursache: `completedTasks` wurde für jeden verarbeiteten Task inkrementiert, auch für Abhängigkeiten, die `Map.forEach` beim erneuten Besuch ein zweites Mal zählt — der Zähler überschritt `tasks.size`, was eine negative `emptyLength` und `'░'.repeat(-1)` verursachte. Lösung: `completedTasks` wird nur für Tasks inkrementiert, die vorher `pending` waren und in `this.tasks` registriert sind. `'skipped'`-Abhängigkeiten (außerhalb des Versionsbereichs) gelten nun als erfüllt und blockieren nicht mehr den abhängigen Task. `displayProgressBar` wurde mit `Math.min`-Clamps abgesichert.

### Verknüpfte Tickets

- Closes #10314 — Migration stürzt mit RangeError in der Fortschrittsanzeige ab

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/tools/kolibri-cli/src/migrate/runner/task-runner.ts` — Korrektur der `completedTasks`-Inkrementierung, Behandlung von `'skipped'`-Abhängigkeiten, `Math.min`-Clamps in `displayProgressBar`
- `packages/tools/kolibri-cli/test/task-runner.spec.ts` — Zwei neue Regressionstests für Map-Revisit und ausgeschlossene Abhängigkeiten

</details>