### PR TITLE
fix: table header textalign

### DIFF
--- a/packages/components/src/components/@shared/_table-stateless.mixin.scss
+++ b/packages/components/src/components/@shared/_table-stateless.mixin.scss
@@ -81,15 +81,16 @@
 			&--align-left {
 				text-align: left;
 
-				.kol-button__text {
+				.kol-table__sort-button .kol-button__text {
 					align-items: start;
+					text-align: start;
 				}
 			}
 
 			&--align-center {
 				text-align: center;
 
-				& .kol-button__text {
+				.kol-table__sort-button .kol-button__text {
 					align-items: center;
 				}
 			}
@@ -97,8 +98,9 @@
 			&--align-right {
 				text-align: right;
 
-				.kol-button__text {
+				.kol-table__sort-button .kol-button__text {
 					align-items: end;
+					text-align: end;
 				}
 			}
 


### PR DESCRIPTION
## What changed?

This fixes the header text alignment of sortable table columns in `packages/components/src/components/@shared/_table-stateless.mixin.scss`. Previously the `--align-left`/`--align-center`/`--align-right` header modifiers targeted `.kol-button__text` generally, which was too broad and did not reliably align the header label. The selectors are now scoped to `.kol-table__sort-button .kol-button__text`, and `text-align: start`/`text-align: end` are added for the left/right cases so the sort-button label text is aligned within the button, not only the flex items. No API changes — behavior of the `textAlign` header option is corrected for the sort-button header.

## Linked issues

- Closes #10723 — Table header (sort button) text did not follow the column `textAlign`.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies behebt die Ausrichtung des Header-Textes sortierbarer Tabellenspalten in `packages/components/src/components/@shared/_table-stateless.mixin.scss`. Bisher zielten die Header-Modifier `--align-left`/`--align-center`/`--align-right` allgemein auf `.kol-button__text`, was zu weit gefasst war und den Header-Text nicht zuverlässig ausrichtete. Die Selektoren sind jetzt auf `.kol-table__sort-button .kol-button__text` eingegrenzt, und für die Fälle links/rechts wird zusätzlich `text-align: start`/`text-align: end` gesetzt, damit der Text der Sort-Button-Beschriftung innerhalb des Buttons ausgerichtet wird, nicht nur die Flex-Items. Keine API-Änderung — das Verhalten der Header-Option `textAlign` wird für den Sort-Button-Header korrigiert.

### Verknüpfte Tickets

- Schließt #10723 — Der Text im Tabellen-Header (Sort-Button) folgte nicht dem Spalten-`textAlign`.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/@shared/_table-stateless.mixin.scss` — Selektoren der Header-Ausrichtung auf `.kol-table__sort-button .kol-button__text` eingegrenzt und `text-align: start/end` für links/rechts ergänzt.

</details>
