### PR TITLE
fix(components): correct type re-export path in loader/index.d.ts

### DIFF
--- a/packages/components/loader/index.d.ts
+++ b/packages/components/loader/index.d.ts
@@ -1,1 +1,1 @@
-export { defineCustomElements } from '../dist/types/loader';
+export { defineCustomElements } from '../dist/loader';


### PR DESCRIPTION
## What changed?

Corrects the TypeScript type re-export path in the committed loader stub `packages/components/loader/index.d.ts`. It re-exported `defineCustomElements` from `../dist/types/loader`, a declaration file Stencil's `dist` output target never emits — the loader's declarations are actually generated at `dist/loader/index.d.ts`. The one-line fix repoints the re-export to `../dist/loader`. Because the wrong path made TypeScript report `Cannot find module`, `defineCustomElements` resolved to type `error`, which surfaced downstream as an `@typescript-eslint/no-unsafe-argument` failure when consumers call `register(theme, defineCustomElements)`. The `.mjs`/`.cjs` runtime re-exports were already pointing at the correct outputs, so only type-checking/lint was affected — runtime behavior is unchanged.

## Linked issues

- Closes #10730 — `defineCustomElements` from the `./loader` subpath is typed as `error`, breaking consumer type-checking/lint.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Korrigiert den TypeScript-Typ-Re-Export-Pfad in der eingecheckten Loader-Stub-Datei `packages/components/loader/index.d.ts`. Diese re-exportierte `defineCustomElements` aus `../dist/types/loader` — eine Deklarationsdatei, die Stencils `dist`-Output-Target nie erzeugt; die Loader-Typen entstehen tatsächlich unter `dist/loader/index.d.ts`. Der Einzeiler-Fix zeigt nun auf `../dist/loader`. Da der falsche Pfad TypeScript `Cannot find module` melden ließ, wurde `defineCustomElements` als Typ `error` aufgelöst, was sich beim Consumer als `@typescript-eslint/no-unsafe-argument`-Fehler beim Aufruf `register(theme, defineCustomElements)` zeigte. Die `.mjs`/`.cjs`-Runtime-Re-Exporte waren bereits korrekt — betroffen war nur die Typprüfung/Lint, nicht das Laufzeitverhalten.

### Verknüpfte Tickets

- Schließt #10730 — `defineCustomElements` aus dem `./loader`-Subpath wird als `error` typisiert und bricht die Typprüfung/Lint beim Consumer.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/loader/index.d.ts` — Typ-Re-Export-Pfad von `../dist/types/loader` auf `../dist/loader` korrigiert.

</details>