### PR TITLE
refactor(skeleton): pass stateLess sentinel to stateless controllers

### DIFF
--- a/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
+++ b/packages/components/src/components/_skeleton/web-components/click-button/component.tsx
@@ -16,7 +16,7 @@ import { createCtaRef, delegateFocus } from '../../../../utils/element-interacti
 	shadow: true,
 })
 export class KolClickButton extends BaseWebComponent<ClickButtonApi> implements WebComponentInterface<ClickButtonApi> {
-	private readonly ctrl = new ClickButtonController(this.stateAccess);
+	private readonly ctrl = new ClickButtonController(BaseWebComponent.stateLess);
 	private readonly buttonRef = createCtaRef<HTMLButtonElement>();
 
 	/**

--- a/packages/components/src/components/meter/component.tsx
+++ b/packages/components/src/components/meter/component.tsx
@@ -15,7 +15,7 @@ import type { OrientationPropType } from '../../internal/props';
 	shadow: true,
 })
 export class KolMeter extends BaseWebComponent<MeterApi> implements WebComponentInterface<MeterApi> {
-	private readonly ctrl = new MeterController(this.stateAccess);
+	private readonly ctrl = new MeterController(BaseWebComponent.stateLess);
 
 	/**
 	 * From this value to the max value is the high range of the meter. Below this value is the middle range.


### PR DESCRIPTION
Automated Skeleton Pattern Find & Fix routine (2026-06-11).

## Finding (🔴 Critical, ARC42 §4 Constructor Pattern)

`KolMeter` and the blueprint's own `KolClickButton` passed `this.stateAccess` to their controllers although `MeterApi`/`ClickButtonApi` define no `States` and the controllers never call `setState`/`getState`. ARC42 mandates: "Controllers with no `@State` fields receive `BaseWebComponent.stateLess` instead (a frozen sentinel that throws on access)." Notably, the blueprint reference implementation itself contradicted the spec here — `KolMeter` demonstrably copied the deviation from it. Migrated components (`icon`, `quote`, `image`, `heading`) already use the sentinel correctly.

## Fix

Two one-line changes — the stateless sentinel now provides runtime defense-in-depth against accidental state access:

- `packages/components/src/components/meter/component.tsx`: `new MeterController(BaseWebComponent.stateLess)`
- `packages/components/src/components/_skeleton/web-components/click-button/component.tsx`: `new ClickButtonController(BaseWebComponent.stateLess)`

No spec update needed — ARC42 already clearly covers this pattern; the code was aligned to the existing spec.

**Verification:** Build ✅ · Snapshot tests 20/20 ✅ (meter + click-button)

## Session memory (for the next routine run)

```
[SKELETON 2026-06-11] Fixed: stateless Controller erhält stateAccess statt BaseWebComponent.stateLess (meter, _skeleton/click-button) | Open: `as TranslationKey` Cast in MeterFC (critical, Fix 4), _max=1 vs maxProp-Default 100 (high, Fix 3), Avatar JSDoc auf privaten Helpers (high, Fix 5), Inline-Kommentare spin/progress/meter/avatar (high, Fix 5), Progress JSDoc auf @State (low, Fix 5) | NeedsLook: MeterApi manual interface, Meter getMeterData() Side-Channel, MeterFC Custom-Typ | Score: 88/100
```

```
[SKELETON FINDING] MeterApi manuelle interface statt ApiFromConfig | Sev: critical | Fix: 2 | Files: 3 | internal/functional-components/meter/api.tsx:22 | Reason: nullable high/low/optimum sind im renderProps-Pipeline-Typmodell (StrictFields) nicht abbildbar
[SKELETON FINDING] Meter getMeterData() Side-Channel bypasses Props-Pipeline | Sev: critical | Fix: 2 | Files: 2 | internal/functional-components/meter/controller.ts:15 | Reason: Folge des fehlenden nullable-Prop-Supports; Dual-Access im WC-Render
[SKELETON FINDING] MeterFC nutzt Custom-Typ MeterFCProps statt FunctionalComponentProps | Sev: critical | Fix: 2 | Files: 1 | internal/functional-components/meter/component.tsx:41 | Reason: Folgefehler der beiden obigen Findings
```

https://claude.ai/code/session_01YPhBuScTZSHc8dUPPLQ3MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPhBuScTZSHc8dUPPLQ3MW)_