### PR TITLE
fix: add accessible name to table selection column header (#10414)

### DIFF
--- a/packages/components/src/components/table-stateless/component.tsx
+++ b/packages/components/src/components/table-stateless/component.tsx
@@ -1029,7 +1029,11 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 		}
 
 		if (selection.multiple === false) {
-			return <td key={`thead-0-selection`} class="kol-table__cell kol-table__cell--header kol-table__cell--selection"></td>;
+			return (
+				<th scope="col" key={`thead-0-selection`} class="kol-table__cell kol-table__cell--header kol-table__cell--selection">
+					<span class="visually-hidden">{translate('kol-table-selection')}</span>
+				</th>
+			);
 		}
 
 		const selectedKeyLength = this.getSelectedKeysWithoutDisabledKeys()?.length ?? 0;
@@ -1045,7 +1049,8 @@ export class KolTableStatelessWc implements TableStatelessAPI {
 		}
 		const label = translate(translationKey);
 		return (
-			<th key={`thead-0-selection`} class="kol-table__cell kol-table__cell--header kol-table__cell--selection">
+			<th scope="col" key={`thead-0-selection`} class="kol-table__cell kol-table__cell--header kol-table__cell--selection">
+				<span class="visually-hidden">{translate('kol-table-selection')}</span>
 				<div
 					class={clsx('kol-table__selection', {
 						'kol-table__selection--indeterminate': indeterminate,

--- a/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap
@@ -126,6 +126,82 @@ exports[`kol-table-stateless-wc should render with _label="Table with merged par
 </kol-table-stateless-wc>
 `;
 
+exports[`kol-table-stateless-wc should render with _label="Table with multiple selection renders selection header with accessible name" _selection={"selectedKeys":[],"keyPropertyName":"id"} _headerCells={"horizontal":[[{"key":"header1","label":"Header 1","width":180}]],"vertical":[]} _data=[{"id":"1","header1":"Cell 1.1"}] 1`] = `
+<kol-table-stateless-wc>
+  <div class="kol-table">
+    <div class="kol-table__scroll-container">
+      <table aria-labelledby="caption" class="kol-table__table" style="min-width: 180px;">
+        <caption class="kol-table__caption kol-table__focus-element" id="caption">
+          Table with multiple selection renders selection header with accessible name
+        </caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <th class="kol-table__cell kol-table__cell--header kol-table__cell--selection" scope="col">
+              <span class="visually-hidden">
+                kol-table-selection
+              </span>
+              <div class="kol-table__selection">
+                <label class="kol-table__selection-label">
+                  <i aria-hidden="true" class="kol-icon kol-icon__icon kol-table__selection-icon kolicon" role="presentation"></i>
+                  <input aria-label="kol-table-selection-all" class="kol-table__selection-input kol-table__selection-input--checkbox" data-testid="selection-checkbox-all" name="selection" type="checkbox">
+                </label>
+                <div class="kol-table__selection-input-tooltip">
+                  <div class="kol-tooltip__floating">
+                    <div class="kol-tooltip__arrow"></div>
+                    <span class="kol-span kol-tooltip__content" id="kol-table-selection-all-label">
+                      <span class="kol-span__container">
+                        <span class="kol-span__label">
+                          kol-table-selection-all
+                        </span>
+                        <span aria-hidden="true" class="kol-span__slot" hidden=""></span>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" scope="col" style="width: 180px;">
+              Header 1
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="2"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <td class="kol-table__cell kol-table__cell--selection">
+              <div class="kol-table__selection">
+                <label class="kol-table__selection-label">
+                  <i aria-hidden="true" class="kol-icon kol-icon__icon kol-table__selection-icon kolicon" role="presentation"></i>
+                  <input aria-label="Selection" class="kol-table__selection-input kol-table__selection-input--checkbox" id="1" name="selection" type="checkbox">
+                </label>
+                <div class="kol-table__selection-input-tooltip">
+                  <div class="kol-tooltip__floating">
+                    <div class="kol-tooltip__arrow"></div>
+                    <span class="kol-span kol-tooltip__content" id="1-label">
+                      <span class="kol-span__container">
+                        <span class="kol-span__label">
+                          Selection
+                        </span>
+                        <span aria-hidden="true" class="kol-span__slot" hidden=""></span>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="kol-table__cell kol-table__cell--body">
+              Cell 1.1
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;
+
 exports[`kol-table-stateless-wc should render with _label="Table with only horizontal headers" _headerCells={"horizontal":[[{"key":"header1","label":"Header 1","textAlign":"left","width":150},{"key":"header2","label":"Header 2","textAlign":"center","width":180}]],"vertical":[]} _data=[{"header1":"Cell 1.1","header2":"Cell 1.2"},{"header1":"Cell 2.1","header2":"Cell 2.2"}] 1`] = `
 <kol-table-stateless-wc>
   <div class="kol-table">
@@ -162,6 +238,62 @@ exports[`kol-table-stateless-wc should render with _label="Table with only horiz
             </td>
             <td class="kol-table__cell kol-table__cell--align-center kol-table__cell--body" style="text-align: center;">
               Cell 2.2
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</kol-table-stateless-wc>
+`;
+
+exports[`kol-table-stateless-wc should render with _label="Table with single selection renders selection header with accessible name" _selection={"multiple":false,"selectedKeys":[],"keyPropertyName":"id"} _headerCells={"horizontal":[[{"key":"header1","label":"Header 1","width":180}]],"vertical":[]} _data=[{"id":"1","header1":"Cell 1.1"}] 1`] = `
+<kol-table-stateless-wc>
+  <div class="kol-table">
+    <div class="kol-table__scroll-container">
+      <table aria-labelledby="caption" class="kol-table__table" style="min-width: 180px;">
+        <caption class="kol-table__caption kol-table__focus-element" id="caption">
+          Table with single selection renders selection header with accessible name
+        </caption>
+        <thead class="kol-table__head">
+          <tr class="kol-table__head-row">
+            <th class="kol-table__cell kol-table__cell--header kol-table__cell--selection" scope="col">
+              <span class="visually-hidden">
+                kol-table-selection
+              </span>
+            </th>
+            <th aria-sort="none" class="kol-table__cell kol-table__cell--header kol-table__cell--none" scope="col" style="width: 180px;">
+              Header 1
+            </th>
+          </tr>
+          <tr aria-hidden="true" class="kol-table__spacer kol-table__spacer--head">
+            <td class="kol-table__spacer-line kol-table__spacer-line--head" colspan="2"></td>
+          </tr>
+        </thead>
+        <tbody class="kol-table__body">
+          <tr class="kol-table__row kol-table__row--body">
+            <td class="kol-table__cell kol-table__cell--selection">
+              <div class="kol-table__selection">
+                <label class="kol-table__selection-label">
+                  <input aria-label="Selection" class="kol-table__selection-input kol-table__selection-input--radio" id="1" name="selection" type="radio">
+                </label>
+                <div class="kol-table__selection-input-tooltip">
+                  <div class="kol-tooltip__floating">
+                    <div class="kol-tooltip__arrow"></div>
+                    <span class="kol-span kol-tooltip__content" id="1-label">
+                      <span class="kol-span__container">
+                        <span class="kol-span__label">
+                          Selection
+                        </span>
+                        <span aria-hidden="true" class="kol-span__slot" hidden=""></span>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="kol-table__cell kol-table__cell--body">
+              Cell 1.1
             </td>
           </tr>
         </tbody>

--- a/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
+++ b/packages/components/src/components/table-stateless/test/snapshot.spec.tsx
@@ -143,5 +143,32 @@ executeSnapshotTests<TableStatelessProps>(
 			},
 			_data: [],
 		},
+		{
+			_label: 'Table with single selection renders selection header with accessible name',
+			_selection: {
+				label: () => 'Selection',
+				multiple: false,
+				selectedKeys: [],
+				keyPropertyName: 'id',
+			},
+			_headerCells: {
+				horizontal: [[{ key: 'header1', label: 'Header 1', width: 180 }]],
+				vertical: [],
+			},
+			_data: [{ id: '1', header1: 'Cell 1.1' }],
+		},
+		{
+			_label: 'Table with multiple selection renders selection header with accessible name',
+			_selection: {
+				label: () => 'Selection',
+				selectedKeys: [],
+				keyPropertyName: 'id',
+			},
+			_headerCells: {
+				horizontal: [[{ key: 'header1', label: 'Header 1', width: 180 }]],
+				vertical: [],
+			},
+			_data: [{ id: '1', header1: 'Cell 1.1' }],
+		},
 	],
 );

--- a/packages/components/src/locales/de.ts
+++ b/packages/components/src/locales/de.ts
@@ -36,6 +36,7 @@ export default {
 	'error-list-message': 'Bitte korrigieren Sie folgende Fehler:',
 	version: 'Versionsnummer',
 	'table-visible-range': 'Einträge {{start}} bis {{end}} von {{total}}',
+	'table-selection': 'Auswahl',
 	'table-selection-all': 'Alle auswählen',
 	'table-selection-none': 'Alle abwählen',
 	'table-selection-indeterminate': 'Alle auswählen bei teilweiser Auswahl',

--- a/packages/components/src/locales/en.ts
+++ b/packages/components/src/locales/en.ts
@@ -36,6 +36,7 @@ export default {
 	'error-list-message': 'Please correct the following errors',
 	version: 'Version number',
 	'table-visible-range': 'Entries {{start}} to {{end}} of {{total}}',
+	'table-selection': 'Selection',
 	'table-selection-all': 'Select all',
 	'table-selection-none': 'Deselect all',
 	'table-selection-indeterminate': 'Select all with partial selection',


### PR DESCRIPTION
## What changed?

This adds a programmatic accessible name to the selection column header of `kol-table-stateless` (consumed by `kol-table-stateful`), which previously exposed none. In `renderHeadingSelectionCell()` (`table-stateless/component.tsx`) the single-select case no longer renders an empty `<td>` but a `<th scope="col">` containing a `visually-hidden` `<span>` with the translated column name; the multi-select case keeps its `<th>` but now gains `scope="col"` and the same `visually-hidden` name alongside the "select all" checkbox's own `aria-label`. An `aria-label` on the `<th>` was intentionally avoided because NVDA ignores it (the repo already standardises on a visually-hidden text node for this, cf. `AlertIcon.tsx`). A new locale key `table-selection` is added (`de` → "Auswahl", `en` → "Selection"). Two snapshot cases covering the single- and multi-select selection headers were added. No public API or breaking changes.

## Linked issues

- Closes #10414 — Table selection column header has no accessible name (empty `<td>` / `<th>` without `scope` or name)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ergänzt einen programmatischen zugänglichen Namen für die Auswahl-Spaltenüberschrift von `kol-table-stateless` (genutzt von `kol-table-stateful`), die bisher keinen hatte. In `renderHeadingSelectionCell()` (`table-stateless/component.tsx`) rendert der Single-Select-Fall statt eines leeren `<td>` nun ein `<th scope="col">` mit einem `visually-hidden`-`<span>` und dem übersetzten Spaltennamen; der Multi-Select-Fall behält sein `<th>`, erhält aber `scope="col"` sowie denselben `visually-hidden`-Namen zusätzlich zum `aria-label` der „Alle auswählen“-Checkbox. Ein `aria-label` am `<th>` wurde bewusst vermieden, da NVDA es ignoriert (das Repo verwendet hierfür standardmäßig einen visually-hidden-Textknoten, vgl. `AlertIcon.tsx`). Ein neuer Locale-Schlüssel `table-selection` wird ergänzt (`de` → „Auswahl“, `en` → „Selection“). Zwei Snapshot-Fälle für die Single- und Multi-Select-Auswahlüberschrift wurden hinzugefügt. Keine Änderung an der öffentlichen API, keine Breaking Changes.

### Verknüpfte Tickets

- Schließt #10414 — Auswahl-Spaltenüberschrift der Tabelle hat keinen zugänglichen Namen (leeres `<td>` / `<th>` ohne `scope` oder Namen)

### Art der Änderung

🐛 Fehlerbehebung (Barrierefreiheit)

### Geänderte Dateien

- `packages/components/src/components/table-stateless/component.tsx` — Auswahl-Header rendert nun `<th scope="col">` mit `visually-hidden`-Namen (Single- und Multi-Select).
- `packages/components/src/components/table-stateless/test/snapshot.spec.tsx` — zwei Snapshot-Fälle für den zugänglichen Namen der Auswahlüberschrift ergänzt.
- `packages/components/src/components/table-stateless/test/__snapshots__/snapshot.spec.tsx.snap` — zugehörige Snapshots geschrieben.
- `packages/components/src/locales/de.ts` — Locale-Schlüssel `table-selection` = „Auswahl“ ergänzt.
- `packages/components/src/locales/en.ts` — Locale-Schlüssel `table-selection` = „Selection“ ergänzt.

</details>