### PR TITLE
docs(mcp): update README with local MCP server configuration

### DIFF
--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -111,16 +111,19 @@ kolibri-mcp
 
 #### VS Code Copilot (Local)
 
+Open the global configuration via `Strg` + `Shift` + `P` and search for "MCP: Open User Configuration" or define the MCP servers per project at `.vscode/mcp.json`. Add lokal server to the json file:
+
 ```json
 {
 	"servers": {
 		"kolibri": {
 			"command": "kolibri-mcp"
 		}
-	},
-	"inputs": []
+	}
 }
 ```
+
+For general documentation about MCP in VSCode see https://code.visualstudio.com/docs/agent-customization/mcp-servers.
 
 #### Claude Desktop (Local)
 


### PR DESCRIPTION
## What changed?

This change updates `packages/tools/mcp/README.md` in the "VS Code Copilot (Local)" section. It adds instructions explaining how to open the global MCP configuration (via `Strg` + `Shift` + `P` → "MCP: Open User Configuration") or define MCP servers per project at `.vscode/mcp.json`. The example JSON snippet was simplified by removing the now-unnecessary `"inputs": []` entry, and a link to the official VS Code MCP documentation was added. No code or public API is affected — the change is purely documentation for configuring the local Kolibri MCP server.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung aktualisiert `packages/tools/mcp/README.md` im Abschnitt "VS Code Copilot (Local)". Es wird eine Anleitung ergänzt, wie die globale MCP-Konfiguration geöffnet werden kann (über `Strg` + `Shift` + `P` → "MCP: Open User Configuration") oder wie MCP-Server projektbezogen unter `.vscode/mcp.json` definiert werden. Das Beispiel-JSON wurde vereinfacht, indem der nicht mehr benötigte Eintrag `"inputs": []` entfernt wurde, und ein Link zur offiziellen VS-Code-MCP-Dokumentation wurde hinzugefügt. Es ist kein Code und keine öffentliche API betroffen — die Änderung betrifft ausschließlich die Dokumentation zur Konfiguration des lokalen Kolibri-MCP-Servers.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/mcp/README.md` — Anleitung zur lokalen MCP-Server-Konfiguration in VS Code ergänzt, JSON-Beispiel vereinfacht und Link zur offiziellen VS-Code-Dokumentation hinzugefügt.

</details>