### PR TITLE
feat(visual-tests): element screenshot infrastructure via data-visual-block

### DIFF
--- a/packages/samples/react/src/components/SampleBlock.tsx
+++ b/packages/samples/react/src/components/SampleBlock.tsx
@@ -1,0 +1,40 @@
+import { KolHeading } from '@public-ui/react-v19';
+import type { FC, PropsWithChildren } from 'react';
+import React from 'react';
+
+/**
+ * Converts an arbitrary label into a kebab-case block id, e.g. `Text (hideLabel)` → `text-hide-label`.
+ * Use this only for data-driven blocks; prefer hard-coded ids so label changes don't rename snapshots.
+ */
+export function toKebabCase(value: string): string {
+	return value
+		.replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}
+
+type SampleBlockProps = PropsWithChildren<{
+	/**
+	 * Unique within the route, kebab-case, max. 30 characters.
+	 * Becomes part of the visual snapshot file name — renaming it renames the snapshot.
+	 */
+	id: string;
+	/** Optional heading rendered above the block content. */
+	heading?: string;
+	level?: 1 | 2 | 3 | 4 | 5 | 6;
+}>;
+
+/**
+ * Wraps a sample variant block in a container addressable by the visual tests.
+ * Each `data-visual-block` container is captured as an individual element screenshot
+ * instead of one full-page screenshot per route. See packages/tools/visual-tests/README.md.
+ */
+export const SampleBlock: FC<SampleBlockProps> = ({ id, heading, level = 2, children }) => {
+	return (
+		<section className="grid gap-4" data-visual-block={id}>
+			{heading ? <KolHeading _level={level} _label={heading} /> : null}
+			{children}
+		</section>
+	);
+};

--- a/packages/tools/visual-tests/README.md
+++ b/packages/tools/visual-tests/README.md
@@ -63,4 +63,18 @@ In the following runs, new screenshots will be compared to this reference.
 
 To update the reference screenshots call `npm run test:update`.
 
+### Element screenshots (`data-visual-block`)
+
+Sample views in the [React Sample App](https://github.com/public-ui/kolibri/tree/develop/packages/samples/react) mark their variant blocks with a `data-visual-block` attribute — either via the `SampleBlock` helper component or by setting the attribute directly on a container element (e.g. a `<fieldset>`). When a route contains such blocks, the visual tests capture **one element screenshot per block** (`<route-slug>--<block-id>.png`) instead of one full-page screenshot. This isolates diffs: a change to one variant no longer invalidates the entire page screenshot through layout shifts.
+
+Rules for block ids:
+
+- kebab-case (`[a-z0-9]+(-[a-z0-9]+)*`), max. 30 characters — enforced by the test.
+- Unique within a route — duplicates fail the test.
+- Hard-code ids instead of deriving them from visible labels, so text changes don't rename snapshot files.
+- Blocks must be visible in `?hideMenus` mode and must not have zero size.
+- Overlay content (tooltips, toasts, popovers) that extends beyond the block's bounding box is clipped — such routes should use full-page screenshots instead.
+
+Routes without any `data-visual-block` container fall back to a full-page screenshot. Routes that should deliberately be captured as a whole page (composition tests) set `snapshot.forceFullPage: true` in `tests/sample-app.routes.js`.
+
 For details on theming see the [default theme README](../../themes/default/README.md).

--- a/packages/tools/visual-tests/tests/sample-app.routes.js
+++ b/packages/tools/visual-tests/tests/sample-app.routes.js
@@ -13,6 +13,9 @@ export const ROUTES = new Map();
  *   - options:
  *     - maxDiffPixelRatio: number (Default: 0)
  *   - skip: boolean (Default: false)
+ *   - forceFullPage: boolean (Default: false) – capture the route as one full-page screenshot even if
+ *     the view contains `data-visual-block` containers. Use for deliberate composition tests
+ *     (component spacing, page layout).
  *   - viewportSize:
  *     - width (Default: 800)
  *     - height (Default: 100)

--- a/packages/tools/visual-tests/tests/theme-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/theme-snapshots.spec.js
@@ -21,6 +21,17 @@ const DEFAULT_SNAPSHOT_OPTIONS = {
 	timeout: 10000,
 };
 
+/**
+ * Sample views mark their variant blocks with a `data-visual-block` attribute (see SampleBlock in
+ * @public-ui/sample-react). Each block is captured as an individual element screenshot instead of one
+ * full-page screenshot per route: a change only affects the block's own snapshot instead of cascading
+ * through the whole page. Routes without blocks fall back to a full-page screenshot; routes that should
+ * deliberately be captured as a whole page set `snapshot.forceFullPage` in sample-app.routes.js.
+ */
+const BLOCK_SELECTOR = '[data-visual-block]';
+const BLOCK_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/; // kebab-case
+const MAX_BLOCK_ID_LENGTH = 30; // keeps snapshot file paths safely below the Windows path limit
+
 ROUTES.forEach((options, route) => {
 	// Skip unnecessary snapshot tests
 	if (options?.snapshot?.skip === true && options?.snapshot?.zoom?.skip === true) {
@@ -58,7 +69,35 @@ ROUTES.forEach((options, route) => {
 
 		// Skip unnecessary normal tests
 		if (options?.snapshot?.skip !== true) {
-			await expect(page).toHaveScreenshot(`${snapshotName}.png`, SNAPSHOT_OPTIONS);
+			const forceFullPage = options?.snapshot?.forceFullPage === true;
+			const blockIds = forceFullPage
+				? []
+				: await page.$$eval(BLOCK_SELECTOR, (elements) => elements.map((element) => element.getAttribute('data-visual-block')));
+
+			if (blockIds.length > 0) {
+				const seenBlockIds = new Set();
+				for (const blockId of blockIds) {
+					if (!blockId || !BLOCK_ID_PATTERN.test(blockId) || blockId.length > MAX_BLOCK_ID_LENGTH) {
+						throw new Error(`Route "${route}": invalid data-visual-block id "${blockId}" (must be kebab-case, max. ${MAX_BLOCK_ID_LENGTH} characters)`);
+					}
+					if (seenBlockIds.has(blockId)) {
+						throw new Error(`Route "${route}": duplicate data-visual-block id "${blockId}"`);
+					}
+					seenBlockIds.add(blockId);
+				}
+
+				const { fullPage: _fullPage, ...ELEMENT_SNAPSHOT_OPTIONS } = SNAPSHOT_OPTIONS; // fullPage is not allowed for element screenshots
+				for (const blockId of blockIds) {
+					const block = page.locator(`[data-visual-block="${blockId}"]`);
+					const boundingBox = await block.boundingBox();
+					if (!boundingBox || boundingBox.width === 0 || boundingBox.height === 0) {
+						throw new Error(`Route "${route}": data-visual-block "${blockId}" is not visible or has zero size`);
+					}
+					await expect(block).toHaveScreenshot(`${snapshotName}--${blockId}.png`, ELEMENT_SNAPSHOT_OPTIONS);
+				}
+			} else {
+				await expect(page).toHaveScreenshot(`${snapshotName}.png`, SNAPSHOT_OPTIONS);
+			}
 		}
 
 		// Skip unnecessary zoom tests


### PR DESCRIPTION
## Motivation

Wichtigster Task aus der Analyse der visuellen Snapshot-Tests: Full-Page-Screenshots kaskadieren jede Layout-Änderung über die gesamte Seite — eine Höhenänderung einer Variante invalidiert das komplette Bild, über alle 5 Themes. Dieser PR legt die Infrastruktur für Element-Screenshots pro Varianten-Block, **ohne** bestehende Snapshots zu verändern.

## Änderungen

- **Neu `SampleBlock`** (`packages/samples/react/src/components/SampleBlock.tsx`): Wrapper-Komponente, die einen Varianten-Block als `<section data-visual-block={id}>` mit optionalem `KolHeading` rendert. Exportiert zusätzlich einen `toKebabCase`-Helfer für datengetriebene Varianten (Folge-PR).
- **Auto-Discovery in `theme-snapshots.spec.js`**: Enthält eine Route `[data-visual-block]`-Container, entsteht pro Block ein Element-Screenshot (`<name>--<block-id>.png`) statt eines Full-Page-Shots. Block-IDs werden validiert: kebab-case, max. 30 Zeichen (Windows-Pfadlimit), eindeutig pro Route, keine 0-Größe — Verstöße schlagen mit sprechender Fehlermeldung fehl.
- **Fallback**: Routen ohne Container werden unverändert als Full-Page geschossen. Neues Routen-Feld `snapshot.forceFullPage` für bewusste Kompositions-Tests (Doc-Kommentar in `sample-app.routes.js` erweitert).
- **Doku**: Konvention in `packages/tools/visual-tests/README.md` beschrieben.

## Verifikation (Neutralitätsbeweis)

Dieser PR ist **snapshot-neutral**: Noch trägt keine Sample-Datei das Attribut, daher greift überall der Fallback. Beweis: Nach Merge von #10683 (inkl. Container-Baseline-Reset) wird dieser Branch rebased — der `ci.yml`-Job `visual-tests` muss dann grün bleiben (null Snapshot-Diffs).

Die Big-Bang-Migration der Sample-Dateien auf `SampleBlock`/`data-visual-block` folgt in einem separaten PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)