### PR TITLE
ci: run workflows identically for draft and ready PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI-Pipeline
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened, synchronize]
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/.github/workflows/visual-tests-base.yml
+++ b/.github/workflows/visual-tests-base.yml
@@ -2,7 +2,7 @@ name: Visual Tests Snapshot Comparison
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened, synchronize]
+    types: [opened, reopened, synchronize]
     paths:
       - 'packages/components/**'
       - 'packages/themes/**'
@@ -22,7 +22,6 @@ permissions:
 
 jobs:
   visual-tests-snapshots:
-    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         package: ['test-tag-name-transformer', 'theme-default', 'theme-bwst', 'theme-ecl', 'theme-desy', 'theme-kern']


### PR DESCRIPTION
## Was

Es soll keinen Unterschied mehr zwischen **Draft-PRs** und **„Ready for review"-PRs** geben — alle Workflows sollen für beide gleich laufen.

## Änderungen

- **`ci.yml`**: `ready_for_review` aus dem `types`-Filter entfernt → `types: [opened, reopened, synchronize]`
- **`visual-tests-base.yml`**:
  - `ready_for_review` aus dem `types`-Filter entfernt
  - die Job-Bedingung `if: github.event.pull_request.draft == false` entfernt

## Warum auch der Draft-Check?

In `visual-tests-base.yml` blockte `draft == false` Draft-PRs aktiv ab. Hätte man **nur** `ready_for_review` entfernt, wären die Visual-Tests bei Drafts gar nicht und beim Wechsel auf „Ready" erst beim nächsten Push gelaufen — also genau der Unterschied, der hier wegfallen soll. Deshalb fällt der Draft-Check mit weg.

In `ci.yml` existiert kein Draft-Check; dort genügt das Entfernen von `ready_for_review`.

Andere Workflows (z. B. `draft-deploy.yml`) triggern bereits ohne `ready_for_review`/Draft-Check und waren nicht betroffen. `draft: true` in `license-report.yml`, `cve-overview.yml` und `auto-dependency-updater.yml` bezieht sich auf das Erstellen von Draft-PRs (create-pull-request-Action) und ist nicht relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAnV42voJ8jSB4Jkg9oLp7)_