### PR TITLE
fix: show current column widths in table settings and prevent collapse (#10386)

### DIFF
--- a/packages/components/src/components/table-stateless/table-settings.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-settings.e2e.ts
@@ -170,6 +170,23 @@ test.describe('kol-table-settings', () => {
 			const idColumn = page.locator('kol-table-stateless-wc th').filter({ hasText: 'ID' });
 			await expect(idColumn).toHaveCSS('width', '50px');
 		});
+
+		test('it does not collapse a column when the width field is cleared', async ({ page }) => {
+			const settingsButton = page.locator('.kol-table-settings').locator('button').first();
+			await settingsButton.click();
+
+			// Clearing the field used to apply width 0 -> the column collapsed to a sliver.
+			const nameWidthInput = page.getByRole('spinbutton', { name: 'Name' });
+			await nameWidthInput.fill('');
+
+			const applyButton = page.locator('.kol-table-settings__actions').locator('button').last();
+			await applyButton.click();
+
+			// The column should fall back to auto width instead of collapsing.
+			const nameColumn = page.locator('kol-table-stateless-wc th').filter({ hasText: 'Name' });
+			const box = await nameColumn.boundingBox();
+			expect(box?.width ?? 0).toBeGreaterThan(10);
+		});
 	});
 
 	test.describe('Column Order Management', () => {

--- a/packages/components/src/components/table-stateless/table-settings.tsx
+++ b/packages/components/src/components/table-stateless/table-settings.tsx
@@ -75,7 +75,11 @@ export class KolTableSettings {
 	}
 
 	private handleWidthChange(key: string, width: unknown): void {
-		const row = this.getPrimaryRow().map((col) => (col.key === key && col.resizable !== false ? { ...col, width: Number(width) } : col));
+		// Clearing/invalid input must not collapse the column: parseColumnWidth maps
+		// non-positive or non-finite values (e.g. an emptied field => 0) back to undefined,
+		// which renders as an auto-width column instead of a 0px/1px sliver.
+		const parsedWidth = parseColumnWidth(Number(width));
+		const row = this.getPrimaryRow().map((col) => (col.key === key && col.resizable !== false ? { ...col, width: parsedWidth } : col));
 		this.updatePrimaryRow(row);
 	}
 

--- a/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
+++ b/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
@@ -24,6 +24,10 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 				This sample shows <code>KolTableStateless</code> with the settings menu enabled via
 				<code>_hasSettingsMenu</code>. Each column demonstrates a different combination of sorting and resizing options.
 			</p>
+			<p>
+				Every column declares an explicit <code>width</code>, so the width fields in the settings menu show the current pixel values instead of
+				starting empty. This also prevents a resizable column from collapsing when its width is adjusted from the menu.
+			</p>
 			<ul>
 				<li>
 					<strong>ID</strong> keeps a fixed width with <code>resizable: false</code> while still allowing sorting.
@@ -57,6 +61,7 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 							sortDirection: 'NOS',
 							sortable: true,
 							resizable: false,
+							width: 120,
 						},
 						{
 							key: 'name',
@@ -65,6 +70,7 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 							sortDirection: 'NOS',
 							sortable: true,
 							resizable: true,
+							width: 200,
 						},
 						{
 							key: 'role',
@@ -73,6 +79,7 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 							sortDirection: 'NOS',
 							sortable: false,
 							resizable: true,
+							width: 160,
 						},
 						{
 							key: 'email',
@@ -81,6 +88,7 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 							sortDirection: 'NOS',
 							sortable: true,
 							resizable: false,
+							width: 240,
 						},
 						{
 							key: 'active',
@@ -89,6 +97,7 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 							sortDirection: 'NOS',
 							sortable: false,
 							resizable: false,
+							width: 120,
 						},
 					],
 				],

--- a/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
+++ b/packages/samples/react/src/components/table/stateless-with-settings-menu.tsx
@@ -25,8 +25,8 @@ export const TableStatelessWithSettingsMenu: FC = () => (
 				<code>_hasSettingsMenu</code>. Each column demonstrates a different combination of sorting and resizing options.
 			</p>
 			<p>
-				Every column declares an explicit <code>width</code>, so the width fields in the settings menu show the current pixel values instead of
-				starting empty. This also prevents a resizable column from collapsing when its width is adjusted from the menu.
+				Every column declares an explicit <code>width</code>, so the width fields in the settings menu show the current pixel values instead of starting empty.
+				This also prevents a resizable column from collapsing when its width is adjusted from the menu.
 			</p>
 			<ul>
 				<li>


### PR DESCRIPTION
## What changed?

`handleWidthChange` in `packages/components/src/components/table-stateless/table-settings.tsx` previously applied `Number(width)` directly, so an emptied width field resolved to `0` and rendered the column as a ~1px sliver. It now routes the value through the existing `parseColumnWidth` helper, which maps non-positive/non-finite input back to `undefined`, letting the column fall back to auto width instead of collapsing. The `stateless-with-settings-menu` React sample now declares an explicit `width` on every column so the settings-menu width fields display the current pixel values instead of starting empty, and a new e2e test asserts that clearing a width field no longer collapses the column. No public API changes.

## Linked issues

- Closes #10386 — table settings menu width fields were empty and editing/clearing a width collapsed the column to ~1px.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`handleWidthChange` in `packages/components/src/components/table-stateless/table-settings.tsx` hat den eingegebenen Wert bisher direkt über `Number(width)` angewendet, wodurch ein geleertes Breitenfeld zu `0` wurde und die Spalte auf einen ~1px-Splitter zusammenfiel. Der Wert wird nun über den bestehenden Helfer `parseColumnWidth` geleitet, der nicht-positive/nicht-endliche Eingaben auf `undefined` abbildet, sodass die Spalte auf Auto-Breite zurückfällt statt zu kollabieren. Das React-Sample `stateless-with-settings-menu` deklariert jetzt für jede Spalte eine explizite `width`, damit die Breitenfelder im Einstellungsmenü die aktuellen Pixelwerte anzeigen statt leer zu starten. Ein neuer e2e-Test stellt sicher, dass das Leeren eines Breitenfelds die Spalte nicht mehr kollabieren lässt. Keine Änderung an der öffentlichen API.

### Verknüpfte Tickets

- Schließt #10386 — Breitenfelder im Tabellen-Einstellungsmenü waren leer und das Bearbeiten/Leeren einer Breite ließ die Spalte auf ~1px kollabieren.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/table-stateless/table-settings.tsx` — `handleWidthChange` nutzt jetzt `parseColumnWidth`, um leere/ungültige Breiten auf Auto-Breite statt auf 0px abzubilden.
- `packages/samples/react/src/components/table/stateless-with-settings-menu.tsx` — jede Spalte deklariert eine explizite `width`; Beschreibung ergänzt.
- `packages/components/src/components/table-stateless/table-settings.e2e.ts` — neuer Test: das Leeren eines Breitenfelds kollabiert die Spalte nicht.

</details>