### PR TITLE
feat(a11y): expose font color, background and font family as CSS custom properties

### DIFF
--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -20,9 +20,9 @@
 		 * By initially setting the background color to white and the font color to black,
 		 * the contrast ratio is ensured and explicit adjustment is forced.
 		 */
-		--kol-a11y-text-color: black;
+		--kol-a11y-font-color: black;
 		--kol-a11y-background-color: white;
-		color: var(--kol-a11y-text-color);
+		color: var(--kol-a11y-font-color);
 		background-color: var(--kol-a11y-background-color);
 
 		/*

--- a/packages/components/src/components/a11y.scss
+++ b/packages/components/src/components/a11y.scss
@@ -20,12 +20,16 @@
 		 * By initially setting the background color to white and the font color to black,
 		 * the contrast ratio is ensured and explicit adjustment is forced.
 		 */
-		color: black;
-		background-color: white;
+		--kol-a11y-text-color: black;
+		--kol-a11y-background-color: white;
+		color: var(--kol-a11y-text-color);
+		background-color: var(--kol-a11y-background-color);
+
 		/*
 		 * Verdana is an accessible font that can be used without requiring additional loading time.
 		 */
-		font-family: Verdana;
+		--kol-a11y-font-family: Verdana;
+		font-family: var(--kol-a11y-font-family);
 		/*
 		 * Letter spacing is required for all texts.
 		 */


### PR DESCRIPTION
## What changed?

In `packages/components/src/components/a11y.scss`, the hard-coded defaults of the accessibility layer were turned into overridable CSS custom properties: `--kol-a11y-font-color` (default `black`), `--kol-a11y-background-color` (default `white`) and `--kol-a11y-font-family` (default `Verdana`), each now consumed via `var()`. The rendered result is unchanged by default — the same contrast-safe black/white/Verdana values apply — but consumers and themes can now override the a11y layer's text color, background color and font family through these custom properties instead of being locked to the built-in values.

## Linked issues

- Refs #10597 — request to make the a11y-layer styles configurable (branch `refactor/10597-a11y-css-props`).

## Type of change

- [ ] ✨ New feature
- [x] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

In `packages/components/src/components/a11y.scss` wurden die fest verdrahteten Standardwerte des Accessibility-Layers in überschreibbare CSS Custom Properties überführt: `--kol-a11y-font-color` (Default `black`), `--kol-a11y-background-color` (Default `white`) und `--kol-a11y-font-family` (Default `Verdana`), jeweils via `var()` genutzt. Standardmäßig ändert sich nichts an der Darstellung (gleiche kontrastsichere Werte), aber Anwendungen und Themes können Textfarbe, Hintergrundfarbe und Schriftart des a11y-Layers nun über diese Custom Properties überschreiben.

### Verknüpfte Tickets

- Referenziert #10597 — Wunsch, die a11y-Layer-Styles konfigurierbar zu machen (Branch `refactor/10597-a11y-css-props`).

### Art der Änderung

🔼 Verbesserung

### Geänderte Dateien

- `packages/components/src/components/a11y.scss` — Farben und Schriftart als `--kol-a11y-*` Custom Properties bereitgestellt (Defaults unverändert).

</details>
