### PR TITLE
fix(sample-app): replace 'public' with 'assets' in package.json files

### DIFF
--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -47,7 +47,7 @@
 		"stylelint": "17.13.0"
 	},
 	"files": [
-		"public",
+		"assets",
 		"src",
 		"tsconfig.json"
 	],


### PR DESCRIPTION
This pull request updates the list of files included in the package distribution for the React sample project. The most important change is:

Package distribution update:

* [`package.json`](diffhunk://#diff-ed3152191d96cecda1937e0c6ef89f87668cf18d86265a97696ad30cf29dcd45L50-R50): Replaces the `public` directory with the `assets` directory in the `files` array, so that the `assets` folder will be included in the published package instead of `public`.