### PR TITLE
refactor(button): controller initialization to use applyProps method

### DIFF
--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -512,6 +512,67 @@ This separation ensures that:
 - Web components satisfy the Stencil `@Method()` Promise requirement automatically
 - `Awaited<R>` is used internally for idempotency — writing `() => Promise<void>` in the API still resolves to `Promise<void>`, not `Promise<Promise<void>>`
 
+### Render Props vs. Imperative / Runtime State
+
+Not every external input is a render prop. Inputs fall into two categories:
+
+1. **Render props** — normalized and validated through schema helpers, stored via `setRenderProp`, read via `getRenderProp` and passed to the Functional Component. They determine the visual output (e.g. `_label`, `_disabled`).
+2. **Imperative / runtime state** — inputs that do **not** affect rendering: form values, payloads read at interaction time, or values mirrored from the DOM at runtime. They bypass the render-prop pipeline entirely — stored via a dedicated controller setter, exposed through `Methods` (not `Props`), **never** passed to the Functional Component and **never** run through `*Prop.apply`.
+
+**Canonical example — a button's `value`** (native `<button value>` semantics):
+
+- **API** — declared under `Methods` (`getValue`), **not** in the props config:
+
+  ```ts
+  // internal/functional-components/button/api.tsx
+  Methods: {
+  	getValue: () => StencilUnknown;
+  } // value is a Method, not a Prop
+  ```
+
+- **Web Component** — a normal underscored `@Prop`, but its watcher routes to `setValue` + form association (not to a render prop). The initial value is applied in `componentWillLoad`, because `@Watch` only fires on _change_:
+
+  ```ts
+  // components/button/shadow.tsx
+  @Prop() public _value?: StencilUnknown;
+
+  @Watch('_value')
+  public watchValue(value?: StencilUnknown): void {
+    this.ctrl.setValue(value);                          // for click / callback / form result
+    this.formController.setFormAssociatedValue(value);  // native form submission
+  }
+
+  public componentWillLoad(): void {
+    this.ctrl.componentWillLoad({ /* …render props… */ }); // value is NOT part of this
+    this.ctrl.setValue(this._value);                       // initial value, applied separately
+  }
+  ```
+
+- **Controller** — a private field with `setValue`/`getValue`; the value is read at interaction time in `handleClick` and handed to the consumer callback and form submit/reset. No `valueProp.apply` validation, since the payload is arbitrary `StencilUnknown`.
+- **Runtime sync** — `_syncValueBySelector` lets the value mirror another element's value at runtime, a deliberate write that sits outside the validate/render pipeline.
+
+**Setting it from the outside is unchanged.** Consumers assign `el._value = …` exactly like any other `_`-prop — only the _internal route_ differs:
+
+| Input                                       | External entry | Internal route                                          |
+| ------------------------------------------- | -------------- | ------------------------------------------------------- |
+| Render-affecting (`_label`, `_disabled`, …) | `_x`           | `@Watch → ctrl.watchX → xProp.apply → renderProp → FC`  |
+| `_value`                                    | `_value`       | `@Watch('_value') → ctrl.setValue (+ form association)` |
+
+**Embedding.** Components that embed a button drive a `ButtonController` directly and feed render props **and** the value in one type-safe call via `applyProps`, which wraps `componentWillLoad` + `setValue`. The lifecycle-named `componentWillLoad` stays for the genuine web-component lifecycle:
+
+```ts
+// controller.ts — value-aware entry for embedders
+public applyProps(props: ResolvedInputProps<ButtonApi> & { value?: StencilUnknown }): void {
+  this.componentWillLoad(props);
+  this.setValue(props.value);
+}
+
+// embedding site
+ctrl.applyProps({ label: 'Submit', type: 'submit', value: payload });
+```
+
+> **Do not confuse this with a _render-affecting_ value** such as the blueprint's numeric `value` prop (see §4 _Available Properties_), which **is** a normal validated render prop. The category is decided by whether the input affects rendering — not by the name `value`.
+
 ### Implementation Flow
 
 1. **Initialisation** – `componentWillLoad` forwards the current prop snapshot to the controller, ensuring that internal state reflects external values before the first render.
@@ -715,6 +776,7 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 | **Event-driven communication**   | User interaction is emitted as DOM events rather than calling functions across layers.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | **FC-First Composition**         | Web component `render()` methods compose exclusively via Functional Components. KoliBri web component tags (`<kol-*>`) must never appear inside another web component's `render()`. Required controller behaviour from replaced web components must be migrated into the enclosing component's controller.                                                                                                                                                                                                               |
 | **Props Pattern**                | Functional components exclusively receive Props that contain either normalized/validated external data or internal component state. Props must always be initialized.                                                                                                                                                                                                                                                                                                                                                    |
+| **Render vs. runtime state**     | External inputs are either validated render props (→ Functional Component) or imperative/runtime state (e.g. a button's `value`: form-associated and runtime-synced) exposed via `Methods` and dedicated setters. Runtime state never reaches the renderer and skips validation. See §4 _Render Props vs. Imperative / Runtime State_.                                                                                                                                                                                   |
 | **Shadow DOM First**             | All web components use `shadow: true`. Components that should not use Shadow DOM are implemented as Functional Components instead.                                                                                                                                                                                                                                                                                                                                                                                       |
 | **Single-Root FC**               | Every Functional Component returns exactly one BEM block container as its root. Fragments and multi-sibling returns are forbidden: all direct children of `<Host>` become flex/grid items when the host applies `display: flex/grid`, causing unintended layout effects for conditionally rendered siblings such as tooltip wrappers.                                                                                                                                                                                    |
 | **ARIA ID Uniqueness via nonce** | Any DOM `id` referenced by ARIA attributes (e.g. `aria-controls`, `aria-labelledby`) must be unique per component instance. Use `private readonly someId = \`prefix-${nonce()}\``with`nonce()`from`utils/dev.utils`. This prevents ID collisions when components are composed inside a shared DOM scope (e.g. multiple WC instances within one shadow root, or direct light-DOM usage). Shadow DOM alone is not sufficient when a shadow component renders multiple instances of an internal WC in the same shadow root. |
@@ -780,6 +842,10 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
     - Both file names are **uniform** across all components — no component-specific prefixes.
     - _Alternative_: group all tests into a dedicated `test/` subdirectory per component.
     - _Reason_: co-located tests are easier to discover, eliminate unnecessary directory nesting, and keep related files visible side-by-side. This reduces cognitive overhead when navigating the codebase and aligns with common industry conventions.
+16. **`value` as imperative/form state, not a render prop**
+    - _Pattern_: Inputs that do not affect rendering (e.g. a button `value`) are exposed via `Methods` (`getValue`) and a dedicated controller setter (`setValue`), never via the props config. They skip `*Prop.apply` and are never passed to the Functional Component. See §4 _Render Props vs. Imperative / Runtime State_.
+    - _Alternative_: model `value` as a normal entry in the props config (a render prop the FC ignores).
+    - _Reason_: it has no presentational effect, carries arbitrary `StencilUnknown` payload (nothing to validate), is read at interaction time and integrates with form association (`AssociatedInputController`) plus runtime sync (`_syncValueBySelector`) — concerns that belong at the web-component/controller boundary, not in the render-prop pipeline. Forcing it into the pipeline would create a misleading "render prop" that never renders and would still require a web-component-level form hook. Embedders feed it through the value-aware `ButtonController.applyProps({ …, value })`.
 
 ## 10. Quality Requirements
 
@@ -797,12 +863,13 @@ The skeleton ships as part of the `@public-ui/components` package. During build 
 
 ## 12. Glossary
 
-| Term                     | Definition                                                                                                                                     |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **BEM**                  | Block Element Modifier naming convention for CSS class names.                                                                                  |
-| **Controller**           | Orchestrates state transitions and validation; extends `BaseController`.                                                                       |
-| **Functional Component** | Pure renderer without side effects that exclusively works with Props.                                                                          |
-| **Props**                | Normalized and validated props or internal state passed to functional components. Must always be initialized.                                  |
-| **Schema Helper**        | Utility providing `normalize` (unknown → TInternal), `validate` (TInternal → boolean) and `apply` (normalize + validate + callback) for props. |
-| **Stencil**              | Compiler for building framework-agnostic web components.                                                                                       |
-| **Watch Decorator**      | Stencil decorator (`@Watch`) that observes prop changes.                                                                                       |
+| Term                     | Definition                                                                                                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BEM**                  | Block Element Modifier naming convention for CSS class names.                                                                                                                            |
+| **Controller**           | Orchestrates state transitions and validation; extends `BaseController`.                                                                                                                 |
+| **Functional Component** | Pure renderer without side effects that exclusively works with Props.                                                                                                                    |
+| **Props**                | Normalized and validated props or internal state passed to functional components. Must always be initialized.                                                                            |
+| **Runtime/Form State**   | External input that does not affect rendering (e.g. a button `value`); exposed via `Methods` + a dedicated setter, integrates with form association, and skips the render-prop pipeline. |
+| **Schema Helper**        | Utility providing `normalize` (unknown → TInternal), `validate` (TInternal → boolean) and `apply` (normalize + validate + callback) for props.                                           |
+| **Stencil**              | Compiler for building framework-agnostic web components.                                                                                                                                 |
+| **Watch Decorator**      | Stencil decorator (`@Watch`) that observes prop changes.                                                                                                                                 |

--- a/packages/components/src/components/card/component.tsx
+++ b/packages/components/src/components/card/component.tsx
@@ -8,7 +8,7 @@ import { watchHeadingLevel } from '../heading/validation';
 
 import { KolHeadingFc } from '../../functional-components';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { createUniqueId } from '../../utils/dev.utils';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
@@ -144,12 +144,12 @@ export class KolCardWc implements CardAPI {
 		this.validateLabel(this._label);
 		this.validateLevel(this._level);
 		this.validateOn(this._on);
-		initButtonControllerFromProps(this.closeButtonCtrl, {
-			_hideLabel: true,
-			_icons: { left: { icon: 'kolicon-cross' } },
-			_label: this.translateClose,
-			_on: this.on,
-			_tooltipAlign: 'left',
+		this.closeButtonCtrl.componentWillLoad({
+			hideLabel: true,
+			icons: { left: { icon: 'kolicon-cross' } },
+			label: this.translateClose,
+			on: this.on,
+			tooltipAlign: 'left',
 		});
 	}
 }

--- a/packages/components/src/components/card/component.tsx
+++ b/packages/components/src/components/card/component.tsx
@@ -144,7 +144,7 @@ export class KolCardWc implements CardAPI {
 		this.validateLabel(this._label);
 		this.validateLevel(this._level);
 		this.validateOn(this._on);
-		this.closeButtonCtrl.componentWillLoad({
+		this.closeButtonCtrl.applyProps({
 			hideLabel: true,
 			icons: { left: { icon: 'kolicon-cross' } },
 			label: this.translateClose,

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -9,7 +9,7 @@ import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggest
 import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { IconFC } from '../../internal/functional-components/icon/component';
 import type {
@@ -294,13 +294,13 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 						{this.state._value &&
 							this.state._hasClearButton &&
 							(() => {
-								initButtonControllerFromProps(this.clearButtonCtrl, {
-									_icons: 'kolicon-cross',
-									_label: this.translateDeleteSelection,
-									_hideLabel: true,
-									_variant: 'ghost',
-									_disabled: isDisabled,
-									_on: this.clearButtonCallbacks,
+								this.clearButtonCtrl.componentWillLoad({
+									icons: 'kolicon-cross',
+									label: this.translateDeleteSelection,
+									hideLabel: true,
+									variant: 'ghost',
+									disabled: isDisabled,
+									on: this.clearButtonCallbacks,
 								});
 								return renderButtonFC(this.clearButtonCtrl, {
 									class: 'kol-combobox__delete',

--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -294,7 +294,7 @@ export class KolCombobox implements ComboboxAPI, FocusableElement {
 						{this.state._value &&
 							this.state._hasClearButton &&
 							(() => {
-								this.clearButtonCtrl.componentWillLoad({
+								this.clearButtonCtrl.applyProps({
 									icons: 'kolicon-cross',
 									label: this.translateDeleteSelection,
 									hideLabel: true,

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -33,7 +33,7 @@ import KolInputContainerFc from '../../functional-component-wrappers/InputContai
 import KolInputStateWrapperFc, { type InputStateWrapperProps } from '../../functional-component-wrappers/InputStateWrapper/InputStateWrapper';
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { createUniqueId } from '../../utils/dev.utils';
 import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
@@ -136,10 +136,10 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 					<span class={clsx('kol-input-container__filename', { 'kol-input-container__filename--has-file': this.hasFileSelected })}>{this.filename}</span>
 					<KolInputStateWrapperFc {...this.getInputProps()} />
 					{(() => {
-						initButtonControllerFromProps(this.browseButtonCtrl, {
-							_label: this.translateDataBrowseText,
-							_variant: 'primary',
-							_disabled: this._disabled,
+						this.browseButtonCtrl.componentWillLoad({
+							label: this.translateDataBrowseText,
+							variant: 'primary',
+							disabled: this._disabled,
 						});
 						return renderButtonFC(this.browseButtonCtrl, { class: 'kol-input-container__button' });
 					})()}

--- a/packages/components/src/components/input-file/shadow.tsx
+++ b/packages/components/src/components/input-file/shadow.tsx
@@ -136,7 +136,7 @@ export class KolInputFile implements InputFileAPI, FocusableElement {
 					<span class={clsx('kol-input-container__filename', { 'kol-input-container__filename--has-file': this.hasFileSelected })}>{this.filename}</span>
 					<KolInputStateWrapperFc {...this.getInputProps()} />
 					{(() => {
-						this.browseButtonCtrl.componentWillLoad({
+						this.browseButtonCtrl.applyProps({
 							label: this.translateDataBrowseText,
 							variant: 'primary',
 							disabled: this._disabled,

--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -218,7 +218,7 @@ export class KolNav implements NavAPI {
 						})()
 					: (() => {
 							const ctrl = this.getNavButtonCtrl(entry);
-							ctrl.componentWillLoad({
+							ctrl.applyProps({
 								label: entry._label,
 								hideLabel: this.state._hideLabel,
 								icons: icons,
@@ -323,7 +323,7 @@ export class KolNav implements NavAPI {
 				{this.state._hasCompactButton && (
 					<div class="kol-nav__compact">
 						{(() => {
-							this.compactButtonCtrl.componentWillLoad({
+							this.compactButtonCtrl.applyProps({
 								ariaControls: this.navId,
 								ariaExpanded: !this.state._hideLabel,
 								icons: this.state._hideLabel ? 'kolicon-chevron-right' : 'kolicon-chevron-left',

--- a/packages/components/src/components/nav/shadow.tsx
+++ b/packages/components/src/components/nav/shadow.tsx
@@ -25,7 +25,7 @@ import {
 
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { LinkFC } from '../../internal/functional-components/link/component';
 import { createLinkStateAccess, initLinkControllerFromProps, LinkController } from '../../internal/functional-components/link/controller';
@@ -218,13 +218,13 @@ export class KolNav implements NavAPI {
 						})()
 					: (() => {
 							const ctrl = this.getNavButtonCtrl(entry);
-							initButtonControllerFromProps(ctrl, {
-								_label: entry._label,
-								_hideLabel: this.state._hideLabel,
-								_icons: icons,
-								_ariaControls: collapsible && hasChildren && expanded ? ariaID : undefined,
-								_ariaExpanded: collapsible && hasChildren ? expanded : undefined,
-								_on: {
+							ctrl.componentWillLoad({
+								label: entry._label,
+								hideLabel: this.state._hideLabel,
+								icons: icons,
+								ariaControls: collapsible && hasChildren && expanded ? ariaID : undefined,
+								ariaExpanded: collapsible && hasChildren ? expanded : undefined,
+								on: {
 									onClick: (event: MouseEvent, value: Stringified<StencilUnknown>) => {
 										if (entryIsButton(entry) && typeof entry._on.onClick === 'function') {
 											entry._on.onClick(event, value);
@@ -323,13 +323,13 @@ export class KolNav implements NavAPI {
 				{this.state._hasCompactButton && (
 					<div class="kol-nav__compact">
 						{(() => {
-							initButtonControllerFromProps(this.compactButtonCtrl, {
-								_ariaControls: this.navId,
-								_ariaExpanded: !this.state._hideLabel,
-								_icons: this.state._hideLabel ? 'kolicon-chevron-right' : 'kolicon-chevron-left',
-								_hideLabel: true,
-								_label: translate(this.state._hideLabel ? 'kol-nav-maximize' : 'kol-nav-minimize'),
-								_on: {
+							this.compactButtonCtrl.componentWillLoad({
+								ariaControls: this.navId,
+								ariaExpanded: !this.state._hideLabel,
+								icons: this.state._hideLabel ? 'kolicon-chevron-right' : 'kolicon-chevron-left',
+								hideLabel: true,
+								label: translate(this.state._hideLabel ? 'kol-nav-maximize' : 'kol-nav-minimize'),
+								on: {
 									onClick: (): void => {
 										this.state = {
 											...this.state,
@@ -337,7 +337,7 @@ export class KolNav implements NavAPI {
 										};
 									},
 								},
-								_tooltipAlign: 'right',
+								tooltipAlign: 'right',
 							});
 							return renderButtonFC(this.compactButtonCtrl, { class: 'kol-nav__toggle-button' });
 						})()}

--- a/packages/components/src/components/pagination/component.tsx
+++ b/packages/components/src/components/pagination/component.tsx
@@ -331,7 +331,7 @@ export class KolPaginationWc implements PaginationAPI {
 		ctrl: ButtonController,
 		props: { class: string; disabled: boolean; icons: IconsPropType; label: string; on: ButtonCallbacksPropType<StencilUnknown> },
 	): JSX.Element {
-		ctrl.componentWillLoad({
+		ctrl.applyProps({
 			customClass: this.state._customClass,
 			disabled: props.disabled,
 			icons: props.icons,
@@ -368,7 +368,7 @@ export class KolPaginationWc implements PaginationAPI {
 		const pageText = NUMBER_FORMATTER.format(page);
 		const ariaDescription = `${this.translatePage} ${pageText}`;
 		const ctrl = this.getPageButtonCtrl(page);
-		ctrl.componentWillLoad({
+		ctrl.applyProps({
 			ariaDescription: ariaDescription,
 			customClass: this.state._customClass,
 			label: pageText,
@@ -390,7 +390,7 @@ export class KolPaginationWc implements PaginationAPI {
 	private getSelectedPageButton(page: number): JSX.Element {
 		const pageText = NUMBER_FORMATTER.format(page);
 		const ariaDescription = `${this.translatePage} ${pageText}`;
-		this.selectedButtonCtrl.componentWillLoad({
+		this.selectedButtonCtrl.applyProps({
 			ariaDescription: ariaDescription,
 			customClass: this.state._customClass,
 			label: pageText,

--- a/packages/components/src/components/pagination/component.tsx
+++ b/packages/components/src/components/pagination/component.tsx
@@ -1,7 +1,9 @@
 import type { JSX } from '@stencil/core';
 import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
 import type {
+	ButtonCallbacksPropType,
 	CustomClassPropType,
+	IconsPropType,
 	KoliBriPaginationButtonCallbacks,
 	LabelPropType,
 	MaxPropType,
@@ -9,6 +11,7 @@ import type {
 	PaginationAPI,
 	PaginationHasButton,
 	PaginationStates,
+	StencilUnknown,
 	Stringified,
 	TooltipAlignPropType,
 } from '../../schema';
@@ -27,7 +30,7 @@ import {
 import { KolSelectWcTag } from '../../core/component-names';
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { nonce } from '../../utils/dev.utils';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
@@ -136,10 +139,10 @@ export class KolPaginationWc implements PaginationAPI {
 							<li>
 								{this.renderNavButton(this.firstButtonCtrl, {
 									class: 'kol-pagination__button kol-pagination__button--first',
-									_disabled: this.state._page <= 1,
-									_icons: leftDoubleArrowIcon,
-									_label: this.translatePageFirst,
-									_on: this.onGoToFirst,
+									disabled: this.state._page <= 1,
+									icons: leftDoubleArrowIcon,
+									label: this.translatePageFirst,
+									on: this.onGoToFirst,
 								})}
 							</li>
 						)}
@@ -147,10 +150,10 @@ export class KolPaginationWc implements PaginationAPI {
 							<li>
 								{this.renderNavButton(this.previousButtonCtrl, {
 									class: 'kol-pagination__button kol-pagination__button--previous',
-									_disabled: this.state._page <= 1,
-									_icons: leftSingleArrow,
-									_label: this.translatePageBack,
-									_on: this.onGoBackward,
+									disabled: this.state._page <= 1,
+									icons: leftSingleArrow,
+									label: this.translatePageBack,
+									on: this.onGoBackward,
 								})}
 							</li>
 						)}
@@ -159,10 +162,10 @@ export class KolPaginationWc implements PaginationAPI {
 							<li>
 								{this.renderNavButton(this.nextButtonCtrl, {
 									class: 'kol-pagination__button kol-pagination__button--next',
-									_disabled: count <= this.state._page,
-									_icons: rightSingleArrowIcon,
-									_label: this.translatePageNext,
-									_on: this.onGoForward,
+									disabled: count <= this.state._page,
+									icons: rightSingleArrowIcon,
+									label: this.translatePageNext,
+									on: this.onGoForward,
 								})}
 							</li>
 						)}
@@ -170,10 +173,10 @@ export class KolPaginationWc implements PaginationAPI {
 							<li>
 								{this.renderNavButton(this.lastButtonCtrl, {
 									class: 'kol-pagination__button kol-pagination__button--last',
-									_disabled: count <= this.state._page,
-									_icons: rightDoubleArrowIcon,
-									_label: this.translatePageLast,
-									_on: this.onGoToEnd,
+									disabled: count <= this.state._page,
+									icons: rightDoubleArrowIcon,
+									label: this.translatePageLast,
+									on: this.onGoToEnd,
 								})}
 							</li>
 						)}
@@ -326,16 +329,16 @@ export class KolPaginationWc implements PaginationAPI {
 
 	private renderNavButton(
 		ctrl: ButtonController,
-		props: { class: string; _disabled: boolean; _icons: unknown; _label: string; _on: { onClick: (event: Event) => void } },
+		props: { class: string; disabled: boolean; icons: IconsPropType; label: string; on: ButtonCallbacksPropType<StencilUnknown> },
 	): JSX.Element {
-		initButtonControllerFromProps(ctrl, {
-			_customClass: this.state._customClass,
-			_disabled: props._disabled,
-			_icons: props._icons,
-			_hideLabel: true,
-			_label: props._label,
-			_on: props._on,
-			_tooltipAlign: this.state._tooltipAlign,
+		ctrl.componentWillLoad({
+			customClass: this.state._customClass,
+			disabled: props.disabled,
+			icons: props.icons,
+			hideLabel: true,
+			label: props.label,
+			on: props.on,
+			tooltipAlign: this.state._tooltipAlign,
 		});
 		return renderButtonFC(ctrl, { class: props.class });
 	}
@@ -365,11 +368,11 @@ export class KolPaginationWc implements PaginationAPI {
 		const pageText = NUMBER_FORMATTER.format(page);
 		const ariaDescription = `${this.translatePage} ${pageText}`;
 		const ctrl = this.getPageButtonCtrl(page);
-		initButtonControllerFromProps(ctrl, {
-			_ariaDescription: ariaDescription,
-			_customClass: this.state._customClass,
-			_label: pageText,
-			_on: {
+		ctrl.componentWillLoad({
+			ariaDescription: ariaDescription,
+			customClass: this.state._customClass,
+			label: pageText,
+			on: {
 				onClick: (event: Event) => {
 					this.onClick(event, page);
 				},
@@ -387,10 +390,10 @@ export class KolPaginationWc implements PaginationAPI {
 	private getSelectedPageButton(page: number): JSX.Element {
 		const pageText = NUMBER_FORMATTER.format(page);
 		const ariaDescription = `${this.translatePage} ${pageText}`;
-		initButtonControllerFromProps(this.selectedButtonCtrl, {
-			_ariaDescription: ariaDescription,
-			_customClass: this.state._customClass,
-			_label: pageText,
+		this.selectedButtonCtrl.componentWillLoad({
+			ariaDescription: ariaDescription,
+			customClass: this.state._customClass,
+			label: pageText,
 		});
 		return (
 			<li key={`selected-${page}`}>

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from '@stencil/core';
 import { Component, Fragment, h, Method, Prop, State, Watch } from '@stencil/core';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { PopoverFC } from '../../internal/functional-components/popover/component';
 import { PopoverController } from '../../internal/functional-components/popover/controller';
@@ -116,27 +116,27 @@ export class KolPopoverButtonWc implements PopoverButtonProps, FocusableElement 
 		return (
 			<>
 				{(() => {
-					initButtonControllerFromProps(this.buttonCtrl, {
-						_accessKey: this._accessKey,
-						_ariaControls: this.popoverId,
-						_ariaDescription: this._ariaDescription,
-						_ariaExpanded: this.popoverOpen,
-						_customClass: this._customClass,
-						_disabled: this._disabled,
-						_hideLabel: this._hideLabel,
-						_icons: this._icons,
-						_id: this._id,
-						_inline: this._inline,
-						_label: this._label,
-						_name: this._name,
-						_on: this.on,
-						_shortKey: this._shortKey,
-						_tabIndex: this._tabIndex,
-						_tooltipAlign: this._tooltipAlign,
-						_type: this._type,
-						_value: this._value,
-						_variant: this._variant,
+					this.buttonCtrl.componentWillLoad({
+						accessKey: this._accessKey,
+						ariaControls: this.popoverId,
+						ariaDescription: this._ariaDescription,
+						ariaExpanded: this.popoverOpen,
+						customClass: this._customClass,
+						disabled: this._disabled,
+						hideLabel: this._hideLabel,
+						icons: this._icons,
+						id: this._id,
+						inline: this._inline,
+						label: this._label,
+						name: this._name,
+						on: this.on,
+						shortKey: this._shortKey,
+						tabIndex: this._tabIndex,
+						tooltipAlign: this._tooltipAlign,
+						type: this._type,
+						variant: this._variant,
 					});
+					this.buttonCtrl.setValue(this._value);
 					return renderButtonFC(this.buttonCtrl, {
 						class: clsx('kol-popover-button', {
 							'kol-popover-button--open': this.popoverOpen,

--- a/packages/components/src/components/popover-button/component.tsx
+++ b/packages/components/src/components/popover-button/component.tsx
@@ -116,7 +116,7 @@ export class KolPopoverButtonWc implements PopoverButtonProps, FocusableElement 
 		return (
 			<>
 				{(() => {
-					this.buttonCtrl.componentWillLoad({
+					this.buttonCtrl.applyProps({
 						accessKey: this._accessKey,
 						ariaControls: this.popoverId,
 						ariaDescription: this._ariaDescription,
@@ -134,9 +134,9 @@ export class KolPopoverButtonWc implements PopoverButtonProps, FocusableElement 
 						tabIndex: this._tabIndex,
 						tooltipAlign: this._tooltipAlign,
 						type: this._type,
+						value: this._value,
 						variant: this._variant,
 					});
-					this.buttonCtrl.setValue(this._value);
 					return renderButtonFC(this.buttonCtrl, {
 						class: clsx('kol-popover-button', {
 							'kol-popover-button--open': this.popoverOpen,

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -351,7 +351,7 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 						{this._inputValue &&
 							this.state._hasClearButton &&
 							(() => {
-								this.clearButtonCtrl.componentWillLoad({
+								this.clearButtonCtrl.applyProps({
 									icons: 'kolicon-cross',
 									label: this.translateDeleteSelection,
 									hideLabel: true,

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -37,7 +37,7 @@ import CustomSuggestionsOptionFc from '../../functional-components/CustomSuggest
 import CustomSuggestionsOptionsGroupFc from '../../functional-components/CustomSuggestionsOptionsGroup';
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { IconFC } from '../../internal/functional-components/icon/component';
 import type { EventDetail } from '../../schema/interfaces/EventDetail';
@@ -351,13 +351,13 @@ export class KolSingleSelect implements SingleSelectAPI, FocusableElement {
 						{this._inputValue &&
 							this.state._hasClearButton &&
 							(() => {
-								initButtonControllerFromProps(this.clearButtonCtrl, {
-									_icons: 'kolicon-cross',
-									_label: this.translateDeleteSelection,
-									_hideLabel: true,
-									_variant: 'ghost',
-									_disabled: isDisabled,
-									_on: this.clearButtonCallbacks,
+								this.clearButtonCtrl.componentWillLoad({
+									icons: 'kolicon-cross',
+									label: this.translateDeleteSelection,
+									hideLabel: true,
+									variant: 'ghost',
+									disabled: isDisabled,
+									on: this.clearButtonCallbacks,
 								});
 								return renderButtonFC(this.clearButtonCtrl, {
 									class: 'kol-single-select__delete',

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -94,7 +94,7 @@ export class KolSplitButton implements SplitButtonProps, FocusableElement /*, Sp
 			<div class="kol-split-button">
 				<div class="kol-split-button__root">
 					{(() => {
-						this.buttonCtrl.componentWillLoad({
+						this.buttonCtrl.applyProps({
 							accessKey: this._accessKey,
 							ariaControls: this._ariaControls,
 							ariaDescription: this._ariaDescription,
@@ -110,9 +110,9 @@ export class KolSplitButton implements SplitButtonProps, FocusableElement /*, Sp
 							shortKey: this._shortKey,
 							tooltipAlign: this._tooltipAlign,
 							type: this._type,
+							value: this._value,
 							variant: this._variant,
 						});
-						this.buttonCtrl.setValue(this._value);
 						return renderButtonFC(this.buttonCtrl, {
 							class: clsx('kol-split-button__button', {
 								[this._variant as string]: this._variant !== 'custom',

--- a/packages/components/src/components/split-button/shadow.tsx
+++ b/packages/components/src/components/split-button/shadow.tsx
@@ -23,7 +23,7 @@ import type {
 import { KolPopoverButtonWcTag } from '../../core/component-names';
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import clsx from '../../utils/clsx';
 import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
@@ -94,25 +94,25 @@ export class KolSplitButton implements SplitButtonProps, FocusableElement /*, Sp
 			<div class="kol-split-button">
 				<div class="kol-split-button__root">
 					{(() => {
-						initButtonControllerFromProps(this.buttonCtrl, {
-							_accessKey: this._accessKey,
-							_ariaControls: this._ariaControls,
-							_ariaDescription: this._ariaDescription,
-							_ariaExpanded: this._ariaExpanded,
-							_ariaSelected: this._ariaSelected,
-							_customClass: this._customClass,
-							_disabled: this._disabled,
-							_icons: this._icons,
-							_hideLabel: this._hideLabel,
-							_label: this._label,
-							_name: this._name,
-							_on: this.clickButtonHandler,
-							_shortKey: this._shortKey,
-							_tooltipAlign: this._tooltipAlign,
-							_type: this._type,
-							_value: this._value,
-							_variant: this._variant,
+						this.buttonCtrl.componentWillLoad({
+							accessKey: this._accessKey,
+							ariaControls: this._ariaControls,
+							ariaDescription: this._ariaDescription,
+							ariaExpanded: this._ariaExpanded,
+							ariaSelected: this._ariaSelected,
+							customClass: this._customClass,
+							disabled: this._disabled,
+							icons: this._icons,
+							hideLabel: this._hideLabel,
+							label: this._label,
+							name: this._name,
+							on: this.clickButtonHandler,
+							shortKey: this._shortKey,
+							tooltipAlign: this._tooltipAlign,
+							type: this._type,
+							variant: this._variant,
 						});
+						this.buttonCtrl.setValue(this._value);
 						return renderButtonFC(this.buttonCtrl, {
 							class: clsx('kol-split-button__button', {
 								[this._variant as string]: this._variant !== 'custom',

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -1263,7 +1263,7 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 					<span class="kol-table__sort">
 						{(() => {
 							const sortCtrl = this.getSortButtonCtrl(cell.key ?? cell.label);
-							sortCtrl.componentWillLoad({
+							sortCtrl.applyProps({
 								icons: { right: sortButtonIcon },
 								label: cell.label,
 								ariaDescription: sortDescription,

--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -1263,11 +1263,11 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 					<span class="kol-table__sort">
 						{(() => {
 							const sortCtrl = this.getSortButtonCtrl(cell.key ?? cell.label);
-							initButtonControllerFromProps(sortCtrl, {
-								_icons: { right: sortButtonIcon },
-								_label: cell.label,
-								_ariaDescription: sortDescription,
-								_on: {
+							sortCtrl.componentWillLoad({
+								icons: { right: sortButtonIcon },
+								label: cell.label,
+								ariaDescription: sortDescription,
+								on: {
 									onClick: (event: MouseEvent) => {
 										if (typeof this.state._on?.onSort === 'function' && cell.key && cell.sortDirection) {
 											this.state._on.onSort(event, {

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -177,7 +177,7 @@ export class KolTableSettings {
 											_on={{ onInput: (_, value: unknown) => this.handleWidthChange(column.key ?? '', value) }}
 										/>
 										{(() => {
-											const upCtrl = this.getMoveButtonCtrl(`${column.key ?? ''}-up`);
+											const upCtrl = this.getMoveButtonCtrl(`${column.key ?? column.label}-up`);
 											upCtrl.applyProps({
 												icons: 'kolicon-chevron-up',
 												label: translate('kol-table-settings-move-up', { placeholders: { column: column.label } }),
@@ -189,7 +189,7 @@ export class KolTableSettings {
 											return renderButtonFC(upCtrl, { dataTestId: 'table-settings-move-up' });
 										})()}
 										{(() => {
-											const downCtrl = this.getMoveButtonCtrl(`${column.key ?? ''}-down`);
+											const downCtrl = this.getMoveButtonCtrl(`${column.key ?? column.label}-down`);
 											downCtrl.applyProps({
 												icons: 'kolicon-chevron-down',
 												label: translate('kol-table-settings-move-down', { placeholders: { column: column.label } }),

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -178,7 +178,7 @@ export class KolTableSettings {
 										/>
 										{(() => {
 											const upCtrl = this.getMoveButtonCtrl(`${column.key ?? ''}-up`);
-											upCtrl.componentWillLoad({
+											upCtrl.applyProps({
 												icons: 'kolicon-chevron-up',
 												label: translate('kol-table-settings-move-up', { placeholders: { column: column.label } }),
 												hideLabel: true,
@@ -190,7 +190,7 @@ export class KolTableSettings {
 										})()}
 										{(() => {
 											const downCtrl = this.getMoveButtonCtrl(`${column.key ?? ''}-down`);
-											downCtrl.componentWillLoad({
+											downCtrl.applyProps({
 												icons: 'kolicon-chevron-down',
 												label: translate('kol-table-settings-move-down', { placeholders: { column: column.label } }),
 												hideLabel: true,
@@ -207,7 +207,7 @@ export class KolTableSettings {
 
 						<div class="kol-table-settings__actions">
 							{(() => {
-								this.cancelButtonCtrl.componentWillLoad({
+								this.cancelButtonCtrl.applyProps({
 									label: this.translateTableSettingsCancel,
 									variant: 'secondary',
 									on: { onClick: () => this.handleCancel() },
@@ -215,7 +215,7 @@ export class KolTableSettings {
 								return renderButtonFC(this.cancelButtonCtrl, { dataTestId: 'table-settings-cancel' });
 							})()}
 							{(() => {
-								this.applyButtonCtrl.componentWillLoad({
+								this.applyButtonCtrl.applyProps({
 									label: this.translateTableSettingsApply,
 									variant: 'primary',
 									type: 'submit',

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -3,7 +3,7 @@ import { Component, Element, h, Prop, State, Watch } from '@stencil/core';
 import { KolAlertWcTag, KolHeadingTag, KolInputCheckboxTag, KolInputNumberTag, KolPopoverButtonWcTag } from '../../core/component-names';
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import type { KoliBriTableHeaderCell } from '../../schema';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
@@ -178,25 +178,25 @@ export class KolTableSettings {
 										/>
 										{(() => {
 											const upCtrl = this.getMoveButtonCtrl(`${column.key ?? ''}-up`);
-											initButtonControllerFromProps(upCtrl, {
-												_icons: 'kolicon-chevron-up',
-												_label: translate('kol-table-settings-move-up', { placeholders: { column: column.label } }),
-												_hideLabel: true,
-												_variant: 'ghost',
-												_on: { onClick: () => this.moveColumn(column.key ?? '', 'up') },
-												_disabled: column.sortable === false || index === 0,
+											upCtrl.componentWillLoad({
+												icons: 'kolicon-chevron-up',
+												label: translate('kol-table-settings-move-up', { placeholders: { column: column.label } }),
+												hideLabel: true,
+												variant: 'ghost',
+												on: { onClick: () => this.moveColumn(column.key ?? '', 'up') },
+												disabled: column.sortable === false || index === 0,
 											});
 											return renderButtonFC(upCtrl, { dataTestId: 'table-settings-move-up' });
 										})()}
 										{(() => {
 											const downCtrl = this.getMoveButtonCtrl(`${column.key ?? ''}-down`);
-											initButtonControllerFromProps(downCtrl, {
-												_icons: 'kolicon-chevron-down',
-												_label: translate('kol-table-settings-move-down', { placeholders: { column: column.label } }),
-												_hideLabel: true,
-												_variant: 'ghost',
-												_on: { onClick: () => this.moveColumn(column.key ?? '', 'down') },
-												_disabled: column.sortable === false || index === columns.length - 1,
+											downCtrl.componentWillLoad({
+												icons: 'kolicon-chevron-down',
+												label: translate('kol-table-settings-move-down', { placeholders: { column: column.label } }),
+												hideLabel: true,
+												variant: 'ghost',
+												on: { onClick: () => this.moveColumn(column.key ?? '', 'down') },
+												disabled: column.sortable === false || index === columns.length - 1,
 											});
 											return renderButtonFC(downCtrl, { dataTestId: 'table-settings-move-down' });
 										})()}
@@ -207,18 +207,18 @@ export class KolTableSettings {
 
 						<div class="kol-table-settings__actions">
 							{(() => {
-								initButtonControllerFromProps(this.cancelButtonCtrl, {
-									_label: this.translateTableSettingsCancel,
-									_variant: 'secondary',
-									_on: { onClick: () => this.handleCancel() },
+								this.cancelButtonCtrl.componentWillLoad({
+									label: this.translateTableSettingsCancel,
+									variant: 'secondary',
+									on: { onClick: () => this.handleCancel() },
 								});
 								return renderButtonFC(this.cancelButtonCtrl, { dataTestId: 'table-settings-cancel' });
 							})()}
 							{(() => {
-								initButtonControllerFromProps(this.applyButtonCtrl, {
-									_label: this.translateTableSettingsApply,
-									_variant: 'primary',
-									_type: 'submit',
+								this.applyButtonCtrl.componentWillLoad({
+									label: this.translateTableSettingsApply,
+									variant: 'primary',
+									type: 'submit',
 								});
 								return renderButtonFC(this.applyButtonCtrl, { dataTestId: 'table-settings-apply' });
 							})()}

--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -29,7 +29,7 @@ import {
 import type { Generic } from 'adopted-style-sheets';
 import { translate } from '../../i18n';
 import { BaseWebComponent } from '../../internal/functional-components/base-web-component';
-import { ButtonController, initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
+import { ButtonController } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { KeyboardKey } from '../../schema/enums';
 import type { HasCreateButtonPropType } from '../../schema/props/has-create-button';
@@ -196,32 +196,32 @@ export class KolTabs implements TabsAPI, FocusableElement {
 				{this.state._tabs.map((button: TabButtonProps, index: number) => {
 					const selected = this.state._selected === index;
 					const ctrl = this.getTabButtonCtrl(index);
-					initButtonControllerFromProps(ctrl, {
-						_disabled: button._disabled,
-						_icons: button._icons,
-						_hideLabel: button._hideLabel,
-						_label: button._label, // TODO: ariaLabel-Konzept prüfen
-						_on: this.callbacks as ButtonCallbacksPropType<StencilUnknown>,
-						_tabIndex: selected ? 0 : -1,
-						_tooltipAlign: button._tooltipAlign,
-						_variant: selected ? 'custom' : undefined,
-						_customClass: selected ? 'selected' : '',
-						_ariaControls: `tabpanel-${index}`,
-						_ariaSelected: selected,
-						_id: `${this.state._label.replace(/\s/g, '-')}-tab-${index}`,
-						_role: 'tab',
-						_value: index,
+					ctrl.componentWillLoad({
+						disabled: button._disabled,
+						icons: button._icons,
+						hideLabel: button._hideLabel,
+						label: button._label, // TODO: ariaLabel-Konzept prüfen
+						on: this.callbacks as ButtonCallbacksPropType<StencilUnknown>,
+						tabIndex: selected ? 0 : -1,
+						tooltipAlign: button._tooltipAlign,
+						variant: selected ? 'custom' : undefined,
+						customClass: selected ? 'selected' : '',
+						ariaControls: `tabpanel-${index}`,
+						ariaSelected: selected,
+						id: `${this.state._label.replace(/\s/g, '-')}-tab-${index}`,
+						role: 'tab',
 					});
+					ctrl.setValue(index);
 					return renderButtonFC(ctrl, {
 						refButton: selected ? this.ctaRef : undefined,
 					});
 				})}
 				{this.state._hasCreateButton &&
 					(() => {
-						initButtonControllerFromProps(this.createButtonCtrl, {
-							_label: this.onCreateLabel,
-							_on: { onClick: this.onCreate },
-							_icons: 'kolicon-plus',
+						this.createButtonCtrl.componentWillLoad({
+							label: this.onCreateLabel,
+							on: { onClick: this.onCreate },
+							icons: 'kolicon-plus',
 						});
 						return renderButtonFC(this.createButtonCtrl, {
 							class: 'kol-tabs__button-create',

--- a/packages/components/src/components/tabs/shadow.tsx
+++ b/packages/components/src/components/tabs/shadow.tsx
@@ -196,7 +196,7 @@ export class KolTabs implements TabsAPI, FocusableElement {
 				{this.state._tabs.map((button: TabButtonProps, index: number) => {
 					const selected = this.state._selected === index;
 					const ctrl = this.getTabButtonCtrl(index);
-					ctrl.componentWillLoad({
+					ctrl.applyProps({
 						disabled: button._disabled,
 						icons: button._icons,
 						hideLabel: button._hideLabel,
@@ -210,15 +210,15 @@ export class KolTabs implements TabsAPI, FocusableElement {
 						ariaSelected: selected,
 						id: `${this.state._label.replace(/\s/g, '-')}-tab-${index}`,
 						role: 'tab',
+						value: index,
 					});
-					ctrl.setValue(index);
 					return renderButtonFC(ctrl, {
 						refButton: selected ? this.ctaRef : undefined,
 					});
 				})}
 				{this.state._hasCreateButton &&
 					(() => {
-						this.createButtonCtrl.componentWillLoad({
+						this.createButtonCtrl.applyProps({
 							label: this.onCreateLabel,
 							on: { onClick: this.onCreate },
 							icons: 'kolicon-plus',

--- a/packages/components/src/functional-components/Alert/Alert.tsx
+++ b/packages/components/src/functional-components/Alert/Alert.tsx
@@ -4,7 +4,6 @@ import clsx from '../../utils/clsx';
 
 import { translate } from '../../i18n';
 import type { ButtonController } from '../../internal/functional-components/button/controller';
-import { initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import { type InternalAlertProps } from '../../schema';
 import { bem } from '../../schema/bem-registry';
@@ -109,13 +108,13 @@ const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 				{hasCloser &&
 					closeButtonCtrl &&
 					(() => {
-						initButtonControllerFromProps(closeButtonCtrl, {
-							_ariaDescription: label?.trim() || '',
-							_hideLabel: true,
-							_icons: { left: { icon: 'kolicon-cross' } },
-							_label: translateCloseAlert,
-							_on: { onClick: onCloserClick },
-							_tooltipAlign: 'left',
+						closeButtonCtrl.componentWillLoad({
+							ariaDescription: label?.trim() || '',
+							hideLabel: true,
+							icons: { left: { icon: 'kolicon-cross' } },
+							label: translateCloseAlert,
+							on: { onClick: onCloserClick },
+							tooltipAlign: 'left',
 						});
 						return renderButtonFC(closeButtonCtrl, {
 							class: BEM_CLASS_ALERT__CLOSER + ' kol-close-button',

--- a/packages/components/src/functional-components/Alert/Alert.tsx
+++ b/packages/components/src/functional-components/Alert/Alert.tsx
@@ -108,7 +108,7 @@ const KolAlertFc: FC<KolAlertFcProps> = (props, children) => {
 				{hasCloser &&
 					closeButtonCtrl &&
 					(() => {
-						closeButtonCtrl.componentWillLoad({
+						closeButtonCtrl.applyProps({
 							ariaDescription: label?.trim() || '',
 							hideLabel: true,
 							icons: { left: { icon: 'kolicon-cross' } },

--- a/packages/components/src/functional-components/Collapsible/Collapsible.tsx
+++ b/packages/components/src/functional-components/Collapsible/Collapsible.tsx
@@ -78,7 +78,7 @@ const KolCollapsibleFc: FC<CollapsibleProps> = (props, children) => {
 		>
 			<KolHeadingFc ref={HeadingProps?.ref} level={level} class={clsx('collapsible__heading', HeadingProps?.class)}>
 				{(() => {
-					buttonCtrl.componentWillLoad({
+					buttonCtrl.applyProps({
 						id: headingId,
 						ariaControls: controlId,
 						ariaExpanded: open,

--- a/packages/components/src/functional-components/Collapsible/Collapsible.tsx
+++ b/packages/components/src/functional-components/Collapsible/Collapsible.tsx
@@ -2,7 +2,6 @@ import type { FunctionalComponent as FC } from '@stencil/core';
 import { h } from '@stencil/core';
 import type { JSXBase } from '@stencil/core/internal';
 import type { ButtonController } from '../../internal/functional-components/button/controller';
-import { initButtonControllerFromProps } from '../../internal/functional-components/button/controller';
 import { renderButtonFC } from '../../internal/functional-components/button/render';
 import type { EventValueOrEventCallback, HeadingLevel, IconsPropType, StencilUnknown } from '../../schema';
 import clsx from '../../utils/clsx';
@@ -79,14 +78,14 @@ const KolCollapsibleFc: FC<CollapsibleProps> = (props, children) => {
 		>
 			<KolHeadingFc ref={HeadingProps?.ref} level={level} class={clsx('collapsible__heading', HeadingProps?.class)}>
 				{(() => {
-					initButtonControllerFromProps(buttonCtrl, {
-						_id: headingId,
-						_ariaControls: controlId,
-						_ariaExpanded: open,
-						_disabled: disabled,
-						_icons: HeadingButtonProps?._icons || `${icon}`,
-						_label: label,
-						_on: { onClick },
+					buttonCtrl.componentWillLoad({
+						id: headingId,
+						ariaControls: controlId,
+						ariaExpanded: open,
+						disabled: disabled,
+						icons: HeadingButtonProps?._icons || `${icon}`,
+						label: label,
+						on: { onClick },
 					});
 					return renderButtonFC(buttonCtrl, {
 						class: clsx('collapsible__heading-button', HeadingButtonProps?.class),

--- a/packages/components/src/internal/functional-components/button/EMBEDDING_API_UNIFICATION.md
+++ b/packages/components/src/internal/functional-components/button/EMBEDDING_API_UNIFICATION.md
@@ -1,0 +1,114 @@
+# Out-of-Scope-Optimierung: Button-Embedding-API vollständig vereinheitlichen
+
+> Status: **Vorschlag / nicht umgesetzt** (bewusst außerhalb des aktuellen PR-Scopes).
+> Kontext-PR: public-ui/kolibri#10377 (Branch `claude/eloquent-fermat-9wfves`).
+> Voraussetzung: Die bereits gemergten/anstehenden Commits dieses Branches
+> (`applyProps` + Umstellung der Hand-Sites + ARC42-Doku).
+
+## Problem / verbleibende Kante
+
+Nach der „Brücke glätten"-Umsetzung gibt es für das Einbetten eines Buttons **zwei** Wege:
+
+1. **`ctrl.applyProps({ label, disabled, … , value })`** — für Sites, die die Button-Props
+   **von Hand** aufbauen (clean benannt, typsicher). Das ist der gewünschte Standardweg.
+2. **`initButtonControllerFromProps(ctrl, { ...bag, _override })`** — für die wenigen Sites, die ein
+   **echtes öffentliches `_`-Bag** durchreichen (der Wert stammt aus einem externen KoliBri-Prop-Objekt,
+   trägt also `_`-Präfixe von außen).
+
+Diese Koexistenz ist die einzige verbliebene Lernkurven-Kante: Ein neuer Contributor muss wissen, **wann**
+welcher Weg gilt. Außerdem bleibt `initButtonControllerFromProps` der letzte **un-typisierte** Eingang
+(`Partial<Record<string, unknown>>` + interne `as`-Casts).
+
+### Betroffene Bag-Sites (Stand Branch)
+
+- `components/badge/shadow.tsx` — `{ ...props, _ariaControls, _hideLabel }` (`props: InternalButtonProps`)
+- `components/toolbar/shadow.tsx` — `{ ...element, _tabIndex, _variant }`
+- `functional-components/Button/Button.tsx` — `{ ...other, _label, _disabled, … , _on }`
+- `components/table-stateless/component.tsx:~956` — `initButtonControllerFromProps(buttonCtrl, buttonProps)`
+
+## Ziel
+
+Genau **einen** typisierten Embedding-Eingang (`applyProps`) für **alle** Sites — auch die Bag-Sites —
+ohne die Wiederverwendbarkeit oder die Validierung anzutasten.
+
+## Vorgeschlagener Ansatz
+
+### 1. Generischer, typsicherer `stripUnderscore`-Adapter
+
+Ein kleiner, **rein mechanischer** Mapper, der die `_`-Präfixe eines öffentlichen Bags entfernt und dabei
+die Typen 1:1 abbildet (Mapped Type), statt 20 handgeschriebener `as`-Casts:
+
+```ts
+// internal/functional-components/strip-underscore.ts (Vorschlag)
+type StripUnderscore<T> = {
+	[K in keyof T as K extends `_${infer R}` ? R : K]: T[K];
+};
+
+export function stripUnderscore<T extends Record<string, unknown>>(bag: T): StripUnderscore<T> {
+	const out: Record<string, unknown> = {};
+	for (const key in bag) out[key.startsWith('_') ? key.slice(1) : key] = bag[key];
+	return out as StripUnderscore<T>;
+}
+```
+
+- **Generisch & wiederverwendbar** — funktioniert für jedes `_`-Bag (auch Link-/andere Embedder später).
+- **Keine Validierungs-Berührung**: liefert nur umbenannte Keys; der Wert-Pfad bleibt
+  `applyProps → componentWillLoad → watch* → *Prop.apply` (das „absolute Muss" bleibt erhalten).
+
+### 2. Bag-Sites auf `applyProps` umstellen
+
+```ts
+// vorher (badge)
+initButtonControllerFromProps(this.smartButtonCtrl, { ...props, _ariaControls: this.id, _hideLabel: true });
+
+// nachher
+this.smartButtonCtrl.applyProps({ ...stripUnderscore(props), ariaControls: this.id, hideLabel: true });
+```
+
+- `value` wird vom Bag automatisch mit übernommen (Bags enthalten ggf. `_value` → `value`), passend zur
+  `applyProps`-Signatur `ResolvedInputProps<ButtonApi> & { value?: StencilUnknown }`.
+- Edge-Case `functional-components/Button/Button.tsx`: die `_on`-Präzedenz beibehalten
+  (`on: onClick ? { ...stripUnderscore(other).on, onClick } : … }`) — vor der Umstellung genau prüfen.
+- Edge-Case `table-stateless:956`: `buttonProps` ist eine Variable; Typ des Bags muss zu
+  `StripUnderscore<…>` passen — ggf. den Quelltyp von `buttonProps` schärfen.
+
+### 3. `initButtonControllerFromProps` entfernen
+
+Nach Umstellung aller Bag-Sites ist die Funktion ungenutzt → löschen (inkl. Re-Exports). Damit gibt es
+**einen** Embedding-Weg und **keinen** un-typisierten Eingang mehr.
+
+## Warum out of scope
+
+- Der aktuelle PR sollte **risikoarm** bleiben („Brücke glätten") und die Struktur (Cache/`stateLess`/
+  feed-in-render) unangetastet lassen.
+- `stripUnderscore` als neues geteiltes Utility + Entfernen einer öffentlichen Hilfsfunktion ist eine
+  eigenständige, breiter wirkende Änderung (Mapped-Type-Korrektheit, Edge-Cases bei `_on`/Variablen-Bags),
+  die einen eigenen, fokussierten Review verdient.
+- Mittel-/langfristig wird sie teils obsolet: Sobald die Consumer selbst **Skeletons** werden, liefern ihre
+  eigenen Controller bereits clean validierte Werte (`getRenderProp`) — dann entfällt das Bag-Spreading an
+  vielen Stellen ohnehin (siehe „Komposition als Ziel-Pattern").
+
+## Nutzen
+
+- **Eine** typisierte Embedding-API (`applyProps`) für alle Sites → flachere Lernkurve, keine
+  „wann welcher Weg?"-Entscheidung mehr.
+- Letzter un-typisierter Eingang (`initButtonControllerFromProps`) verschwindet → durchgängige Typprüfung.
+- `stripUnderscore` ist wiederverwendbar für künftige Bag-Boundaries (z. B. Link-Embedder).
+
+## Verifikation (bei Umsetzung)
+
+1. **tsc-Diff gegen Baseline**: `tsc --noemit` vorher/nachher — **0 neue** Fehler (außer bekanntem
+   Codegen-Rauschen `HTMLKol*`/`components.d`). Der `StripUnderscore`-Mapped-Type muss jede Bag-Site
+   ohne `as`-Casts auflösen.
+2. **Snapshots unverändert** für badge, toolbar, table-stateless + alle Consumer von
+   `functional-components/Button` (Alert, Collapsible, …): reines Wiring-Refactoring, gleiches Markup.
+3. **ESLint-Diff**: keine neuen Probleme; `initButtonControllerFromProps`-Import-Reste entfernt.
+4. **Konsistenz**: `grep -r "initButtonControllerFromProps" packages/components/src` → leer (Funktion und
+   alle Aufrufe entfernt).
+5. **`_on`-Präzedenz-Test** (Button-FC mit direktem `onClick` + Bag-`_on`): Klick ruft beide korrekt auf.
+
+## Nicht Teil dieser Optimierung
+
+- Cache-Absicherung von `getEmbeddedButtonController` (eigener Punkt).
+- Embed-Rezept-JSDoc bei `renderButtonFC`/`applyProps` (eigener Punkt).
+- Skeleton-Migration der Consumer + Controller-Komposition (größeres, separates Vorhaben).

--- a/packages/components/src/internal/functional-components/button/controller.ts
+++ b/packages/components/src/internal/functional-components/button/controller.ts
@@ -282,6 +282,17 @@ export class ButtonController extends BaseController<ButtonApi> implements Contr
 		this.value = value;
 	}
 
+	/**
+	 * Applies a full set of (already clean-named) button props and synchronises the
+	 * value in one call. Intended for components that embed a button and re-feed it
+	 * on every render — the readable, value-aware counterpart of the lifecycle-named
+	 * `componentWillLoad`. Validation still runs through the per-prop watchers.
+	 */
+	public applyProps(props: ResolvedInputProps<ButtonApi> & { value?: StencilUnknown }): void {
+		this.componentWillLoad(props);
+		this.setValue(props.value);
+	}
+
 	public getTooltipId(): string {
 		return this.tooltipCtrl.getRenderProp('id');
 	}


### PR DESCRIPTION
## Summary
This PR refactors button controller initialization across multiple components by replacing the `initButtonControllerFromProps` function with a new `applyProps` method on the `ButtonController` class. This change improves code readability and provides a more intuitive API for components that embed buttons and re-render them frequently.

## Key Changes

- **New `applyProps` method**: Added to `ButtonController` class to apply a full set of clean-named button props and synchronize the value in a single call. This serves as the readable, value-aware counterpart to the lifecycle-named `componentWillLoad`.

- **Removed `initButtonControllerFromProps` import**: Eliminated the import of `initButtonControllerFromProps` from all affected components since the functionality is now encapsulated in the `applyProps` method.

- **Property naming convention**: Updated all button prop assignments from underscore-prefixed names (e.g., `_disabled`, `_label`, `_icons`) to clean names (e.g., `disabled`, `label`, `icons`) to match the new method's expected input format.

- **Components updated**:
  - Pagination component
  - Table stateless component
  - Table settings component
  - Popover button component
  - Tabs component
  - Split button component
  - Nav component
  - Collapsible functional component
  - Combobox component
  - Single select component
  - Alert functional component
  - Card component
  - Input file component

## Implementation Details

The `applyProps` method internally calls `componentWillLoad` with the provided props and then calls `setValue` with the optional value property. This ensures that validation still runs through the per-prop watchers while providing a cleaner, more declarative API for components that manage button state across multiple render cycles.

https://claude.ai/code/session_01CpVU1kN1qx1HVXQnBTssrz