### PR TITLE
refactor(styles): hoist universal button text border to base and slim…

### DIFF
--- a/packages/components/src/components/@shared/_button.mixin.scss
+++ b/packages/components/src/components/@shared/_button.mixin.scss
@@ -49,6 +49,11 @@
 		}
 
 		&__text {
+			/* Every theme paints the text as a solid-bordered box; color and width are theme tokens.
+			   `border-width: 0` keeps the theme-less fallback borderless — a theme opts into the
+			   visible border purely via its own `border-width`. */
+			border-style: solid;
+			border-width: 0;
 			flex: 1 0 100%;
 		}
 

--- a/packages/themes/bwst/src/mixins/alert.scss
+++ b/packages/themes/bwst/src/mixins/alert.scss
@@ -1,11 +1,6 @@
 @use './to-rem' as *;
 @use './button' as *;
 
-@mixin kol-alert {
-	display: block;
-	width: 100%;
-}
-
 @mixin kol-input-error-with-kol-alert-error($color: null) {
 	color: var($color);
 
@@ -43,8 +38,6 @@
 		grid-template-areas:
 			'icon heading close'
 			'content content content';
-		grid-template-columns: min-content 1fr min-content;
-		grid-template-rows: min-content min-content;
 		border: var(--border-width) solid var(--alert-accent-color);
 	}
 

--- a/packages/themes/bwst/src/mixins/button.scss
+++ b/packages/themes/bwst/src/mixins/button.scss
@@ -7,8 +7,6 @@
 	}
 
 	.#{$block-classname} {
-		$root: &;
-
 		/* The shared skeleton mixin sets `text-align: left` on the interactive element (copied from
 		   the anchor case). A real `<button>` had the user-agent `text-align: center` before the
 		   migration, so a wrapping label (e.g. a narrow icon-only pill) would otherwise align left
@@ -18,7 +16,6 @@
 		}
 
 		&__text {
-			border-style: solid;
 			border-radius: var(--border-radius);
 			border-width: var(--border-width);
 
@@ -108,7 +105,7 @@
 				border-color: var(--text-border-color);
 			}
 
-			@at-root #{$root}--hide-label & {
+			.#{$block-classname}--hide-label & {
 				padding: to-rem(12);
 
 				.kol-span__label {
@@ -116,19 +113,19 @@
 				}
 			}
 
-			@at-root #{$root}:focus-visible,
-				#{$root}__button:focus-visible,
-				#{$root}__anchor:focus-visible {
-				@include focus-outline;
-				position: relative; // make sure focus outline is visible and not covered by adjacent element
-			}
-
-			@at-root #{$root}__button:is(:disabled, [aria-disabled='true']):hover & {
+			.#{$block-classname}__button:is(:disabled, [aria-disabled='true']):hover & {
 				color: var(--text-color);
 				background-color: var(--text-background-color);
 				box-shadow: none;
 				border-color: var(--text-border-color);
 			}
+		}
+
+		&:focus-visible,
+		&__button:focus-visible,
+		&__anchor:focus-visible {
+			@include focus-outline;
+			position: relative; // make sure focus outline is visible and not covered by adjacent element
 		}
 	}
 

--- a/packages/themes/bwst/src/mixins/kol-card.scss
+++ b/packages/themes/bwst/src/mixins/kol-card.scss
@@ -9,7 +9,6 @@
 		background-color: var(--color-light);
 		border-radius: $border-radius;
 		width: 100%;
-		height: 100%;
 		//		box-shadow: 0 0 4px color-mix(in srgb, black 80%, var(--color-subtle)); // darken by 80% to maintain contrast of 3:1
 		border: to-rem(1) solid var(--color-subtle);
 

--- a/packages/themes/default/src/mixins/alert.scss
+++ b/packages/themes/default/src/mixins/alert.scss
@@ -1,11 +1,6 @@
 @use './to-rem' as *;
 @use './button' as *;
 
-@mixin kol-alert {
-	display: block;
-	width: 100%;
-}
-
 @mixin kol-input-error-with-kol-alert-error($color: null) {
 	color: var($color);
 
@@ -44,8 +39,6 @@
 		grid-template-areas:
 			'icon heading close'
 			'content content content';
-		grid-template-columns: min-content 1fr min-content;
-		grid-template-rows: min-content min-content;
 		border: var(--border-width) solid var(--alert-accent-color);
 	}
 

--- a/packages/themes/default/src/mixins/button.scss
+++ b/packages/themes/default/src/mixins/button.scss
@@ -7,8 +7,6 @@
 	}
 
 	.#{$block-classname} {
-		$root: &;
-
 		/* The shared skeleton mixin sets `text-align: left` on the interactive element (copied from
 		   the anchor case). A real `<button>` had the user-agent `text-align: center` before the
 		   migration, so a wrapping label (e.g. a narrow icon-only pill) would otherwise align left
@@ -18,7 +16,6 @@
 		}
 
 		&__text {
-			border-style: solid;
 			border-radius: var(--border-radius);
 			border-width: var(--border-width);
 
@@ -107,7 +104,7 @@
 				border-color: var(--text-border-color);
 			}
 
-			@at-root #{$root}--hide-label & {
+			.#{$block-classname}--hide-label & {
 				padding: to-rem(12);
 
 				.kol-span__label {
@@ -115,18 +112,18 @@
 				}
 			}
 
-			@at-root #{$root}__anchor:focus,
-				#{$root}__button:focus {
-				@include focus-outline;
-				position: relative; // make sure focus outline is visible and not covered by adjacent element
-			}
-
-			@at-root #{$root}__button:is(:disabled, [aria-disabled='true']):hover & {
+			.#{$block-classname}__button:is(:disabled, [aria-disabled='true']):hover & {
 				color: var(--text-color);
 				background-color: var(--text-background-color);
 				box-shadow: none;
 				border-color: var(--text-border-color);
 			}
+		}
+
+		&__anchor:focus,
+		&__button:focus {
+			@include focus-outline;
+			position: relative; // make sure focus outline is visible and not covered by adjacent element
 		}
 	}
 

--- a/packages/themes/default/src/mixins/card.scss
+++ b/packages/themes/default/src/mixins/card.scss
@@ -10,7 +10,6 @@
 		box-shadow: 0 0 4px color-mix(in srgb, black 80%, var(--color-subtle)); // darken by 80% to maintain contrast of 3:1
 		border-radius: $border-radius;
 		width: 100%;
-		height: 100%;
 		gap: to-rem(8);
 
 		&__header {

--- a/packages/themes/desy/src/mixins/alert.scss
+++ b/packages/themes/desy/src/mixins/alert.scss
@@ -24,8 +24,6 @@
 			grid-template-areas:
 				'icon heading close'
 				'icon content content';
-			grid-template-columns: min-content 1fr min-content;
-			grid-template-rows: min-content min-content;
 			border: var(--border-width-s) solid var(--alert-accent-color);
 
 			&:not(:has(#{$root}__heading)) {

--- a/packages/themes/desy/src/mixins/button.scss
+++ b/packages/themes/desy/src/mixins/button.scss
@@ -6,7 +6,6 @@
 	@include icon;
 
 	.#{$block-classname} {
-		$root: &;
 		--a11y-min-size: #{to-rem(36)};
 		--text-background-color: transparent;
 		--text-border-color: var(--color-blue-100);
@@ -67,7 +66,6 @@
 			color: var(--text-color);
 			background-color: var(--text-background-color);
 			border-color: var(--text-border-color);
-			border-style: solid;
 			border-radius: var(--radius-m);
 			position: relative;
 			min-height: to-rem(36);
@@ -93,14 +91,14 @@
 				padding: to-rem(4) to-rem(16); // vertical padding results in specified container height of 36px
 			}
 
-			@at-root #{$root}--hide-label & {
+			.#{$block-classname}--hide-label & {
 				.kol-span__label {
 					display: none;
 				}
 			}
 
-			@at-root #{$root}:focus &,
-				#{$root}:focus-within & {
+			.#{$block-classname}:focus &,
+			.#{$block-classname}:focus-within & {
 				@include focus-outline;
 				position: relative; // make sure focus outline is visible and not covered by adjacent element
 			}

--- a/packages/themes/ecl/src/ecl-ec/mixins/button.scss
+++ b/packages/themes/ecl/src/ecl-ec/mixins/button.scss
@@ -129,14 +129,15 @@
 		&__text {
 			color: var(--button-text-color);
 			background-color: var(--button-background-color);
+			border-color: var(--button-border-color);
 			border-radius: 2px;
 
 			min-width: var(--a11y-min-size);
 			min-height: var(--a11y-min-size);
 			padding: var(--ecl-spacing-xs) var(--ecl-spacing-m);
+			border-width: var(--button-border-width);
 
 			line-height: 1.2;
-			border: var(--button-border-color) solid var(--button-border-width);
 
 			.kol-span {
 				&__container {

--- a/packages/themes/kern/src/mixins/_button.mixin.scss
+++ b/packages/themes/kern/src/mixins/_button.mixin.scss
@@ -55,7 +55,6 @@
 			color: var(--button-text-color);
 			background-color: var(--button-text-background-color);
 			border-color: var(--button-text-border-color);
-			border-style: solid;
 			border-radius: var(--kern-metric-border-radius-default);
 			min-width: var(--button-min-size);
 			min-height: var(--button-min-size);


### PR DESCRIPTION
… theme styles

Move generic styles that every theme repeats identically into the base component layer and remove them from the themes:

- base kol-button-styles: .kol-button__text now carries 'border-style: solid; border-width: 0'. Every theme painted the text as a solid-bordered box; color/width remain theme tokens. The 0-width default keeps the theme-less fallback borderless (ecl-eu, which sets only border-color, is unaffected).
- default/bwst/desy/kern button: drop the redundant per-theme 'border-style: solid'.
- ecl ecl-ec button: replace the 'border: color solid width' shorthand with border-color/border-width longhands.
- default/bwst alert: drop grid-template-columns/rows re-declarations that repeat base values in --variant-card; remove the dead unused 'kol-alert' mixin.
- desy alert: drop the same redundant grid re-declarations.
- default/bwst card: drop 'height: 100%' (already set by base kol-card).
- default/bwst/desy button: replace deprecated $root/@at-root patterns with direct nesting; the focus-outline rules now sit at block level and, when the mixin is nested (alert/card), naturally keep the host component prefix instead of the old double-prefixed dead selectors.

Verified by compiling every touched mixin before/after with sass and diffing the emitted CSS, plus full builds of all five themes and the components unit (916 tests, 773 snapshots) and e2e (402 tests) suites.