### PR TITLE
refactor(skeleton): type watchOrientation parameter as OrientationPropType

### DIFF
--- a/packages/components/src/internal/functional-components/meter/controller.ts
+++ b/packages/components/src/internal/functional-components/meter/controller.ts
@@ -1,3 +1,4 @@
+import type { OrientationPropType } from '../../props';
 import { clampedNumberValueProp, highProp, labelProp, lowProp, maxProp, minProp, optimumProp, orientationProp, unitProp } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps, StateAccess } from '../generic-types';
@@ -84,7 +85,7 @@ export class MeterController extends BaseController<MeterApi> implements Control
 		}
 	}
 
-	public watchOrientation(value?: string): void {
+	public watchOrientation(value?: OrientationPropType): void {
 		orientationProp.apply(value, (v) => {
 			this.setRenderProp('orientation', v);
 		});


### PR DESCRIPTION
## What changed?

The `MeterController.watchOrientation` method's parameter type was changed from the overly broad `string` to the precise `OrientationPropType` (`'horizontal' | 'vertical'`). This is a purely internal type-safety improvement to the Meter component's internal controller. The change aligns the implementation with the `ControllerInterface` contract and mirrors similar fixes for Spin (#10356) and Progress (#10358). No runtime behavior is affected.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Parameter-Typ der Methode `MeterController.watchOrientation` wurde vom zu allgemeinen Typ `string` auf den präzisen Typ `OrientationPropType` (`'horizontal' | 'vertical'`) geändert. Es handelt sich um eine rein interne Typverbesserung des Meter-Komponenten-Controllers. Die Änderung gleicht die Implementierung dem `ControllerInterface`-Vertrag an und spiegelt ähnliche Korrekturen für die Spin- (#10356) und Progress- (#10358) Komponenten wider. Das Laufzeitverhalten ist unverändert.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/components/src/internal/functional-components/meter/controller.ts` — Typ-Import für `OrientationPropType` hinzugefügt; Parameter-Typ von `string` auf `OrientationPropType` geändert.

</details>