### PR TITLE
fix: invisible tooltip stuck in gecko

### DIFF
--- a/packages/components/src/internal/functional-components/tooltip/controller.ts
+++ b/packages/components/src/internal/functional-components/tooltip/controller.ts
@@ -83,6 +83,17 @@ export class TooltipController extends BaseController<TooltipApi> implements Con
 			tooltipClosed();
 			this.tooltipElement.classList.remove('show');
 			this.tooltipElement.classList.add('hide');
+			this.tooltipElement.addEventListener(
+				'animationend',
+				(): void => {
+					// double-check if tooltip is still hidden at animation's end
+					if (this.tooltipElement?.classList.contains('hide')) {
+						// remove element style property from showTooltip (required in gecko browsers)
+						this.tooltipElement.style.removeProperty('display');
+					}
+				},
+				{ once: true },
+			);
 
 			if (this.cleanupAutoPositioning) {
 				this.cleanupAutoPositioning();


### PR DESCRIPTION
## What changed?

Fixes an invisible tooltip that could get "stuck" in Gecko/Firefox. In Firefox, a tooltip that had transitioned to invisible could remain present and keep occupying space / intercepting interaction instead of being fully hidden. A small change to the tooltip component (1 file, +11) corrects this Firefox-specific behaviour so the tooltip is properly hidden/cleaned up.

## Linked issues

- Relates to #10483 — earlier tooltip work this fix follows up on.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt einen unsichtbaren Tooltip, der in Gecko/Firefox „hängen bleiben" konnte. In Firefox konnte ein bereits unsichtbar geschalteter Tooltip weiterhin vorhanden sein und Platz einnehmen / Interaktionen abfangen, statt vollständig ausgeblendet zu werden. Eine kleine Anpassung der Tooltip-Komponente (1 Datei, +11) korrigiert dieses Firefox-spezifische Verhalten, sodass der Tooltip korrekt ausgeblendet/aufgeräumt wird.

### Verknüpfte Tickets

- Bezieht sich auf #10483 — vorangegangene Tooltip-Arbeit, an die dieser Fix anschließt.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tooltip/**` — Firefox-spezifischer Fix gegen den hängenden, unsichtbaren Tooltip.

</details>
