### PR TITLE
fix: show default column widths in table settings menu and prevent column collapse (#10386)

### DIFF
--- a/packages/components/src/components/table-stateless/table-settings.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-settings.e2e.ts
@@ -170,6 +170,24 @@ test.describe('kol-table-settings', () => {
 			const idColumn = page.locator('kol-table-stateless-wc th').filter({ hasText: 'ID' });
 			await expect(idColumn).toHaveCSS('width', '50px');
 		});
+
+		test('it does not collapse a column when its width input is cleared', async ({ page }) => {
+			const settingsButton = page.locator('.kol-table-settings').locator('button').first();
+			await settingsButton.click();
+
+			// Clear the preset width of the ID column instead of setting a tiny/zero value.
+			const idWidthInput = page.getByRole('spinbutton', { name: 'ID' });
+			await idWidthInput.fill('');
+
+			const applyButton = page.locator('.kol-table-settings__actions').locator('button').last();
+			await applyButton.click();
+
+			// Clearing the width must fall back to the automatic width, not collapse the column to ~0/1px.
+			const idColumn = page.locator('kol-table-stateless-wc th').filter({ hasText: 'ID' });
+			await expect(idColumn).not.toHaveCSS('width', '0px');
+			const box = await idColumn.boundingBox();
+			expect(box?.width ?? 0).toBeGreaterThan(10);
+		});
 	});
 
 	test.describe('Column Order Management', () => {

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -75,11 +75,10 @@ export class KolTableSettings {
 	}
 
 	private handleWidthChange(key: string, width: unknown): void {
-		// An empty or invalid input must not be coerced to `0` (Number('') === 0),
-		// otherwise applying the settings collapses the column to ~1px. Treat such
-		// input as "no explicit width" (undefined) so the column keeps its automatic width.
-		const numericWidth = width === '' || width === null || width === undefined ? Number.NaN : Number(width);
-		const newWidth = parseColumnWidth(numericWidth);
+		// parseColumnWidth filters out non-positive and non-finite values, so an empty or
+		// invalid input (Number('') === 0, Number(undefined) === NaN) becomes undefined
+		// instead of collapsing the column to ~1px when the settings are applied.
+		const newWidth = parseColumnWidth(Number(width));
 		const row = this.getPrimaryRow().map((col) => (col.key === key && col.resizable !== false ? { ...col, width: newWidth } : col));
 		this.updatePrimaryRow(row);
 	}

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -75,7 +75,12 @@ export class KolTableSettings {
 	}
 
 	private handleWidthChange(key: string, width: unknown): void {
-		const row = this.getPrimaryRow().map((col) => (col.key === key && col.resizable !== false ? { ...col, width: Number(width) } : col));
+		// An empty or invalid input must not be coerced to `0` (Number('') === 0),
+		// otherwise applying the settings collapses the column to ~1px. Treat such
+		// input as "no explicit width" (undefined) so the column keeps its automatic width.
+		const numericWidth = width === '' || width === null || width === undefined ? Number.NaN : Number(width);
+		const newWidth = parseColumnWidth(numericWidth);
+		const row = this.getPrimaryRow().map((col) => (col.key === key && col.resizable !== false ? { ...col, width: newWidth } : col));
 		this.updatePrimaryRow(row);
 	}
 

--- a/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
+++ b/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
@@ -29,10 +29,12 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 					<strong>ID</strong> keeps a fixed width with <code>resizable: false</code> while still allowing sorting.
 				</li>
 				<li>
-					<strong>Name</strong> represents the default behavior with both sorting and resizing enabled.
+					<strong>Name</strong> represents the default behavior with both sorting and resizing enabled and a preset <code>width</code> of 220px, which
+					is shown as the current value in the settings menu.
 				</li>
 				<li>
-					<strong>Role</strong> disables sorting but keeps <code>resizable: true</code> so users can widen the column if necessary.
+					<strong>Role</strong> disables sorting but keeps <code>resizable: true</code> with a preset <code>width</code> of 160px so users can adjust it
+					starting from its current value.
 				</li>
 				<li>
 					<strong>E-Mail</strong> allows sorting but locks its width with <code>resizable: false</code> to keep the layout stable.
@@ -65,6 +67,7 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 							sortDirection: 'NOS',
 							sortable: true,
 							resizable: true,
+							width: 220,
 						},
 						{
 							key: 'role',
@@ -73,6 +76,7 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 							sortDirection: 'NOS',
 							sortable: false,
 							resizable: true,
+							width: 160,
 						},
 						{
 							key: 'email',

--- a/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
+++ b/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
@@ -29,8 +29,8 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 					<strong>ID</strong> keeps a fixed width with <code>resizable: false</code> while still allowing sorting.
 				</li>
 				<li>
-					<strong>Name</strong> represents the default behavior with both sorting and resizing enabled and a preset <code>width</code> of 220px, which
-					is shown as the current value in the settings menu.
+					<strong>Name</strong> represents the default behavior with both sorting and resizing enabled and a preset <code>width</code> of 220px, which is shown
+					as the current value in the settings menu.
 				</li>
 				<li>
 					<strong>Role</strong> disables sorting but keeps <code>resizable: true</code> with a preset <code>width</code> of 160px so users can adjust it


### PR DESCRIPTION
Closes #10386

## Problem

In the table settings menu (`kol-table-settings-wc`) the column-width input fields stayed **empty** for any column without an explicitly configured `width` (the reporter's "Standardwerte werden nicht angezeigt"). Worse, once a user interacted with such an empty field, the input value was coerced via `Number('') === 0`, so applying the settings set the column width to `0` and **collapsed the column to ~1px**. An empty number field is also hard to recognise as editable in high-contrast mode (BITV/EN 301 549 11.9).

## Change

- **`table-settings.tsx`** — `handleWidthChange` now reuses the existing `parseColumnWidth` helper. Empty or invalid input is treated as "no explicit width" (`undefined`), so the column keeps its automatic width instead of collapsing. Valid positive values are applied as before.
- **`stateless-with-settings-menu.tsx` (sample)** — the resizable columns (`Name`, `Role`) now define explicit `width` values (220px / 160px), so the settings menu shows real default values, matching the other settings-menu examples. The sample description was updated accordingly.
- **`table-settings.e2e.ts`** — added a regression test verifying that clearing a width input no longer collapses the column.

The fully accurate "show the live rendered px width" for auto-sized columns would require measuring the rendered DOM width and plumbing it into the settings component; that is intentionally left out of this minimal fix to keep the diff small and low-risk.

## Manual test (Sample App)

`packages/samples/react/src/components/table/stateless-with-settings-menu.tsx` → route `table/stateless-with-settings-menu`:
1. Open the settings menu — the `Name` (220) and `Role` (160) width fields now show their current values.
2. Clear a width field and apply — the column keeps a sensible automatic width instead of collapsing to ~1px.

## Checks

⚠️ Typecheck/Lint/Unit/Build skipped — no local `node_modules` in this environment (MCP). A manual diff review was performed; the new behaviour is covered by the added e2e regression test.

This PR addresses a contributor-reported issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lv6pd1HQx5h6SE6XZb42Fp)_