### PR TITLE
fix(tooltip): remove invisible stuck tooltip in Gecko browsers

### DIFF
--- a/packages/components/src/internal/functional-components/tooltip/controller.ts
+++ b/packages/components/src/internal/functional-components/tooltip/controller.ts
@@ -83,6 +83,17 @@ export class TooltipController extends BaseController<TooltipApi> implements Con
 			tooltipClosed();
 			this.tooltipElement.classList.remove('show');
 			this.tooltipElement.classList.add('hide');
+			this.tooltipElement.addEventListener(
+				'animationend',
+				(): void => {
+					// double-check if tooltip is still hidden at animation's end
+					if (this.tooltipElement?.classList.contains('hide')) {
+						// remove element style property from showTooltip (required in gecko browsers)
+						this.tooltipElement.style.removeProperty('display');
+					}
+				},
+				{ once: true },
+			);
 
 			if (this.cleanupAutoPositioning) {
 				this.cleanupAutoPositioning();


### PR DESCRIPTION
## What changed?

In `packages/components/src/internal/functional-components/tooltip/controller.ts`, the `TooltipController.hideTooltip` logic now attaches a one-time `animationend` listener when a tooltip is hidden. When the hide animation finishes and the tooltip still carries the `hide` class, the listener removes the inline `display` style property that was set programmatically by `showTooltip`. In Gecko/Firefox this leftover inline style was never cleared, so the tooltip element stayed in the layout invisibly and kept an active hover region above the trigger. Removing the property collapses the element correctly, restoring the expected hover behavior. This is a purely internal fix to the tooltip controller with no public API change.

## Linked issues

- Closes #10471 — Icon-only button in Firefox: invisible tooltip stays hoverable above the button, blocking clicks on elements above it.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/internal/functional-components/tooltip/controller.ts` registriert die `hideTooltip`-Logik des `TooltipController` beim Ausblenden eines Tooltips nun einen einmaligen `animationend`-Listener. Sobald die Ausblend-Animation endet und der Tooltip weiterhin die Klasse `hide` trägt, entfernt der Listener die Inline-Stileigenschaft `display`, die zuvor von `showTooltip` programmatisch gesetzt wurde. In Gecko/Firefox wurde dieser verbliebene Inline-Style nie zurückgesetzt, wodurch das Tooltip-Element unsichtbar im Layout verblieb und einen aktiven Hover-Bereich oberhalb des Auslösers behielt. Durch das Entfernen der Eigenschaft klappt das Element korrekt zusammen und das erwartete Hover-Verhalten wird wiederhergestellt. Es handelt sich um eine rein interne Korrektur am Tooltip-Controller ohne Änderung der öffentlichen API.

### Verknüpfte Tickets

- Schließt #10471 — Icon-Only-Button in Firefox: unsichtbarer Tooltip bleibt oberhalb des Buttons hoverbar und blockiert Klicks auf darüberliegende Elemente.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/internal/functional-components/tooltip/controller.ts` — Fügt beim Ausblenden einen einmaligen `animationend`-Listener hinzu, der die von `showTooltip` gesetzte Inline-`display`-Eigenschaft entfernt, sofern der Tooltip noch verborgen ist.

</details>
