### PR TITLE
refactor: replace react-router-dom with react-router v8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,10 +104,10 @@ jobs:
         if: github.event.inputs.increment == 'true' && github.event.inputs.tag == 'dev'
         run: 'HUSKY=0 node scripts/version.mjs prerelease --preid=$GITHUB_SHA --no-push'
 
-      - name: Build
+      - name: Build all packages
         run: pnpm -r build
 
-      - name: Build and publish all packages
+      - name: Publish all packages
         run: |
           PACKAGE_DIRS=(
             'packages/components'

--- a/packages/samples/presentation/package.json
+++ b/packages/samples/presentation/package.json
@@ -31,10 +31,9 @@
 		"@public-ui/theme-desy": "workspace:*",
 		"@public-ui/theme-ecl": "workspace:*",
 		"@public-ui/theme-kern": "workspace:*",
-		"adopted-style-sheets": "1.1.9-rc.25",
 		"react": "19.2.8",
 		"react-dom": "19.2.8",
-		"react-router-dom": "7.18.2"
+		"react-router": "8.3.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.60.0",
@@ -45,6 +44,7 @@
 		"@unocss/preset-mini": "66.7.5",
 		"@unocss/vite": "66.7.5",
 		"@vitejs/plugin-react-swc": "4.3.2",
+		"adopted-style-sheets": "1.1.9-rc.25",
 		"eslint": "9.39.5",
 		"knip": "6.29.0",
 		"prettier": "3.9.6",

--- a/packages/samples/presentation/src/react.main.tsx
+++ b/packages/samples/presentation/src/react.main.tsx
@@ -1,6 +1,6 @@
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { HashRouter as Router } from 'react-router-dom';
+import { HashRouter as Router } from 'react-router';
 
 import { bootstrap } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/loader';

--- a/packages/samples/react/package.json
+++ b/packages/samples/react/package.json
@@ -18,33 +18,34 @@
 	},
 	"dependencies": {
 		"@hookform/resolvers": "5.5.7",
-		"@public-ui/components": "workspace:*",
 		"@public-ui/react-hook-form-adapter": "workspace:*",
 		"@public-ui/react-v19": "workspace:*",
 		"@stencil/core": "4.38.3",
 		"@types/node": "26.1.2",
 		"@types/papaparse": "5.5.2",
-		"@types/react": "19.2.17",
-		"@types/react-dom": "19.2.3",
-		"adopted-style-sheets": "1.1.9-rc.25",
 		"papaparse": "5.5.4",
-		"react": "19.2.8",
-		"react-dom": "19.2.8",
 		"react-hook-form": "7.83.0",
 		"react-number-format": "5.4.5",
-		"react-router": "8.3.0",
-		"react-router-dom": "7.18.2",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"world_countries_lists": "3.3.0",
 		"zod": "4.4.3"
 	},
 	"devDependencies": {
+		"@types/react": "19.2.18",
+		"@types/react-dom": "19.2.4",
+		"adopted-style-sheets": "1.1.9-rc.25",
 		"eslint": "9.39.5",
 		"knip": "6.29.0",
 		"prettier": "3.9.6",
 		"prettier-plugin-organize-imports": "4.3.0",
 		"stylelint": "17.14.1"
+	},
+	"peerDependencies": {
+		"@public-ui/components": "workspace:*",
+		"react": "19.2.8",
+		"react-dom": "19.2.8",
+		"react-router": "8.3.0"
 	},
 	"files": [
 		"assets",

--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router';
-import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useSearchParams } from 'react-router';
 
 import PackageJson from '@public-ui/components/package.json';
 

--- a/packages/samples/react/src/components/Navigation.tsx
+++ b/packages/samples/react/src/components/Navigation.tsx
@@ -1,7 +1,7 @@
 import { KolInputText, KolTree, KolTreeItem } from '@public-ui/react-v19';
 import * as React from 'react';
 import { useState } from 'react';
-import { useHref, useMatch, useResolvedPath } from 'react-router-dom';
+import { useHref, useMatch, useResolvedPath } from 'react-router';
 import type { Route, Routes } from '../shares/types';
 
 type NavigationProps = {

--- a/packages/samples/react/src/components/SampleColumns.tsx
+++ b/packages/samples/react/src/components/SampleColumns.tsx
@@ -1,5 +1,5 @@
 import React, { type PropsWithChildren } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 export function SampleColumns({ children }: PropsWithChildren) {
 	const [searchParams] = useSearchParams();

--- a/packages/samples/react/src/components/button/expert-slot.tsx
+++ b/packages/samples/react/src/components/button/expert-slot.tsx
@@ -1,6 +1,6 @@
 import { KolButton, KolHeading, KolIcon } from '@public-ui/react-v19';
 import type { FC } from 'react';
-import React, { useRef } from 'react';
+import React from 'react';
 import { useToasterService } from '../../hooks/useToasterService';
 import { SampleDescription } from '../SampleDescription';
 
@@ -10,7 +10,6 @@ const KolTooltip = 'kol-tooltip-wc' as unknown as React.FC<{ _label: string }>;
 
 export const ButtonExpertSlot: FC = () => {
 	const { dummyClickEventHandler } = useToasterService();
-	const iconButtonRef = useRef<HTMLElement>(null);
 
 	const dummyEventHandler = {
 		onClick: dummyClickEventHandler,
@@ -38,7 +37,7 @@ export const ButtonExpertSlot: FC = () => {
 						<KolButton _icons="kolicon-alert-warning" _label="" _variant="danger" _on={dummyEventHandler}>
 							<span slot="expert">Delete with custom text</span>
 						</KolButton>
-						<KolButton ref={iconButtonRef as React.Ref<never>} _label="" _variant="danger" _on={dummyEventHandler}>
+						<KolButton _label="" _variant="danger" _on={dummyEventHandler}>
 							<KolIcon _icons="kolicon-alert-warning" _label="Delete with custom text" slot="expert" />
 						</KolButton>
 						<KolTooltip _label="Delete with custom text" />

--- a/packages/samples/react/src/components/button/variants.tsx
+++ b/packages/samples/react/src/components/button/variants.tsx
@@ -1,7 +1,7 @@
 import { KolButton, KolHeading } from '@public-ui/react-v19';
 import type { FC } from 'react';
 import React, { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useToasterService } from '../../hooks/useToasterService';
 import { fetchVariantData } from '../../shares/fetchVariantData';
 import { getCustomThemes } from '../../shares/store';

--- a/packages/samples/react/src/components/drawer/basic.tsx
+++ b/packages/samples/react/src/components/drawer/basic.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import type { AlignPropType } from '@public-ui/components';
 import { KolButton, KolDrawer, KolInputCheckbox } from '@public-ui/react-v19';

--- a/packages/samples/react/src/components/drawer/controlled.tsx
+++ b/packages/samples/react/src/components/drawer/controlled.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import React, { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import type { AlignPropType } from '@public-ui/components';
 import { KolButton, KolDrawer } from '@public-ui/react-v19';

--- a/packages/samples/react/src/components/icon/font.tsx
+++ b/packages/samples/react/src/components/icon/font.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { KolButton, KolIcon, KolInputText } from '@public-ui/react-v19';
 

--- a/packages/samples/react/src/components/link-button/basic.tsx
+++ b/packages/samples/react/src/components/link-button/basic.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { KolLinkButton } from '@public-ui/react-v19';
 
 import type { FC } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useToasterService } from '../../hooks/useToasterService';
 import { fetchVariantData } from '../../shares/fetchVariantData';
 import { getCustomThemes } from '../../shares/store';

--- a/packages/samples/react/src/components/link/link-react-router.tsx
+++ b/packages/samples/react/src/components/link/link-react-router.tsx
@@ -1,7 +1,7 @@
 import { KolLink } from '@public-ui/react-v19';
 import type { FC } from 'react';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { SampleDescription } from '../SampleDescription';
 
 export const LinkReactRouter: FC = () => {

--- a/packages/samples/react/src/components/link/variant.tsx
+++ b/packages/samples/react/src/components/link/variant.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { KolLink } from '@public-ui/react-v19';
 import { fetchVariantData } from '../../shares/fetchVariantData';

--- a/packages/samples/react/src/components/toast/basic.tsx
+++ b/packages/samples/react/src/components/toast/basic.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import type { AlertTypePropType } from '@public-ui/components';
 import { ToasterService } from '@public-ui/components';

--- a/packages/samples/react/src/components/toast/configurator.tsx
+++ b/packages/samples/react/src/components/toast/configurator.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import type { AlertTypePropType } from '@public-ui/components';
 import { ToasterService } from '@public-ui/components';

--- a/packages/samples/react/src/scenarios/focus-elements.tsx
+++ b/packages/samples/react/src/scenarios/focus-elements.tsx
@@ -33,7 +33,7 @@ import {
 } from '@public-ui/react-v19';
 import type { FC, ForwardRefRenderFunction } from 'react';
 import React, { forwardRef, useCallback, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { SampleDescription } from '../components/SampleDescription';
 
 const getFocusElements = () => {

--- a/packages/tools/visual-tests/app/src/react.main.tsx
+++ b/packages/tools/visual-tests/app/src/react.main.tsx
@@ -1,7 +1,7 @@
 import { setTagNameTransformer } from '@public-ui/react-v19';
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { HashRouter as Router } from 'react-router-dom';
+import { HashRouter as Router } from 'react-router';
 
 import { bootstrap, getDefaultThemeName, KoliBriDevHelper } from '@public-ui/components';
 import { defineCustomElements } from '@public-ui/components/loader';

--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -49,7 +49,7 @@
 		"portfinder": "1.0.38",
 		"react": "19.2.8",
 		"react-dom": "19.2.8",
-		"react-router-dom": "7.18.2",
+		"react-router": "8.3.0",
 		"vite": "8.1.5"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,18 +696,15 @@ importers:
       '@public-ui/theme-kern':
         specifier: workspace:*
         version: link:../../themes/kern
-      adopted-style-sheets:
-        specifier: 1.1.9-rc.25
-        version: 1.1.9-rc.25
       react:
         specifier: 19.2.8
         version: 19.2.8
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      react-router-dom:
-        specifier: 7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@playwright/test':
         specifier: 1.60.0
@@ -733,6 +730,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: 4.3.2
         version: 4.3.2(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      adopted-style-sheets:
+        specifier: 1.1.9-rc.25
+        version: 1.1.9-rc.25
       eslint:
         specifier: 9.39.5
         version: 9.39.5(jiti@2.7.0)
@@ -781,15 +781,6 @@ importers:
       '@types/papaparse':
         specifier: 5.5.2
         version: 5.5.2
-      '@types/react':
-        specifier: 19.2.17
-        version: 19.2.17
-      '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.17)
-      adopted-style-sheets:
-        specifier: 1.1.9-rc.25
-        version: 1.1.9-rc.25
       papaparse:
         specifier: 5.5.4
         version: 5.5.4
@@ -808,9 +799,6 @@ importers:
       react-router:
         specifier: 8.3.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react-router-dom:
-        specifier: 7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -824,6 +812,15 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/react':
+        specifier: 19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: 19.2.4
+        version: 19.2.4(@types/react@19.2.18)
+      adopted-style-sheets:
+        specifier: 1.1.9-rc.25
+        version: 1.1.9-rc.25
       eslint:
         specifier: 9.39.5
         version: 9.39.5(jiti@2.7.0)
@@ -1478,7 +1475,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/inspector':
         specifier: 2.0.0
-        version: 2.0.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@26.1.2)(@types/react@19.2.17)(esbuild@0.28.1)(express@5.2.1)(jiti@2.7.0)(less@4.4.2)(react-dom@19.2.8(react@19.2.8))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)
+        version: 2.0.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@26.1.2)(@types/react@19.2.18)(esbuild@0.28.1)(express@5.2.1)(jiti@2.7.0)(less@4.4.2)(react-dom@19.2.8(react@19.2.8))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)
       '@public-ui/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -1587,9 +1584,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      react-router-dom:
-        specifier: 7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vite:
         specifier: 8.1.5
         version: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -5391,8 +5388,8 @@ packages:
   '@simple-git/argv-parser@1.1.1':
     resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
-  '@sinclair/typebox@0.27.12':
-    resolution: {integrity: sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==}
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
@@ -5826,11 +5823,19 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -5886,6 +5891,9 @@ packages:
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
+  '@types/yargs@17.0.33':
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
@@ -5933,6 +5941,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/tsconfig-utils@8.65.0':
     resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5948,6 +5962,10 @@ packages:
 
   '@typescript-eslint/types@8.58.2':
     resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.65.0':
@@ -6146,8 +6164,8 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7 || ^8
 
-  '@vitejs/plugin-react@6.0.4':
-    resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
+  '@vitejs/plugin-react@6.0.5':
+    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -12200,13 +12218,6 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
   react-router@8.3.0:
     resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
     engines: {node: '>=22.22.0'}
@@ -13449,6 +13460,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
@@ -14948,7 +14963,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
-    optional: true
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -16620,7 +16634,7 @@ snapshots:
 
   '@jest/schemas@29.6.3':
     dependencies:
-      '@sinclair/typebox': 0.27.12
+      '@sinclair/typebox': 0.27.10
 
   '@jest/schemas@30.4.1':
     dependencies:
@@ -16723,7 +16737,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 26.1.2
-      '@types/yargs': 17.0.35
+      '@types/yargs': 17.0.33
       chalk: 4.1.2
 
   '@jest/types@30.4.1':
@@ -17098,7 +17112,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@modelcontextprotocol/inspector@2.0.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@26.1.2)(@types/react@19.2.17)(esbuild@0.28.1)(express@5.2.1)(jiti@2.7.0)(less@4.4.2)(react-dom@19.2.8(react@19.2.8))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)':
+  '@modelcontextprotocol/inspector@2.0.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@26.1.2)(@types/react@19.2.18)(esbuild@0.28.1)(express@5.2.1)(jiti@2.7.0)(less@4.4.2)(react-dom@19.2.8(react@19.2.8))(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.12.32)
       '@modelcontextprotocol/client': 2.0.0-beta.5
@@ -17107,15 +17121,15 @@ snapshots:
       '@modelcontextprotocol/server': 2.0.0-beta.5
       '@modelcontextprotocol/server-legacy': 2.0.0-beta.5(express@5.2.1)
       '@napi-rs/keyring': 1.3.0
-      '@vitejs/plugin-react': 6.0.4(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitejs/plugin-react': 6.0.5(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       ajv: 8.18.0
       atomically: 2.1.1
       chokidar: 4.0.3
       commander: 13.1.0
       hono: 4.12.32
-      ink: 6.8.0(@types/react@19.2.17)(react@19.2.8)
-      ink-form: 2.0.1(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)
-      ink-scroll-view: 0.3.7(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)
+      ink: 6.8.0(@types/react@19.2.18)(react@19.2.8)
+      ink-form: 2.0.1(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+      ink-scroll-view: 0.3.7(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
       open: 10.2.0
       pino: 9.14.0
       react: 19.2.8
@@ -18281,7 +18295,7 @@ snapshots:
     dependencies:
       '@simple-git/args-pathspec': 1.0.3
 
-  '@sinclair/typebox@0.27.12': {}
+  '@sinclair/typebox@0.27.10': {}
 
   '@sinclair/typebox@0.34.49': {}
 
@@ -18689,12 +18703,20 @@ snapshots:
     dependencies:
       '@types/react': 19.2.17
 
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+
   '@types/react@18.3.31':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
   '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/react@19.2.18':
     dependencies:
       csstype: 3.2.3
 
@@ -18752,6 +18774,10 @@ snapshots:
 
   '@types/yargs-parser@21.0.3': {}
 
+  '@types/yargs@17.0.33':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
@@ -18791,8 +18817,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.58.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18821,6 +18847,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
   '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
@@ -18839,6 +18869,8 @@ snapshots:
 
   '@typescript-eslint/types@8.58.2': {}
 
+  '@typescript-eslint/types@8.59.0': {}
+
   '@typescript-eslint/types@8.65.0': {}
 
   '@typescript-eslint/typescript-estree@8.58.2(typescript@5.9.3)':
@@ -18850,7 +18882,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.6
       semver: 7.8.5
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19033,7 +19065,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.5(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -22896,34 +22928,34 @@ snapshots:
 
   ini@7.0.0: {}
 
-  ink-form@2.0.1(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8):
+  ink-form@2.0.1(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
     dependencies:
-      ink: 6.8.0(@types/react@19.2.17)(react@19.2.8)
-      ink-select-input: 5.0.0(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)
-      ink-text-input: 6.0.0(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8)
+      ink: 6.8.0(@types/react@19.2.18)(react@19.2.8)
+      ink-select-input: 5.0.0(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+      ink-text-input: 6.0.0(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
-  ink-scroll-view@0.3.7(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8):
+  ink-scroll-view@0.3.7(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
     dependencies:
-      ink: 6.8.0(@types/react@19.2.17)(react@19.2.8)
+      ink: 6.8.0(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
 
-  ink-select-input@5.0.0(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8):
+  ink-select-input@5.0.0(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
     dependencies:
       arr-rotate: 1.0.0
       figures: 5.0.0
-      ink: 6.8.0(@types/react@19.2.17)(react@19.2.8)
+      ink: 6.8.0(@types/react@19.2.18)(react@19.2.8)
       lodash.isequal: 4.5.0
       react: 19.2.8
 
-  ink-text-input@6.0.0(ink@6.8.0(@types/react@19.2.17)(react@19.2.8))(react@19.2.8):
+  ink-text-input@6.0.0(ink@6.8.0(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
     dependencies:
       chalk: 5.6.2
-      ink: 6.8.0(@types/react@19.2.17)(react@19.2.8)
+      ink: 6.8.0(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
       type-fest: 4.41.0
 
-  ink@6.8.0(@types/react@19.2.17)(react@19.2.8):
+  ink@6.8.0(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.2.5
       ansi-escapes: 7.3.0
@@ -22952,7 +22984,7 @@ snapshots:
       ws: 8.21.1
       yoga-layout: 3.2.1
     optionalDependencies:
-      '@types/react': 19.2.17
+      '@types/react': 19.2.18
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -23602,7 +23634,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.29.7
+      '@babel/code-frame': 7.29.0
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -23801,7 +23833,7 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/generator': 7.29.7
+      '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
       '@babel/types': 7.29.7
@@ -26579,12 +26611,6 @@ snapshots:
       react: 19.2.8
       scheduler: 0.27.0
 
-  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
   react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       cookie-es: 3.1.1
@@ -28181,6 +28207,11 @@ snapshots:
   tinycolor2@1.6.0: {}
 
   tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4


### PR DESCRIPTION
## What changed?

Replaces the deprecated `react-router-dom` (v7) with `react-router` (v8) across the React-based samples and tooling. All hooks and components (`useSearchParams`, `useLocation`, `useNavigate`, `useHref`, `useMatch`, `useResolvedPath`, `Navigate`, `Route`, `Routes`, `HashRouter`) now import from `react-router` instead of `react-router-dom`, and the dependency was swapped in `packages/samples/react`, `packages/samples/presentation` and `packages/tools/visual-tests` (with the React sample additionally moving `@public-ui/components`/`react`/`react-dom`/`react-router` to `peerDependencies`). The pnpm lock file was regenerated and two step names in `.github/workflows/publish.yml` were clarified. Only sample/demo apps and internal tooling are touched — no shipped component library code changes.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ersetzt das veraltete `react-router-dom` (v7) durch `react-router` (v8) in den React-basierten Samples und im Tooling. Alle Hooks und Komponenten (`useSearchParams`, `useLocation`, `useNavigate`, `useHref`, `useMatch`, `useResolvedPath`, `Navigate`, `Route`, `Routes`, `HashRouter`) importieren jetzt aus `react-router` statt aus `react-router-dom`; die Abhängigkeit wurde in `packages/samples/react`, `packages/samples/presentation` und `packages/tools/visual-tests` ausgetauscht (im React-Sample wandern `@public-ui/components`/`react`/`react-dom`/`react-router` zusätzlich in die `peerDependencies`). Die pnpm-Lock-Datei wurde neu erzeugt und zwei Step-Namen in `.github/workflows/publish.yml` präzisiert. Betroffen sind nur Sample-/Demo-Apps und internes Tooling — kein ausgelieferter Komponenten-Code.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern (Engineering)

### Geänderte Dateien

- `packages/samples/react/**`, `packages/samples/presentation/**` — Imports auf `react-router` umgestellt, Dependencies angepasst.
- `packages/tools/visual-tests/**` — `react-router-dom` → `react-router` in App und `package.json`.
- `pnpm-lock.yaml` — neu erzeugte Lock-Datei.
- `.github/workflows/publish.yml` — Step-Namen „Build all packages" / „Publish all packages" präzisiert.

</details>
