### PR TITLE
chore: stop dependabot from proposing angular major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,63 @@ updates:
     schedule:
       interval: weekly
 
+  # The npm entries only carry ignore rules for Dependabot security updates:
+  # each Angular adapter (and the Angular sample) is pinned to one Angular major
+  # line on purpose (see docs/RENOVATE.md), so updates to the next major are
+  # ignored. Security updates respect `versions`-based ignore rules, while
+  # `update-types` would only affect version updates. Regular npm version
+  # updates stay disabled (`open-pull-requests-limit: 0`), as they are handled
+  # by the dependency-update automation of the team.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '@angular/*'
+        versions:
+          - '>=20.0.0'
+
+  - package-ecosystem: npm
+    directory: /packages/adapters/angular/v19
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '@angular/*'
+        versions:
+          - '>=20.0.0'
+
+  - package-ecosystem: npm
+    directory: /packages/adapters/angular/v20
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '@angular/*'
+        versions:
+          - '>=21.0.0'
+
+  - package-ecosystem: npm
+    directory: /packages/adapters/angular/v21
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '@angular/*'
+        versions:
+          - '>=22.0.0'
+
+  - package-ecosystem: npm
+    directory: /packages/samples/angular
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: '@angular/*'
+        versions:
+          - '>=22.0.0'
+
   # === Release Branch: v3 ===
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Problem

Dependabot keeps opening grouped npm security-update PRs (e.g. #10674) that bump `@angular/*` across major lines:

- `packages/adapters/angular/v19`: 19.x → 20.x
- `packages/adapters/angular/v20`: 20.x → 21.x
- `packages/adapters/angular/v21` and `packages/samples/angular`: 21.x → 22.x

These major bumps are unwanted: every adapter is intentionally pinned to one Angular major line (see `docs/RENOVATE.md`, "intentionally pinned major lines"). The PRs arrive as **grouped security updates**, which GitHub creates by default since 2024 even without any `npm` entry in `dependabot.yml` — that is why they kept coming although npm was removed from the config in the past.

## Solution

Add `npm` entries whose only purpose is to carry `versions`-based ignore rules for `@angular/*`. Security updates honor `versions`-based ignores, while `update-types` (e.g. `version-update:semver-major`) would only affect version updates and be ignored here.

- `open-pull-requests-limit: 0` keeps regular npm version updates disabled (status quo — they are handled by the team's dependency-update automation), and security-update PRs are explicitly not subject to this limit.
- Updates within the pinned major lines (19.2.x, 20.3.x, 21.2.x) remain allowed, so in-line Angular security fixes still arrive.

Dependabot alerts themselves are not affected by `dependabot.yml` and stay visible in the Security tab and the daily CVE overview workflow.