### PR TITLE
chore: release.yml for changelog categories and labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  exclude:
+    labels:
+      - release:ignore
+    authors:
+      - dependabot
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - release:breaking-change
+    - title: 🎉 New Features
+      labels:
+        - release:feature
+    - title: 🐞 Bug Fixes
+      labels:
+        - release:fix
+    - title: 🚀 Improvements
+      labels:
+        - release:improvement
+    - title: 🔧 Engineering
+      labels:
+        - release:engineering
+    - title: 📚 Samples
+      labels:
+        - release:sample
+    - title: 🌈 Theming
+      labels:
+        - release:theming
+    - title: 💪 Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,7 +2,9 @@ changelog:
   exclude:
     labels:
       - release:ignore
+      - dependabot
     authors:
+      - dependabot[bot]
       - dependabot
   categories:
     - title: 💥 Breaking Changes

--- a/.github/workflows/pr-release-label-validation.yml
+++ b/.github/workflows/pr-release-label-validation.yml
@@ -1,0 +1,27 @@
+name: PR Release Label Validation
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+
+jobs:
+  validate-release-label:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Ensure a release:* label is set
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((l) => l.name);
+            const hasReleaseLabel = labels.some((name) => name.startsWith('release:'));
+            if (!hasReleaseLabel) {
+              core.setFailed(
+                'This PR needs a "release:*" label (e.g. release:feature, release:fix, ' +
+                  'release:improvement, release:engineering, or release:ignore) so it is ' +
+                  'categorized correctly in the changelog. ' +
+                  'See .github/release.yml for the available categories.',
+              );
+            }


### PR DESCRIPTION
## What changed?

Added `.github/release.yml` to configure GitHub's automated release notes generator with changelog categories mapped to `release:*` labels (Breaking Changes, New Features, Bug Fixes, Improvements, Engineering, Samples, Theming). Added `.github/workflows/pr-release-label-validation.yml` to enforce that every non-Dependabot PR carries a `release:*` label before merging. No user-facing component code was modified.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Es wurde `.github/release.yml` hinzugefügt, das GitHub's automatischen Release-Notes-Generator mit Changelog-Kategorien konfiguriert, die auf `release:*`-Labels gemappt sind (Breaking Changes, Features, Bug Fixes, Improvements, Engineering, Samples, Theming). Außerdem wurde `.github/workflows/pr-release-label-validation.yml` hinzugefügt, das sicherstellt, dass jeder Nicht-Dependabot-PR vor dem Mergen ein `release:*`-Label trägt. Es wurde kein nutzerorientierter Komponentencode geändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/release.yml` — Konfiguriert GitHub-Changelog-Kategorien für automatische Release-Notes
- `.github/workflows/pr-release-label-validation.yml` — Neuer CI-Workflow, der das Vorhandensein eines `release:*`-Labels auf jedem PR erzwingt

</details>