### PR TITLE
fix: use named imports for js-yaml v5 ESM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"version": "4.3.0",
 	"devDependencies": {
 		"@evilmartians/lefthook": "2.1.10",
+		"js-yaml": "5.2.3",
 		"license-report": "6.8.5",
 		"npm-check-updates": "23.0.2",
 		"npm-run-all2": "9.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@evilmartians/lefthook':
         specifier: 2.1.10
         version: 2.1.10
+      js-yaml:
+        specifier: 5.2.3
+        version: 5.2.3
       license-report:
         specifier: 6.8.5
         version: 6.8.5

--- a/scripts/update-publiccode.mjs
+++ b/scripts/update-publiccode.mjs
@@ -1,19 +1,19 @@
 #! /usr/bin/env node
 
-import yaml from 'js-yaml';
 import fs from 'fs';
+import { dump, load } from 'js-yaml';
 import * as prettier from 'prettier';
 
 const packageJsonPath = new URL('../package.json', import.meta.url);
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
 const filePath = new URL('../publiccode.yml', import.meta.url);
-const doc = yaml.load(fs.readFileSync(filePath, 'utf8'));
+const doc = load(fs.readFileSync(filePath, 'utf8'));
 
 doc.releaseDate = new Date().toISOString().split('T')[0];
 doc.softwareVersion = packageJson.version;
 
-const yamlString = yaml.dump(doc);
+const yamlString = dump(doc);
 
 const prettierOptions = await prettier.resolveConfig(new URL('../prettier.config.js', import.meta.url));
 const formattedYamlString = await prettier.format(yamlString, { ...prettierOptions, parser: 'yaml' });


### PR DESCRIPTION
## Summary

The **01 - Publish** workflow (#878) crashes on Node 24 with:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
    at scripts/update-publiccode.mjs:3
```

## Root cause

js-yaml was bumped from **4.x → 5.2.3** in a recent dependency update (`chore: update dependencies and lock file`). Version 5.x ships a real ESM build (`dist/js-yaml.mjs`) with **named exports only** — there is no `export default`. The default import `import yaml from 'js-yaml'` worked under 4.x (CJS interop) but crashes under 5.x.

Additionally, `js-yaml` was **not declared** as a dependency in any `package.json` — it only resolved as a hoisted transitive dependency via `stylelint → cosmiconfig → js-yaml` (surviving only because `.npmrc` sets `shamefully-hoist=true`). This masked the version bump entirely.

## Changes

- **`scripts/update-publiccode.mjs`**: Switch from default import (`import yaml from 'js-yaml'`) to named imports (`import { dump, load } from 'js-yaml'`) — the `load`/`dump` signatures are unchanged from 4.x
- **`package.json`**: Declare `js-yaml@5.2.3` as explicit devDependency so the version is tracked and not at the mercy of transitive resolution
- **`pnpm-lock.yaml`**: Updated lockfile (no new download — 5.2.3 was already in the store)

## Verification

✅ `node scripts/update-publiccode.mjs` runs successfully (previously crashed immediately)
✅ `pnpm format` — all files pass