### PR TITLE
chore: enhance PR preview cleanup and remove sourcemap from builds

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -3,14 +3,20 @@ name: PR-Preview - Cleanup
 on:
   pull_request:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      delete_all:
+        description: 'Delete ALL pr-* preview deployments from gh-pages (leave unchecked to do nothing)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
   cleanup:
-    # Skip this job when the base clone URL may be different from the head clone URL.
-    if: github.event.pull_request.head.repo.fork == false
+    # On PR close, skip forks (their token cannot push). Manual runs are always allowed.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -18,15 +24,32 @@ jobs:
           ref: gh-pages
           persist-credentials: true
 
-      - name: Remove PR preview folder
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Remove preview for the closed PR
+        if: github.event_name == 'pull_request'
         run: |
           PR_FOLDER="pr-${{ github.event.pull_request.number }}"
           if [ -d "$PR_FOLDER" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
             git rm -rf "$PR_FOLDER"
             git commit -m "chore: remove preview for PR #${{ github.event.pull_request.number }}"
             git push
           else
             echo "No preview folder found for PR #${{ github.event.pull_request.number }}, skipping."
           fi
+
+      - name: Remove all PR previews
+        if: github.event_name == 'workflow_dispatch' && inputs.delete_all
+        run: |
+          mapfile -t folders < <(find . -maxdepth 1 -type d -name 'pr-*' -printf '%P\n')
+          if [ ${#folders[@]} -eq 0 ]; then
+            echo "No pr-* preview folders found on gh-pages, nothing to delete."
+            exit 0
+          fi
+          echo "Removing ${#folders[@]} preview folder(s): ${folders[*]}"
+          git rm -rf "${folders[@]}"
+          git commit -m "chore: remove all PR preview deployments"
+          git push

--- a/packages/samples/presentation/vite.config.ts
+++ b/packages/samples/presentation/vite.config.ts
@@ -31,7 +31,8 @@ export default defineConfig({
 		'process.env.PLATFORM': JSON.stringify(process.platform),
 	},
 	build: {
-		sourcemap: true,
+		// Dev server (vite serve) always emits sourcemaps; disable them for the production build to keep the output small.
+		sourcemap: false,
 	},
 	server: {
 		allowedHosts: true,

--- a/packages/samples/presentation/vite.config.ts
+++ b/packages/samples/presentation/vite.config.ts
@@ -30,10 +30,6 @@ export default defineConfig({
 		'process.env.COMMIT_HASH': JSON.stringify(getGitCommitHash()),
 		'process.env.PLATFORM': JSON.stringify(process.platform),
 	},
-	build: {
-		// Dev server (vite serve) always emits sourcemaps; disable them for the production build to keep the output small.
-		sourcemap: false,
-	},
 	server: {
 		allowedHosts: true,
 		port: parseInt(process.env.KOLIBRI_VISUAL_TEST_PORT || '9191', 10),

--- a/packages/samples/react/vite.config.ts
+++ b/packages/samples/react/vite.config.ts
@@ -31,7 +31,8 @@ export default defineConfig({
 		'process.env.PLATFORM': JSON.stringify(process.platform),
 	},
 	build: {
-		sourcemap: true,
+		// Dev server (vite serve) always emits sourcemaps; disable them for the production build to keep the output small.
+		sourcemap: false,
 	},
 	server: {
 		allowedHosts: true,

--- a/packages/samples/react/vite.config.ts
+++ b/packages/samples/react/vite.config.ts
@@ -30,10 +30,6 @@ export default defineConfig({
 		'process.env.COMMIT_HASH': JSON.stringify(getGitCommitHash()),
 		'process.env.PLATFORM': JSON.stringify(process.platform),
 	},
-	build: {
-		// Dev server (vite serve) always emits sourcemaps; disable them for the production build to keep the output small.
-		sourcemap: false,
-	},
 	server: {
 		allowedHosts: true,
 		port: parseInt(process.env.KOLIBRI_VISUAL_TEST_PORT || '9191', 10),


### PR DESCRIPTION
## Summary
This PR improves the PR preview cleanup workflow and removes sourcemap generation from sample builds.

## Key Changes

### GitHub Actions Workflow Enhancement
- **Added manual trigger support**: The cleanup workflow can now be manually triggered via `workflow_dispatch` with a `delete_all` option
- **Improved fork handling**: Updated the job condition to allow manual runs while still skipping forks on automatic PR close events
- **Added git configuration step**: Extracted git identity configuration into a dedicated step for better clarity
- **Added bulk cleanup capability**: New step to remove all `pr-*` preview deployments when manually triggered with `delete_all` flag enabled
- **Better step organization**: Separated the PR-specific cleanup from the manual bulk cleanup with conditional execution

### Build Configuration
- **Removed sourcemap generation**: Disabled `sourcemap: true` in build configuration for both `packages/samples/presentation` and `packages/samples/react` vite configs
  - This reduces build artifact size and improves build performance for sample applications

## Implementation Details
- The workflow now supports two modes:
  1. **Automatic (on PR close)**: Removes the preview folder for the specific closed PR
  2. **Manual (workflow_dispatch)**: Optionally removes all PR preview deployments when `delete_all` is checked
- The bulk cleanup uses `find` to locate all `pr-*` directories and removes them in a single commit
- Git configuration is now centralized and reused across both cleanup scenarios

https://claude.ai/code/session_014Jy26hcypEMvYE6D1o9Bcz