### PR TITLE
feat: themes all dev script 

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -47,7 +47,7 @@
 	"scripts": {
 		"build": "rollup -c",
 		"build:deps": "pnpm --filter @public-ui/themes^... --filter @public-ui/theme-ecl --filter @public-ui/theme-desy build",
-		"dev": "rollup -c --watch",
+		"dev:all": "pnpm -r --parallel dev",
 		"format": "prettier --check src",
 		"lint": "pnpm lint:eslint && pnpm lint:tsc",
 		"lint:eslint": "eslint src",


### PR DESCRIPTION
dev entfernt -> nicht mehr funktional
dev:all hinzugefügt -> startet alle themes dev parallel