### PR TITLE
chore: keep renovate PRs under release:engineering

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
 	"semanticCommitScope": "deps",
 	"timezone": "Europe/Berlin",
 	"schedule": ["before 6am on monday"],
-	"labels": ["dependencies", "renovate", "release:engineering", "release:ignore"],
+	"labels": ["dependencies", "renovate", "release:engineering"],
 	"rebaseWhen": "behind-base-branch",
 	"prConcurrentLimit": 10,
 	"prHourlyLimit": 4,


### PR DESCRIPTION
## Summary

Follow-up to [#10707](https://github.com/public-ui/kolibri/pull/10707), resolving the review findings on `renovate.json`. Targets that PR's branch so it can be merged straight in — the three workflow changes there (`auto-dependency-updater.yml`, `cve-overview.yml`, `license-report.yml`) are untouched and keep their `release:ignore` label.

## Changes

- **`renovate.json`** — dropped the `release:ignore` label that #10707 added to the root `labels` array.

Carrying `release:engineering` and `release:ignore` together was contradictory: `changelog.exclude.labels` in `.github/release.yml` is applied *before* the categories, so Renovate PRs would have vanished from the release notes entirely instead of being filed under _🔧 Engineering_ — and not under _💪 Other Changes_ either.

Dependency PRs should stay visible in the changelog, so `release:engineering` is the label that stays. It also satisfies the `release:*` requirement of `pr-release-label-validation.yml` on its own.

`vulnerabilityAlerts.labels` keeps its own list (Renovate *replaces* array options rather than merging them — only `addLabels` merges) and stays on `release:engineering` as well, so security update PRs are categorized the same way as every other Renovate PR. `docs/RENOVATE.md` describes exactly this behaviour already and needs no change.

## Validation

- `renovate-config-validator renovate.json` → `Config validated successfully`
- Net diff against #10707's branch is a single line in `renovate.json`

## Related Issues

Follow-up to [#10707](https://github.com/public-ui/kolibri/pull/10707)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGWN37DCRwk5LcWU9WeYFK