### PR TITLE
fix: lock background scroll while modal dialog, modal or drawer is open

### DIFF
--- a/packages/components/src/components/dialog/component.tsx
+++ b/packages/components/src/components/dialog/component.tsx
@@ -8,6 +8,7 @@ import { validateModalVariant } from '../../schema/props/variant/modal';
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
+import { lockScroll, unlockScroll } from '../../utils/scroll-lock';
 import { handleCancelOverlay } from '../../utils/tooltip-open-tracking';
 import { watchHeadingLevel } from '../heading/validation';
 
@@ -32,6 +33,7 @@ export class KolDialogWc implements DialogAPI {
 
 	public disconnectedCallback(): void {
 		void this.close();
+		unlockScroll(this);
 	}
 
 	private handleCancelEvent = (event: Event): void => {
@@ -52,6 +54,7 @@ export class KolDialogWc implements DialogAPI {
 		if (event.target !== this.refDialog) {
 			return;
 		}
+		unlockScroll(this);
 		if (typeof this.state._on?.onClose === 'function') {
 			this.state._on.onClose();
 		}
@@ -72,6 +75,9 @@ export class KolDialogWc implements DialogAPI {
 		this.isModal = modal;
 		if (modal) {
 			this.refDialog?.showModal?.();
+			if (this.refDialog) {
+				lockScroll(this);
+			}
 		} else {
 			this.refDialog?.show?.();
 		}

--- a/packages/components/src/components/dialog/dialog.e2e.ts
+++ b/packages/components/src/components/dialog/dialog.e2e.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
 
@@ -121,6 +122,60 @@ dialogTags.forEach((tag) => {
 				await page.keyboard.press('Escape');
 
 				await expect(eventPromise).resolves.toBeUndefined();
+			});
+		});
+
+		test.describe('scroll lock', () => {
+			const getDocumentOverflow = (page: Page) => page.evaluate(() => getComputedStyle(document.documentElement).overflow);
+
+			test('it locks the background scroll while open and unlocks it after closing', async ({ page }) => {
+				await page.setContent(`<div style="height: 200vh;"><${tag} _label="">Modal content</${tag}></div>`);
+				const dialogElement = page.locator(tag);
+
+				await dialogElement.evaluate((element) => (element as HTMLKolDialogElement).openModal());
+				await expect.poll(() => getDocumentOverflow(page)).toBe('hidden');
+
+				await dialogElement.evaluate((element) => (element as HTMLKolDialogElement).closeModal());
+				await expect.poll(() => getDocumentOverflow(page)).toBe('visible');
+			});
+
+			test('it unlocks the background scroll when the dialog closes natively', async ({ page }) => {
+				await page.setContent(`<div style="height: 200vh;"><${tag} _label="">Modal content</${tag}></div>`);
+				const dialogElement = page.locator(tag);
+
+				await dialogElement.evaluate((element) => (element as HTMLKolDialogElement).openModal());
+				await expect.poll(() => getDocumentOverflow(page)).toBe('hidden');
+
+				await page.keyboard.press('Escape');
+				await expect.poll(() => getDocumentOverflow(page)).toBe('visible');
+			});
+
+			test('it does not lock the background scroll when opened non-modally', async ({ page }) => {
+				await page.setContent(`<div style="height: 200vh;"><${tag} _label="">Modal content</${tag}></div>`);
+				const dialogElement = page.locator(tag);
+
+				await dialogElement.evaluate((element) => (element as HTMLKolDialogElement).show());
+				await expect(page.locator('dialog')).toBeVisible();
+				expect(await getDocumentOverflow(page)).toBe('visible');
+			});
+
+			test('it keeps the lock until the last of two stacked dialogs closes', async ({ page }) => {
+				await page.setContent(
+					`<div style="height: 200vh;"><${tag} id="outer" _label="">Outer content</${tag}><${tag} id="inner" _label="">Inner content</${tag}></div>`,
+				);
+				const outer = page.locator('#outer');
+				const inner = page.locator('#inner');
+
+				await outer.evaluate((element) => (element as HTMLKolDialogElement).openModal());
+				await inner.evaluate((element) => (element as HTMLKolDialogElement).openModal());
+				await expect.poll(() => getDocumentOverflow(page)).toBe('hidden');
+
+				await inner.evaluate((element) => (element as HTMLKolDialogElement).closeModal());
+				await expect(page.locator('#inner dialog')).toBeHidden();
+				expect(await getDocumentOverflow(page)).toBe('hidden');
+
+				await outer.evaluate((element) => (element as HTMLKolDialogElement).closeModal());
+				await expect.poll(() => getDocumentOverflow(page)).toBe('visible');
 			});
 		});
 

--- a/packages/components/src/components/dialog/style.scss
+++ b/packages/components/src/components/dialog/style.scss
@@ -11,6 +11,8 @@
 		min-height: var(--a11y-min-size);
 		padding: 0;
 		border: 0;
+		/* Prevent scroll chaining from scrollable dialog content to the page. */
+		overscroll-behavior: contain;
 	}
 
 	.kol-dialog__close-button,

--- a/packages/components/src/components/dialog/test/scroll-lock.spec.tsx
+++ b/packages/components/src/components/dialog/test/scroll-lock.spec.tsx
@@ -1,0 +1,67 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { KolCardWc } from '../../card/component';
+import { KolDialogWc } from '../component';
+
+describe('kol-dialog-wc scroll lock', () => {
+	const getOverflow = () => document.documentElement.style.getPropertyValue('overflow');
+	let currentComponent: KolDialogWc | undefined;
+
+	const setUpPage = async () => {
+		const page = await newSpecPage({
+			components: [KolDialogWc, KolCardWc],
+			template: () => <kol-dialog-wc _label="Test" _variant="blank" />,
+		});
+		await page.waitForChanges();
+		const component = page.rootInstance as KolDialogWc;
+		currentComponent = component;
+		const dialog = page.root?.querySelector('dialog');
+		expect(dialog).not.toBeNull();
+		return { component, dialog: dialog! };
+	};
+
+	afterEach(() => {
+		// Release a possibly remaining lock so the module-level registry is empty for the next test.
+		currentComponent?.disconnectedCallback();
+		currentComponent = undefined;
+		document.documentElement.style.removeProperty('overflow');
+		document.documentElement.style.removeProperty('padding-right');
+	});
+
+	it('locks the document scroll when shown modally', async () => {
+		const { component } = await setUpPage();
+
+		await component.show(true);
+
+		expect(getOverflow()).toBe('hidden');
+	});
+
+	it('does not lock the document scroll when shown non-modally', async () => {
+		const { component } = await setUpPage();
+
+		await component.show(false);
+
+		expect(getOverflow()).toBe('');
+	});
+
+	it('unlocks the document scroll when the native dialog fires a close event', async () => {
+		const { component, dialog } = await setUpPage();
+
+		await component.show(true);
+		expect(getOverflow()).toBe('hidden');
+
+		dialog.dispatchEvent(new Event('close', { bubbles: false }));
+		expect(getOverflow()).toBe('');
+	});
+
+	it('unlocks the document scroll when the component is disconnected while open', async () => {
+		const { component } = await setUpPage();
+
+		await component.show(true);
+		expect(getOverflow()).toBe('hidden');
+
+		component.disconnectedCallback();
+		expect(getOverflow()).toBe('');
+	});
+});

--- a/packages/components/src/components/drawer/drawer.e2e.ts
+++ b/packages/components/src/components/drawer/drawer.e2e.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
 
@@ -84,6 +85,31 @@ test.describe('kol-drawer', () => {
 				element._open = false;
 			});
 			await expect(page.getByTestId('drawer-content')).not.toBeVisible();
+		});
+	});
+
+	test.describe('scroll lock', () => {
+		const getDocumentOverflow = (page: Page) => page.evaluate(() => getComputedStyle(document.documentElement).overflow);
+
+		test('it locks the background scroll while open and unlocks it after closing', async ({ page }) => {
+			await page.setContent('<div style="height: 200vh;"><kol-drawer _label="Details" _open>Drawer content</kol-drawer></div>');
+			await page.waitForChanges();
+			await expect.poll(() => getDocumentOverflow(page)).toBe('hidden');
+
+			await page.keyboard.press('Escape');
+			// The scroll lock is released after the slide-out animation, when the native dialog closes.
+			await expect.poll(() => getDocumentOverflow(page)).toBe('visible');
+		});
+
+		test('it does not lock the background scroll when opened non-modally', async ({ page }) => {
+			await page.setContent(
+				'<div style="height: 200vh;"><kol-drawer _label="Details"><div data-testid="drawer-content">Drawer content</div></kol-drawer></div>',
+			);
+			const kolDrawer = page.locator('kol-drawer');
+
+			await kolDrawer.evaluate((element: HTMLKolDrawerElement) => element.show());
+			await expect(page.getByTestId('drawer-content')).toBeVisible();
+			expect(await getDocumentOverflow(page)).toBe('visible');
 		});
 	});
 

--- a/packages/components/src/components/drawer/shadow.tsx
+++ b/packages/components/src/components/drawer/shadow.tsx
@@ -15,6 +15,7 @@ import { setState, validateAlign, validateHasCloser, validateLabel, validateOpen
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
 import { dispatchDomEvent, KolEvent } from '../../utils/events';
+import { lockScroll, unlockScroll } from '../../utils/scroll-lock';
 import { handleCancelOverlay } from '../../utils/tooltip-open-tracking';
 import { watchHeadingLevel } from '../heading/validation';
 
@@ -52,6 +53,9 @@ export class KolDrawer implements DrawerAPI {
 		};
 		if (modal) {
 			this.dialogElement?.showModal?.();
+			if (this.dialogElement) {
+				lockScroll(this);
+			}
 		} else {
 			this.dialogElement?.show?.();
 		}
@@ -262,6 +266,7 @@ export class KolDrawer implements DrawerAPI {
 	}
 
 	private readonly handleClose = () => {
+		unlockScroll(this);
 		void (async () => {
 			await this.close();
 			this.handleCloseDialog();
@@ -283,6 +288,7 @@ export class KolDrawer implements DrawerAPI {
 	public disconnectedCallback(): void {
 		this.dialogElement?.removeEventListener('animationend', this.handleAnimationEnd);
 		this.dialogElement?.removeEventListener('close', this.handleClose);
+		unlockScroll(this);
 	}
 
 	public componentWillLoad() {

--- a/packages/components/src/components/drawer/style.scss
+++ b/packages/components/src/components/drawer/style.scss
@@ -12,11 +12,14 @@
 		&__dialog {
 			padding: 0;
 			border: none;
+			/* Prevent scroll chaining from scrollable drawer content to the page. */
+			overscroll-behavior: contain;
 		}
 
 		&__wrapper {
 			position: fixed;
 			overflow: auto;
+			overscroll-behavior: contain;
 
 			&--left,
 			&--right {
@@ -64,5 +67,6 @@
 
 	.kol-drawer__dialog .kol-card__content {
 		overflow-y: auto;
+		overscroll-behavior: contain;
 	}
 }

--- a/packages/components/src/components/drawer/test/methods.spec.ts
+++ b/packages/components/src/components/drawer/test/methods.spec.ts
@@ -17,3 +17,64 @@ describe('kol-drawer methods', () => {
 		await expect(drawer.close()).resolves.toBeUndefined();
 	});
 });
+
+describe('kol-drawer scroll lock', () => {
+	const getOverflow = () => document.documentElement.style.getPropertyValue('overflow');
+
+	let currentDrawer: KolDrawer | undefined;
+
+	const setUpDrawer = () => {
+		const drawer = new KolDrawer();
+		(drawer as unknown as { dialogElement: object }).dialogElement = {
+			addEventListener: jest.fn(),
+			removeEventListener: jest.fn(),
+		};
+		currentDrawer = drawer;
+		return drawer;
+	};
+
+	afterEach(() => {
+		// Release a possibly remaining lock so the module-level registry is empty for the next test.
+		currentDrawer?.disconnectedCallback();
+		currentDrawer = undefined;
+		document.documentElement.style.removeProperty('overflow');
+		document.documentElement.style.removeProperty('padding-right');
+	});
+
+	it('locks the document scroll when shown modally', async () => {
+		const drawer = setUpDrawer();
+
+		await drawer.show(true);
+
+		expect(getOverflow()).toBe('hidden');
+	});
+
+	it('does not lock the document scroll when shown non-modally', async () => {
+		const drawer = setUpDrawer();
+
+		await drawer.show(false);
+
+		expect(getOverflow()).toBe('');
+	});
+
+	it('unlocks the document scroll when the native dialog closes', async () => {
+		const drawer = setUpDrawer();
+		jest.spyOn(window, 'getComputedStyle').mockReturnValue({ animationName: 'none' } as CSSStyleDeclaration);
+
+		await drawer.show(true);
+		expect(getOverflow()).toBe('hidden');
+
+		(drawer as unknown as { handleClose: () => void }).handleClose();
+		expect(getOverflow()).toBe('');
+	});
+
+	it('unlocks the document scroll when the component is disconnected while open', async () => {
+		const drawer = setUpDrawer();
+
+		await drawer.show(true);
+		expect(getOverflow()).toBe('hidden');
+
+		drawer.disconnectedCallback();
+		expect(getOverflow()).toBe('');
+	});
+});

--- a/packages/components/src/components/drawer/test/methods.spec.ts
+++ b/packages/components/src/components/drawer/test/methods.spec.ts
@@ -1,5 +1,9 @@
 import { KolDrawer } from '../shadow';
 
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
 describe('kol-drawer methods', () => {
 	it('does not throw in open when dialog showModal is unavailable', async () => {
 		const drawer = new KolDrawer();

--- a/packages/components/src/utils/scroll-lock.ts
+++ b/packages/components/src/utils/scroll-lock.ts
@@ -1,0 +1,78 @@
+/**
+ * This file contains the functions used to lock the background scroll while
+ * a modal overlay (dialog, modal, drawer) is open. The native `showModal()`
+ * makes the background inert, but does not prevent the document from scrolling.
+ */
+
+/**
+ * This set contains all owners (component instances) currently holding the lock.
+ * The scroll lock is released once the last owner unlocks.
+ */
+const SCROLL_LOCK_OWNERS: Set<unknown> = new Set();
+
+let previousOverflow: string | null = null;
+let previousPaddingRight: string | null = null;
+
+/**
+ * Locks the document scroll for the given owner. The first lock stores the
+ * current inline styles and hides the viewport scrollbar; the removed
+ * scrollbar width is compensated with padding to avoid a layout shift.
+ *
+ * @param owner The component instance requesting the lock
+ */
+export function lockScroll(owner: unknown): void {
+	if (typeof document === 'undefined' || typeof window === 'undefined') {
+		return;
+	}
+	if (SCROLL_LOCK_OWNERS.has(owner)) {
+		return;
+	}
+
+	if (SCROLL_LOCK_OWNERS.size === 0) {
+		const docEl = document.documentElement;
+		previousOverflow = docEl.style.getPropertyValue('overflow');
+		previousPaddingRight = docEl.style.getPropertyValue('padding-right');
+
+		// Measure before hiding the scrollbar; overlay scrollbars yield 0.
+		const scrollbarWidth = window.innerWidth - docEl.clientWidth;
+		if (scrollbarWidth > 0) {
+			const currentPaddingRight = Number.parseFloat(window.getComputedStyle(docEl).paddingRight) || 0;
+			docEl.style.setProperty('padding-right', `${currentPaddingRight + scrollbarWidth}px`);
+		}
+		docEl.style.setProperty('overflow', 'hidden');
+	}
+
+	SCROLL_LOCK_OWNERS.add(owner);
+}
+
+/**
+ * Releases the scroll lock for the given owner. Calling it for an owner that
+ * does not hold a lock is a no-op, so unlocking is idempotent per owner. The
+ * previous inline styles are restored once the last owner unlocks.
+ *
+ * @param owner The component instance releasing the lock
+ */
+export function unlockScroll(owner: unknown): void {
+	if (typeof document === 'undefined' || typeof window === 'undefined') {
+		return;
+	}
+	if (!SCROLL_LOCK_OWNERS.delete(owner)) {
+		return;
+	}
+
+	if (SCROLL_LOCK_OWNERS.size === 0) {
+		const docEl = document.documentElement;
+		if (previousOverflow) {
+			docEl.style.setProperty('overflow', previousOverflow);
+		} else {
+			docEl.style.removeProperty('overflow');
+		}
+		if (previousPaddingRight) {
+			docEl.style.setProperty('padding-right', previousPaddingRight);
+		} else {
+			docEl.style.removeProperty('padding-right');
+		}
+		previousOverflow = null;
+		previousPaddingRight = null;
+	}
+}

--- a/packages/components/src/utils/test/scroll-lock.spec.ts
+++ b/packages/components/src/utils/test/scroll-lock.spec.ts
@@ -1,0 +1,89 @@
+import { lockScroll, unlockScroll } from '../scroll-lock';
+
+describe('scroll-lock', () => {
+	const docEl = document.documentElement;
+	const ownerA = {};
+	const ownerB = {};
+
+	const stubClientWidth = (value: number) => {
+		Object.defineProperty(docEl, 'clientWidth', { value, configurable: true });
+	};
+
+	beforeEach(() => {
+		// No visible scrollbar by default, so no padding compensation applies.
+		stubClientWidth(window.innerWidth);
+	});
+
+	afterEach(() => {
+		unlockScroll(ownerA);
+		unlockScroll(ownerB);
+		docEl.style.removeProperty('overflow');
+		docEl.style.removeProperty('padding-right');
+	});
+
+	it('hides the document overflow on the first lock', () => {
+		lockScroll(ownerA);
+
+		expect(docEl.style.getPropertyValue('overflow')).toBe('hidden');
+	});
+
+	it('keeps the lock until the last owner unlocks', () => {
+		lockScroll(ownerA);
+		lockScroll(ownerB);
+
+		unlockScroll(ownerA);
+		expect(docEl.style.getPropertyValue('overflow')).toBe('hidden');
+
+		unlockScroll(ownerB);
+		expect(docEl.style.getPropertyValue('overflow')).toBe('');
+	});
+
+	it('restores previous inline styles after unlocking', () => {
+		docEl.style.setProperty('overflow', 'auto');
+		docEl.style.setProperty('padding-right', '10px');
+
+		lockScroll(ownerA);
+		expect(docEl.style.getPropertyValue('overflow')).toBe('hidden');
+
+		unlockScroll(ownerA);
+		expect(docEl.style.getPropertyValue('overflow')).toBe('auto');
+		expect(docEl.style.getPropertyValue('padding-right')).toBe('10px');
+	});
+
+	it('removes the inline styles when none were set before locking', () => {
+		lockScroll(ownerA);
+		unlockScroll(ownerA);
+
+		expect(docEl.style.getPropertyValue('overflow')).toBe('');
+		expect(docEl.style.getPropertyValue('padding-right')).toBe('');
+	});
+
+	it('ignores repeated locks of the same owner', () => {
+		lockScroll(ownerA);
+		lockScroll(ownerA);
+
+		unlockScroll(ownerA);
+		expect(docEl.style.getPropertyValue('overflow')).toBe('');
+	});
+
+	it('ignores unlocks of unknown owners', () => {
+		lockScroll(ownerA);
+
+		unlockScroll(ownerB);
+		expect(docEl.style.getPropertyValue('overflow')).toBe('hidden');
+
+		unlockScroll(ownerA);
+		unlockScroll(ownerA);
+		expect(docEl.style.getPropertyValue('overflow')).toBe('');
+	});
+
+	it('compensates the scrollbar width with padding while locked', () => {
+		stubClientWidth(window.innerWidth - 15);
+
+		lockScroll(ownerA);
+		expect(docEl.style.getPropertyValue('padding-right')).toBe('15px');
+
+		unlockScroll(ownerA);
+		expect(docEl.style.getPropertyValue('padding-right')).toBe('');
+	});
+});

--- a/packages/components/src/utils/test/scroll-lock.spec.ts
+++ b/packages/components/src/utils/test/scroll-lock.spec.ts
@@ -21,6 +21,11 @@ describe('scroll-lock', () => {
 		docEl.style.removeProperty('padding-right');
 	});
 
+	afterAll(() => {
+		// Remove the stubbed own property so the prototype getter applies again.
+		Reflect.deleteProperty(docEl, 'clientWidth');
+	});
+
 	it('hides the document overflow on the first lock', () => {
 		lockScroll(ownerA);
 

--- a/packages/samples/react/src/components/dialog/routes.ts
+++ b/packages/samples/react/src/components/dialog/routes.ts
@@ -1,10 +1,12 @@
 import type { Routes } from '../../shares/types';
 import { DialogBasic } from './basic';
+import { DialogScrollLock } from './scroll-lock';
 import { DialogWithAlert } from './with-alert';
 
 export const DIALOG_ROUTES: Routes = {
 	dialog: {
 		basic: DialogBasic,
+		'scroll-lock': DialogScrollLock,
 		'with-alert': DialogWithAlert,
 	},
 };

--- a/packages/samples/react/src/components/dialog/scroll-lock.tsx
+++ b/packages/samples/react/src/components/dialog/scroll-lock.tsx
@@ -1,0 +1,46 @@
+import type { FC } from 'react';
+import React, { useRef } from 'react';
+
+import { KolButton, KolDialog, KolDrawer } from '@public-ui/react-v19';
+import { SampleDescription } from '../SampleDescription';
+
+export const DialogScrollLock: FC = () => {
+	const dialogRef = useRef<HTMLKolDialogElement>(null);
+	const drawerRef = useRef<HTMLKolDrawerElement>(null);
+
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					Demonstrates that opening <strong>KolDialog</strong>/<strong>KolModal</strong> or <strong>KolDrawer</strong> modally locks the background scroll: the
+					page behind the overlay must not scroll, neither via mouse wheel/touch over the backdrop nor by dragging the page scrollbar. Non-modal{' '}
+					<code>show()</code> does not lock.
+				</p>
+				<p>
+					<strong>How to test:</strong> scroll this long page down a bit, open the dialog or drawer below, then try to scroll the background (mouse wheel over
+					the dimmed backdrop, or drag the scrollbar) – it should stay put. Close the overlay again and the page should scroll normally, restored to the same
+					position without a layout shift.
+				</p>
+			</SampleDescription>
+
+			<div className="flex flex-wrap gap-4 mb-4">
+				<KolButton _label="Open modal dialog" _on={{ onClick: () => dialogRef.current?.showModal() }} />
+				<KolButton _label="Open modal drawer" _on={{ onClick: () => drawerRef.current?.showModal() }} />
+			</div>
+
+			<KolDialog ref={dialogRef} _label="Scroll lock dialog" _variant="card" _width="30%">
+				<p className="mt-0">While I am open, the background must not scroll.</p>
+				<KolButton _label="Close" _on={{ onClick: () => dialogRef.current?.closeModal() }} />
+			</KolDialog>
+
+			<KolDrawer ref={drawerRef} _label="Scroll lock drawer" _align="right">
+				<p className="mt-0">While I am open, the background must not scroll.</p>
+				<KolButton _label="Close" _on={{ onClick: () => drawerRef.current?.close() }} />
+			</KolDrawer>
+
+			<div style={{ height: '200vh', flexShrink: 0 }} className="border border-dashed border-gray p-4">
+				<p>This tall block simulates a long page. Scroll down, open an overlay above, and try to scroll here.</p>
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
## What changed?

Adds a new reference-counted, owner-keyed scroll-lock utility at `packages/components/src/utils/scroll-lock.ts` and wires it into the modal overlay components. The native `<dialog>.showModal()` makes the background inert but does not stop the document behind the overlay from scrolling, so `kol-dialog-wc` (which powers `kol-dialog` and `kol-modal`) and `kol-drawer` now call `lockScroll` when opened modally and `unlockScroll` on the native `close` event and in `disconnectedCallback`. The utility stores and restores the inline `overflow`/`padding-right` of `document.documentElement`, compensates the removed scrollbar width with padding to avoid layout shift, is SSR-safe, and only releases when the last stacked overlay closes. The SCSS for dialog and drawer additionally sets `overscroll-behavior: contain` to prevent scroll chaining from scrollable overlay content to the page. Non-modal `show()` intentionally does not lock.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Es wird ein neues, referenzgezähltes und ownerbasiertes Scroll-Lock-Utility unter `packages/components/src/utils/scroll-lock.ts` hinzugefügt und in die modalen Overlay-Komponenten eingebunden. Das native `<dialog>.showModal()` macht den Hintergrund zwar inert, verhindert aber nicht, dass das Dokument hinter dem Overlay scrollt. Daher rufen `kol-dialog-wc` (Basis für `kol-dialog` und `kol-modal`) und `kol-drawer` beim modalen Öffnen nun `lockScroll` auf und `unlockScroll` beim nativen `close`-Event sowie in `disconnectedCallback`. Das Utility speichert und stellt die Inline-Werte `overflow`/`padding-right` von `document.documentElement` wieder her, kompensiert die entfernte Scrollbar-Breite per Padding gegen Layout-Sprünge, ist SSR-sicher und gibt den Lock erst frei, wenn das letzte gestapelte Overlay geschlossen wird. Zusätzlich setzt das SCSS für Dialog und Drawer `overscroll-behavior: contain`, um Scroll-Chaining von scrollbarem Overlay-Inhalt auf die Seite zu verhindern. Nicht-modales `show()` sperrt bewusst nicht.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/utils/scroll-lock.ts` — Neues, referenzgezähltes Scroll-Lock-Utility mit Scrollbar-Kompensation und Wiederherstellung der Inline-Styles.
- `packages/components/src/utils/test/scroll-lock.spec.ts` — Neue Unit-Tests für Referenzzählung, Style-Wiederherstellung, Idempotenz und Scrollbar-Kompensation.
- `packages/components/src/components/dialog/component.tsx` — `lockScroll` beim modalen Öffnen, `unlockScroll` beim nativen Close und in `disconnectedCallback`.
- `packages/components/src/components/dialog/style.scss` — `overscroll-behavior: contain` zur Verhinderung von Scroll-Chaining.
- `packages/components/src/components/dialog/dialog.e2e.ts` — Erweiterte E2E-Tests für Lock/Unlock, Escape, non-modal und gestapelte Dialoge.
- `packages/components/src/components/dialog/test/scroll-lock.spec.tsx` — Neue Unit-Tests für den Scroll-Lock von `kol-dialog-wc`.
- `packages/components/src/components/drawer/shadow.tsx` — `lockScroll` beim modalen Öffnen, `unlockScroll` beim Schließen und in `disconnectedCallback`.
- `packages/components/src/components/drawer/style.scss` — `overscroll-behavior: contain` für Dialog, Wrapper und Card-Content.
- `packages/components/src/components/drawer/drawer.e2e.ts` — Erweiterte E2E-Tests für Lock/Unlock nach der Slide-out-Animation und non-modal.
- `packages/components/src/components/drawer/test/methods.spec.ts` — Neue Unit-Tests für den Scroll-Lock des Drawers.
- `packages/samples/react/src/components/dialog/scroll-lock.tsx` — Neue Beispielseite, die den Scroll-Lock für Dialog und Drawer demonstriert.
- `packages/samples/react/src/components/dialog/routes.ts` — Registrierung der neuen Scroll-Lock-Beispielroute.

</details>