### PR TITLE
chore(deps): update @stencil/playwright to 0.4.3; document @stencil/core 4.39+ regressions

### DIFF
--- a/docs/UPGRADEABLE_DEPENDENCIES.md
+++ b/docs/UPGRADEABLE_DEPENDENCIES.md
@@ -8,11 +8,19 @@
 
 ## 🔴 Critical (Breaking Changes – Manual Work Required)
 
-### 1. **@stencil/core** | 4.38.3 → 4.43.3 (patch) / 5.0.0-next.0 (major)
+### 1. **@stencil/core** | 4.38.3 (pinned) → 4.43.5 (patch, BLOCKED) / 5.0.0-alpha.7 (major)
 
-- **Status:** v5 is in pre-release (next channel), v4.43.3 is latest stable
-- **Breaking Changes:**
-  - v5.0.0-next.0 is not production-ready (next channel)
+- **Status:** ⚠️ Pinned to 4.38.3 — every newer 4.x release changes runtime behavior
+  (verified 2026-06-11 by E2E A/B bisect on this codebase):
+  - 4.39.0 / 4.40.0: build fails (SCSS parse error in input-date; fixed in 4.40.1)
+  - 4.40.1: tooltip no longer hides when a popover opens
+    (popover-button.e2e.ts:41 fails consistently); CI visual tests fail across all
+    themes; hydrate output differs (e.g. kol-input-file browse button renders
+    `kol-button--normal` → behavior drift in SSR output)
+  - 4.41.0 – 4.43.5: native Popover API broken — `showPopover()` elements stay
+    hidden (kol-popover, kol-popover-button, kol-split-button, table settings)
+- **Breaking Changes (v5):**
+  - v5.0.0-alpha.7 is not production-ready (alpha channel)
   - Multiple output-target packages block v5 upgrade:
     - @public-ui/stencil-angular-output-target
     - @public-ui/stencil-react-output-target
@@ -20,8 +28,10 @@
     - @public-ui/stencil-vue-output-target
   - @stencil/playwright requires >=4.13.0, conflicts with 5.x
 - **Risk:** VERY HIGH – Core platform dependency
-- **Recommendation:** Stay on v4.43.3 until v5 is stable and output-targets are compatible
-- **Effort:** Would require coordinating 4+ downstream packages
+- **Recommendation:** Stay on 4.38.3; before any future bump, run the popover/tooltip
+  E2E suites and the visual tests against the candidate version
+- **Effort:** Would require coordinating 4+ downstream packages plus resolving the
+  popover/tooltip regressions (upstream fix or component-side adaptation)
 
 ### 2. **eslint** | 9.39.4 → 10.1.0
 
@@ -243,7 +253,8 @@
    - @public-ui/stencil-solid-output-target (requires >=2.17.2)
    - @public-ui/stencil-vue-output-target (requires >=4)
    - @stencil/playwright (requires >=4.13.0)
-   ACTION: Keep on v4.43.3 until output-targets are v5-compatible
+   ACTION: Keep on 4.38.3 — 4.39+ regresses popover/tooltip behavior (see Critical #1);
+   v5 additionally blocked until output-targets are v5-compatible
 
 2. eslint@10.0.0 blocks:
    - @stencil-community/eslint-plugin (requires ^8.0.0 || ^9.0.0)

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -113,7 +113,7 @@
 		"@stencil-community/eslint-plugin": "0.10.0",
 		"@stencil-community/postcss": "2.2.0",
 		"@stencil/core": "4.38.3",
-		"@stencil/playwright": "0.2.3",
+		"@stencil/playwright": "0.4.3",
 		"@stencil/sass": "3.2.3",
 		"@types/color-convert": "2.0.4",
 		"@types/jest": "29.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,8 +444,8 @@ importers:
         specifier: 4.38.3
         version: 4.38.3
       '@stencil/playwright':
-        specifier: 0.2.3
-        version: 0.2.3(@playwright/test@1.60.0)(@stencil/core@4.38.3)
+        specifier: 0.4.3
+        version: 0.4.3(@playwright/test@1.60.0)(@stencil/core@4.38.3)
       '@stencil/sass':
         specifier: 3.2.3
         version: 3.2.3(@stencil/core@4.38.3)
@@ -5977,12 +5977,12 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=7.10.0'}
     hasBin: true
 
-  '@stencil/playwright@0.2.3':
-    resolution: {integrity: sha512-UUQOPu2DvI2zXSLbL1uYbhbYpn7cR11nQyWZDE2Pl7xuwLmmZQLiYvp6IQTMOwm/PS4h+jXU7Jgj7Fu/bSOAEQ==}
+  '@stencil/playwright@0.4.3':
+    resolution: {integrity: sha512-p5VWjPUTStntdLYjnQdoMhh/FpdTbl9oV8wVAFkY9fjstCS7zB/CADYfillDKNtfsb7VGNbD1SkJaQ7ez2yQhA==}
     engines: {node: '>=12.0.0', npm: '>=6.0.0'}
     peerDependencies:
-      '@playwright/test': '>=1.41.2'
-      '@stencil/core': '>=4.13.0'
+      '@playwright/test': '>=1.50.0'
+      '@stencil/core': ^4.0.0 || >=5.0.0-alpha.0 <5.0.0-beta.0
 
   '@stencil/sass@3.2.3':
     resolution: {integrity: sha512-Wru76NJqa6D79/fDjSuiXoe2U0Ky1j7LLycqn7DV0jCmVO3tiWqXHBUPg0gMXJtxEiIbIJeiH/VpKhjNrBIUkQ==}
@@ -19710,7 +19710,7 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.34.9
       '@rollup/rollup-win32-x64-msvc': 4.34.9
 
-  '@stencil/playwright@0.2.3(@playwright/test@1.60.0)(@stencil/core@4.38.3)':
+  '@stencil/playwright@0.4.3(@playwright/test@1.60.0)(@stencil/core@4.38.3)':
     dependencies:
       '@playwright/test': 1.60.0
       '@stencil/core': 4.38.3


### PR DESCRIPTION
## Summary

Behavior-preserving dependency update for the `@stencil/*` packages.

- **@stencil/playwright `0.2.3` → `0.4.3`** — E2E test harness only, no runtime impact. Popover, popover-button and split-button E2E suites verified green with the new harness.
- **@stencil/core stays pinned at `4.38.3`** — every newer 4.x release changes runtime behavior in this codebase (see below).
- **@stencil/sass `3.2.3`** — already latest.

## Why @stencil/core is NOT upgraded

Verified by building this repo and A/B-running the popover E2E suites against each candidate version:

| Version | Result |
| --- | --- |
| 4.38.3 (current) | ✅ all tests pass |
| 4.39.0 / 4.40.0 | ❌ build fails (SCSS parse error in `input-date`, fixed upstream in 4.40.1) |
| 4.40.1 | ❌ tooltip no longer hides when a popover opens (`popover-button.e2e.ts:41`); visual tests fail across all themes; hydrate SSR output differs (e.g. `kol-input-file` browse button renders `kol-button--normal` instead of `kol-button--primary`) |
| 4.41.0 – 4.43.5 (latest) | ❌ native Popover API broken — `showPopover()` elements stay hidden (kol-popover, kol-popover-button, kol-split-button, table settings popover) |

The blockers and a re-test checklist for future bumps are recorded in `docs/UPGRADEABLE_DEPENDENCIES.md`.

> Note: this branch previously carried the core 4.43.5/4.40.1 bumps; CI failures on those commits (e2e, visual tests, hydrate snapshots) are what surfaced the regressions. The branch was reset to a minimal, behavior-preserving diff.

https://claude.ai/code/session_018ojkTDseJEbq4QLU8QPsqh