### PR TITLE
refactor(skeleton): remove Callbacks misuse in SpinApi for translation getters

### DIFF
--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -261,6 +261,7 @@ private catchElement = (element?: HTMLElement): void => {
 - Is a pure renderer that receives props, callbacks, emitters and refs from the controller.
 - Avoids any side effects or state mutation. User interactions are signalled via DOM events which bubble back to the web component.
 - Maps controller props to accessible markup and wires refs for imperative access when required.
+- May call stateless utility functions (e.g. `translate()`, formatters) directly — the `Callbacks` bucket in `ComponentApi` is reserved for event-driven callbacks only, not data accessors.
 
 ### Schema Helper Layer
 

--- a/packages/components/src/components/spin/component.tsx
+++ b/packages/components/src/components/spin/component.tsx
@@ -69,8 +69,6 @@ export class KolSpin extends BaseWebComponent<SpinApi> implements WebComponentIn
 					label={this.ctrl.getRenderProp('label')}
 					variant={this.ctrl.getRenderProp('variant')}
 					showToggled={this.showToggled}
-					handleGetTranslateActionRunning={this.ctrl.handleGetTranslateActionRunning}
-					handleGetTranslateActionDone={this.ctrl.handleGetTranslateActionDone}
 				/>
 			</Host>
 		);

--- a/packages/components/src/internal/functional-components/spin/api.tsx
+++ b/packages/components/src/internal/functional-components/spin/api.tsx
@@ -11,9 +11,5 @@ export type SpinApi = ApiFromConfig<
 		States: {
 			showToggled: boolean;
 		};
-		Callbacks: {
-			getTranslateActionRunning: () => string;
-			getTranslateActionDone: () => string;
-		};
 	}
 >;

--- a/packages/components/src/internal/functional-components/spin/component.tsx
+++ b/packages/components/src/internal/functional-components/spin/component.tsx
@@ -1,6 +1,7 @@
 import type { FunctionalComponent as FC } from '@stencil/core';
 import { Fragment, h } from '@stencil/core';
 
+import { translate } from '../../../i18n';
 import type { FunctionalComponentProps } from '../generic-types';
 import type { SpinApi } from './api';
 
@@ -43,7 +44,7 @@ function renderSpinVariant(variant: string): unknown {
 }
 
 export const SpinFC: FC<FunctionalComponentProps<SpinApi>> = (props) => {
-	const { show, label, variant, showToggled, handleGetTranslateActionRunning, handleGetTranslateActionDone } = props;
+	const { show, label, variant, showToggled } = props;
 
 	return (
 		<Fragment>
@@ -51,13 +52,13 @@ export const SpinFC: FC<FunctionalComponentProps<SpinApi>> = (props) => {
 				<Fragment>
 					<span class={`kol-spin__spinner kol-spin__spinner--${variant}`}>{renderSpinVariant(variant)}</span>
 					<span aria-busy="true" class="visually-hidden" role="alert">
-						{label || handleGetTranslateActionRunning()}
+						{label || translate('kol-action-running')}
 					</span>
 				</Fragment>
 			) : (
 				showToggled && (
 					<span aria-busy="false" class="visually-hidden" role="alert">
-						{label || handleGetTranslateActionDone()}
+						{label || translate('kol-action-done')}
 					</span>
 				)
 			)}

--- a/packages/components/src/internal/functional-components/spin/controller.ts
+++ b/packages/components/src/internal/functional-components/spin/controller.ts
@@ -1,4 +1,3 @@
-import { translate } from '../../../i18n';
 import { labelProp, showProp, variantSpinProp, type SpinVariantType } from '../../props';
 import { BaseController } from '../base-controller';
 import type { ControllerInterface, ResolvedInputProps, StateAccess } from '../generic-types';
@@ -6,9 +5,6 @@ import type { SpinApi } from './api';
 import { spinPropsConfig } from './api';
 
 export class SpinController extends BaseController<SpinApi> implements ControllerInterface<SpinApi> {
-	private readonly translateActionRunning: string = translate('kol-action-running');
-	private readonly translateActionDone: string = translate('kol-action-done');
-
 	public constructor(stateAccess: StateAccess<SpinApi>) {
 		super(stateAccess, spinPropsConfig);
 	}
@@ -41,12 +37,4 @@ export class SpinController extends BaseController<SpinApi> implements Controlle
 			this.setRenderProp('variant', v);
 		});
 	}
-
-	public handleGetTranslateActionRunning = (): string => {
-		return this.translateActionRunning;
-	};
-
-	public handleGetTranslateActionDone = (): string => {
-		return this.translateActionDone;
-	};
 }


### PR DESCRIPTION
[SKELETON 2026-06-10] Fixed: SpinApi Callbacks misused for translation data getters (spin) | Open: Avatar JSDoc on private fns (low), Progress inline comment (low) | NeedsLook: Meter getMeterData() dual-access (high,fix=2), Meter manual MeterApi interface (high,fix=2) | Score: 88/100

## Finding

**🟡 High — SpinApi `Callbacks` misused for translation data getters**

`SpinApi.Callbacks` defined `getTranslateActionRunning` and `getTranslateActionDone` as data accessors — not event-driven callbacks. Per ARC42 §4 and §8, the `Callbacks` bucket is reserved for event handlers and ref setters. Additionally, the `ControllerCallbackHandlers` type mapping in `generic-types.ts` generated a structurally mismatched signature (`(element?: () => string) => void` vs. the actual `(): string`). The `SpinController` also pre-cached the translation strings as private fields — premature optimization, since `AvatarFC` and `MeterFC` already call `translate()` directly without caching.

## Changes

- **`spin/api.tsx`**: Remove `Callbacks` field from `SpinApi`
- **`spin/controller.ts`**: Remove `translateActionRunning`, `translateActionDone` cached fields and `handleGetTranslateActionRunning`, `handleGetTranslateActionDone` arrow methods; remove `translate` import
- **`spin/component.tsx` (FC)**: Call `translate('kol-action-running')` and `translate('kol-action-done')` directly — consistent with `AvatarFC` and `MeterFC`; add `translate` import
- **`spin/component.tsx` (WC)**: Remove handler props from `<SpinFC>` render call
- **`ARC42.md` §4**: One-sentence clarification added to "Functional Component Layer" — FCs may call stateless utility functions directly; `Callbacks` is for event-driven callbacks only

## Test plan

- [ ] Build `@public-ui/components` green
- [ ] Spin component renders correctly (show=true: "action running" accessible label; show toggled to false: "action done" label)
- [ ] No regression in `AvatarFC` / `MeterFC` (both already called translate directly)

Automated Skeleton Pattern Find & Fix routine.

https://claude.ai/code/session_01JUDCLc1azUKvcQcUhBjKw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUDCLc1azUKvcQcUhBjKw8)_