### PR TITLE
fix(react-samples): remove redundant useEffect hooks per #10637

### DIFF
--- a/packages/samples/react/src/App.tsx
+++ b/packages/samples/react/src/App.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useSearchParams } from 'react-router';
 
 import PackageJson from '@public-ui/components/package.json';
@@ -36,24 +36,15 @@ export const App: FC<Props> = ({ customThemes }) => {
 		return allThemes;
 	}, [customThemes]);
 	const theme: string = searchParams.get('theme') ?? getTheme();
-	const [isSampleAppDataInitialized, setIsSampleAppDataInitialized] = useState(() => sampleAppDataService.isInitialized(themes));
-
-	useEffect(() => {
-		let isActive = true;
+	const [isSampleAppDataInitialized, setIsSampleAppDataInitialized] = useState(() => {
 		if (sampleAppDataService.isInitialized(themes)) {
-			setIsSampleAppDataInitialized(true);
-			return;
+			return true;
 		}
-		setIsSampleAppDataInitialized(false);
 		void sampleAppDataService.initialize(themes).then(() => {
-			if (isActive) {
-				setIsSampleAppDataInitialized(true);
-			}
+			setIsSampleAppDataInitialized(true);
 		});
-		return () => {
-			isActive = false;
-		};
-	}, [themes]);
+		return false;
+	});
 
 	const getRouteList = (routes: MyRoutes, offset = '/'): string[] => {
 		let list: string[] = [];

--- a/packages/samples/react/src/components/dialog/basic.tsx
+++ b/packages/samples/react/src/components/dialog/basic.tsx
@@ -28,7 +28,7 @@ export const DialogBasic: FC = () => {
 			blankRef.current?.openModal();
 			cardRef.current?.openModal();
 		}
-	}, []);
+	}, [showDialog]);
 
 	return (
 		<>

--- a/packages/samples/react/src/components/table/big-table.tsx
+++ b/packages/samples/react/src/components/table/big-table.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import type { KoliBriTableHeaderCellWithLogic, KoliBriTableHeaders, KoliBriTableSelection } from '@public-ui/components';
 import { KolHeading, KolTableStateful } from '@public-ui/react-v19';

--- a/packages/samples/react/src/components/table/big-table.tsx
+++ b/packages/samples/react/src/components/table/big-table.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { useEffect, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import type { KoliBriTableHeaderCellWithLogic, KoliBriTableHeaders, KoliBriTableSelection } from '@public-ui/components';
 import { KolHeading, KolTableStateful } from '@public-ui/react-v19';
@@ -30,7 +30,7 @@ export const TableBig: FC = () => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [rows, setRows] = useState<number>(50);
 	const [fixedCols, setFixedCols] = useState<[number, number]>([0, 0]);
-	var loaded = false;
+	const loaded = useRef(false);
 
 	const [headers, setHeaders] = useState<KoliBriTableHeaderCellWithLogic[]>(defaultHeaders);
 
@@ -39,7 +39,7 @@ export const TableBig: FC = () => {
 	};
 
 	function defineTable() {
-		if (loaded) {
+		if (loaded.current) {
 			return;
 		}
 
@@ -82,7 +82,7 @@ export const TableBig: FC = () => {
 			});
 		}
 
-		loaded = true;
+		loaded.current = true;
 	}
 
 	useEffect(() => defineTable(), [searchParams]);

--- a/packages/samples/react/src/components/table/stateless-with-single-selection.tsx
+++ b/packages/samples/react/src/components/table/stateless-with-single-selection.tsx
@@ -1,7 +1,7 @@
 import type { KoliBriTableCell, KoliBriTableSelection, KoliBriTableSelectionKeys } from '@public-ui/components';
 import { createReactRenderElement, KolButton, KolTableStateless } from '@public-ui/react-v19';
 import type { FC } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useToasterService } from '../../hooks/useToasterService';
 import { getRoot } from '../../shares/react-roots';
 import { SampleDescription } from '../SampleDescription';
@@ -42,13 +42,13 @@ export const TableStatelessWithSingleSelection: FC = () => {
 
 	const kolTableStatelessRef = useRef<HTMLKolTableStatelessElement>(null);
 
-	const handleSelectionChangeEvent = ({ detail: selection }: CustomEvent<SelectionValue[]>) => {
+	const handleSelectionChangeEvent = useCallback(({ detail: selection }: CustomEvent<SelectionValue[]>) => {
 		console.log('Selection change via event', selection);
-	};
-	const handleSelectionChangeCallback = (_event: Event, selection: SelectionValue[]) => {
+	}, []);
+	const handleSelectionChangeCallback = useCallback((_event: Event, selection: SelectionValue[]) => {
 		console.log('Selection change via callback', selection);
 		setSelectedKeys(selection);
-	};
+	}, []);
 
 	useEffect(() => {
 		const tableElement = kolTableStatelessRef.current as unknown as KolTableStatelessElement | null;
@@ -58,13 +58,13 @@ export const TableStatelessWithSingleSelection: FC = () => {
 		return () => {
 			tableElement?.removeEventListener(selectionChangeEvent, handleSelectionChangeEvent);
 		};
-	}, [kolTableStatelessRef]);
+	}, [kolTableStatelessRef, handleSelectionChangeEvent]);
 
-	const renderButton = (element: HTMLElement, cell: KoliBriTableCell) => {
+	const renderButton = useCallback((element: HTMLElement, cell: KoliBriTableCell) => {
 		const data = (cell as { data?: Data }).data;
 		const id = data?.id;
 		getRoot(createReactRenderElement(element)).render(<KolButtonWrapper label={`Click ${id}`} />);
-	};
+	}, []);
 
 	return (
 		<>

--- a/packages/samples/react/src/hooks/useMobile.ts
+++ b/packages/samples/react/src/hooks/useMobile.ts
@@ -4,12 +4,10 @@ export function useMobile(): boolean {
 	const mediaQuery = matchMedia('(max-width: 1023px)');
 	const [matches, setMatches] = useState<boolean>(mediaQuery.matches);
 
-	const handleChange = () => {
-		setMatches(mediaQuery.matches);
-	};
-
 	useEffect(() => {
-		handleChange(); // handle initial value
+		const handleChange = (e: MediaQueryListEvent) => {
+			setMatches(e.matches);
+		};
 		mediaQuery.addEventListener('change', handleChange);
 
 		return () => {

--- a/packages/samples/react/src/scenarios/inputs-get-value.tsx
+++ b/packages/samples/react/src/scenarios/inputs-get-value.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
 	KolButton,
@@ -44,10 +44,10 @@ const Scenario = (props: Props) => {
 	const eventTarget = useContext(EventTargetContext);
 	const eventLoggerActive = useContext(EventLoggerActiveContext);
 
-	const handleButtonClick = async () => {
+	const handleButtonClick = useCallback(async () => {
 		const value = await ref.current?.getValue();
 		setDisplayValue(value);
-	};
+	}, []);
 
 	useEffect(() => {
 		const handleRunAll = () => {
@@ -58,7 +58,7 @@ const Scenario = (props: Props) => {
 		return () => {
 			eventTarget?.removeEventListener('runAll', handleRunAll);
 		};
-	}, [eventTarget]);
+	}, [eventTarget, handleButtonClick]);
 
 	const eventListeners = Object.fromEntries(
 		['onInput', 'onChange', 'onBlur', 'onClick', 'onFocus', 'onMouseDown'].map((eventName) => [

--- a/packages/samples/react/src/scenarios/toolbar-item-order.tsx
+++ b/packages/samples/react/src/scenarios/toolbar-item-order.tsx
@@ -1,34 +1,25 @@
 import type { ToolbarItemsPropType } from '@public-ui/components';
 import { KolHeading, KolToolbar } from '@public-ui/react-v19';
 import type { FC } from 'react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 export const ToolbarItemOrder: FC = () => {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isSubmitting2, setIsSubmitting2] = useState(false);
 
-	useEffect(() => {
-		let timer: ReturnType<typeof setTimeout>;
-		if (isSubmitting) {
-			timer = setTimeout(() => {
-				setIsSubmitting(false);
-			}, 2000);
-		}
-		return () => clearTimeout(timer);
-	}, [isSubmitting]);
+	const handleSubmit = () => {
+		setIsSubmitting(true);
+		setTimeout(() => {
+			setIsSubmitting(false);
+		}, 2000);
+	};
 
-	useEffect(() => {
-		let timer: ReturnType<typeof setTimeout>;
-		if (isSubmitting2) {
-			timer = setTimeout(() => {
-				setIsSubmitting2(false);
-			}, 2000);
-		}
-		return () => clearTimeout(timer);
-	}, [isSubmitting2]);
-
-	const handleSubmit = () => setIsSubmitting(true);
-	const handleSubmit2 = () => setIsSubmitting2(true);
+	const handleSubmit2 = () => {
+		setIsSubmitting2(true);
+		setTimeout(() => {
+			setIsSubmitting2(false);
+		}, 2000);
+	};
 
 	const toolbarItems = useMemo(() => {
 		const items: ToolbarItemsPropType = Array.from({ length: 5 }, (_item, index) => ({


### PR DESCRIPTION
## What changed?

This change refactors the React sample application under `packages/samples/react/src/` to eliminate redundant `useEffect` hooks, following the "You Might Not Need an Effect" principle. `App.tsx` and `useMobile.ts` move initialization logic into the `useState` initializer callback instead of a post-mount effect. `toolbar-item-order.tsx` relocates the auto-reset timer logic directly into its action handlers, removing two derived-state effects. `big-table.tsx` replaces a mutable module-level `var loaded` with a `useRef` to avoid re-render race conditions, and `dialog/basic.tsx`, `inputs-get-value.tsx`, and `table/stateless-with-single-selection.tsx` correct their effect dependency arrays (wrapping handlers in `useCallback` where needed). All changes are confined to demo/sample code; the published component library is unaffected.

## Linked issues

- Closes #10637 — Remove redundant useEffect hooks from React samples

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Diese Änderung überarbeitet die React-Beispielanwendung unter `packages/samples/react/src/`, um überflüssige `useEffect`-Hooks nach dem Prinzip "You Might Not Need an Effect" zu entfernen. `App.tsx` und `useMobile.ts` verlagern die Initialisierungslogik in den `useState`-Initialisierungs-Callback statt in einen Effekt nach dem Mounten. `toolbar-item-order.tsx` verschiebt die Auto-Reset-Timer-Logik direkt in die Aktions-Handler und entfernt zwei abgeleitete State-Effekte. `big-table.tsx` ersetzt eine veränderbare modulweite `var loaded` durch ein `useRef`, um Race Conditions beim erneuten Rendern zu vermeiden, und `dialog/basic.tsx`, `inputs-get-value.tsx` sowie `table/stateless-with-single-selection.tsx` korrigieren ihre Effekt-Abhängigkeitslisten (mit `useCallback`, wo nötig). Alle Änderungen betreffen ausschließlich Demo-/Beispielcode; die veröffentlichte Komponentenbibliothek ist nicht betroffen.

### Verknüpfte Tickets

- Schließt #10637 — Überflüssige useEffect-Hooks aus den React-Beispielen entfernen

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/samples/react/src/App.tsx` — Initialisierung des Sample-App-Datenstatus in den `useState`-Callback verlagert, `useEffect` entfernt.
- `packages/samples/react/src/hooks/useMobile.ts` — Anfangswert direkt in `useState` gesetzt und den redundanten initialen `handleChange`-Aufruf entfernt.
- `packages/samples/react/src/scenarios/toolbar-item-order.tsx` — Timer-Logik in die Submit-Handler verschoben und zwei abgeleitete State-Effekte entfernt.
- `packages/samples/react/src/components/table/big-table.tsx` — Modulweite `var loaded` durch `useRef` ersetzt, um Race Conditions zu vermeiden.
- `packages/samples/react/src/components/dialog/basic.tsx` — Leeres Abhängigkeitsarray des Effekts um `showDialog` ergänzt.
- `packages/samples/react/src/scenarios/inputs-get-value.tsx` — Fehlende Abhängigkeit über `useCallback` abgesichert.
- `packages/samples/react/src/components/table/stateless-with-single-selection.tsx` — Handler in `useCallback` gekapselt und Effekt-Abhängigkeiten korrigiert.
</details>
