### PR TITLE
ci(visual-tests): publish reports to pr-#/snaps-{theme} and post one consolidated comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,130 @@ jobs:
         if: failure()
         with:
           name: report-${{ matrix.package }}
+      - name: Determine report path
+        id: report-path
+        if: ${{ !cancelled() }}
+        run: |
+          PACKAGE="${{ matrix.package }}"
+          if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
+            REPORT_DIR="packages/test-tag-name-transformer/playwright-report"
+            SLUG="tag-name-transformer"
+          else
+            THEME_DIR="${PACKAGE#theme-}"
+            REPORT_DIR="packages/themes/${THEME_DIR}/playwright-report"
+            SLUG="${THEME_DIR}"
+          fi
+          echo "dir=${REPORT_DIR}" >> "$GITHUB_OUTPUT"
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
+          if [ -d "${REPORT_DIR}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload HTML report for consolidation
+        if: ${{ !cancelled() && steps.report-path.outputs.exists == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-report-${{ steps.report-path.outputs.slug }}
+          path: ${{ steps.report-path.outputs.dir }}
+          if-no-files-found: ignore
+          retention-days: 5
+
+  visual-tests-report:
+    needs: visual-tests
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Download report artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: visual-report-*
+          path: artifacts
+      - name: Stage reports under snaps-<theme>
+        id: stage
+        run: |
+          set -o pipefail
+          rm -rf public
+          mkdir -p public
+          shopt -s nullglob
+          count=0
+          for d in artifacts/visual-report-*/; do
+            slug="$(basename "$d")"
+            slug="${slug#visual-report-}"
+            index="$(find "$d" -name index.html -printf '%d %p\n' 2>/dev/null | sort -n | head -1 | cut -d' ' -f2- || true)"
+            if [ -n "$index" ]; then
+              src="$(dirname "$index")"
+              mkdir -p "public/snaps-${slug}"
+              cp -a "${src}/." "public/snaps-${slug}/"
+              count=$((count + 1))
+            fi
+          done
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Staged ${count} report(s)."
+      - name: Ensure .nojekyll at gh-pages root
+        if: ${{ steps.stage.outputs.count != '0' }}
+        run: mkdir -p nojekyll-root && touch nojekyll-root/.nojekyll
+      - name: Deploy .nojekyll to gh-pages root
+        if: ${{ steps.stage.outputs.count != '0' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: nojekyll-root
+          branch: gh-pages
+          clean: false
+      - name: Deploy reports to GitHub Pages
+        if: ${{ steps.stage.outputs.count != '0' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: public
+          target-folder: pr-${{ github.event.pull_request.number }}
+          branch: gh-pages
+          clean: false
+      - name: Post consolidated PR comment with report links
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const pr = context.issue.number;
+            const marker = '<!-- visual-test-reports -->';
+            const base = `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${pr}`;
+            const run = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const dir = 'public';
+            const slugs = fs.existsSync(dir)
+              ? fs
+                  .readdirSync(dir)
+                  .filter((n) => n.startsWith('snaps-') && fs.existsSync(path.join(dir, n, 'index.html')))
+                  .map((n) => n.replace(/^snaps-/, ''))
+                  .sort()
+              : [];
+            const label = (slug) => (slug === 'tag-name-transformer' ? 'test-tag-name-transformer' : `theme-${slug}`);
+            const rows = slugs.map((slug) => `| \`${label(slug)}\` | [Open report](${base}/snaps-${slug}/) |`);
+            const body =
+              rows.length === 0
+                ? `${marker}\n## 📸 Visual Test Reports\n\nNo Playwright HTML reports were produced for this run.\n\nRun: ${run}`
+                : `${marker}\n## 📸 Visual Test Reports\n\n| Theme | Report |\n| --- | --- |\n${rows.join('\n')}\n\nRun: ${run}`;
+            const { owner, repo } = context.repo;
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr });
+              const existing = comments.find((c) => c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+              }
+            } catch (error) {
+              core.warning(`Could not post visual test report comment to PR #${pr}: ${error.message}`);
+            }
 
   # lighthouse:
   #   continue-on-error: true

--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -110,11 +110,14 @@ jobs:
           PACKAGE="${{ matrix.package }}"
           if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
             REPORT_DIR="packages/test-tag-name-transformer/playwright-report"
+            SLUG="tag-name-transformer"
           else
             THEME_DIR="${PACKAGE#theme-}"
             REPORT_DIR="packages/themes/${THEME_DIR}/playwright-report"
+            SLUG="${THEME_DIR}"
           fi
           echo "path=${REPORT_DIR}" >> $GITHUB_OUTPUT
+          echo "slug=${SLUG}" >> $GITHUB_OUTPUT
           if [ -d "${REPORT_DIR}" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
@@ -126,29 +129,64 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: ${{ steps.report-path.outputs.path }}
-          target-folder: pr-${{ github.event.pull_request.number }}/${{ matrix.package }}
+          target-folder: pr-${{ github.event.pull_request.number }}/snaps-${{ steps.report-path.outputs.slug }}
           branch: gh-pages
           clean: false
 
-      - name: Find existing PR comment
-        if: always() && github.event.pull_request.head.repo.fork == false
-        uses: peter-evans/find-comment@v4
-        id: fc
+  report-comment:
+    needs: visual-tests-snapshots
+    if: ${{ !cancelled() && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '<!-- visual-test-report-${{ matrix.package }} -->'
+          ref: gh-pages
+          persist-credentials: true
 
-      - name: Post PR comment with report link
-        if: always() && github.event.pull_request.head.repo.fork == false
-        uses: peter-evans/create-or-update-comment@v5
+      - name: Ensure .nojekyll at gh-pages root
+        run: |
+          if [ ! -f .nojekyll ]; then
+            touch .nojekyll
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add .nojekyll
+            git commit -m "chore: add .nojekyll to gh-pages root"
+            git push
+          fi
+
+      - name: Post consolidated PR comment with report links
+        uses: actions/github-script@v9
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body: |
-            <!-- visual-test-report-${{ matrix.package }} -->
-            ## Visual Test Report — `${{ matrix.package }}`
-            [Open Playwright Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/${{ matrix.package }}/)
-
-            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          script: |
+            const fs = require('fs');
+            const pr = context.issue.number;
+            const marker = '<!-- visual-test-reports -->';
+            const base = `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${pr}`;
+            const run = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const reports = [
+              { slug: 'default', label: 'theme-default' },
+              { slug: 'bwst', label: 'theme-bwst' },
+              { slug: 'ecl', label: 'theme-ecl' },
+              { slug: 'desy', label: 'theme-desy' },
+              { slug: 'kern', label: 'theme-kern' },
+              { slug: 'tag-name-transformer', label: 'test-tag-name-transformer' },
+            ];
+            const rows = reports
+              .filter((r) => fs.existsSync(`pr-${pr}/snaps-${r.slug}/index.html`))
+              .map((r) => `| \`${r.label}\` | [Open report](${base}/snaps-${r.slug}/) |`);
+            const body = rows.length === 0
+              ? `${marker}\n## 📸 Visual Test Reports\n\nNo Playwright HTML reports were produced for this run.\n\nRun: ${run}`
+              : `${marker}\n## 📸 Visual Test Reports\n\n| Theme | Report |\n| --- | --- |\n${rows.join('\n')}\n\nRun: ${run}`;
+            const { owner, repo } = context.repo;
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr });
+              const existing = comments.find((c) => c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+              }
+            } catch (error) {
+              core.warning(`Could not post visual test report comment to PR #${pr}: ${error.message}`);
+            }

--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -110,14 +110,11 @@ jobs:
           PACKAGE="${{ matrix.package }}"
           if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
             REPORT_DIR="packages/test-tag-name-transformer/playwright-report"
-            SLUG="tag-name-transformer"
           else
             THEME_DIR="${PACKAGE#theme-}"
             REPORT_DIR="packages/themes/${THEME_DIR}/playwright-report"
-            SLUG="${THEME_DIR}"
           fi
           echo "path=${REPORT_DIR}" >> $GITHUB_OUTPUT
-          echo "slug=${SLUG}" >> $GITHUB_OUTPUT
           if [ -d "${REPORT_DIR}" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
@@ -129,64 +126,29 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: ${{ steps.report-path.outputs.path }}
-          target-folder: pr-${{ github.event.pull_request.number }}/snaps-${{ steps.report-path.outputs.slug }}
+          target-folder: pr-${{ github.event.pull_request.number }}/${{ matrix.package }}
           branch: gh-pages
           clean: false
 
-  report-comment:
-    needs: visual-tests-snapshots
-    if: ${{ !cancelled() && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v6
+      - name: Find existing PR comment
+        if: always() && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/find-comment@v4
+        id: fc
         with:
-          ref: gh-pages
-          persist-credentials: true
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- visual-test-report-${{ matrix.package }} -->'
 
-      - name: Ensure .nojekyll at gh-pages root
-        run: |
-          if [ ! -f .nojekyll ]; then
-            touch .nojekyll
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add .nojekyll
-            git commit -m "chore: add .nojekyll to gh-pages root"
-            git push
-          fi
-
-      - name: Post consolidated PR comment with report links
-        uses: actions/github-script@v9
+      - name: Post PR comment with report link
+        if: always() && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/create-or-update-comment@v5
         with:
-          script: |
-            const fs = require('fs');
-            const pr = context.issue.number;
-            const marker = '<!-- visual-test-reports -->';
-            const base = `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${pr}`;
-            const run = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
-            const reports = [
-              { slug: 'default', label: 'theme-default' },
-              { slug: 'bwst', label: 'theme-bwst' },
-              { slug: 'ecl', label: 'theme-ecl' },
-              { slug: 'desy', label: 'theme-desy' },
-              { slug: 'kern', label: 'theme-kern' },
-              { slug: 'tag-name-transformer', label: 'test-tag-name-transformer' },
-            ];
-            const rows = reports
-              .filter((r) => fs.existsSync(`pr-${pr}/snaps-${r.slug}/index.html`))
-              .map((r) => `| \`${r.label}\` | [Open report](${base}/snaps-${r.slug}/) |`);
-            const body = rows.length === 0
-              ? `${marker}\n## 📸 Visual Test Reports\n\nNo Playwright HTML reports were produced for this run.\n\nRun: ${run}`
-              : `${marker}\n## 📸 Visual Test Reports\n\n| Theme | Report |\n| --- | --- |\n${rows.join('\n')}\n\nRun: ${run}`;
-            const { owner, repo } = context.repo;
-            try {
-              const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr });
-              const existing = comments.find((c) => c.body.includes(marker));
-              if (existing) {
-                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-              } else {
-                await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
-              }
-            } catch (error) {
-              core.warning(`Could not post visual test report comment to PR #${pr}: ${error.message}`);
-            }
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- visual-test-report-${{ matrix.package }} -->
+            ## Visual Test Report — `${{ matrix.package }}`
+            [Open Playwright Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}/${{ matrix.package }}/)
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -7,9 +7,9 @@
 @layer kol-a11y {
 	:host {
 		/*
-                 * Minimum size of interactive elements.
-                 */
-		--a11y-min-size: #{to-rem(44)};
+		 * Minimum size of interactive elements.
+		 */
+		--a11y-min-size: #{to-rem(50)};
 		/*
 		 * No element should be used without verifying the contrast ratio of its background and font colors.
 		 * By initially setting the background color to white and the font color to black,

--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -9,7 +9,7 @@
 		/*
 		 * Minimum size of interactive elements.
 		 */
-		--a11y-min-size: #{to-rem(50)};
+		--a11y-min-size: #{to-rem(44)};
 		/*
 		 * No element should be used without verifying the contrast ratio of its background and font colors.
 		 * By initially setting the background color to white and the font color to black,


### PR DESCRIPTION
## What & why

Visual-test reports should be published to GitHub Pages under `pr-#/snaps-{theme}/` and announced in **one** consolidated PR comment.

The originally-targeted workflow `visual-tests-base.yml` ("Visual Tests Snapshot Comparison") turned out to be **disabled** in repo Actions settings (`disabled_manually`) — it never runs on PRs. The visual tests that actually run come from the **active `ci.yml` ("CI-Pipeline")** `visual-tests` matrix. So this PR implements the feature there instead, and reverts the (dormant) `visual-tests-base.yml` edit.

## Changes (`.github/workflows/ci.yml`)

**`visual-tests` matrix job** — each leg now publishes its Playwright HTML report:
- A `Determine report path` step derives the report dir + a `slug` (`test-tag-name-transformer` → `tag-name-transformer`, `theme-*` → `*`).
- An `Upload HTML report for consolidation` step uploads the report as a `visual-report-{slug}` artifact, on `!cancelled()` so **failing** themes' diff reports are included too.

**New `visual-tests-report` consolidation job** (`needs: visual-tests`):
- Downloads all `visual-report-*` artifacts and stages them as `snaps-{slug}/`.
- Ensures `.nojekyll` at the gh-pages root, then deploys all reports **together** to `gh-pages` under `pr-#/` (so each becomes `pr-#/snaps-{slug}/`), `clean: false`.
- Upserts a **single** comment (marker `visual-test-reports`) linking only the reports that actually exist.
- Gated on `!cancelled() && pull_request && not a fork` — **no draft gate**, matching the `visual-tests` job, so it works on draft PRs. Job-level `permissions: contents: write, pull-requests: write`; `continue-on-error: true` so report plumbing never blocks the PR.

## Notes
- `check-results` (the required gate) is unchanged — the report job is not in its `needs`.
- The `a11y.scss` change on this branch is the maintainer's deliberate "test deviation" to exercise the reports; left as-is.

## Verification
- ✅ `ci.yml` parses (`yaml.safe_load`).
- ✅ Embedded `github-script` passes `node --check` and renders the correct table (excludes dirs without `index.html`, maps slug→label).
- ✅ The stage shell logic was unit-tested against flattened, nested, and missing-`index.html` artifact layouts (picks the shallowest `index.html`, skips reports without one).
- 🔄 End-to-end: this push re-runs `ci.yml`; expect reports at `pr-10423/snaps-{default,bwst,ecl,desy,kern,tag-name-transformer}/` and one consolidated comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)