### PR TITLE
fix(single-select): ESC inside a dialog closes the dropdown, not the dialog

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -388,9 +388,11 @@ export class KolCombobox implements ClickableElement, ComboboxAPI, FocusableElem
 				break;
 			case 'Esc':
 			case 'Escape': {
-				this._isOpen = false;
-				event.preventDefault();
-				this.ctaRef.el?.focus();
+				if (this._isOpen) {
+					event.preventDefault();
+					this._isOpen = false;
+					this.ctaRef.el?.focus();
+				}
 				break;
 			}
 			case 'Enter':

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -468,8 +468,11 @@ export class KolSingleSelect implements FocusableElement, SingleSelectAPI {
 				break;
 			case 'Esc':
 			case 'Escape': {
-				this._isOpen = false;
-				handleEvent(false);
+				if (this._isOpen) {
+					event.preventDefault();
+					this._isOpen = false;
+					this.ctaRef.el?.focus();
+				}
 				break;
 			}
 			case ' ':


### PR DESCRIPTION
## What changed?

Fixes Escape-key handling for `single-select` and `combobox` when they are used inside a dialog. Previously, pressing <kbd>ESC</kbd> to dismiss the open single-select/combobox dropdown could also close the surrounding dialog. The key handling was adjusted (2 files, +10/−5) so that <kbd>ESC</kbd> now closes only the open dropdown while leaving the dialog open, which is the expected behaviour.

## Linked issues

- Closes #10454 — ESC in single-select/combobox inside a dialog (branch `fix/10454-dialog-single-select-esc`).

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt die Escape-Tasten-Behandlung für `single-select` und `combobox` innerhalb eines Dialogs. Bisher konnte <kbd>ESC</kbd> zum Schließen des geöffneten Single-Select-/Combobox-Dropdowns auch den umgebenden Dialog schließen. Die Tastenbehandlung wurde angepasst (2 Dateien, +10/−5), sodass <kbd>ESC</kbd> nun nur das offene Dropdown schließt und der Dialog geöffnet bleibt — das erwartete Verhalten.

### Verknüpfte Tickets

- Schließt #10454 — ESC in Single-Select/Combobox innerhalb eines Dialogs (Branch `fix/10454-dialog-single-select-esc`).

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/single-select/**`, `combobox/**` — ESC-Handling im Dialog-Kontext korrigiert.

</details>
