### PR TITLE
fix: desy input readonly styles

### DIFF
--- a/packages/themes/desy/src/mixins/kol-input-container.scss
+++ b/packages/themes/desy/src/mixins/kol-input-container.scss
@@ -34,13 +34,13 @@
 			border: 2px solid var(--color-black-70);
 		}
 
-		&:not(&--disabled):hover {
+		&:not(&--disabled, &:has(.kol-input--readonly)):hover {
 			box-shadow: inset 0 0 0 1px var(--border-color);
 		}
 
 		&:has(.kol-input:focus, .kol-select:focus, .kol-textarea:focus, .kol-select:focus-visible) {
 			outline: var(--color-dark-blue-100) solid 2px;
-			border: 1px solid var(--border-color);
+			border-color: var(--border-color);
 			outline-offset: 2px;
 		}
 


### PR DESCRIPTION
## What changed?

Fixes the styling of read-only inputs in the **desy** theme. A small styling change (1 file, +2/−2) corrects how inputs in the `readonly` state are rendered in the desy theme so they display as intended.

## Linked issues

- Closes #10337 — desy input readonly styles (branch `fix/10337-desy-input-readonly`).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt das Styling von schreibgeschützten (readonly) Eingabefeldern im **desy**-Theme. Eine kleine Styling-Änderung (1 Datei, +2/−2) korrigiert die Darstellung von Inputs im `readonly`-Zustand im desy-Theme.

### Verknüpfte Tickets

- Schließt #10337 — desy Input-Readonly-Styles (Branch `fix/10337-desy-input-readonly`).

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/themes/desy/**` — Korrektur des Readonly-Input-Stylings.

</details>
