### PR TITLE
fix: correct gitignore filename and prevent CRLF duplicate entries (#10315)

### DIFF
--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GitIgnoreAddRuleTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GitIgnoreAddRuleTask.ts
@@ -36,7 +36,7 @@ export class GitIgnoreAddRuleTask extends AbstractTask {
 		} else {
 			const fileContent = fs.readFileSync(gitignorePath, 'utf8');
 
-			if (!fileContent.split(/\r?\n/).map((l) => l.trim()).includes(lineToAdd)) {
+			if (!fileContent.split(/\r?\n/).map((l) => l.trimEnd()).includes(lineToAdd)) {
 				fs.appendFileSync(gitignorePath, '\n' + lineToAdd);
 			}
 		}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GitIgnoreAddRuleTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GitIgnoreAddRuleTask.ts
@@ -36,7 +36,12 @@ export class GitIgnoreAddRuleTask extends AbstractTask {
 		} else {
 			const fileContent = fs.readFileSync(gitignorePath, 'utf8');
 
-			if (!fileContent.split(/\r?\n/).map((l) => l.trimEnd()).includes(lineToAdd)) {
+			if (
+				!fileContent
+					.split(/\r?\n/)
+					.map((l) => l.trimEnd())
+					.includes(lineToAdd)
+			) {
 				fs.appendFileSync(gitignorePath, '\n' + lineToAdd);
 			}
 		}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GitIgnoreAddRuleTask.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GitIgnoreAddRuleTask.ts
@@ -36,7 +36,7 @@ export class GitIgnoreAddRuleTask extends AbstractTask {
 		} else {
 			const fileContent = fs.readFileSync(gitignorePath, 'utf8');
 
-			if (!fileContent.split('\n').includes(lineToAdd)) {
+			if (!fileContent.split(/\r?\n/).map((l) => l.trim()).includes(lineToAdd)) {
 				fs.appendFileSync(gitignorePath, '\n' + lineToAdd);
 			}
 		}

--- a/packages/tools/kolibri-cli/src/migrate/runner/tasks/index.ts
+++ b/packages/tools/kolibri-cli/src/migrate/runner/tasks/index.ts
@@ -5,7 +5,7 @@ import { TsConfigReconfigureTask } from './common/TsConfigReconfigureTask';
 import { VsCodeSettingsReconfigureTask } from './common/VsCodeSettingsReconfigureTask';
 
 export const commonTasks: AbstractTask[] = [];
-commonTasks.push(GitIgnoreAddRuleTask.getInstance('.kolibri.migrate.json', '*'));
+commonTasks.push(GitIgnoreAddRuleTask.getInstance('.kolibri.config.json', '*'));
 commonTasks.push(NpmRcAddRuleTask.getInstance('save-exact=true', '*'));
 commonTasks.push(VsCodeSettingsReconfigureTask.getInstance('html.customData', ['./node_modules/@public-ui/components/vscode-custom-data.json'], '*'));
 

--- a/packages/tools/kolibri-cli/test/gitignore-add-rule.spec.ts
+++ b/packages/tools/kolibri-cli/test/gitignore-add-rule.spec.ts
@@ -9,11 +9,12 @@ describe('GitIgnoreAddRuleTask', () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
 		const cwd = process.cwd();
 		process.chdir(tmpDir);
-
-		const task = GitIgnoreAddRuleTask.getInstance('dist', '^1');
-		task.run();
-
-		process.chdir(cwd);
+		try {
+			const task = GitIgnoreAddRuleTask.getInstance('dist', '^1');
+			task.run();
+		} finally {
+			process.chdir(cwd);
+		}
 		const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
 		assert.ok(content.includes('dist'));
 	});
@@ -22,12 +23,14 @@ describe('GitIgnoreAddRuleTask', () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
 		const cwd = process.cwd();
 		process.chdir(tmpDir);
-		fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules\n.kolibri.config.json\n');
+		try {
+			fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules\n.kolibri.config.json\n');
 
-		const task = GitIgnoreAddRuleTask.getInstance('.kolibri.config.json', '^1');
-		task.run();
-
-		process.chdir(cwd);
+			const task = GitIgnoreAddRuleTask.getInstance('.kolibri.config.json', '^1');
+			task.run();
+		} finally {
+			process.chdir(cwd);
+		}
 		const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
 		const occurrences = (content.match(/\.kolibri\.config\.json/g) ?? []).length;
 		assert.strictEqual(occurrences, 1, 'rule must not be duplicated on LF files');
@@ -37,13 +40,15 @@ describe('GitIgnoreAddRuleTask', () => {
 		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
 		const cwd = process.cwd();
 		process.chdir(tmpDir);
-		// Simulate a Windows .gitignore with CRLF line endings where the rule already exists
-		fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules\r\n.kolibri.config.json\r\n');
+		try {
+			// Simulate a Windows .gitignore with CRLF line endings where the rule already exists
+			fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules\r\n.kolibri.config.json\r\n');
 
-		// getInstance returns a cached singleton; run() reads process.cwd() dynamically
-		GitIgnoreAddRuleTask.getInstance('.kolibri.config.json', '*').run();
-
-		process.chdir(cwd);
+			// getInstance returns a cached singleton; run() reads process.cwd() dynamically
+			GitIgnoreAddRuleTask.getInstance('.kolibri.config.json', '*').run();
+		} finally {
+			process.chdir(cwd);
+		}
 		const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
 		const occurrences = (content.match(/\.kolibri\.config\.json/g) ?? []).length;
 		assert.strictEqual(occurrences, 1, 'rule must not be duplicated on CRLF files');

--- a/packages/tools/kolibri-cli/test/gitignore-add-rule.spec.ts
+++ b/packages/tools/kolibri-cli/test/gitignore-add-rule.spec.ts
@@ -17,4 +17,35 @@ describe('GitIgnoreAddRuleTask', () => {
 		const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
 		assert.ok(content.includes('dist'));
 	});
+
+	it('does not duplicate rule when .gitignore uses LF line endings', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const cwd = process.cwd();
+		process.chdir(tmpDir);
+		fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules\n.kolibri.config.json\n');
+
+		const task = GitIgnoreAddRuleTask.getInstance('.kolibri.config.json', '^1');
+		task.run();
+
+		process.chdir(cwd);
+		const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
+		const occurrences = (content.match(/\.kolibri\.config\.json/g) ?? []).length;
+		assert.strictEqual(occurrences, 1, 'rule must not be duplicated on LF files');
+	});
+
+	it('does not duplicate rule when .gitignore uses CRLF line endings (Windows)', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kolibri-cli-'));
+		const cwd = process.cwd();
+		process.chdir(tmpDir);
+		// Simulate a Windows .gitignore with CRLF line endings where the rule already exists
+		fs.writeFileSync(path.join(tmpDir, '.gitignore'), 'node_modules\r\n.kolibri.config.json\r\n');
+
+		// getInstance returns a cached singleton; run() reads process.cwd() dynamically
+		GitIgnoreAddRuleTask.getInstance('.kolibri.config.json', '*').run();
+
+		process.chdir(cwd);
+		const content = fs.readFileSync(path.join(tmpDir, '.gitignore'), 'utf8');
+		const occurrences = (content.match(/\.kolibri\.config\.json/g) ?? []).length;
+		assert.strictEqual(occurrences, 1, 'rule must not be duplicated on CRLF files');
+	});
 });


### PR DESCRIPTION
## What changed?

Two independent bugs in the migration CLI's `.gitignore` handling were fixed. First, the rule registered in `commonTasks` was `.kolibri.migrate.json` — a filename that does not exist — instead of the actual migration output file `.kolibri.config.json`, so the generated config file was never gitignored. Second, `GitIgnoreAddRuleTask.run()` checked for existing entries using `fileContent.split('\n').includes(lineToAdd)`, which left a trailing `\r` on each line when the file used CRLF line endings (Windows), causing the strict string comparison to always fail and the rule to be appended on every migration run. The fix corrects the filename in `tasks/index.ts` and changes the split to `split(/\r?\n/).map((l) => l.trimEnd())` to handle both LF and CRLF line endings. Two regression tests (LF and CRLF scenarios) were added.

## Linked issues

- Closes #10315 — Wrong gitignore filename and duplicate entries on Windows

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Zwei unabhängige Fehler in der `.gitignore`-Verarbeitung des Migrations-CLIs wurden behoben. Erstens wurde in `commonTasks` der nicht existierende Dateiname `.kolibri.migrate.json` statt des tatsächlichen Ausgabe-Dateinamens `.kolibri.config.json` registriert — die generierte Konfig-Datei wurde nie gitignored. Zweitens nutzte `GitIgnoreAddRuleTask.run()` `split('\n').includes()`, das unter Windows mit CRLF-Zeilenenden ein abschließendes `\r` in jeder Zeile belässt, wodurch der Vergleich immer scheitert und die Regel bei jedem Migrations-Run erneut eingefügt wird. Lösung: Korrektur des Dateinamens und Änderung auf `split(/\r?\n/).map((l) => l.trimEnd())`. Zwei Regressionstests wurden ergänzt.

### Verknüpfte Tickets

- Closes #10315 — Falscher Dateiname in gitignore und doppelte Einträge unter Windows

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/tools/kolibri-cli/src/migrate/runner/tasks/index.ts` — `.kolibri.migrate.json` → `.kolibri.config.json`
- `packages/tools/kolibri-cli/src/migrate/runner/tasks/common/GitIgnoreAddRuleTask.ts` — CRLF-robuster Duplikat-Check mit `split(/\r?\n/).map((l) => l.trimEnd())`
- `packages/tools/kolibri-cli/test/gitignore-add-rule.spec.ts` — Zwei neue Regressionstests für LF- und CRLF-Zeilenenden

</details>