### PR TITLE
fix: correct mislabeled disabled button-link short-key example (#10388)

### DIFF
--- a/packages/samples/react/src/components/button-link/basic.tsx
+++ b/packages/samples/react/src/components/button-link/basic.tsx
@@ -49,7 +49,7 @@ export const ButtonLinkBasic: FC = () => {
 					<KolButtonLink _label="With access key" _accessKey="c" _inline={false} _on={dummyEventHandler} />
 				</p>
 				<p>
-					<KolButtonLink _label="Disabled ButtonLink" _inline={false} _shortKey="s" />
+					<KolButtonLink _label="With short key" _shortKey="s" _inline={false} _on={dummyEventHandler} />
 				</p>
 				<p>
 					<KolButtonLink _label="Special Variant ButtonLink" _variant="theme-link" />


### PR DESCRIPTION
## What changed?

In the `button-link/basic` React sample (`packages/samples/react/src/components/button-link/basic.tsx`), one entry was labeled "Disabled ButtonLink" but carried `_shortKey="s"` and no `_disabled`, so it rendered as an active, focusable element that contradicted its label. The entry is relabeled to "With short key" so the label matches the actual behavior, and the `dummyEventHandler` `_on` handler is added (mirroring the adjacent access-key example) so the short key triggers a visible action. This is a one-line sample/demo-data correction — the genuinely disabled example is untouched and there are no component or public API changes.

## Linked issues

- Closes #10388 — a `button-link/basic` sample entry was mislabeled "Disabled" while actually being an active short-key demo.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Im React-Sample `button-link/basic` (`packages/samples/react/src/components/button-link/basic.tsx`) war ein Eintrag mit „Disabled ButtonLink" beschriftet, trug aber `_shortKey="s"` und kein `_disabled` und wurde daher als aktives, fokussierbares Element dargestellt, das seiner Beschriftung widersprach. Der Eintrag wird auf „With short key" umbenannt, damit die Beschriftung dem tatsächlichen Verhalten entspricht, und erhält den `dummyEventHandler`-`_on`-Handler (analog zum benachbarten Access-Key-Beispiel), damit die Kurztaste eine sichtbare Aktion auslöst. Es handelt sich um eine einzeilige Korrektur von Beispiel-/Demodaten — das tatsächlich deaktivierte Beispiel bleibt unverändert, keine Komponenten- oder API-Änderungen.

### Verknüpfte Tickets

- Schließt #10388 — ein Eintrag im Sample `button-link/basic` war fälschlich als „Disabled" beschriftet, obwohl es sich um ein aktives Kurztasten-Demo handelte.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/samples/react/src/components/button-link/basic.tsx` — Eintrag von „Disabled ButtonLink" auf „With short key" umbenannt und `_on`-Handler ergänzt, damit Beschriftung und Verhalten übereinstimmen.

</details>