### PR TITLE
fix: add accessible name to table selection column header (#10414)

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -1029,7 +1029,14 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 		}
 
 		if (selection.multiple === false) {
-			return <td key={`thead-0-selection`} class="kol-table__cell kol-table__cell--header kol-table__cell--selection"></td>;
+			return (
+				<th
+					key={`thead-0-selection`}
+					scope="col"
+					class="kol-table__cell kol-table__cell--header kol-table__cell--selection"
+					aria-label={translate('kol-table-selection')}
+				></th>
+			);
 		}
 
 		const selectedKeyLength = this.getSelectedKeysWithoutDisabledKeys()?.length ?? 0;
@@ -1045,7 +1052,12 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 		}
 		const label = translate(translationKey);
 		return (
-			<th key={`thead-0-selection`} class="kol-table__cell kol-table__cell--header kol-table__cell--selection">
+			<th
+				key={`thead-0-selection`}
+				scope="col"
+				class="kol-table__cell kol-table__cell--header kol-table__cell--selection"
+				aria-label={translate('kol-table-selection')}
+			>
 				<div
 					class={clsx('kol-table__selection', {
 						'kol-table__selection--indeterminate': indeterminate,

--- a/packages/components/src/components/table-stateless/table-stateless.e2e.ts
+++ b/packages/components/src/components/table-stateless/table-stateless.e2e.ts
@@ -216,6 +216,31 @@ test.describe('kol-table-stateless', () => {
 
 			await expect(callbackPromise).resolves.toEqual([DATA[0].id]);
 		});
+
+		test('renders the multi-select selection column header as a th with an accessible name', async ({ page }) => {
+			const kolTableStateless = page.locator('kol-table-stateless');
+			const selectionHeader = kolTableStateless.locator('th.kol-table__cell--selection');
+
+			await expect(selectionHeader).toHaveAttribute('scope', 'col');
+			await expect(selectionHeader).toHaveAttribute('aria-label', /.+/);
+		});
+
+		test('renders the single-select selection column header as a th with an accessible name', async ({ page }) => {
+			const kolTableStateless = page.locator('kol-table-stateless');
+			await kolTableStateless.evaluate((element: HTMLKolTableStatelessElement) => {
+				const currentSelection = element._selection as KoliBriTableSelection;
+				element._selection = {
+					...currentSelection,
+					multiple: false,
+				};
+			});
+			await page.waitForChanges();
+
+			const selectionHeader = kolTableStateless.locator('th.kol-table__cell--selection');
+
+			await expect(selectionHeader).toHaveAttribute('scope', 'col');
+			await expect(selectionHeader).toHaveAttribute('aria-label', /.+/);
+		});
 	});
 
 	test('hides internal caption and removes aria-labelledby when external target is found', async ({ page }) => {

--- a/packages/components/src/locales/de.ts
+++ b/packages/components/src/locales/de.ts
@@ -36,6 +36,7 @@ export default {
 	'error-list-message': 'Bitte korrigieren Sie folgende Fehler:',
 	version: 'Versionsnummer',
 	'table-visible-range': 'Einträge {{start}} bis {{end}} von {{total}}',
+	'table-selection': 'Auswahl',
 	'table-selection-all': 'Alle auswählen',
 	'table-selection-none': 'Alle abwählen',
 	'table-selection-indeterminate': 'Alle auswählen bei teilweiser Auswahl',

--- a/packages/components/src/locales/en.ts
+++ b/packages/components/src/locales/en.ts
@@ -36,6 +36,7 @@ export default {
 	'error-list-message': 'Please correct the following errors',
 	version: 'Version number',
 	'table-visible-range': 'Entries {{start}} to {{end}} of {{total}}',
+	'table-selection': 'Selection',
 	'table-selection-all': 'Select all',
 	'table-selection-none': 'Deselect all',
 	'table-selection-indeterminate': 'Select all with partial selection',


### PR DESCRIPTION
Closes #10414

## Problem

The row-selection column header in `kol-table-stateless` (also used by `kol-table-stateful`) had no accessible name, failing WCAG 1.3.1 / 4.1.2:

- **single-select** — rendered an **empty `<td>`** (no `<th>`, no name).
- **multi-select** — rendered a `<th>` **without `scope` and without its own accessible name** (only the inner "select all" checkbox was labelled; the column header itself was anonymous).

Every other header cell already renders `<th scope=…>`, so the selection header was the only one missing both.

## Change

In `renderHeadingSelectionCell()` (`packages/components/src/components/table-stateless/component.tsx`):

- single-select branch: the empty `<td>` becomes `<th scope="col" aria-label={translate('kol-table-selection')}>`.
- multi-select branch: the existing `<th>` gains `scope="col"` and `aria-label={translate('kol-table-selection')}`. The inner checkbox keeps its own `aria-label` (it names the *action*; the `<th>` names the *column*).

A new locale key `table-selection` is added to `de.ts` (`Auswahl`) and `en.ts` (`Selection`). An empty `<th>` is valid as long as it carries an accessible name — this matches the issue's "Ziel" and answers its open question.

No API changes, no breaking changes, no refactoring outside the affected area.

## Tests

Added two e2e tests in `table-stateless.e2e.ts` asserting that both the single- and multi-select selection headers render as a `<th scope="col">` with a non-empty accessible name. The single-select test would be **red without this fix** (the cell was previously a `<td>`).

## Manually testable example

Existing sample-app examples cover both modes (inspect the selection column header in the DOM):
- `table/stateless-with-selection` — multi-select
- `table/stateless-with-single-selection` — single-select

## Notes

- ⚠️ Checks übersprungen (kein `node_modules`, MCP-Umgebung) — manueller Diff-Review durchgeführt. The new key is type-checked against `TranslationKey` (`kol-` + `table-selection` ∈ `keyof locale_de`); existing jest snapshots do not exercise `_selection` and are unaffected.

This PR addresses a community-reported issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AarQfTpBo54qTPj3w8eCj5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AarQfTpBo54qTPj3w8eCj5)_