### PR TITLE
fix: _rows must not activate listbox appearance without _multiple (#10328)

### DIFF
--- a/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/select/test/__snapshots__/snapshot.spec.tsx.snap
@@ -490,6 +490,266 @@ exports[`kol-select should render with _label="Label" _name="field" _placeholder
 </kol-select>
 `;
 
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _accessKey="V" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _accesskey="V" _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _alert=true 1`] = `
+<kol-select _alert="" _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _disabled=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _disabled="" _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _hint="Hint" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="Hint" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top" _touched="">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _accessKey="V" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _accesskey="V" _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _alert=true 1`] = `
+<kol-select _alert="" _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _disabled=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _disabled="" _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _hint="Hint" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="Hint" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _icons={"left":{"icon":"codicon codicon-arrow-left"},"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _icons={"left":{"icon":"codicon codicon-arrow-left"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _icons={"right":{"icon":"codicon codicon-arrow-right"}} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} _hideMsg=true _touched=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hidemsg="" _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top" _touched="">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _msg={"_type":"error","_description":"Es ist ein Fehler aufgetreten"} 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _readOnly=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _readonly="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _shortKey="S" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _shortkey="S" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true _touched=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top" _touched="">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _multiple=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _multiple="" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _readOnly=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _readonly="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _shortKey="S" 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _shortkey="S" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 _touched=true 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" _touched="" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top" _touched="">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
+exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _rows=3 1`] = `
+<kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
+  <template shadowrootmode="open">
+    <kol-select-wc _hint="" _label="Label" _name="field" _rows="3" _tooltipalign="top">
+      <slot name="expert" slot="expert"></slot>
+    </kol-select-wc>
+  </template>
+</kol-select>
+`;
+
 exports[`kol-select should render with _label="Label" _name="field" _placeholder="Hier steht ein Platzhaltertext" _options=[{"label":"Frau","value":"Frau","disabled":true},{"label":"Herr","value":"Herr"},{"label":"Divers","value":"Divers"}] _shortKey="S" 1`] = `
 <kol-select _placeholder="Hier steht ein Platzhaltertext" class="kol-select">
   <template shadowrootmode="open">

--- a/packages/components/src/components/select/test/snapshot.spec.tsx
+++ b/packages/components/src/components/select/test/snapshot.spec.tsx
@@ -45,3 +45,15 @@ executeInputSnapshotTests<SelectProps>(KolSelectTag, [KolSelect], {
 	_hideMsg: true,
 	_msg: { _type: 'error', _description: 'This is a combined error message' },
 });
+
+// Regression test for #10328: _rows must not activate listbox appearance without _multiple
+executeInputSnapshotTests<SelectProps>(KolSelectTag, [KolSelect], {
+	_options: options,
+	_rows: 3,
+});
+
+executeInputSnapshotTests<SelectProps>(KolSelectTag, [KolSelect], {
+	_options: options,
+	_rows: 3,
+	_multiple: true,
+});

--- a/packages/components/src/functional-component-wrappers/SelectStateWrapper/SelectStateWrapper.tsx
+++ b/packages/components/src/functional-component-wrappers/SelectStateWrapper/SelectStateWrapper.tsx
@@ -21,7 +21,7 @@ function getSelectProps(state: SelectStates): SelectProps {
 		disabled: state._disabled,
 		name: state._name,
 		ariaDescribedBy: ariaDescribedBy,
-		size: state._rows,
+		size: state._multiple ? state._rows : undefined,
 		multiple: state._multiple,
 		required: state._required,
 		touched: state._touched,


### PR DESCRIPTION
## What changed?

In `SelectStateWrapper.tsx`, the `_rows` prop was previously passed unconditionally as the HTML `size` attribute on the native `<select>` element, causing any single-select dropdown with `_rows > 1` to visually render as a scrollable multi-select listbox in all browsers. The fix guards the `size` attribute behind a `_multiple` check so it is only applied when the select is configured as a multi-select. Two regression snapshot tests were added to `snapshot.spec.tsx` to prevent future regressions. This resolves a contributor-reported visual defect.

## Linked issues

- Closes #10328 — `_rows` prop incorrectly activates listbox appearance on single-select

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `SelectStateWrapper.tsx` wurde die `_rows`-Prop bisher bedingungslos als HTML-`size`-Attribut an das native `<select>`-Element weitergegeben. Dies führte dazu, dass jede einfache Auswahlbox (Single-Select) mit `_rows > 1` in allen Browsern als scrollbare Multi-Select-Listbox dargestellt wurde. Der Fix macht das `size`-Attribut von `_multiple` abhängig, sodass es nur bei expliziter Multi-Select-Konfiguration gesetzt wird. Zwei Regressions-Snapshot-Tests wurden hinzugefügt, um diesen Bug künftig zu verhindern.

### Verknüpfte Tickets

- Schließt #10328 — `_rows`-Prop aktiviert irrtümlich Listbox-Darstellung bei Single-Select

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/functional-component-wrappers/SelectStateWrapper/SelectStateWrapper.tsx` — Guard hinzugefügt: `size` wird nur noch bei `_multiple: true` gesetzt
- `packages/components/src/components/select/test/snapshot.spec.tsx` — Zwei neue Regressions-Snapshot-Tests für `_rows` ohne und mit `_multiple`
- (dritte Datei: zugehöriger Snapshot-Baseline-Update)

</details>