### PR TITLE
fix(link): restore empty-string _download as download="" presence attribute

### DIFF
--- a/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
+++ b/packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`kol-link should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _download="" 1`] = `
+<kol-link>
+  <template shadowrootmode="open">
+    <div class="kol-link kol-link--external-link kol-link--inline">
+      <a class="kol-link__anchor" download="" href="https://example.com" rel="noopener" target="self">
+        <span class="kol-link__text kol-span">
+          <span class="kol-span__container">
+            <i aria-hidden="true" class="codicon codicon-home kol-icon kol-icon__icon kol-span__icon kol-span__icon--left" role="presentation"></i>
+            <span class="kol-span__label">
+              Label
+            </span>
+            <span aria-hidden="true" class="kol-span__slot" hidden="">
+              <slot name="expert" slot="expert"></slot>
+            </span>
+          </span>
+        </span>
+        <i aria-label="kol-open-link-in-tab" class="kol-icon kol-icon__icon kol-link__icon kolicon-link-external" role="img"></i>
+      </a>
+    </div>
+  </template>
+</kol-link>
+`;
+
 exports[`kol-link should render with _href="https://example.com" _icons="codicon codicon-home" _label="Label" _target="self" _tooltipAlign="bottom" 1`] = `
 <kol-link>
   <template shadowrootmode="open">

--- a/packages/components/src/components/link/test/snapshot.spec.tsx
+++ b/packages/components/src/components/link/test/snapshot.spec.tsx
@@ -19,5 +19,7 @@ executeSnapshotTests<LinkProps>(
 		{ ...baseObj, _tooltipAlign: 'top', _hideLabel: true },
 
 		{ _label: 'Label', _href: '', _download: 'download-file.zip', _target: 'blank' },
+		// `download` is a presence attribute: an empty string must render as `download=""`.
+		{ ...baseObj, _download: '' },
 	],
 );

--- a/packages/components/src/internal/functional-components/link/component.tsx
+++ b/packages/components/src/internal/functional-components/link/component.tsx
@@ -49,7 +49,9 @@ export const LinkFC: FC<FunctionalComponentProps<LinkApi>> = (props) => {
 		href: typeof href === 'string' && href.length > 0 ? href : 'javascript:void(0);',
 		target: typeof target === 'string' && target.length > 0 ? target : undefined,
 		rel: isExternal ? 'noopener' : undefined,
-		download: typeof download === 'string' && download.length > 0 ? download : undefined,
+		// `download` is a presence attribute: an explicitly empty string means "download without a
+		// suggested filename" and must render as `download=""`, unlike an unset download.
+		download: typeof download === 'string' ? download : undefined,
 	};
 
 	if (hideLabel === true && !label) {

--- a/packages/components/src/internal/props/download.ts
+++ b/packages/components/src/internal/props/download.ts
@@ -3,4 +3,8 @@ import { createPropDefinition } from './helpers/factory';
 import { normalizeString } from './helpers/normalizers';
 
 export type DownloadProp = SimpleProp<'download', string>;
-export const downloadProp = createPropDefinition<DownloadProp>('download', '', normalizeString);
+// The default is `undefined` (not `''` like other string props) to keep "not set" distinguishable
+// from "explicitly empty": `download` is a presence attribute, so `_download=""` must render as
+// `download=""` (download without a suggested filename) while an unset `_download` must not
+// render the attribute at all.
+export const downloadProp = createPropDefinition<DownloadProp>('download', undefined as unknown as string, normalizeString);


### PR DESCRIPTION
## What changed?

Restores `_download=""` rendering the HTML `download` presence attribute on links. The link skeleton migration (#10652) had `LinkFC` filter the value with `download.length > 0`, so an explicitly empty string no longer emitted the attribute. Per the HTML spec `download` is a presence attribute — an empty value means "download the file without a suggested filename", which is the only way to express that through the component API. Root cause: the `downloadProp` factory default was `''`, making "not set" and "explicitly empty" indistinguishable at the functional component. The fix changes the prop default to `undefined` (so unset → no attribute, explicitly empty → `download=""`, and clearing `_download` later removes the attribute again) and restores `typeof download === 'string' ? download : undefined` in `LinkFC`. This covers `kol-link`, `kol-link-wc` and `kol-link-button` (which delegates to link-wc). The regression was never released, so no migration note is required.

## Linked issues

- Closes #10688 — `_download=""` stopped rendering `download=""` after the link skeleton migration.
- Refs #10652 — the link skeleton migration that introduced the regression.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Stellt wieder her, dass `_download=""` das HTML-Präsenzattribut `download` an Links rendert. Durch die Link-Skeleton-Migration (#10652) filterte `LinkFC` den Wert mit `download.length > 0`, sodass ein explizit leerer String das Attribut nicht mehr ausgab. Laut HTML-Spezifikation ist `download` ein Präsenzattribut — ein leerer Wert bedeutet „Datei ohne vorgeschlagenen Dateinamen herunterladen“ und ist die einzige Möglichkeit, dies über die Komponenten-API auszudrücken. Ursache: Der Default der `downloadProp`-Factory war `''`, wodurch „nicht gesetzt“ und „explizit leer“ am Functional Component nicht unterscheidbar waren. Der Fix setzt den Prop-Default auf `undefined` (nicht gesetzt → kein Attribut, explizit leer → `download=""`, spätere Leerung entfernt das Attribut wieder) und stellt `typeof download === 'string' ? download : undefined` in `LinkFC` wieder her. Abgedeckt sind `kol-link`, `kol-link-wc` und `kol-link-button` (delegiert an link-wc). Die Regression wurde nie veröffentlicht, daher kein Migrationshinweis.

### Verknüpfte Tickets

- Schließt #10688 — `_download=""` rendert nach der Link-Skeleton-Migration kein `download=""` mehr.
- Referenziert #10652 — die Link-Skeleton-Migration, die die Regression verursacht hat.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/internal/props/download.ts` — Prop-Default von `''` auf `undefined` geändert, um „nicht gesetzt“ von „explizit leer“ zu unterscheiden.
- `packages/components/src/internal/functional-components/link/component.tsx` — `LinkFC` gibt `download=""` bei explizit leerem String wieder aus.
- `packages/components/src/components/link/test/snapshot.spec.tsx` — Snapshot-Variante `_download=""` ergänzt.
- `packages/components/src/components/link/test/__snapshots__/snapshot.spec.tsx.snap` — zugehöriger Snapshot aktualisiert (Anker rendert `download=""`).

</details>