### PR TITLE
feat(samples): add on-click reproduction sample for issue #10726

### DIFF
--- a/packages/samples/react/src/components/link/on-click.tsx
+++ b/packages/samples/react/src/components/link/on-click.tsx
@@ -1,0 +1,176 @@
+import type { FC } from 'react';
+import React, { useState } from 'react';
+
+import { KolLink } from '@public-ui/react-v19';
+import { SampleBlock } from '../SampleBlock';
+import { SampleDescription } from '../SampleDescription';
+
+export const LinkOnClick: FC = () => {
+	const [clickCount, setClickCount] = useState(0);
+	const [navigateCount, setNavigateCount] = useState(0);
+
+	// Test 1: onClick ohne preventDefault - sollte navigieren UND onClick ausführen
+	const onClickWithoutPrevent = {
+		onClick: (event: Event, href: string) => {
+			console.log('Test 1: onClick ohne preventDefault', { event, href });
+			setClickCount((c) => c + 1);
+			// Kein preventDefault - Navigation sollte stattfinden
+		},
+	};
+
+	// Test 2: onClick mit preventDefault - sollte NUR onClick ausführen, NICHT navigieren
+	const onClickWithPrevent = {
+		onClick: (event: Event, href: string) => {
+			console.log('Test 2: onClick mit preventDefault', { event, href });
+			setClickCount((c) => c + 1);
+			event.preventDefault();
+			// Navigation sollte blockiert sein
+		},
+	};
+
+	// Test 3: onClick mit return false - sollte NUR onClick ausführen, NICHT navigieren
+	const onClickWithReturnFalse = {
+		onClick: (event: Event, href: string) => {
+			console.log('Test 3: onClick mit return false', { event, href });
+			setClickCount((c) => c + 1);
+			return false;
+			// Navigation sollte blockiert sein
+		},
+	};
+
+	// Test 4: onClick mit useNavigate (React Router Pattern)
+	// Dies ist der Use-Case aus Issue #10726
+	const onClickWithNavigate = {
+		onClick: (event: Event, href: string) => {
+			console.log('Test 4: onClick mit simulate navigate', { event, href });
+			setClickCount((c) => c + 1);
+			event.preventDefault();
+			// Simuliere useNavigate.navigate("/home") - sollte NICHT zu href navigieren
+			console.log('Simulated navigate to:', href);
+		},
+	};
+
+	// Track navigation (für Demo-Zwecke)
+	const handleNavigation = () => {
+		setNavigateCount((n) => n + 1);
+	};
+
+	return (
+		<>
+			<SampleDescription>
+				<p>
+					This sample demonstrates the issue described in{' '}
+					<a href="https://github.com/public-ui/kolibri/issues/10726" target="_blank" rel="noopener noreferrer">
+						#10726
+					</a>
+					.
+					<br />
+					Test the behavior of KolLink with onClick handlers and compare it to native &lt;a&gt; tags.
+				</p>
+				<p>
+					<strong>Expected behavior (like native &lt;a&gt; tag):</strong>
+					<ul>
+						<li>onClick without preventDefault: Execute onClick AND navigate to href</li>
+						<li>onClick with preventDefault: Execute onClick, BLOCK navigation</li>
+						<li>onClick returning false: Execute onClick, BLOCK navigation</li>
+					</ul>
+				</p>
+				<p>
+					<strong>Current behavior (Issue #10726):</strong>
+					<ul>
+						<li>❌ onClick with preventDefault: Still navigates to href (should only execute onClick)</li>
+						<li>❌ onClick returning false: Still navigates to href (should only execute onClick)</li>
+					</ul>
+				</p>
+			</SampleDescription>
+
+			<SampleBlock id="on-click">
+				<div className="grid gap-4">
+					{/* Info Panel */}
+					<div className="bg-gray-100 p-4 rounded">
+						<h2 className="h3 mb-2">Test Results</h2>
+						<p>
+							<strong>onClick executions:</strong> {clickCount}
+						</p>
+						<p>
+							<strong>Page navigations:</strong> {navigateCount}
+							<br />
+							<span className="text-sm text-gray-600">(Open browser console to see detailed logs)</span>
+						</p>
+						<p className="text-sm text-gray-600">
+							Note: This demo uses href=&quot;#test&quot; to avoid actual page reloads. Check the URL hash and console output.
+						</p>
+					</div>
+
+					{/* Test 1: onClick ohne preventDefault */}
+					<div className="bg-white p-4 rounded border">
+						<h3 className="h4 mb-2">Test 1: onClick ohne preventDefault</h3>
+						<p className="text-sm text-gray-600 mb-2">Expected: Click increments counter AND adds #test-1 to URL</p>
+						<KolLink _href="#test-1" _label="Click me (no preventDefault)" _on={onClickWithoutPrevent} _inline={false} />
+					</div>
+
+					{/* Test 2: onClick mit preventDefault */}
+					<div className="bg-white p-4 rounded border">
+						<h3 className="h4 mb-2">Test 2: onClick mit preventDefault()</h3>
+						<p className="text-sm text-gray-600 mb-2">Expected: Click increments counter but does NOT add #test-2 to URL</p>
+						<KolLink _href="#test-2" _label="Click me (with preventDefault)" _on={onClickWithPrevent} _inline={false} />
+					</div>
+
+					{/* Test 3: onClick mit return false */}
+					<div className="bg-white p-4 rounded border">
+						<h3 className="h4 mb-2">Test 3: onClick returning false</h3>
+						<p className="text-sm text-gray-600 mb-2">Expected: Click increments counter but does NOT add #test-3 to URL</p>
+						<KolLink _href="#test-3" _label="Click me (return false)" _on={onClickWithReturnFalse} _inline={false} />
+					</div>
+
+					{/* Test 4: useNavigate Pattern (Issue #10726) */}
+					<div className="bg-white p-4 rounded border">
+						<h3 className="h4 mb-2">Test 4: useNavigate Pattern (Issue #10726)</h3>
+						<p className="text-sm text-gray-600 mb-2">Expected: Click logs navigate action but does NOT add #test-4 to URL</p>
+						<KolLink _href="#test-4" _label="Click me (simulate useNavigate)" _on={onClickWithNavigate} _inline={false} />
+					</div>
+
+					{/* Vergleich: Natives <a>-Tag */}
+					<div className="bg-white p-4 rounded border">
+						<h3 className="h4 mb-2">Reference: Native &lt;a&gt; Tag</h3>
+						<p className="text-sm text-gray-600 mb-2">Test native &lt;a&gt; tag behavior for comparison</p>
+						<div className="grid gap-2">
+							<a
+								href="#native-test-1"
+								onClick={() => {
+									console.log('Native a: onClick ohne preventDefault');
+									setClickCount((c) => c + 1);
+								}}
+								className="btn btn-primary"
+							>
+								Native: No preventDefault
+							</a>
+							<a
+								href="#native-test-2"
+								onClick={(e) => {
+									console.log('Native a: onClick mit preventDefault');
+									setClickCount((c) => c + 1);
+									e.preventDefault();
+								}}
+								className="btn btn-primary"
+							>
+								Native: With preventDefault
+							</a>
+							<a
+								href="#native-test-3"
+								onClick={(e) => {
+									console.log('Native a: onClick mit return false');
+									setClickCount((c) => c + 1);
+									return false;
+								}}
+								className="btn btn-primary"
+							>
+								Native: Return false
+							</a>
+						</div>
+					</div>
+				</div>
+			</SampleBlock>
+		</>
+	);
+};

--- a/packages/samples/react/src/components/link/on-click.tsx
+++ b/packages/samples/react/src/components/link/on-click.tsx
@@ -7,7 +7,6 @@ import { SampleDescription } from '../SampleDescription';
 
 export const LinkOnClick: FC = () => {
 	const [clickCount, setClickCount] = useState(0);
-	const [navigateCount, setNavigateCount] = useState(0);
 
 	// Test 1: onClick ohne preventDefault - sollte navigieren UND onClick ausführen
 	const onClickWithoutPrevent = {
@@ -50,11 +49,6 @@ export const LinkOnClick: FC = () => {
 		},
 	};
 
-	// Track navigation (für Demo-Zwecke)
-	const handleNavigation = () => {
-		setNavigateCount((n) => n + 1);
-	};
-
 	return (
 		<>
 			<SampleDescription>
@@ -92,11 +86,7 @@ export const LinkOnClick: FC = () => {
 						<p>
 							<strong>onClick executions:</strong> {clickCount}
 						</p>
-						<p>
-							<strong>Page navigations:</strong> {navigateCount}
-							<br />
-							<span className="text-sm text-gray-600">(Open browser console to see detailed logs)</span>
-						</p>
+						<p className="text-sm text-gray-600">(Open browser console to see detailed logs)</p>
 						<p className="text-sm text-gray-600">
 							Note: This demo uses href=&quot;#test&quot; to avoid actual page reloads. Check the URL hash and console output.
 						</p>
@@ -147,10 +137,10 @@ export const LinkOnClick: FC = () => {
 							</a>
 							<a
 								href="#native-test-2"
-								onClick={(e) => {
+								onClick={(event: React.MouseEvent) => {
 									console.log('Native a: onClick mit preventDefault');
 									setClickCount((c) => c + 1);
-									e.preventDefault();
+									event.preventDefault();
 								}}
 								className="btn btn-primary"
 							>
@@ -158,7 +148,7 @@ export const LinkOnClick: FC = () => {
 							</a>
 							<a
 								href="#native-test-3"
-								onClick={(e) => {
+								onClick={() => {
 									console.log('Native a: onClick mit return false');
 									setClickCount((c) => c + 1);
 									return false;

--- a/packages/samples/react/src/components/link/routes.ts
+++ b/packages/samples/react/src/components/link/routes.ts
@@ -6,6 +6,7 @@ import { LinkIcons } from './icons';
 import { LinkImage } from './image';
 import { LinkReactRouter } from './link-react-router';
 import { LinkHeadline } from './linked-headline';
+import { LinkOnClick } from './on-click';
 import { LinkShortKey } from './short-key';
 import { LinkTarget } from './target';
 import { LinkVariant } from './variant';
@@ -21,6 +22,7 @@ export const LINK_ROUTES: Routes = {
 		'short-key': LinkShortKey,
 		'react-router': LinkReactRouter,
 		'linked-headline': LinkHeadline,
+		'on-click': LinkOnClick,
 		'link-variant': LinkVariant,
 	},
 };


### PR DESCRIPTION
## What changed?

Adds a new React sample `on-click.tsx` under the link samples that reproduces issue #10726 — `KolLink` not honoring `preventDefault()` / `return false` in `onClick` handlers the way a native `<a>` element does. The sample renders four `KolLink` test cases (onClick without `preventDefault`, with `preventDefault`, returning `false`, and a simulated `useNavigate` pattern) alongside native `<a>` references for comparison, and registers the new sample in the link route table. No component/library source is changed — this is a demonstration/reproduction sample only.

## Linked issues

- Closes #10726 — `KolLink` `onClick` does not respect `preventDefault()` / `return false` like a native anchor.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Fügt ein neues React-Sample `on-click.tsx` bei den Link-Samples hinzu, das Issue #10726 reproduziert — `KolLink` respektiert `preventDefault()` / `return false` in `onClick`-Handlern nicht so wie ein natives `<a>`-Element. Das Sample rendert vier `KolLink`-Testfälle (onClick ohne `preventDefault`, mit `preventDefault`, mit `return false` sowie ein simuliertes `useNavigate`-Muster) neben nativen `<a>`-Referenzen zum Vergleich und registriert das Sample in der Link-Routentabelle. Es wird kein Komponenten-/Bibliothekscode geändert — es handelt sich ausschließlich um ein Demonstrations-/Reproduktions-Sample.

### Verknüpfte Tickets

- Schließt #10726 — `KolLink` `onClick` respektiert `preventDefault()` / `return false` nicht wie ein nativer Anker.

### Art der Änderung

🔧 Intern (Demo/Reproduktions-Sample)

### Geänderte Dateien

- `packages/samples/react/src/components/link/on-click.tsx` — neues Reproduktions-Sample mit vier `KolLink`-Testfällen und nativen `<a>`-Vergleichen.
- `packages/samples/react/src/components/link/routes.ts` — Sample als Route `on-click` registriert.

</details>