### PR TITLE
fix(tooltip): ESC inside a dialog behaves as expected

### DIFF
--- a/packages/components/src/internal/functional-components/tooltip/controller.ts
+++ b/packages/components/src/internal/functional-components/tooltip/controller.ts
@@ -159,7 +159,7 @@ export class TooltipController extends BaseController<TooltipApi> implements Con
 			this.tooltipElement.classList.remove('hide');
 			this.tooltipElement.classList.add('show');
 			this.tooltipElement.style.setProperty('display', 'block');
-			getDocument().addEventListener('keyup', this.hideTooltipByEscape, { once: true });
+			getDocument().addEventListener('keydown', this.hideTooltipByEscape, { once: true });
 
 			const target = this.previousSibling;
 			const tooltipEl = this.tooltipElement;
@@ -182,6 +182,8 @@ export class TooltipController extends BaseController<TooltipApi> implements Con
 
 	private hideTooltipByEscape = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape') {
+			event.stopPropagation();
+			event.preventDefault();
 			this.hideTooltip();
 		}
 	};


### PR DESCRIPTION
## What changed?

Fixes Escape-key handling for the `tooltip` component when it is shown inside a dialog. Previously, pressing <kbd>ESC</kbd> in relation to a tooltip inside a dialog did not behave as expected. A small key-handling change (1 file, +3/−1) makes <kbd>ESC</kbd> behave correctly in the dialog context (dismissing the tooltip without unexpectedly closing the dialog).

## Linked issues

- Closes #10455 — tooltip in dialog / ESC handling (branch `fix/10455-tooltip-in-dialog`).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt die Escape-Tasten-Behandlung der `tooltip`-Komponente innerhalb eines Dialogs. Bisher verhielt sich <kbd>ESC</kbd> im Zusammenhang mit einem Tooltip in einem Dialog nicht wie erwartet. Eine kleine Anpassung der Tastenbehandlung (1 Datei, +3/−1) sorgt dafür, dass <kbd>ESC</kbd> im Dialog-Kontext korrekt reagiert (Tooltip wird geschlossen, ohne den Dialog unerwartet zu schließen).

### Verknüpfte Tickets

- Schließt #10455 — Tooltip im Dialog / ESC-Handling (Branch `fix/10455-tooltip-in-dialog`).

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/tooltip/**` — ESC-Handling im Dialog-Kontext korrigiert.

</details>
