### PR TITLE
fix(link): consumer onClick receives anchor as event.target via setEventTarget

### DIFF
--- a/packages/components/src/components/link/component.tsx
+++ b/packages/components/src/components/link/component.tsx
@@ -44,6 +44,7 @@ import type {
 	TooltipAlignPropType,
 	VariantClassNamePropType,
 } from '../../schema';
+import { setEventTarget } from '../../schema';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 import { nonce } from '../../utils/dev.utils';
 import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
@@ -141,6 +142,7 @@ export class KolLink extends BaseWebComponent<LinkApi> implements FocusableEleme
 		const href = this.getRenderProp('href');
 		const on = this.getRenderProp('on');
 		if (typeof on?.onClick === 'function') {
+			setEventTarget(event, this.ctaRef.el);
 			on.onClick(event, href);
 		}
 		if (this.host) {

--- a/packages/components/src/components/link/link.e2e.ts
+++ b/packages/components/src/components/link/link.e2e.ts
@@ -30,7 +30,7 @@ test.describe('kol-link', () => {
 				const targetIsAnchorPromise = kolLink.evaluate((element: HTMLKolLinkElement) => {
 					return new Promise<boolean>((resolve) => {
 						element._on = {
-							onClick: (event: MouseEvent) => {
+							onClick: (event: Event, value: string) => {
 								resolve(event.target instanceof HTMLAnchorElement && event.target.classList.contains('kol-link__anchor'));
 							},
 						};

--- a/packages/components/src/components/link/link.e2e.ts
+++ b/packages/components/src/components/link/link.e2e.ts
@@ -21,6 +21,29 @@ test.describe('kol-link', () => {
 			await page.locator('a').dispatchEvent('click');
 			await expect(callbackPromise).resolves.toBeUndefined();
 		});
+
+		['kol-link', 'kol-link-wc'].forEach((tag) => {
+			test(`should pass the internal anchor as event.target to the onClick callback (${tag})`, async ({ page }) => {
+				await page.setContent(`<${tag} _label="Link"></${tag}>`);
+				const kolLink = page.locator(tag);
+
+				const targetIsAnchorPromise = kolLink.evaluate((element: HTMLKolLinkElement) => {
+					return new Promise<boolean>((resolve) => {
+						element._on = {
+							onClick: (event: MouseEvent) => {
+								resolve(event.target instanceof HTMLAnchorElement && event.target.classList.contains('kol-link__anchor'));
+							},
+						};
+					});
+				});
+				await page.waitForChanges();
+
+				// Dispatch directly on the anchor to verify that setEventTarget pins the target
+				await page.locator(`${tag} a`).dispatchEvent('click');
+
+				await expect(targetIsAnchorPromise).resolves.toBe(true);
+			});
+		});
 	});
 
 	test.describe('DOM events', () => {

--- a/packages/components/src/components/link/link.e2e.ts
+++ b/packages/components/src/components/link/link.e2e.ts
@@ -30,7 +30,7 @@ test.describe('kol-link', () => {
 				const targetIsAnchorPromise = kolLink.evaluate((element: HTMLKolLinkElement) => {
 					return new Promise<boolean>((resolve) => {
 						element._on = {
-							onClick: (event: Event, value: string) => {
+							onClick: (event: Event, _value: string) => {
 								resolve(event.target instanceof HTMLAnchorElement && event.target.classList.contains('kol-link__anchor'));
 							},
 						};

--- a/packages/components/src/components/link/wc.tsx
+++ b/packages/components/src/components/link/wc.tsx
@@ -52,6 +52,7 @@ import type {
 	TooltipAlignPropType,
 	VariantClassNamePropType,
 } from '../../schema';
+import { setEventTarget } from '../../schema';
 import { validateAccessAndShortKey } from '../../schema/validators/access-and-short-key';
 import { nonce } from '../../utils/dev.utils';
 import { createCtaRef, directClick, directFocus } from '../../utils/element-interaction';
@@ -164,6 +165,7 @@ export class KolLinkWc extends BaseWebComponent<LinkApi> implements ClickableEle
 		const href = this.getRenderProp('href');
 		const on = this.getRenderProp('on');
 		if (typeof on?.onClick === 'function') {
+			setEventTarget(event, this.ctaRef.el);
 			on.onClick(event, href);
 		}
 		if (this.host) {


### PR DESCRIPTION
## What changed?

Restores the `setEventTarget(event, this.ctaRef.el)` call in `kol-link` and `kol-link-wc` before the consumer's `_on.onClick` callback is invoked. The skeleton migration had dropped this call, so consumers received the raw DOM `event.target` (for example the clicked icon `<svg>`/`<i>`) instead of the `.kol-link__anchor` element. The call is re-added in both `link/component.tsx` (kol-link) and `link/wc.tsx` (kol-link-wc), mirroring the existing button implementation and re-establishing the legacy contract. E2E tests are added that verify both implementations hand the anchor element to the consumer callback as `event.target`.

## Linked issues

- Closes #10687 — `onClick` callback receives the wrong `event.target` (inner icon instead of the anchor) after the link skeleton migration.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Stellt den Aufruf `setEventTarget(event, this.ctaRef.el)` in `kol-link` und `kol-link-wc` wieder her, bevor der Consumer-Callback `_on.onClick` aufgerufen wird. Die Skeleton-Migration hatte diesen Aufruf entfernt, sodass Consumer das rohe DOM-`event.target` (z. B. das angeklickte Icon-`<svg>`/`<i>`) statt des `.kol-link__anchor`-Elements erhielten. Der Aufruf wird in `link/component.tsx` (kol-link) und `link/wc.tsx` (kol-link-wc) wieder eingefügt — analog zur Button-Implementierung — und stellt den bisherigen Vertrag wieder her. Neue E2E-Tests prüfen für beide Implementierungen, dass das Anker-Element als `event.target` an den Consumer-Callback übergeben wird.

### Verknüpfte Tickets

- Schließt #10687 — Der `onClick`-Callback erhält nach der Link-Skeleton-Migration das falsche `event.target` (inneres Icon statt Anker).

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/link/component.tsx` — `setEventTarget`-Aufruf vor `onClick` in `kol-link` wiederhergestellt.
- `packages/components/src/components/link/wc.tsx` — `setEventTarget`-Aufruf vor `onClick` in `kol-link-wc` wiederhergestellt.
- `packages/components/src/components/link/link.e2e.ts` — E2E-Tests ergänzt, die den Anker als `event.target` für beide Implementierungen prüfen.

</details>