### PR TITLE
ci(pr-preview): add optional gh-pages history purge to cleanup

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -9,6 +9,10 @@ on:
         description: 'Delete ALL pr-* preview deployments from gh-pages (leave unchecked to do nothing)'
         type: boolean
         default: false
+      purge_history:
+        description: 'Squash the whole gh-pages history into a single commit to reclaim repository/clone size (destructive force-push; runs after delete_all)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -53,3 +57,14 @@ jobs:
           git rm -rf "${folders[@]}"
           git commit -m "chore: remove all PR preview deployments"
           git push
+
+      - name: Squash gh-pages history
+        if: github.event_name == 'workflow_dispatch' && inputs.purge_history
+        run: |
+          # Collapse the entire gh-pages history into one commit so the accumulated
+          # build blobs become unreachable and can be garbage-collected by GitHub.
+          # Operates on the current tree, i.e. after the delete_all step (if any).
+          git checkout --orphan _gh_pages_squashed
+          git add -A
+          git commit -m "chore: reset gh-pages history to reclaim space"
+          git push -f origin _gh_pages_squashed:gh-pages


### PR DESCRIPTION
## Was

Erweitert den `PR-Preview - Cleanup`-Workflow um eine zweite manuelle Checkbox **`purge_history`**.

Wenn beim manuellen Start (`workflow_dispatch`) angehakt, faltet der Job die **gesamte `gh-pages`-Historie auf einen einzigen Commit zusammen** und force-pusht ihn. Dadurch werden die über die Zeit angehäuften Build-Blobs unerreichbar und können von GitHub per GC entfernt werden → die Repository-/Klon-Größe des `gh-pages`-Branch wird freigegeben.

## Warum

Die per-PR-Preview-Deployments häufen auf `gh-pages` über die Historie sehr viel Volumen an. Das **Löschen** von `pr-*`-Ordnern (`delete_all`) entfernt sie nur aus dem aktuellen Baum — die alten Blobs bleiben in der Git-Historie. `purge_history` schließt diese Lücke und gibt den Speicher tatsächlich frei.

## Details

- Läuft **nach** dem `delete_all`-Schritt, d. h. beide zusammen angehakt ⇒ sauberer Baum **und** bereinigte Historie.
- Default `false`, **nur manuell** auslösbar (`workflow_dispatch`).
- **Destruktiv**: force-push auf `gh-pages` (Historie wird verworfen). Voraussetzung: kein Branch-Schutz mit Force-Push-Verbot auf `gh-pages`.
- Bestehendes Verhalten (per-PR-Close-Cleanup, `delete_all`) bleibt unverändert.

## Hinweis

Für den akuten GitHub-Pages-10-GB-Deployfehler ist `purge_history` **nicht** nötig (dort zählt die Größe des aktuellen Baums, nicht die Historie) — dafür genügt `delete_all`. `purge_history` adressiert die separate Klon-/Repo-Größe.

https://claude.ai/code/session_014Jy26hcypEMvYE6D1o9Bcz

---
_Generated by [Claude Code](https://claude.ai/code/session_014Jy26hcypEMvYE6D1o9Bcz)_