### PR TITLE
ci: add exemplary Renovate configuration

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,65 @@
+name: Renovate
+
+# Self-hosted Renovate runner — see docs/RENOVATE.md.
+#
+# Triggers:
+#   - schedule:          Mondays 04:00 UTC. The repo's renovate.json additionally limits PR
+#                        creation to "before 6am on monday" (Europe/Berlin).
+#   - workflow_dispatch: manual "Run workflow" button; optionally tick "dry_run" to preview
+#                        what Renovate would do without creating branches/PRs.
+#
+# Auth: reuses the existing GitHub App (secrets.APP_ID / secrets.PRIVATE_KEY — the same app as
+#       "04 - Update pnpm Lock"). The app installation must grant:
+#         contents: write, pull-requests: write, issues: write (Dependency Dashboard)
+#         and workflows: write (so the github-actions manager can update .github/workflows/*).
+# Alternative: drop the app-token step and pass a PAT via `token: ${{ secrets.RENOVATE_TOKEN }}`.
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview only — do not create branches/PRs'
+        type: boolean
+        default: false
+      log_level:
+        description: 'Renovate log level'
+        type: choice
+        options:
+          - info
+          - debug
+        default: info
+
+concurrency:
+  group: 'workflow-${{ github.workflow }}'
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    # Never run on forks (scheduled workflows would otherwise fire there too).
+    if: github.repository == 'public-ui/kolibri'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v46
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}
+          RENOVATE_PLATFORM: github
+          RENOVATE_AUTODISCOVER: 'false'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ONBOARDING: 'false'
+          # Empty string is ignored by Renovate (skips unset env vars), so non-dry runs are unaffected.
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run == true && 'full' || '' }}

--- a/docs/RENOVATE.md
+++ b/docs/RENOVATE.md
@@ -1,0 +1,177 @@
+# Renovate — Automated Dependency Updates
+
+This document is the outcome of issue [#10270](https://github.com/public-ui/kolibri/issues/10270)
+(_renovate vs npm-check-updates vs dependabot_). It contains:
+
+1. a comparison of the three candidate tools,
+2. a description of the exemplary [`renovate.json`](../renovate.json) that ships with this repo,
+3. how to enable Renovate, and
+4. the migration checklist for retiring the current tooling.
+
+> **Status:** The `renovate.json` is committed as an **exemplary, ready-to-run configuration**.
+> Renovate is **not active yet** — it requires the Renovate GitHub App to be installed on the
+> `public-ui` organization (see [Enabling Renovate](#enabling-renovate)). Until then the existing
+> Dependabot + npm-check-updates automation stays in charge.
+
+---
+
+## 1. Tool comparison
+
+KoliBri is a **pnpm-workspace monorepo** with 30+ packages, several intentionally pinned major
+lines (Angular `v19`/`v20`/`v21`, React 18/19, Stencil 4, ESLint 9) and four maintained branches
+(`develop`, `release/3`, `release/2`, `release/1`). That shapes the comparison:
+
+| Capability                                   |       **Renovate**       |             Dependabot              |  npm-check-updates (ncu)  |
+| -------------------------------------------- | :----------------------: | :---------------------------------: | :-----------------------: |
+| pnpm-workspace aware                         |        ✅ native         |             ⚠️ partial              |  ❌ manual (per-package)  |
+| One PR grouping related packages             |  ✅ fully configurable   |          ⚠️ `groups:` only          |          ❌ none          |
+| Hold a package on a specific major line      |   ✅ per-folder rules    |        ⚠️ `ignore` (global)         | ⚠️ `-x` exclude (global)  |
+| GitHub Actions updates                       |            ✅            |                 ✅                  |            ❌             |
+| Lockfile-only refresh                        | ✅ `lockFileMaintenance` |             ⚠️ limited              | ❌ (needs `pnpm install`) |
+| Automerge (per update type)                  |            ✅            |             ⚠️ limited              |            ❌             |
+| Multi-base-branch (release/\*) support       | ✅ `baseBranchPatterns`  | ✅ `target-branch` (one entry each) |  ⚠️ matrix in a workflow  |
+| Security / vulnerability remediation         |  ✅ OSV + GitHub alerts  |          ✅ GitHub alerts           |            ❌             |
+| Dependency Dashboard (single overview issue) |            ✅            |                 ❌                  |            ❌             |
+| Schedule / batching                          |            ✅            |              ⚠️ basic               |   ⚠️ via cron workflow    |
+| Self-hostable (no third-party app)           |   ✅ (official Action)   |         ✅ (GitHub-native)          |         ✅ (CLI)          |
+| Config surface                               |          medium          |                 low                 |          minimal          |
+| Cost for open source                         |           free           |                free                 |           free            |
+
+### Verdict
+
+- **Renovate — recommended.** It is the only option that models KoliBri's reality in _one_ config:
+  group the Angular/React/Stencil families, hold each adapter folder on its pinned major, automerge
+  the safe stuff (GitHub Actions, `@types/*`), and route everything risky to a review queue (the
+  Dependency Dashboard). It also folds in what we currently split across **two** systems
+  (Dependabot for Actions + a daily `ncu` workflow for npm).
+- **Dependabot — viable fallback.** Now supports `groups:`, but every package directory needs its
+  own `updates:` entry (≈30 for this monorepo × 4 branches) and it cannot hold a dependency on a
+  specific major _per folder_ — exactly what the `angular/v19|v20|v21` and `react*` adapters need.
+- **npm-check-updates — not an automation tool.** It is a CLI that rewrites version ranges; it has
+  no PR/grouping/scheduling of its own. We only use it _inside_ a hand-written workflow
+  (`.github/workflows/auto-dependency-updater.yml`). Renovate makes that workflow redundant.
+
+---
+
+## 2. What the exemplary `renovate.json` does
+
+The committed [`renovate.json`](../renovate.json) is tailored to this repo. Highlights:
+
+### Global behaviour
+
+- **`extends: ["config:recommended", "security:openssf-scorecard"]`** — sensible defaults plus
+  OpenSSF Scorecard badges on PRs.
+- **Conventional Commits** — `chore(deps): …` titles so PRs pass `pr-title-validation.yml`.
+- **`labels: ["dependencies", "renovate", "release:engineering"]`** — the `release:*` label is
+  **required** by `pr-release-label-validation.yml`; `release:engineering` files dependency PRs
+  under _🔧 Engineering_ in the changelog (see `.github/release.yml`).
+- **Weekly schedule** (`before 6am on monday`, `Europe/Berlin`) with `prConcurrentLimit: 10` /
+  `prHourlyLimit: 4` so the first run does **not** flood the repo with PRs.
+- **`baseBranchPatterns`** — runs on `develop` **and** `release/3|2|1`; the maintenance branches are
+  restricted to security + patch npm updates so released majors stay stable.
+- **`lockFileMaintenance`** — weekly `pnpm-lock.yaml` refresh (replaces the manual
+  `04 - Update pnpm Lock` workflow runs).
+- **`postUpdateOptions: ["pnpmDedupe"]`** — keeps the pnpm lockfile tidy.
+
+### Grouping & guard-rails (the important part for this monorepo)
+
+| Rule                                              | Effect                                                                                                                                                                                             |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **All majors**                                    | Require manual approval via the Dependency Dashboard — KoliBri pins majors deliberately.                                                                                                           |
+| **Angular `@angular/*`, `zone.js`, `ng-packagr`** | Major updates **disabled** entirely; within-major updates grouped per adapter folder (_Angular 19/20/21_). A new Angular major = a new adapter folder, never an auto-bump.                         |
+| **React `react`, `react-dom`, `@types/react*`**   | Major updates **disabled**; within-major React updates of the `react*` adapters grouped and reviewed (not automerged).                                                                             |
+| **Stencil `@stencil/*`, `@stencil-community/*`**  | **All** updates require dashboard approval — every 4.39+ release currently breaks the Popover API, tooltips and visual tests (see [`UPGRADEABLE_DEPENDENCIES.md`](./UPGRADEABLE_DEPENDENCIES.md)). |
+| **`@kern-ux/*`**                                  | Dashboard approval only — upgraded by hand together with theming work.                                                                                                                             |
+| **`@typescript-eslint/*`, ESLint core + plugins** | Minor/major require approval (9 → 10 is a breaking migration).                                                                                                                                     |
+| **`jest*`, `typescript`**                         | Majors/non-patch require approval.                                                                                                                                                                 |
+| **`github-actions`, `@types/*`**                  | Grouped **and automerged** for low-risk update types.                                                                                                                                              |
+| **Stylelint, Playwright**                         | Grouped into single PRs.                                                                                                                                                                           |
+
+> The pins above mirror exactly what the current `ncu:*` scripts exclude
+> (`@kern-ux/*`, `@stencil/*`, `@typescript-eslint/*`) and what `UPGRADEABLE_DEPENDENCIES.md`
+> documents as breaking — so behaviour is preserved, just expressed declaratively.
+
+### Validate the config locally
+
+```sh
+npx --yes --package renovate renovate-config-validator renovate.json
+```
+
+---
+
+## 3. Enabling Renovate
+
+Pick **one** of two ways to run it.
+
+### Option A — Mend-hosted GitHub App (recommended, zero maintenance)
+
+1. An **org admin** installs the [Renovate GitHub App](https://github.com/apps/renovate) on
+   `public-ui` (or just on `public-ui/kolibri`).
+2. Renovate detects `renovate.json` and opens an onboarding/Dependency Dashboard issue.
+3. Review the dashboard, then let it run on the weekly schedule.
+
+### Option B — Self-hosted via GitHub Actions (full control, no third-party app)
+
+Add `.github/workflows/renovate.yml`:
+
+```yaml
+name: Renovate
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Mondays, 04:00 UTC
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: renovatebot/github-action@v43
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }} # PAT or GitHub App token with repo + PR scope
+        env:
+          RENOVATE_REPOSITORIES: public-ui/kolibri
+```
+
+> **Tip:** For the very first run, set `"dryRun": "full"` (or run the Action with
+> `RENOVATE_DRY_RUN=full`) to preview the PRs Renovate _would_ open without creating them.
+
+---
+
+## 4. Migration checklist (do this only after Renovate is verified)
+
+Once Renovate runs green for a cycle, retire the overlapping automation to avoid **duplicate PRs**:
+
+- [ ] Remove `.github/dependabot.yml` (Renovate now manages GitHub Actions — see the
+      `github-actions` group).
+- [ ] Remove `.github/workflows/auto-dependency-updater.yml` (the daily `ncu` PR job).
+- [ ] Drop the `ncu:*` / `update` scripts and the `npm-check-updates` devDependency from the root
+      `package.json`, plus `.ncurc.json` (optional — `ncu` is still handy for manual ad-hoc checks).
+- [ ] Keep `04 - Update pnpm Lock` if you still want a manual lockfile-refresh button; otherwise
+      Renovate's `lockFileMaintenance` covers it.
+
+Until every box is ticked, **leave the existing tooling in place** — the `renovate.json` is inert
+without the App/Action from step 3, so there is no conflict in the meantime.
+
+---
+
+## 🇩🇪 Zusammenfassung
+
+**Empfehlung: Renovate.** Es ist die einzige Lösung, die das KoliBri-Monorepo in _einer_ Konfiguration
+abbildet — verwandte Pakete gruppieren (z. B. alle `@angular/*`), jeden Adapter-Ordner auf seiner
+fixierten Major-Version halten (`angular/v19|v20|v21`, `react*`), sichere Updates automatisch mergen
+(GitHub Actions, `@types/*`) und alles Riskante (Stencil, kern-ux, ESLint-/Angular-Majors) über das
+**Dependency Dashboard** zur manuellen Freigabe leiten.
+
+- **Dependabot** kann zwar gruppieren, braucht aber pro Paketverzeichnis einen eigenen Eintrag
+  (≈30 × 4 Branches) und kann ein Paket nicht _pro Ordner_ auf einer Major-Version halten.
+- **npm-check-updates** ist nur ein CLI ohne eigene Automatisierung (läuft heute im Workflow
+  `auto-dependency-updater.yml`).
+
+Die fertige [`renovate.json`](../renovate.json) liegt im Repo-Root und ist mit dem offiziellen
+`renovate-config-validator` geprüft. **Aktiv wird Renovate erst**, wenn ein Org-Admin die
+[Renovate-GitHub-App](https://github.com/apps/renovate) installiert (Option A) oder der
+self-hosted Workflow (Option B) eingerichtet wird. Bis dahin bleibt die bestehende
+Dependabot-/ncu-Automatisierung zuständig; danach greift die Migrations-Checkliste oben.

--- a/docs/RENOVATE.md
+++ b/docs/RENOVATE.md
@@ -8,10 +8,11 @@ This document is the outcome of issue [#10270](https://github.com/public-ui/koli
 3. how to enable Renovate, and
 4. the migration checklist for retiring the current tooling.
 
-> **Status:** The `renovate.json` is committed as an **exemplary, ready-to-run configuration**.
-> Renovate is **not active yet** — it requires the Renovate GitHub App to be installed on the
-> `public-ui` organization (see [Enabling Renovate](#enabling-renovate)). Until then the existing
-> Dependabot + npm-check-updates automation stays in charge.
+> **Status:** The `renovate.json` and a self-hosted runner workflow
+> ([`.github/workflows/renovate.yml`](../.github/workflows/renovate.yml)) are committed as an
+> **exemplary, ready-to-run setup**. Renovate stays **idle** until that workflow runs — either on its
+> weekly schedule or via the manual **Run workflow** button (see [Enabling Renovate](#enabling-renovate)).
+> Until then the existing Dependabot + npm-check-updates automation stays in charge.
 
 ---
 
@@ -101,42 +102,35 @@ npx --yes --package renovate renovate-config-validator renovate.json
 
 ## 3. Enabling Renovate
 
-Pick **one** of two ways to run it.
+Two ways to run it; **this repo is wired for Option A**.
 
-### Option A — Mend-hosted GitHub App (recommended, zero maintenance)
+### Option A — Self-hosted via GitHub Actions (committed in this repo)
 
-1. An **org admin** installs the [Renovate GitHub App](https://github.com/apps/renovate) on
+This repo ships [`.github/workflows/renovate.yml`](../.github/workflows/renovate.yml). It runs Renovate
+on a weekly schedule (Mondays 04:00 UTC) **and** on demand via the **Run workflow** button
+(`workflow_dispatch`, with an optional `dry_run` preview). It authenticates through the existing GitHub
+App (`APP_ID` / `PRIVATE_KEY` secrets, shared with _04 - Update pnpm Lock_).
+
+To activate it:
+
+1. Ensure that GitHub App installation grants **contents: write**, **pull-requests: write**,
+   **issues: write** (for the Dependency Dashboard) and **workflows: write** (so the `github-actions`
+   manager may update `.github/workflows/*`). _Alternative:_ replace the app-token step with a
+   `RENOVATE_TOKEN` PAT/fine-grained token carrying the same scopes.
+2. Trigger the workflow once via **Run workflow** (optionally with `dry_run` enabled) to verify it, then
+   let the weekly schedule take over.
+
+> **Tip:** The `dry_run` input maps to `RENOVATE_DRY_RUN=full`, so the first manual run previews every PR
+> Renovate _would_ open without creating anything.
+
+### Option B — Mend-hosted GitHub App (alternative, zero maintenance)
+
+If you would rather not self-host, delete `.github/workflows/renovate.yml` and instead:
+
+1. Have an **org admin** install the [Renovate GitHub App](https://github.com/apps/renovate) on
    `public-ui` (or just on `public-ui/kolibri`).
-2. Renovate detects `renovate.json` and opens an onboarding/Dependency Dashboard issue.
+2. Renovate detects `renovate.json` and opens a Dependency Dashboard issue.
 3. Review the dashboard, then let it run on the weekly schedule.
-
-### Option B — Self-hosted via GitHub Actions (full control, no third-party app)
-
-Add `.github/workflows/renovate.yml`:
-
-```yaml
-name: Renovate
-on:
-  schedule:
-    - cron: "0 4 * * 1" # Mondays, 04:00 UTC
-  workflow_dispatch:
-permissions:
-  contents: write
-  pull-requests: write
-jobs:
-  renovate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: renovatebot/github-action@v43
-        with:
-          token: ${{ secrets.RENOVATE_TOKEN }} # PAT or GitHub App token with repo + PR scope
-        env:
-          RENOVATE_REPOSITORIES: public-ui/kolibri
-```
-
-> **Tip:** For the very first run, set `"dryRun": "full"` (or run the Action with
-> `RENOVATE_DRY_RUN=full`) to preview the PRs Renovate _would_ open without creating them.
 
 ---
 
@@ -152,8 +146,8 @@ Once Renovate runs green for a cycle, retire the overlapping automation to avoid
 - [ ] Keep `04 - Update pnpm Lock` if you still want a manual lockfile-refresh button; otherwise
       Renovate's `lockFileMaintenance` covers it.
 
-Until every box is ticked, **leave the existing tooling in place** — the `renovate.json` is inert
-without the App/Action from step 3, so there is no conflict in the meantime.
+Until every box is ticked, **leave the existing tooling in place** — Renovate only acts once the
+workflow (or app) from [§3](#3-enabling-renovate) actually runs, so there is no conflict in the meantime.
 
 ---
 
@@ -170,8 +164,10 @@ fixierten Major-Version halten (`angular/v19|v20|v21`, `react*`), sichere Update
 - **npm-check-updates** ist nur ein CLI ohne eigene Automatisierung (läuft heute im Workflow
   `auto-dependency-updater.yml`).
 
-Die fertige [`renovate.json`](../renovate.json) liegt im Repo-Root und ist mit dem offiziellen
-`renovate-config-validator` geprüft. **Aktiv wird Renovate erst**, wenn ein Org-Admin die
-[Renovate-GitHub-App](https://github.com/apps/renovate) installiert (Option A) oder der
-self-hosted Workflow (Option B) eingerichtet wird. Bis dahin bleibt die bestehende
-Dependabot-/ncu-Automatisierung zuständig; danach greift die Migrations-Checkliste oben.
+Die fertige [`renovate.json`](../renovate.json) liegt im Repo-Root (geprüft mit dem offiziellen
+`renovate-config-validator`), und der self-hosted Runner-Workflow
+[`.github/workflows/renovate.yml`](../.github/workflows/renovate.yml) ist ebenfalls committet.
+**Renovate läuft**, sobald der Workflow startet — wöchentlich per Zeitplan oder manuell über den
+**Run workflow**-Button (Option A); alternativ kann ein Org-Admin die
+[Renovate-GitHub-App](https://github.com/apps/renovate) installieren (Option B). Bis dahin bleibt die
+bestehende Dependabot-/ncu-Automatisierung zuständig; danach greift die Migrations-Checkliste oben.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,146 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended", "security:openssf-scorecard"],
+	"dependencyDashboard": true,
+	"dependencyDashboardTitle": "🤖 Renovate Dependency Dashboard",
+	"semanticCommits": "enabled",
+	"semanticCommitType": "chore",
+	"semanticCommitScope": "deps",
+	"timezone": "Europe/Berlin",
+	"schedule": ["before 6am on monday"],
+	"labels": ["dependencies", "renovate", "release:engineering"],
+	"rebaseWhen": "behind-base-branch",
+	"prConcurrentLimit": 10,
+	"prHourlyLimit": 4,
+	"postUpdateOptions": ["pnpmDedupe"],
+	"platformAutomerge": true,
+	"baseBranchPatterns": ["develop", "release/3", "release/2", "release/1"],
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 6am on monday"]
+	},
+	"vulnerabilityAlerts": {
+		"enabled": true,
+		"labels": ["dependencies", "renovate", "release:engineering", "security"],
+		"schedule": ["at any time"]
+	},
+	"osvVulnerabilityAlerts": true,
+	"packageRules": [
+		{
+			"description": "Maintenance branches (v1–v3) only receive security fixes and patch-level npm bumps — keep the released major lines stable.",
+			"matchBaseBranches": ["release/3", "release/2", "release/1"],
+			"matchManagers": ["npm"],
+			"matchUpdateTypes": ["minor", "major"],
+			"enabled": false
+		},
+		{
+			"description": "Major updates always require manual approval via the dependency dashboard — KoliBri pins its major lines deliberately (Angular v19/v20/v21, React 18/19, Stencil 4, ESLint 9, …).",
+			"matchUpdateTypes": ["major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "Group GitHub Actions updates and automerge them (replaces the github-actions entries in .github/dependabot.yml).",
+			"matchManagers": ["github-actions"],
+			"groupName": "github-actions",
+			"addLabels": ["github-actions"],
+			"matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+			"automerge": true
+		},
+		{
+			"description": "Group all @types/* packages and automerge low-risk type-definition bumps.",
+			"matchPackageNames": ["@types/*"],
+			"groupName": "type definitions",
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
+		},
+		{
+			"description": "Never bump the Angular toolchain across a major — each adapter folder (v19/v20/v21) is intentionally pinned to its Angular major. A new Angular major means a new adapter folder, not an auto-update.",
+			"matchPackageNames": ["@angular/*", "@angular-devkit/*", "ng-packagr", "zone.js"],
+			"matchUpdateTypes": ["major"],
+			"enabled": false
+		},
+		{
+			"description": "Group within-major updates of the Angular 19 toolchain (packages/adapters/angular/v19).",
+			"matchFileNames": ["packages/adapters/angular/v19/**"],
+			"matchPackageNames": ["@angular/*", "@angular-devkit/*", "ng-packagr", "zone.js"],
+			"groupName": "Angular 19 (v19 adapter)"
+		},
+		{
+			"description": "Group within-major updates of the Angular 20 toolchain (packages/adapters/angular/v20).",
+			"matchFileNames": ["packages/adapters/angular/v20/**"],
+			"matchPackageNames": ["@angular/*", "@angular-devkit/*", "ng-packagr", "zone.js"],
+			"groupName": "Angular 20 (v20 adapter)"
+		},
+		{
+			"description": "Group within-major updates of the Angular 21 toolchain (packages/adapters/angular/v21).",
+			"matchFileNames": ["packages/adapters/angular/v21/**"],
+			"matchPackageNames": ["@angular/*", "@angular-devkit/*", "ng-packagr", "zone.js"],
+			"groupName": "Angular 21 (v21 adapter)"
+		},
+		{
+			"description": "Never bump React across a major — the react / react-v19 / react-standalone / preact adapters each pin their React major on purpose.",
+			"matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+			"matchUpdateTypes": ["major"],
+			"enabled": false
+		},
+		{
+			"description": "Group the within-major React updates of the React adapters (review manually instead of automerging the framework).",
+			"matchFileNames": ["packages/adapters/react/**", "packages/adapters/react-v19/**", "packages/adapters/react-standalone/**"],
+			"matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+			"groupName": "React adapters",
+			"automerge": false
+		},
+		{
+			"description": "Stencil is hard-pinned: every 4.39+ release breaks the Popover API, tooltips and the visual tests (see docs/UPGRADEABLE_DEPENDENCIES.md). Require manual approval for ALL Stencil updates.",
+			"matchPackageNames": ["@stencil/*", "@stencil-community/*"],
+			"groupName": "Stencil",
+			"automerge": false,
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "@kern-ux/* (theming) is upgraded by hand together with theming work — surface it on the dashboard but do not open PRs automatically.",
+			"matchPackageNames": ["@kern-ux/*"],
+			"groupName": "kern-ux",
+			"automerge": false,
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "typescript-eslint minor/major bumps must stay in sync with the ESLint config — group and require manual approval.",
+			"matchPackageNames": ["@typescript-eslint/*", "typescript-eslint"],
+			"groupName": "typescript-eslint",
+			"matchUpdateTypes": ["minor", "major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "ESLint core and its plugins are mid-migration (9 → 10 is breaking) — group and require manual approval for non-patch updates.",
+			"matchPackageNames": ["eslint", "@eslint/*", "eslint-plugin-*", "eslint-config-*"],
+			"groupName": "ESLint",
+			"matchUpdateTypes": ["minor", "major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "Jest major jumps are breaking (Node/TS baseline changes — see docs/UPGRADEABLE_DEPENDENCIES.md). Group and require manual approval for majors.",
+			"matchPackageNames": ["jest", "jest-*", "@types/jest", "babel-jest", "ts-jest"],
+			"groupName": "Jest",
+			"matchUpdateTypes": ["major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "TypeScript moves in lock-step with the framework toolchains — coordinate minor/major bumps manually.",
+			"matchPackageNames": ["typescript"],
+			"groupName": "TypeScript",
+			"matchUpdateTypes": ["minor", "major"],
+			"dependencyDashboardApproval": true
+		},
+		{
+			"description": "Group the Stylelint toolchain into a single PR.",
+			"matchPackageNames": ["stylelint", "stylelint-*"],
+			"groupName": "Stylelint"
+		},
+		{
+			"description": "Group the Playwright packages into a single PR.",
+			"matchPackageNames": ["@playwright/test", "playwright", "playwright-*"],
+			"groupName": "Playwright"
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Implements an **exemplary Renovate setup** for the KoliBri monorepo, as requested in #10270 (_renovate vs npm-check-updates vs dependabot_). Additive and safe: Renovate stays idle until the runner workflow is triggered, so it does not conflict with the existing Dependabot + `ncu` automation.

### Added files

- **`renovate.json`** (repo root) — a config tailored to this monorepo, validated with the official `renovate-config-validator`:
  - **Holds each adapter folder on its pinned major** — `@angular/*` majors disabled, within-major updates grouped per folder (_Angular 19/20/21_); same for `react`/`react-dom`/`@types/react*` across the `react*` adapters.
  - **Routes risky packages to the Dependency Dashboard** for manual approval — `@stencil/*` (every 4.39+ release breaks Popover/tooltips/visual tests per `docs/UPGRADEABLE_DEPENDENCIES.md`), `@kern-ux/*`, `@typescript-eslint/*`, ESLint, Jest/TypeScript, and **all majors** — mirroring the current `ncu:*` exclusions.
  - **Automerges low-risk updates** — GitHub Actions + `@types/*`.
  - **Respects repo conventions** — Conventional-Commit titles, the required `release:engineering` label, weekly schedule + PR limits, runs on `develop` + `release/3|2|1`, `lockFileMaintenance` + `pnpmDedupe`.

- **`.github/workflows/renovate.yml`** — a **self-hosted runner** so Renovate can actually be executed from the repo:
  - **Automated**: weekly cron (Mondays 04:00 UTC).
  - **Manual**: `workflow_dispatch` "Run workflow" button, with an optional `dry_run` preview.
  - Authenticates via the existing GitHub App (`APP_ID` / `PRIVATE_KEY`, same pattern as _04 - Update pnpm Lock_); pins `renovatebot/github-action@v46`. Triggers are `schedule`/`workflow_dispatch` only, so it never fires on PRs or pushes.

- **`docs/RENOVATE.md`** — the **research deliverable**: Renovate vs Dependabot vs npm-check-updates comparison, config explanation, how to run it (self-hosted workflow = Option A, Mend app = Option B), and a migration checklist for retiring `.github/dependabot.yml` + `auto-dependency-updater.yml` + the `ncu` scripts once Renovate is verified.

### Verification

- `npx --yes --package renovate renovate-config-validator renovate.json` → `Config validated successfully`
- `renovate.yml` parses as valid YAML; `renovatebot/github-action@v46` confirmed as the current latest major.

### To activate (after merge)

Ensure the GitHub App installation grants **contents/pull-requests/issues/workflows: write**, then trigger the workflow once via **Run workflow** (optionally with `dry_run`) to verify before letting the weekly schedule take over. The migration checklist in `docs/RENOVATE.md` should only be executed **after** Renovate runs green for a cycle.

Refs #10270

https://claude.ai/code/session_018Fy4fd1UtBt8sE2TThmC1t