### PR TITLE
feat(visual-tests): machine-readable visual report for the snapshot review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,19 +117,25 @@ jobs:
       - name: Determine report path
         id: report-path
         if: ${{ !cancelled() }}
+        # The container job runs its scripts with `sh`, not bash: no `[[ … ]]` here, it would silently
+        # fall through to the theme branch and look for unstyled under packages/themes/.
         run: |
           PACKAGE="${{ matrix.package }}"
-          if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
-            PKG_DIR="packages/test-tag-name-transformer"
-            SLUG="tag-name-transformer"
-          elif [[ "${PACKAGE}" == 'unstyled' ]]; then
-            PKG_DIR="packages/unstyled"
-            SLUG="unstyled"
-          else
-            THEME_DIR="${PACKAGE#theme-}"
-            PKG_DIR="packages/themes/${THEME_DIR}"
-            SLUG="${THEME_DIR}"
-          fi
+          case "${PACKAGE}" in
+            test-tag-name-transformer)
+              PKG_DIR="packages/test-tag-name-transformer"
+              SLUG="tag-name-transformer"
+              ;;
+            unstyled)
+              PKG_DIR="packages/unstyled"
+              SLUG="unstyled"
+              ;;
+            *)
+              THEME_DIR="${PACKAGE#theme-}"
+              PKG_DIR="packages/themes/${THEME_DIR}"
+              SLUG="${THEME_DIR}"
+              ;;
+          esac
           REPORT_DIR="${PKG_DIR}/playwright-report"
           echo "pkg=${PKG_DIR}" >> "$GITHUB_OUTPUT"
           echo "dir=${REPORT_DIR}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,22 +108,30 @@ jobs:
         if: failure()
         with:
           name: report-${{ matrix.package }}
+      # Summarises visual-report/report.json (written by packages/tools/visual-tests/src/visual-reporter.js)
+      # into the job summary. Fails only on routes that could not be compared at all – screenshot
+      # differences are a review case and already fail the "Visual Tests" step above.
+      - name: Visual review summary
+        if: ${{ !cancelled() }}
+        run: node scripts/visual-review/assert-no-errors.mjs ${{ matrix.package }}
       - name: Determine report path
         id: report-path
         if: ${{ !cancelled() }}
         run: |
           PACKAGE="${{ matrix.package }}"
           if [[ "${PACKAGE}" == 'test-tag-name-transformer' ]]; then
-            REPORT_DIR="packages/test-tag-name-transformer/playwright-report"
+            PKG_DIR="packages/test-tag-name-transformer"
             SLUG="tag-name-transformer"
           elif [[ "${PACKAGE}" == 'unstyled' ]]; then
-            REPORT_DIR="packages/unstyled/playwright-report"
+            PKG_DIR="packages/unstyled"
             SLUG="unstyled"
           else
             THEME_DIR="${PACKAGE#theme-}"
-            REPORT_DIR="packages/themes/${THEME_DIR}/playwright-report"
+            PKG_DIR="packages/themes/${THEME_DIR}"
             SLUG="${THEME_DIR}"
           fi
+          REPORT_DIR="${PKG_DIR}/playwright-report"
+          echo "pkg=${PKG_DIR}" >> "$GITHUB_OUTPUT"
           echo "dir=${REPORT_DIR}" >> "$GITHUB_OUTPUT"
           echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
           if [ -d "${REPORT_DIR}" ]; then
@@ -139,6 +147,15 @@ jobs:
           path: ${{ steps.report-path.outputs.dir }}
           if-no-files-found: ignore
           retention-days: 5
+      # report.json plus the PNGs of changed/added/removed snapshots – the input of the visual review.
+      - name: Upload visual review report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-review-${{ matrix.package }}
+          path: ${{ steps.report-path.outputs.pkg }}/visual-report
+          if-no-files-found: warn
+          retention-days: 14
 
   visual-tests-report:
     needs: visual-tests

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 node_modules/
 playwright-report/
 test-results/
+visual-report/
 *.log
 *.tgz
 

--- a/packages/tools/visual-tests/README.md
+++ b/packages/tools/visual-tests/README.md
@@ -63,6 +63,22 @@ In the following runs, new screenshots will be compared to this reference.
 
 To update the reference screenshots call `npm run test:update`.
 
+### Visual report (`visual-report/report.json`)
+
+Besides Playwright's own HTML report, every run writes a machine-readable summary of the screenshot comparison to `visual-report/` in the theme folder (`src/visual-reporter.js`). It is the input of the visual review in CI and lists every snapshot of the baseline with one of these states:
+
+| status      | meaning                                                                           | files copied to `visual-report/<package>/` |
+| ----------- | --------------------------------------------------------------------------------- | ------------------------------------------ |
+| `unchanged` | captured and identical to the baseline                                            | –                                          |
+| `changed`   | captured and different (`diffPixels`, `diffRatio` or `sizeMismatch` say how much) | `expected`, `actual`, `diff`               |
+| `added`     | captured, but the baseline has no file for it                                     | `actual`                                   |
+| `removed`   | the baseline has a file, but no test captured it any more                         | `expected`                                 |
+| `error`     | the baseline has a file, but its route failed before the block could be captured  | –                                          |
+
+Each item carries a `hash` of its content (`sha256:…`), and the report a `digest` over all hashes – approvals in the review are bound to those, not to commits. Routes that failed for other reasons than a screenshot difference (missing blocks, invisible blocks, timeouts) are listed under `errors`; `node scripts/visual-review/assert-no-errors.mjs <package>` turns them into a non-zero exit code.
+
+The spec captures every screenshot through `expect.soft`, so one differing block does not stop the remaining blocks of the route, and announces it with a `visual-snapshot` annotation – a passing comparison leaves no other trace, and the reporter needs that signal to tell `unchanged` from `removed`. With `--update-snapshots` the report is a manifest of the generated files instead (`mode: "update"`).
+
 ### Element screenshots (`data-visual-block`)
 
 Sample views in the [React Sample App](https://github.com/public-ui/kolibri/tree/develop/packages/samples/react) mark their variant blocks with the `SampleBlock` component, which renders the `data-visual-block` attribute. `SampleBlock` is the **only** place that sets the attribute — samples must not set it directly on their own elements. When a route contains such blocks, the visual tests capture **one element screenshot per block** (`<route-slug>--<block-id>.png`) instead of one full-page screenshot. This isolates diffs: a change to one variant no longer invalidates the entire page screenshot through layout shifts.

--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -29,6 +29,7 @@
 		"lint": "pnpm lint:eslint",
 		"lint:eslint": "eslint src",
 		"serve": "vite --config app/vite.config.ts",
+		"test:unit": "node --test test/*.test.mjs",
 		"unused": "knip"
 	},
 	"bin": {

--- a/packages/tools/visual-tests/playwright.config.js
+++ b/packages/tools/visual-tests/playwright.config.js
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 import { createRequire } from 'module';
 import * as path from 'path';
 import * as process from 'process';
+import { fileURLToPath } from 'url';
 
 // Validate and set ENVs
 const PORT = parseInt(process.env.KOLIBRI_VISUAL_TEST_PORT || '', 10);
@@ -9,6 +10,7 @@ const BASE_URL = `http://localhost:${PORT}`;
 
 const CWD = process.env.KOLIBRI_CWD ?? '';
 const HTML_REPORT_DIR = 'playwright-report';
+const VISUAL_REPORT_DIR = 'visual-report';
 const TIMEOUT = parseInt(process.env.KOLIBRI_VISUAL_TESTS_TIMEOUT || '15000', 10);
 const EXPECT_TIMEOUT = parseInt(process.env.KOLIBRI_VISUAL_TESTS_EXPECT_TIMEOUT || '5000', 10);
 const BUILD_PATH = process.env.KOLIBRI_VISUAL_TESTS_BUILD_PATH ?? '';
@@ -30,6 +32,9 @@ if (!VALID_COLOR_SCHEMES.includes(colorSchema)) {
    instead and run it with the current node. */
 const HTTP_SERVER_BIN = createRequire(import.meta.url).resolve('http-server/bin/http-server');
 
+/* Folder below snapshotDir that holds the baseline of the theme under test, e.g. `theme-default` or `theme-kern_v2-dark`. */
+const THEME_DIR = `theme-${THEME}${colorSchema === 'light' ? '' : `-${colorSchema}`}`;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -49,7 +54,15 @@ export default defineConfig({
 	/* Allow to override the expectation timeout for slow environments */
 	timeout: TIMEOUT,
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
-	reporter: [['line'], ['html', { open: 'never', outputFolder: path.join(CWD, HTML_REPORT_DIR) }]],
+	reporter: [
+		['line'],
+		['html', { open: 'never', outputFolder: path.join(CWD, HTML_REPORT_DIR) }],
+		/* Machine-readable comparison result for the visual review (see src/visual-reporter.js). */
+		[
+			fileURLToPath(new URL('./src/visual-reporter.js', import.meta.url)),
+			{ outputDir: path.join(CWD, VISUAL_REPORT_DIR), snapshotDir: path.join(CWD, 'snapshots'), themeDir: THEME_DIR, packageDir: CWD },
+		],
+	],
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
@@ -86,5 +99,5 @@ export default defineConfig({
 		url: BASE_URL,
 		reuseExistingServer: false,
 	},
-	snapshotPathTemplate: `{snapshotDir}/theme-${THEME}${colorSchema === 'light' ? '' : `-${colorSchema}`}/{arg}-{projectName}-{platform}{ext}`,
+	snapshotPathTemplate: `{snapshotDir}/${THEME_DIR}/{arg}-{projectName}-{platform}{ext}`,
 });

--- a/packages/tools/visual-tests/src/visual-reporter.js
+++ b/packages/tools/visual-tests/src/visual-reporter.js
@@ -1,0 +1,309 @@
+/**
+ * Playwright reporter that turns the screenshot comparison of theme-snapshots.spec.js into a
+ * machine-readable report (`visual-report/report.json`) plus the PNGs a reviewer needs.
+ *
+ * Playwright itself only reports pass/fail per test. Everything a review UI needs is derived here:
+ *
+ * - `changed`   – the block was captured and differs from the baseline (expected/actual/diff copied)
+ * - `added`     – the block was captured, but the baseline has no file for it (actual copied)
+ * - `removed`   – the baseline has a file, but no test captured that block any more (expected copied)
+ * - `unchanged` – the block was captured and matched the baseline
+ * - `error`     – the baseline has a file, but its route failed before the block could be captured
+ *
+ * Every item carries a content hash. Approvals are bound to those hashes, not to commits, so a new push
+ * that leaves an approved screenshot untouched keeps its approval.
+ *
+ * The spec announces every captured screenshot through a `visual-snapshot` annotation, because a passing
+ * `toHaveScreenshot` leaves no trace (no attachment, no error) – without that signal "unchanged" and
+ * "removed" would be indistinguishable.
+ *
+ * With `--update-snapshots` (baseline generation) the reporter writes a manifest of the generated files
+ * instead; its digest is what the baseline artifact carries as identity.
+ */
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SCHEMA_VERSION = 1;
+export const SNAPSHOT_ANNOTATION = 'visual-snapshot';
+
+const ATTACHMENT_SUFFIX = /-(expected|actual|diff|previous)\.png$/;
+const PIXEL_MISMATCH = /(\d+) pixels \(ratio ([\d.]+) of all image pixels\) are different/;
+const SIZE_MISMATCH = /Expected an image (\d+)px by (\d+)px, received (\d+)px by (\d+)px/;
+const MISSING_SNAPSHOT = /A snapshot doesn't exist at (.+?\.png)/;
+const SNAPSHOT_NAME_LINE = /^\s*Snapshot: (.+\.png)\s*$/m;
+const TEST_TITLE = /^snapshot for (.+)$/;
+// eslint-disable-next-line no-control-regex -- Playwright colours its messages; the escape character is the point here
+const ANSI_SEQUENCE = /\u001b\[[0-9;]*m/g;
+
+/** Mirrors the spec: `button/variants?x=1` → `button-variants-x-1`. */
+export function routeToSnapshotName(route) {
+	return route.replace(/(\/|\?|&|=)/g, '-');
+}
+
+function sha256(buffer) {
+	return `sha256:${crypto.createHash('sha256').update(buffer).digest('hex')}`;
+}
+
+function hashFile(file) {
+	return sha256(fs.readFileSync(file));
+}
+
+/** Width × height from the PNG header – enough to turn Playwright's 2-decimal ratio into an exact one. */
+function pngPixelCount(file) {
+	try {
+		const fd = fs.openSync(file, 'r');
+		const header = Buffer.alloc(24);
+		fs.readSync(fd, header, 0, 24, 0);
+		fs.closeSync(fd);
+		if (header.toString('latin1', 1, 4) !== 'PNG') return null;
+		return header.readUInt32BE(16) * header.readUInt32BE(20);
+	} catch {
+		return null;
+	}
+}
+
+function errorMessage(error) {
+	return (error?.message ?? String(error ?? 'unknown error')).replace(ANSI_SEQUENCE, '');
+}
+
+export default class VisualReporter {
+	/**
+	 * @param {{ outputDir: string, snapshotDir: string, themeDir: string, packageName?: string, packageDir?: string }} options
+	 */
+	constructor(options) {
+		this.outputDir = options.outputDir;
+		this.baselineDir = path.join(options.snapshotDir, options.themeDir);
+		this.themeDir = options.themeDir;
+		this.packageDir = options.packageDir ?? process.cwd();
+		this.packageName = options.packageName ?? readPackageName(this.packageDir);
+		this.results = new Map(); // test id → { test, result } of the last attempt
+	}
+
+	printsToStdio() {
+		return false;
+	}
+
+	onBegin(config) {
+		this.updateMode = config.updateSnapshots === 'all' || config.updateSnapshots === 'changed';
+		this.platform = process.platform;
+		this.projects = config.projects.map((project) => project.name);
+		this.fileSuffix = new RegExp(`-(${this.projects.map(escapeRegExp).join('|')})-${escapeRegExp(this.platform)}\\.png$`);
+		// The baseline must be listed before any test runs: Playwright writes missing snapshots into the
+		// very same folder, and those must not masquerade as baseline files.
+		this.baseline = this.scanBaseline();
+		this.baselineMeta = readJson(path.join(this.outputDir, 'baseline.json'));
+		fs.rmSync(this.outputDir, { recursive: true, force: true });
+		fs.mkdirSync(this.outputDir, { recursive: true });
+		if (this.baselineMeta) {
+			fs.writeFileSync(path.join(this.outputDir, 'baseline.json'), JSON.stringify(this.baselineMeta, null, '\t'));
+		}
+	}
+
+	onTestEnd(test, result) {
+		if (!isSnapshotTest(test)) return;
+		const previous = this.results.get(test.id);
+		if (!previous || previous.result.retry <= result.retry) {
+			this.results.set(test.id, { test, result });
+		}
+	}
+
+	onEnd() {
+		const report = this.updateMode ? this.buildManifest() : this.buildReport();
+		fs.writeFileSync(path.join(this.outputDir, 'report.json'), JSON.stringify(report, null, '\t'));
+	}
+
+	scanBaseline() {
+		const files = new Map();
+		if (!fs.existsSync(this.baselineDir)) return files;
+		for (const entry of fs.readdirSync(this.baselineDir)) {
+			if (!this.fileSuffix.test(entry)) continue;
+			files.set(entry.replace(this.fileSuffix, ''), path.join(this.baselineDir, entry));
+		}
+		return files;
+	}
+
+	baseReport(mode) {
+		return {
+			schema: SCHEMA_VERSION,
+			mode,
+			package: this.packageName,
+			themeDir: this.themeDir,
+			generatedAt: new Date().toISOString(),
+			platform: this.platform,
+			projects: this.projects,
+			baseline: {
+				dir: path.relative(this.packageDir, this.baselineDir).split(path.sep).join('/'),
+				files: this.baseline.size,
+				meta: this.baselineMeta,
+			},
+		};
+	}
+
+	buildManifest() {
+		const items = [...this.scanBaseline().entries()].map(([name, file]) => ({ name, status: 'baseline', hash: hashFile(file) })).sort(byName);
+		return { ...this.baseReport('update'), summary: { baseline: items.length }, digest: digestOf(items), items, errors: [] };
+	}
+
+	buildReport() {
+		const items = new Map(); // name → item
+		const errors = [];
+		const seen = new Set();
+
+		for (const { test, result } of this.results.values()) {
+			if (result.status === 'skipped') continue;
+			const route = test.title.match(TEST_TITLE)?.[1] ?? test.title;
+			const snapshotName = routeToSnapshotName(route);
+			const attachments = groupAttachments(result.attachments);
+
+			for (const annotation of [...test.annotations, ...(result.annotations ?? [])]) {
+				if (annotation.type === SNAPSHOT_ANNOTATION && annotation.description) {
+					seen.add(annotation.description.replace(/\.png$/, ''));
+				}
+			}
+
+			let hardError = null;
+			for (const error of result.errors) {
+				const message = errorMessage(error);
+				const classified = this.classifyError(message, attachments, route);
+				if (classified) {
+					items.set(classified.name, classified);
+					seen.add(classified.name);
+				} else if (!hardError) {
+					hardError = message;
+				}
+			}
+			if (!hardError && (result.status === 'timedOut' || result.status === 'interrupted')) {
+				hardError = `Test ${result.status}`;
+			}
+			if (hardError) {
+				errors.push({ test: test.title, route, message: firstLine(hardError) });
+				// Every baseline file of this route that was not captured is unknown territory, not "removed".
+				for (const [name, file] of this.baseline) {
+					if (!seen.has(name) && belongsToRoute(name, snapshotName)) {
+						items.set(name, { name, route, status: 'error', hash: hashFile(file), message: firstLine(hardError) });
+						seen.add(name);
+					}
+				}
+			}
+		}
+
+		for (const [name, file] of this.baseline) {
+			if (items.has(name)) continue;
+			if (seen.has(name)) {
+				items.set(name, { name, route: routeOf(name), status: 'unchanged', hash: hashFile(file) });
+			} else {
+				items.set(name, { name, route: routeOf(name), status: 'removed', hash: hashFile(file), expected: this.copyImage(file, name, 'expected') });
+			}
+		}
+
+		const sorted = [...items.values()].sort(byName);
+		const summary = { unchanged: 0, changed: 0, added: 0, removed: 0, error: 0 };
+		for (const item of sorted) summary[item.status] += 1;
+
+		return { ...this.baseReport('compare'), summary, digest: digestOf(sorted), items: sorted, errors };
+	}
+
+	/** Maps one soft-assertion error to a `changed` or `added` item; returns null for anything else. */
+	classifyError(message, attachments, route) {
+		const pixel = message.match(PIXEL_MISMATCH);
+		const size = message.match(SIZE_MISMATCH);
+		if (pixel || size) {
+			const name = message.match(SNAPSHOT_NAME_LINE)?.[1]?.replace(/\.png$/, '');
+			const files = name ? attachments.get(name) : undefined;
+			if (!name || !files?.actual) return null;
+			const item = {
+				name,
+				route,
+				status: 'changed',
+				hash: hashFile(files.actual),
+				expected: this.copyImage(files.expected ?? this.baseline.get(name), name, 'expected'),
+				actual: this.copyImage(files.actual, name, 'actual'),
+				diff: files.diff ? this.copyImage(files.diff, name, 'diff') : undefined,
+			};
+			if (pixel) {
+				item.diffPixels = Number(pixel[1]);
+				const total = pngPixelCount(files.actual);
+				item.diffRatio = total ? Number((item.diffPixels / total).toFixed(6)) : Number(pixel[2]);
+			} else {
+				item.sizeMismatch = { expected: [Number(size[1]), Number(size[2])], actual: [Number(size[3]), Number(size[4])] };
+			}
+			return item;
+		}
+		const missing = message.match(MISSING_SNAPSHOT);
+		if (missing) {
+			const name = path
+				.basename(missing[1])
+				.replace(this.fileSuffix, '')
+				.replace(/\.png$/, '');
+			const files = attachments.get(name);
+			if (!files?.actual) return null;
+			return { name, route, status: 'added', hash: hashFile(files.actual), actual: this.copyImage(files.actual, name, 'actual') };
+		}
+		return null;
+	}
+
+	copyImage(source, name, kind) {
+		if (!source || !fs.existsSync(source)) return undefined;
+		const relative = `${this.packageName}/${name}.${kind}.png`;
+		const target = path.join(this.outputDir, relative);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.copyFileSync(source, target);
+		return relative;
+	}
+}
+
+function isSnapshotTest(test) {
+	return test.location?.file?.endsWith('theme-snapshots.spec.js') || TEST_TITLE.test(test.title);
+}
+
+function groupAttachments(attachments) {
+	const groups = new Map();
+	for (const attachment of attachments) {
+		const match = attachment.name.match(ATTACHMENT_SUFFIX);
+		if (!attachment.path || !match) continue;
+		const name = attachment.name.replace(ATTACHMENT_SUFFIX, '');
+		if (!groups.has(name)) groups.set(name, {});
+		groups.get(name)[match[1]] = attachment.path;
+	}
+	return groups;
+}
+
+/** `button-basic--variants` and `button-basic--variants-320` belong to route name `button-basic`; so does the full-page `button-basic`. */
+function belongsToRoute(name, snapshotName) {
+	return name === snapshotName || name.startsWith(`${snapshotName}--`);
+}
+
+function routeOf(name) {
+	return name.split('--')[0];
+}
+
+function digestOf(items) {
+	const lines = items.map((item) => `${item.name}:${item.hash}`).sort();
+	return sha256(Buffer.from(lines.join('\n')));
+}
+
+function byName(a, b) {
+	return a.name.localeCompare(b.name);
+}
+
+function firstLine(message) {
+	return message.split('\n')[0].trim();
+}
+
+function escapeRegExp(text) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function readJson(file) {
+	try {
+		return JSON.parse(fs.readFileSync(file, 'utf8'));
+	} catch {
+		return null;
+	}
+}
+
+function readPackageName(dir) {
+	const pkg = readJson(path.join(dir, 'package.json'));
+	return (pkg?.name ?? path.basename(dir)).replace(/^@public-ui\//, '');
+}

--- a/packages/tools/visual-tests/src/visual-reporter.js
+++ b/packages/tools/visual-tests/src/visual-reporter.js
@@ -10,12 +10,17 @@
  * - `unchanged` – the block was captured and matched the baseline
  * - `error`     – the baseline has a file, but its route failed before the block could be captured
  *
+ * Classification relies on structured data only: the `-expected`/`-actual`/`-diff` attachments a failed
+ * comparison leaves behind and the baseline listing taken before the run. Playwright's free-text error
+ * messages merely add numbers (`diffPixels`, `diffRatio`, `sizeMismatch`) – a reworded message after a
+ * Playwright upgrade costs those numbers, not the classification.
+ *
  * Every item carries a content hash. Approvals are bound to those hashes, not to commits, so a new push
  * that leaves an approved screenshot untouched keeps its approval.
  *
  * The spec announces every captured screenshot through a `visual-snapshot` annotation, because a passing
  * `toHaveScreenshot` leaves no trace (no attachment, no error) – without that signal "unchanged" and
- * "removed" would be indistinguishable.
+ * "removed" would be indistinguishable. A test in test/visual-reporter.test.mjs guards that convention.
  *
  * With `--update-snapshots` (baseline generation) the reporter writes a manifest of the generated files
  * instead; its digest is what the baseline artifact carries as identity.
@@ -26,19 +31,23 @@ import * as path from 'node:path';
 
 const SCHEMA_VERSION = 1;
 export const SNAPSHOT_ANNOTATION = 'visual-snapshot';
+export const SPEC_FILE = 'theme-snapshots.spec.js';
 
 const ATTACHMENT_SUFFIX = /-(expected|actual|diff|previous)\.png$/;
+/* Wording of playwright-core's compareImages(); both sentences appear together when the size differs. */
 const PIXEL_MISMATCH = /(\d+) pixels \(ratio ([\d.]+) of all image pixels\) are different/;
 const SIZE_MISMATCH = /Expected an image (\d+)px by (\d+)px, received (\d+)px by (\d+)px/;
-const MISSING_SNAPSHOT = /A snapshot doesn't exist at (.+?\.png)/;
-const SNAPSHOT_NAME_LINE = /^\s*Snapshot: (.+\.png)\s*$/m;
 const TEST_TITLE = /^snapshot for (.+)$/;
 // eslint-disable-next-line no-control-regex -- Playwright colours its messages; the escape character is the point here
 const ANSI_SEQUENCE = /\u001b\[[0-9;]*m/g;
 
-/** Mirrors the spec: `button/variants?x=1` → `button-variants-x-1`. */
+/**
+ * File name of a route: `button/variants?x=1` → `button-variants-x-1`. Shared with the spec, which names
+ * the snapshot files, so both sides can never drift apart. Consecutive delimiters collapse into one dash:
+ * the route part of a name must never contain the `--` that separates route and block id.
+ */
 export function routeToSnapshotName(route) {
-	return route.replace(/(\/|\?|&|=)/g, '-');
+	return route.replace(/[/?&=]+/g, '-');
 }
 
 function sha256(buffer) {
@@ -84,11 +93,18 @@ export default class VisualReporter {
 		return false;
 	}
 
-	onBegin(config) {
+	onBegin(config, suite) {
 		this.updateMode = config.updateSnapshots === 'all' || config.updateSnapshots === 'changed';
 		this.platform = process.platform;
-		this.projects = config.projects.map((project) => project.name);
-		this.fileSuffix = new RegExp(`-(${this.projects.map(escapeRegExp).join('|')})-${escapeRegExp(this.platform)}\\.png$`);
+		const projects = runningProjects(config, suite);
+		if (projects.length !== 1) {
+			throw new Error(
+				`Visual reporter: snapshot names carry no project name, so exactly one Playwright project can run at a time (got: ${projects.join(', ') || 'none'}). Extend the item keys of the reporter before enabling another project.`,
+			);
+		}
+		this.projects = projects;
+		this.fileSuffixSource = `-${escapeRegExp(projects[0])}-${escapeRegExp(this.platform)}\\.png`;
+		this.fileSuffix = new RegExp(`${this.fileSuffixSource}$`);
 		// The baseline must be listed before any test runs: Playwright writes missing snapshots into the
 		// very same folder, and those must not masquerade as baseline files.
 		this.baseline = this.scanBaseline();
@@ -123,7 +139,7 @@ export default class VisualReporter {
 		return files;
 	}
 
-	baseReport(mode) {
+	baseReport(mode, baselineFiles) {
 		return {
 			schema: SCHEMA_VERSION,
 			mode,
@@ -134,15 +150,17 @@ export default class VisualReporter {
 			projects: this.projects,
 			baseline: {
 				dir: path.relative(this.packageDir, this.baselineDir).split(path.sep).join('/'),
-				files: this.baseline.size,
+				files: baselineFiles,
 				meta: this.baselineMeta,
 			},
 		};
 	}
 
+	/** Update mode: the folder after the run is the new baseline, so every count describes that state. */
 	buildManifest() {
-		const items = [...this.scanBaseline().entries()].map(([name, file]) => ({ name, status: 'baseline', hash: hashFile(file) })).sort(byName);
-		return { ...this.baseReport('update'), summary: { baseline: items.length }, digest: digestOf(items), items, errors: [] };
+		const generated = this.scanBaseline();
+		const items = [...generated.entries()].map(([name, file]) => ({ name, status: 'baseline', hash: hashFile(file) })).sort(byName);
+		return { ...this.baseReport('update', generated.size), summary: { baseline: items.length }, digest: digestOf(items), items, errors: [] };
 	}
 
 	buildReport() {
@@ -154,7 +172,6 @@ export default class VisualReporter {
 			if (result.status === 'skipped') continue;
 			const route = test.title.match(TEST_TITLE)?.[1] ?? test.title;
 			const snapshotName = routeToSnapshotName(route);
-			const attachments = groupAttachments(result.attachments);
 
 			for (const annotation of [...test.annotations, ...(result.annotations ?? [])]) {
 				if (annotation.type === SNAPSHOT_ANNOTATION && annotation.description) {
@@ -162,26 +179,35 @@ export default class VisualReporter {
 				}
 			}
 
-			let hardError = null;
+			// A failed comparison always attaches the actual image; the baseline listing tells changed from added.
+			const groups = groupAttachments(result.attachments);
+			for (const [name, files] of groups) {
+				if (!files.actual) continue;
+				seen.add(name);
+				items.set(name, this.baseline.has(name) ? this.changedItem(name, route, files) : this.addedItem(name, route, files));
+			}
+
+			const hardErrors = [];
 			for (const error of result.errors) {
 				const message = errorMessage(error);
-				const classified = this.classifyError(message, attachments, route);
-				if (classified) {
-					items.set(classified.name, classified);
-					seen.add(classified.name);
-				} else if (!hardError) {
-					hardError = message;
+				const name = this.snapshotNameIn(message, groups);
+				if (name && items.has(name)) {
+					Object.assign(items.get(name), comparisonDetails(message, groups.get(name)));
+				} else {
+					hardErrors.push(firstLine(message));
 				}
 			}
-			if (!hardError && (result.status === 'timedOut' || result.status === 'interrupted')) {
-				hardError = `Test ${result.status}`;
+			if (hardErrors.length === 0 && (result.status === 'timedOut' || result.status === 'interrupted')) {
+				hardErrors.push(`Test ${result.status}`);
 			}
-			if (hardError) {
-				errors.push({ test: test.title, route, message: firstLine(hardError) });
+			for (const message of hardErrors) {
+				errors.push({ test: test.title, route, message });
+			}
+			if (hardErrors.length > 0) {
 				// Every baseline file of this route that was not captured is unknown territory, not "removed".
 				for (const [name, file] of this.baseline) {
 					if (!seen.has(name) && belongsToRoute(name, snapshotName)) {
-						items.set(name, { name, route, status: 'error', hash: hashFile(file), message: firstLine(hardError) });
+						items.set(name, { name, route, status: 'error', hash: hashFile(file), message: hardErrors[0] });
 						seen.add(name);
 					}
 				}
@@ -201,44 +227,29 @@ export default class VisualReporter {
 		const summary = { unchanged: 0, changed: 0, added: 0, removed: 0, error: 0 };
 		for (const item of sorted) summary[item.status] += 1;
 
-		return { ...this.baseReport('compare'), summary, digest: digestOf(sorted), items: sorted, errors };
+		return { ...this.baseReport('compare', this.baseline.size), summary, digest: digestOf(sorted), items: sorted, errors };
 	}
 
-	/** Maps one soft-assertion error to a `changed` or `added` item; returns null for anything else. */
-	classifyError(message, attachments, route) {
-		const pixel = message.match(PIXEL_MISMATCH);
-		const size = message.match(SIZE_MISMATCH);
-		if (pixel || size) {
-			const name = message.match(SNAPSHOT_NAME_LINE)?.[1]?.replace(/\.png$/, '');
-			const files = name ? attachments.get(name) : undefined;
-			if (!name || !files?.actual) return null;
-			const item = {
-				name,
-				route,
-				status: 'changed',
-				hash: hashFile(files.actual),
-				expected: this.copyImage(files.expected ?? this.baseline.get(name), name, 'expected'),
-				actual: this.copyImage(files.actual, name, 'actual'),
-				diff: files.diff ? this.copyImage(files.diff, name, 'diff') : undefined,
-			};
-			if (pixel) {
-				item.diffPixels = Number(pixel[1]);
-				const total = pngPixelCount(files.actual);
-				item.diffRatio = total ? Number((item.diffPixels / total).toFixed(6)) : Number(pixel[2]);
-			} else {
-				item.sizeMismatch = { expected: [Number(size[1]), Number(size[2])], actual: [Number(size[3]), Number(size[4])] };
-			}
-			return item;
-		}
-		const missing = message.match(MISSING_SNAPSHOT);
-		if (missing) {
-			const name = path
-				.basename(missing[1])
-				.replace(this.fileSuffix, '')
-				.replace(/\.png$/, '');
-			const files = attachments.get(name);
-			if (!files?.actual) return null;
-			return { name, route, status: 'added', hash: hashFile(files.actual), actual: this.copyImage(files.actual, name, 'actual') };
+	changedItem(name, route, files) {
+		return {
+			name,
+			route,
+			status: 'changed',
+			hash: hashFile(files.actual),
+			expected: this.copyImage(files.expected ?? this.baseline.get(name), name, 'expected'),
+			actual: this.copyImage(files.actual, name, 'actual'),
+			diff: files.diff ? this.copyImage(files.diff, name, 'diff') : undefined,
+		};
+	}
+
+	addedItem(name, route, files) {
+		return { name, route, status: 'added', hash: hashFile(files.actual), actual: this.copyImage(files.actual, name, 'actual') };
+	}
+
+	/** The attachment group an error message talks about – by file name (`x.png`) or baseline path (`x-firefox-linux.png`). */
+	snapshotNameIn(message, groups) {
+		for (const name of groups.keys()) {
+			if (new RegExp(`${escapeRegExp(name)}(\\.png|${this.fileSuffixSource})`).test(message)) return name;
 		}
 		return null;
 	}
@@ -253,8 +264,36 @@ export default class VisualReporter {
 	}
 }
 
+/**
+ * Numbers from Playwright's message. Both sentences appear when the size differs; the pixels are then
+ * counted on a canvas padded to the larger of both sizes, which is what the ratio has to be based on.
+ */
+function comparisonDetails(message, files) {
+	const details = {};
+	const size = message.match(SIZE_MISMATCH);
+	const pixel = message.match(PIXEL_MISMATCH);
+	if (size) {
+		details.sizeMismatch = { expected: [Number(size[1]), Number(size[2])], actual: [Number(size[3]), Number(size[4])] };
+	}
+	if (pixel) {
+		details.diffPixels = Number(pixel[1]);
+		const total = size
+			? Math.max(details.sizeMismatch.expected[0], details.sizeMismatch.actual[0]) * Math.max(details.sizeMismatch.expected[1], details.sizeMismatch.actual[1])
+			: pngPixelCount(files.actual);
+		details.diffRatio = total ? Number((details.diffPixels / total).toFixed(6)) : Number(pixel[2]);
+	}
+	return details;
+}
+
+/** Projects that actually run (the root suite has one child per project); `--project` filters are respected. */
+function runningProjects(config, suite) {
+	const fromSuite = (suite?.suites ?? []).map((child) => child.project?.()?.name).filter(Boolean);
+	const names = fromSuite.length > 0 ? fromSuite : config.projects.map((project) => project.name);
+	return [...new Set(names)];
+}
+
 function isSnapshotTest(test) {
-	return test.location?.file?.endsWith('theme-snapshots.spec.js') || TEST_TITLE.test(test.title);
+	return path.basename(test.location?.file ?? '') === SPEC_FILE;
 }
 
 function groupAttachments(attachments) {

--- a/packages/tools/visual-tests/test/snapshot-paths.test.mjs
+++ b/packages/tools/visual-tests/test/snapshot-paths.test.mjs
@@ -1,44 +1,71 @@
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, it } from 'node:test';
-import { fileURLToPath } from 'node:url';
-import { BASELINE_PACKAGES, PACKAGES, reportDir, resolvePackage, snapshotDir } from '../../../../scripts/visual-review/snapshot-paths.mjs';
+import { BASELINE_PACKAGES, PACKAGES, discoverPackages, reportDir, resolvePackage, snapshotDir } from '../../../../scripts/visual-review/snapshot-paths.mjs';
 
-const REPO_ROOT = path.resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
-
-/** THEME_EXPORT of the script that `test` ends up running (ecl delegates via npm-run-all2). */
-function themeExportOf(scripts) {
-	let script = scripts.test;
-	const delegate = script.match(/^npm-run-all2 (\S+)$/);
-	if (delegate) script = scripts[delegate[1]];
-	return script.match(/THEME_EXPORT=(\S+)/)[1];
+function writePackage(root, dir, pkg) {
+	fs.mkdirSync(path.join(root, dir), { recursive: true });
+	fs.writeFileSync(path.join(root, dir, 'package.json'), JSON.stringify(pkg));
 }
 
 describe('snapshot-paths', () => {
-	it('lists every package with a visual test script exactly once', () => {
-		const names = PACKAGES.map((pkg) => pkg.name);
-		assert.deepEqual(names, [...new Set(names)]);
-		for (const pkg of PACKAGES) {
-			const scripts = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, pkg.dir, 'package.json'), 'utf8')).scripts;
-			assert.match(scripts.test, /kolibri-visual-test|npm-run-all2/, `${pkg.name} has no visual test script`);
-		}
-	});
-
-	it('derives the theme folder from THEME_EXPORT the same way playwright.config.js does', () => {
-		for (const pkg of PACKAGES) {
-			const scripts = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, pkg.dir, 'package.json'), 'utf8')).scripts;
-			assert.equal(pkg.themeDir, `theme-${themeExportOf(scripts).toLocaleLowerCase()}`, pkg.name);
-		}
-	});
-
-	it('marks packages without their own baseline', () => {
+	it('discovers every package of this repository that runs the visual tests', () => {
 		assert.deepEqual(
-			PACKAGES.filter((pkg) => pkg.baselineFrom).map((pkg) => pkg.name),
-			['test-tag-name-transformer'],
+			PACKAGES.map((pkg) => `${pkg.name} ${pkg.dir} ${pkg.themeDir}${pkg.baselineFrom ? ` (baseline of ${pkg.baselineFrom})` : ''}`),
+			[
+				'test-tag-name-transformer packages/test-tag-name-transformer theme-default (baseline of theme-default)',
+				'theme-bwst packages/themes/bwst theme-bwst',
+				'theme-default packages/themes/default theme-default',
+				'theme-desy packages/themes/desy theme-desyv11',
+				'theme-ecl packages/themes/ecl theme-ecl_ec',
+				'theme-kern packages/themes/kern theme-kern_v2',
+				'unstyled packages/unstyled theme-unstyled',
+			],
 		);
-		assert.equal(BASELINE_PACKAGES.length, PACKAGES.length - 1);
-		assert.ok(PACKAGES.some((pkg) => pkg.name === resolvePackage('test-tag-name-transformer').baselineFrom));
+		assert.deepEqual(
+			BASELINE_PACKAGES.map((pkg) => pkg.name),
+			PACKAGES.filter((pkg) => !pkg.baselineFrom).map((pkg) => pkg.name),
+		);
+	});
+
+	it('derives the theme folder from THEME_EXPORT and the baseline owner from prepare:snapshots', () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-paths-'));
+		try {
+			writePackage(root, 'packages/themes/foo', { name: '@public-ui/theme-foo', scripts: { test: 'cross-env THEME_EXPORT=FooV2 kolibri-visual-test' } });
+			writePackage(root, 'packages/themes/bar', {
+				name: '@public-ui/theme-bar',
+				scripts: { test: 'npm-run-all2 test:theme:bar-a', 'test:theme:bar-a': 'cross-env THEME_EXPORT=BAR_A kolibri-visual-test' },
+			});
+			writePackage(root, 'packages/copycat', {
+				name: '@public-ui/copycat',
+				scripts: { 'prepare:snapshots': 'cpy "../themes/foo/snapshots" ./ --dot', test: 'cross-env THEME_EXPORT=FooV2 kolibri-visual-test' },
+			});
+			writePackage(root, 'packages/plain', { name: '@public-ui/plain', scripts: { test: 'vitest' } });
+			writePackage(root, 'packages/themes', { name: '@public-ui/themes', scripts: { test: 'pnpm -r test' } });
+
+			assert.deepEqual(discoverPackages(root), [
+				{ name: 'copycat', dir: 'packages/copycat', themeDir: 'theme-foov2', baselineFrom: 'theme-foo' },
+				{ name: 'theme-bar', dir: 'packages/themes/bar', themeDir: 'theme-bar_a' },
+				{ name: 'theme-foo', dir: 'packages/themes/foo', themeDir: 'theme-foov2' },
+			]);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('refuses a copier whose source has no visual tests', () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'snapshot-paths-'));
+		try {
+			writePackage(root, 'packages/copycat', {
+				name: '@public-ui/copycat',
+				scripts: { 'prepare:snapshots': 'cpy "../themes/gone/snapshots" ./ --dot', test: 'kolibri-visual-test' },
+			});
+			assert.throws(() => discoverPackages(root), /copies its snapshots from packages\/themes\/gone/);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it('resolves folders', () => {

--- a/packages/tools/visual-tests/test/snapshot-paths.test.mjs
+++ b/packages/tools/visual-tests/test/snapshot-paths.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { BASELINE_PACKAGES, PACKAGES, reportDir, resolvePackage, snapshotDir } from '../../../../scripts/visual-review/snapshot-paths.mjs';
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
+
+/** THEME_EXPORT of the script that `test` ends up running (ecl delegates via npm-run-all2). */
+function themeExportOf(scripts) {
+	let script = scripts.test;
+	const delegate = script.match(/^npm-run-all2 (\S+)$/);
+	if (delegate) script = scripts[delegate[1]];
+	return script.match(/THEME_EXPORT=(\S+)/)[1];
+}
+
+describe('snapshot-paths', () => {
+	it('lists every package with a visual test script exactly once', () => {
+		const names = PACKAGES.map((pkg) => pkg.name);
+		assert.deepEqual(names, [...new Set(names)]);
+		for (const pkg of PACKAGES) {
+			const scripts = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, pkg.dir, 'package.json'), 'utf8')).scripts;
+			assert.match(scripts.test, /kolibri-visual-test|npm-run-all2/, `${pkg.name} has no visual test script`);
+		}
+	});
+
+	it('derives the theme folder from THEME_EXPORT the same way playwright.config.js does', () => {
+		for (const pkg of PACKAGES) {
+			const scripts = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, pkg.dir, 'package.json'), 'utf8')).scripts;
+			assert.equal(pkg.themeDir, `theme-${themeExportOf(scripts).toLocaleLowerCase()}`, pkg.name);
+		}
+	});
+
+	it('marks packages without their own baseline', () => {
+		assert.deepEqual(
+			PACKAGES.filter((pkg) => pkg.baselineFrom).map((pkg) => pkg.name),
+			['test-tag-name-transformer'],
+		);
+		assert.equal(BASELINE_PACKAGES.length, PACKAGES.length - 1);
+		assert.ok(PACKAGES.some((pkg) => pkg.name === resolvePackage('test-tag-name-transformer').baselineFrom));
+	});
+
+	it('resolves folders', () => {
+		assert.equal(snapshotDir(resolvePackage('theme-desy')), 'packages/themes/desy/snapshots/theme-desyv11');
+		assert.equal(reportDir(resolvePackage('unstyled')), 'packages/unstyled/visual-report');
+		assert.throws(() => resolvePackage('nope'), /Unknown visual-test package/);
+	});
+});

--- a/packages/tools/visual-tests/test/visual-reporter.test.mjs
+++ b/packages/tools/visual-tests/test/visual-reporter.test.mjs
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import VisualReporter, { SNAPSHOT_ANNOTATION, routeToSnapshotName } from '../src/visual-reporter.js';
+
+const PLATFORM = process.platform;
+const SUFFIX = `-firefox-${PLATFORM}.png`;
+const SPEC_FILE = path.join('tests', 'theme-snapshots.spec.js');
+
+/** A PNG header that declares `width` × `height` pixels – all the reporter reads from an image. */
+function png(width, height, salt = '') {
+	const header = Buffer.alloc(24);
+	Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(header, 0);
+	header.writeUInt32BE(13, 8);
+	header.write('IHDR', 12, 'latin1');
+	header.writeUInt32BE(width, 16);
+	header.writeUInt32BE(height, 20);
+	return Buffer.concat([header, Buffer.from(`payload-${salt}`)]);
+}
+
+function write(file, content) {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+	return file;
+}
+
+function fakeTest(route, extra = {}) {
+	return { id: route, title: `snapshot for ${route}`, location: { file: SPEC_FILE }, annotations: [], ...extra };
+}
+
+function fakeResult(extra = {}) {
+	return { retry: 0, status: 'passed', errors: [], attachments: [], annotations: [], ...extra };
+}
+
+function annotation(fileName) {
+	return { type: SNAPSHOT_ANNOTATION, description: fileName };
+}
+
+describe('VisualReporter', () => {
+	let root;
+	let packageDir;
+	let baselineDir;
+	let outputDir;
+	let testResults;
+
+	function createReporter() {
+		return new VisualReporter({ outputDir, snapshotDir: path.join(packageDir, 'snapshots'), themeDir: 'theme-default', packageDir });
+	}
+
+	function readReport() {
+		return JSON.parse(fs.readFileSync(path.join(outputDir, 'report.json'), 'utf8'));
+	}
+
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), 'visual-reporter-'));
+		packageDir = path.join(root, 'default');
+		baselineDir = path.join(packageDir, 'snapshots', 'theme-default');
+		outputDir = path.join(packageDir, 'visual-report');
+		testResults = path.join(packageDir, 'test-results');
+		write(path.join(packageDir, 'package.json'), JSON.stringify({ name: '@public-ui/theme-default' }));
+		write(path.join(baselineDir, `a-basic--one${SUFFIX}`), png(4, 3, 'one'));
+		write(path.join(baselineDir, `a-basic--two${SUFFIX}`), png(4, 3, 'two'));
+		write(path.join(baselineDir, `b-gone--x${SUFFIX}`), png(4, 3, 'gone'));
+		write(path.join(baselineDir, `c-broken--y${SUFFIX}`), png(4, 3, 'broken'));
+		write(path.join(baselineDir, `a-basic--one-firefox-otheros.png`), png(4, 3, 'foreign'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it('mirrors the route-to-file-name rule of the spec', () => {
+		assert.equal(routeToSnapshotName('button/variants?x=1&y=2'), 'button-variants-x-1-y-2');
+	});
+
+	it('classifies changed, added, unchanged and removed snapshots', () => {
+		const reporter = createReporter();
+		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+
+		// Playwright writes missing snapshots into the baseline folder while the run is in progress.
+		write(path.join(baselineDir, `a-basic--new${SUFFIX}`), png(4, 3, 'new-expected'));
+		const twoActual = write(path.join(testResults, `a-basic--two-actual.png`), png(4, 3, 'two-actual'));
+		const twoDiff = write(path.join(testResults, `a-basic--two-diff.png`), png(4, 3, 'two-diff'));
+		const newActual = write(path.join(testResults, `a-basic--new-actual.png`), png(4, 3, 'new-actual'));
+
+		reporter.onTestEnd(
+			fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png'), annotation('a-basic--new.png')] }),
+			fakeResult({
+				status: 'failed',
+				errors: [
+					{
+						message:
+							'\u001b[31mScreenshot comparison failed:\u001b[39m\n\n  3 pixels (ratio 0.25 of all image pixels) are different.\n\n  Snapshot: a-basic--two.png\n',
+					},
+					{ message: `A snapshot doesn't exist at ${path.join(baselineDir, `a-basic--new${SUFFIX}`)}, writing actual.` },
+				],
+				attachments: [
+					{ name: 'a-basic--two-expected.png', contentType: 'image/png', path: path.join(baselineDir, `a-basic--two${SUFFIX}`) },
+					{ name: 'a-basic--two-actual.png', contentType: 'image/png', path: twoActual },
+					{ name: 'a-basic--two-diff.png', contentType: 'image/png', path: twoDiff },
+					{ name: 'a-basic--new-expected.png', contentType: 'image/png', path: path.join(baselineDir, `a-basic--new${SUFFIX}`) },
+					{ name: 'a-basic--new-actual.png', contentType: 'image/png', path: newActual },
+				],
+			}),
+		);
+		reporter.onTestEnd(fakeTest('c/broken', { annotations: [annotation('c-broken--y.png')] }), fakeResult());
+		reporter.onTestEnd(fakeTest('d/skipped'), fakeResult({ status: 'skipped' }));
+		reporter.onEnd();
+
+		const report = readReport();
+		assert.equal(report.schema, 1);
+		assert.equal(report.mode, 'compare');
+		assert.equal(report.package, 'theme-default');
+		assert.equal(report.baseline.dir, 'snapshots/theme-default');
+		assert.equal(report.baseline.files, 4, 'files of other platforms and files written during the run are not baseline');
+		assert.deepEqual(report.summary, { unchanged: 2, changed: 1, added: 1, removed: 1, error: 0 });
+		assert.deepEqual(report.errors, []);
+		assert.match(report.digest, /^sha256:[0-9a-f]{64}$/);
+
+		const byName = Object.fromEntries(report.items.map((item) => [item.name, item]));
+		assert.deepEqual(Object.keys(byName), ['a-basic--new', 'a-basic--one', 'a-basic--two', 'b-gone--x', 'c-broken--y']);
+
+		assert.equal(byName['a-basic--one'].status, 'unchanged');
+		assert.equal(byName['c-broken--y'].status, 'unchanged');
+
+		const changed = byName['a-basic--two'];
+		assert.equal(changed.status, 'changed');
+		assert.equal(changed.route, 'a/basic');
+		assert.equal(changed.diffPixels, 3);
+		assert.equal(changed.diffRatio, 0.25);
+		assert.equal(changed.expected, 'theme-default/a-basic--two.expected.png');
+		assert.equal(changed.actual, 'theme-default/a-basic--two.actual.png');
+		assert.equal(changed.diff, 'theme-default/a-basic--two.diff.png');
+		assert.ok(fs.existsSync(path.join(outputDir, changed.diff)));
+		assert.ok(fs.readFileSync(path.join(outputDir, changed.actual)).equals(fs.readFileSync(twoActual)));
+
+		const added = byName['a-basic--new'];
+		assert.equal(added.status, 'added');
+		assert.equal(added.actual, 'theme-default/a-basic--new.actual.png');
+		assert.equal(added.expected, undefined);
+
+		const removed = byName['b-gone--x'];
+		assert.equal(removed.status, 'removed');
+		assert.equal(removed.route, 'b-gone');
+		assert.equal(removed.expected, 'theme-default/b-gone--x.expected.png');
+		assert.ok(fs.existsSync(path.join(outputDir, removed.expected)));
+
+		for (const item of report.items) assert.match(item.hash, /^sha256:[0-9a-f]{64}$/);
+		assert.notEqual(changed.hash, byName['a-basic--one'].hash);
+	});
+
+	it('marks the baseline of a failed route as error instead of removed and reports the failure', () => {
+		const reporter = createReporter();
+		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+		reporter.onTestEnd(fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png')] }), fakeResult());
+		reporter.onTestEnd(
+			fakeTest('c/broken'),
+			fakeResult({ status: 'failed', errors: [{ message: '\u001b[31mError: Route "c/broken": no data-visual-block containers found.\u001b[39m\n    at …' }] }),
+		);
+		reporter.onEnd();
+
+		const report = readReport();
+		assert.deepEqual(report.summary, { unchanged: 2, changed: 0, added: 0, removed: 1, error: 1 });
+		const broken = report.items.find((item) => item.name === 'c-broken--y');
+		assert.equal(broken.status, 'error');
+		assert.equal(broken.message, 'Error: Route "c/broken": no data-visual-block containers found.');
+		assert.deepEqual(report.errors, [
+			{ test: 'snapshot for c/broken', route: 'c/broken', message: 'Error: Route "c/broken": no data-visual-block containers found.' },
+		]);
+	});
+
+	it('only counts the last attempt of a retried test', () => {
+		const reporter = createReporter();
+		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+		reporter.onTestEnd(fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png')] }), fakeResult());
+		reporter.onTestEnd(fakeTest('c/broken'), fakeResult({ status: 'timedOut', errors: [{ message: 'Test timeout of 15000ms exceeded.' }] }));
+		reporter.onTestEnd(fakeTest('c/broken', { annotations: [annotation('c-broken--y.png')] }), fakeResult({ retry: 1 }));
+		reporter.onEnd();
+
+		const report = readReport();
+		assert.deepEqual(report.summary, { unchanged: 3, changed: 0, added: 0, removed: 1, error: 0 });
+		assert.deepEqual(report.errors, []);
+	});
+
+	it('ignores tests of other spec files', () => {
+		const reporter = createReporter();
+		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+		reporter.onTestEnd(
+			{ id: 'axe', title: 'axe for a/basic', location: { file: path.join('tests', 'axe-snapshots.spec.js') }, annotations: [] },
+			fakeResult({ status: 'failed', errors: [{ message: 'axe violations' }] }),
+		);
+		reporter.onEnd();
+		assert.deepEqual(readReport().errors, []);
+	});
+
+	it('writes a manifest of the generated files in update mode', () => {
+		const reporter = createReporter();
+		reporter.onBegin({ updateSnapshots: 'changed', projects: [{ name: 'firefox' }] });
+		fs.rmSync(path.join(baselineDir, `b-gone--x${SUFFIX}`));
+		write(path.join(baselineDir, `a-basic--new${SUFFIX}`), png(4, 3, 'new'));
+		reporter.onEnd();
+
+		const report = readReport();
+		assert.equal(report.mode, 'update');
+		assert.deepEqual(report.summary, { baseline: 4 });
+		assert.deepEqual(
+			report.items.map((item) => item.name),
+			['a-basic--new', 'a-basic--one', 'a-basic--two', 'c-broken--y'],
+		);
+		assert.ok(report.items.every((item) => item.status === 'baseline'));
+		assert.match(report.digest, /^sha256:[0-9a-f]{64}$/);
+	});
+
+	it('keeps baseline.json written by the baseline download and starts from an empty output folder', () => {
+		write(path.join(outputDir, 'baseline.json'), JSON.stringify({ sha: 'abc' }));
+		write(path.join(outputDir, 'stale.txt'), 'old');
+		const reporter = createReporter();
+		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+		reporter.onEnd();
+
+		assert.equal(fs.existsSync(path.join(outputDir, 'stale.txt')), false);
+		assert.deepEqual(readReport().baseline.meta, { sha: 'abc' });
+	});
+});

--- a/packages/tools/visual-tests/test/visual-reporter.test.mjs
+++ b/packages/tools/visual-tests/test/visual-reporter.test.mjs
@@ -3,11 +3,14 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
-import VisualReporter, { SNAPSHOT_ANNOTATION, routeToSnapshotName } from '../src/visual-reporter.js';
+import { fileURLToPath } from 'node:url';
+import VisualReporter, { SNAPSHOT_ANNOTATION, SPEC_FILE, routeToSnapshotName } from '../src/visual-reporter.js';
 
 const PLATFORM = process.platform;
 const SUFFIX = `-firefox-${PLATFORM}.png`;
-const SPEC_FILE = path.join('tests', 'theme-snapshots.spec.js');
+const SPEC_PATH = path.join('tests', SPEC_FILE);
+const CONFIG = { updateSnapshots: 'missing', projects: [{ name: 'firefox' }] };
+const SUITE = { suites: [{ project: () => ({ name: 'firefox' }) }] };
 
 /** A PNG header that declares `width` × `height` pixels – all the reporter reads from an image. */
 function png(width, height, salt = '') {
@@ -27,7 +30,7 @@ function write(file, content) {
 }
 
 function fakeTest(route, extra = {}) {
-	return { id: route, title: `snapshot for ${route}`, location: { file: SPEC_FILE }, annotations: [], ...extra };
+	return { id: route, title: `snapshot for ${route}`, location: { file: SPEC_PATH }, annotations: [], ...extra };
 }
 
 function fakeResult(extra = {}) {
@@ -37,6 +40,36 @@ function fakeResult(extra = {}) {
 function annotation(fileName) {
 	return { type: SNAPSHOT_ANNOTATION, description: fileName };
 }
+
+function attachment(name, file) {
+	return { name, contentType: 'image/png', path: file };
+}
+
+describe('routeToSnapshotName', () => {
+	it('mirrors the file naming of the spec and never produces the block separator', () => {
+		assert.equal(routeToSnapshotName('button/variants?x=1&y=2'), 'button-variants-x-1-y-2');
+		assert.equal(routeToSnapshotName('table/basic/?sort='), 'table-basic-sort-');
+		assert.doesNotMatch(routeToSnapshotName('a//b?=c'), /--/);
+	});
+});
+
+describe('theme-snapshots.spec.js', () => {
+	const source = fs.readFileSync(fileURLToPath(new URL(`../tests/${SPEC_FILE}`, import.meta.url)), 'utf8');
+
+	it('captures every screenshot through captureSnapshot, which announces it to the reporter', () => {
+		const calls = source.match(/toHaveScreenshot\(/g) ?? [];
+		assert.equal(calls.length, 1, 'toHaveScreenshot must only be called inside captureSnapshot');
+		const helper = source.match(/async function captureSnapshot\([^)]*\) \{([\s\S]*?)\n\}/)?.[1] ?? '';
+		assert.match(helper, /expect\.soft\([^)]*\)\.toHaveScreenshot\(/);
+		assert.match(helper, /annotations\.push\(\{ type: SNAPSHOT_ANNOTATION/);
+	});
+
+	it('names snapshot files with the function the reporter uses', () => {
+		assert.match(source, /import \{[^}]*routeToSnapshotName[^}]*\} from '\.\.\/src\/visual-reporter\.js'/);
+		assert.match(source, /const snapshotName = routeToSnapshotName\(route\);/);
+		assert.doesNotMatch(source, /route\.replace\(/);
+	});
+});
 
 describe('VisualReporter', () => {
 	let root;
@@ -62,6 +95,7 @@ describe('VisualReporter', () => {
 		write(path.join(packageDir, 'package.json'), JSON.stringify({ name: '@public-ui/theme-default' }));
 		write(path.join(baselineDir, `a-basic--one${SUFFIX}`), png(4, 3, 'one'));
 		write(path.join(baselineDir, `a-basic--two${SUFFIX}`), png(4, 3, 'two'));
+		write(path.join(baselineDir, `a-basic--three${SUFFIX}`), png(4, 3, 'three'));
 		write(path.join(baselineDir, `b-gone--x${SUFFIX}`), png(4, 3, 'gone'));
 		write(path.join(baselineDir, `c-broken--y${SUFFIX}`), png(4, 3, 'broken'));
 		write(path.join(baselineDir, `a-basic--one-firefox-otheros.png`), png(4, 3, 'foreign'));
@@ -71,37 +105,40 @@ describe('VisualReporter', () => {
 		fs.rmSync(root, { recursive: true, force: true });
 	});
 
-	it('mirrors the route-to-file-name rule of the spec', () => {
-		assert.equal(routeToSnapshotName('button/variants?x=1&y=2'), 'button-variants-x-1-y-2');
-	});
-
-	it('classifies changed, added, unchanged and removed snapshots', () => {
+	it('classifies changed, added, unchanged and removed snapshots from attachments and the baseline listing', () => {
 		const reporter = createReporter();
-		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+		reporter.onBegin(CONFIG, SUITE);
 
 		// Playwright writes missing snapshots into the baseline folder while the run is in progress.
 		write(path.join(baselineDir, `a-basic--new${SUFFIX}`), png(4, 3, 'new-expected'));
-		const twoActual = write(path.join(testResults, `a-basic--two-actual.png`), png(4, 3, 'two-actual'));
-		const twoDiff = write(path.join(testResults, `a-basic--two-diff.png`), png(4, 3, 'two-diff'));
-		const newActual = write(path.join(testResults, `a-basic--new-actual.png`), png(4, 3, 'new-actual'));
+		const twoActual = write(path.join(testResults, 'a-basic--two-actual.png'), png(4, 4, 'two-actual'));
+		const twoDiff = write(path.join(testResults, 'a-basic--two-diff.png'), png(4, 4, 'two-diff'));
+		const threeActual = write(path.join(testResults, 'a-basic--three-actual.png'), png(4, 3, 'three-actual'));
+		const newActual = write(path.join(testResults, 'a-basic--new-actual.png'), png(4, 3, 'new-actual'));
 
 		reporter.onTestEnd(
-			fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png'), annotation('a-basic--new.png')] }),
+			fakeTest('a/basic', {
+				annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png'), annotation('a-basic--three.png'), annotation('a-basic--new.png')],
+			}),
 			fakeResult({
 				status: 'failed',
 				errors: [
 					{
 						message:
-							'\u001b[31mScreenshot comparison failed:\u001b[39m\n\n  3 pixels (ratio 0.25 of all image pixels) are different.\n\n  Snapshot: a-basic--two.png\n',
+							'\u001b[31mScreenshot comparison failed:\u001b[39m\n\n  Expected an image 4px by 3px, received 4px by 4px. 4 pixels (ratio 0.25 of all image pixels) are different.\n\n  Snapshot: a-basic--two.png\n',
 					},
+					// A future Playwright may reword its message – the item still counts as changed, only without numbers.
+					{ message: `Screenshot mismatch for ${path.join(baselineDir, `a-basic--three${SUFFIX}`)}` },
 					{ message: `A snapshot doesn't exist at ${path.join(baselineDir, `a-basic--new${SUFFIX}`)}, writing actual.` },
 				],
 				attachments: [
-					{ name: 'a-basic--two-expected.png', contentType: 'image/png', path: path.join(baselineDir, `a-basic--two${SUFFIX}`) },
-					{ name: 'a-basic--two-actual.png', contentType: 'image/png', path: twoActual },
-					{ name: 'a-basic--two-diff.png', contentType: 'image/png', path: twoDiff },
-					{ name: 'a-basic--new-expected.png', contentType: 'image/png', path: path.join(baselineDir, `a-basic--new${SUFFIX}`) },
-					{ name: 'a-basic--new-actual.png', contentType: 'image/png', path: newActual },
+					attachment('a-basic--two-expected.png', path.join(baselineDir, `a-basic--two${SUFFIX}`)),
+					attachment('a-basic--two-actual.png', twoActual),
+					attachment('a-basic--two-diff.png', twoDiff),
+					attachment('a-basic--three-expected.png', path.join(baselineDir, `a-basic--three${SUFFIX}`)),
+					attachment('a-basic--three-actual.png', threeActual),
+					attachment('a-basic--new-expected.png', path.join(baselineDir, `a-basic--new${SUFFIX}`)),
+					attachment('a-basic--new-actual.png', newActual),
 				],
 			}),
 		);
@@ -113,14 +150,15 @@ describe('VisualReporter', () => {
 		assert.equal(report.schema, 1);
 		assert.equal(report.mode, 'compare');
 		assert.equal(report.package, 'theme-default');
+		assert.deepEqual(report.projects, ['firefox']);
 		assert.equal(report.baseline.dir, 'snapshots/theme-default');
-		assert.equal(report.baseline.files, 4, 'files of other platforms and files written during the run are not baseline');
-		assert.deepEqual(report.summary, { unchanged: 2, changed: 1, added: 1, removed: 1, error: 0 });
+		assert.equal(report.baseline.files, 5, 'files of other platforms and files written during the run are not baseline');
+		assert.deepEqual(report.summary, { unchanged: 2, changed: 2, added: 1, removed: 1, error: 0 });
 		assert.deepEqual(report.errors, []);
 		assert.match(report.digest, /^sha256:[0-9a-f]{64}$/);
 
 		const byName = Object.fromEntries(report.items.map((item) => [item.name, item]));
-		assert.deepEqual(Object.keys(byName), ['a-basic--new', 'a-basic--one', 'a-basic--two', 'b-gone--x', 'c-broken--y']);
+		assert.deepEqual(Object.keys(byName), ['a-basic--new', 'a-basic--one', 'a-basic--three', 'a-basic--two', 'b-gone--x', 'c-broken--y']);
 
 		assert.equal(byName['a-basic--one'].status, 'unchanged');
 		assert.equal(byName['c-broken--y'].status, 'unchanged');
@@ -128,13 +166,20 @@ describe('VisualReporter', () => {
 		const changed = byName['a-basic--two'];
 		assert.equal(changed.status, 'changed');
 		assert.equal(changed.route, 'a/basic');
-		assert.equal(changed.diffPixels, 3);
-		assert.equal(changed.diffRatio, 0.25);
+		assert.deepEqual(changed.sizeMismatch, { expected: [4, 3], actual: [4, 4] });
+		assert.equal(changed.diffPixels, 4);
+		assert.equal(changed.diffRatio, 0.25, 'ratio over the padded 4×4 comparison canvas');
 		assert.equal(changed.expected, 'theme-default/a-basic--two.expected.png');
 		assert.equal(changed.actual, 'theme-default/a-basic--two.actual.png');
 		assert.equal(changed.diff, 'theme-default/a-basic--two.diff.png');
 		assert.ok(fs.existsSync(path.join(outputDir, changed.diff)));
 		assert.ok(fs.readFileSync(path.join(outputDir, changed.actual)).equals(fs.readFileSync(twoActual)));
+
+		const reworded = byName['a-basic--three'];
+		assert.equal(reworded.status, 'changed');
+		assert.equal(reworded.diffPixels, undefined);
+		assert.equal(reworded.diff, undefined);
+		assert.equal(reworded.expected, 'theme-default/a-basic--three.expected.png');
 
 		const added = byName['a-basic--new'];
 		assert.equal(added.status, 'added');
@@ -151,63 +196,108 @@ describe('VisualReporter', () => {
 		assert.notEqual(changed.hash, byName['a-basic--one'].hash);
 	});
 
-	it('marks the baseline of a failed route as error instead of removed and reports the failure', () => {
+	it('computes the ratio from the actual image when the sizes match', () => {
 		const reporter = createReporter();
-		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
-		reporter.onTestEnd(fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png')] }), fakeResult());
+		reporter.onBegin(CONFIG, SUITE);
+		const twoActual = write(path.join(testResults, 'a-basic--two-actual.png'), png(4, 3, 'two-actual'));
+		reporter.onTestEnd(
+			fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png'), annotation('a-basic--three.png')] }),
+			fakeResult({
+				status: 'failed',
+				errors: [{ message: 'Screenshot comparison failed:\n\n  3 pixels (ratio 0.25 of all image pixels) are different.\n\n  Snapshot: a-basic--two.png\n' }],
+				attachments: [
+					attachment('a-basic--two-expected.png', path.join(baselineDir, `a-basic--two${SUFFIX}`)),
+					attachment('a-basic--two-actual.png', twoActual),
+				],
+			}),
+		);
+		reporter.onEnd();
+		const changed = readReport().items.find((item) => item.name === 'a-basic--two');
+		assert.equal(changed.diffPixels, 3);
+		assert.equal(changed.diffRatio, 0.25);
+		assert.equal(changed.sizeMismatch, undefined);
+	});
+
+	it('marks the baseline of a failed route as error instead of removed and keeps every hard error', () => {
+		const reporter = createReporter();
+		reporter.onBegin(CONFIG, SUITE);
+		reporter.onTestEnd(
+			fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png'), annotation('a-basic--three.png')] }),
+			fakeResult(),
+		);
 		reporter.onTestEnd(
 			fakeTest('c/broken'),
-			fakeResult({ status: 'failed', errors: [{ message: '\u001b[31mError: Route "c/broken": no data-visual-block containers found.\u001b[39m\n    at …' }] }),
+			fakeResult({
+				status: 'failed',
+				errors: [
+					{ message: '\u001b[31mError: Route "c/broken": no data-visual-block containers found.\u001b[39m\n    at …' },
+					{ message: 'Error: second problem' },
+				],
+			}),
 		);
 		reporter.onEnd();
 
 		const report = readReport();
-		assert.deepEqual(report.summary, { unchanged: 2, changed: 0, added: 0, removed: 1, error: 1 });
+		assert.deepEqual(report.summary, { unchanged: 3, changed: 0, added: 0, removed: 1, error: 1 });
 		const broken = report.items.find((item) => item.name === 'c-broken--y');
 		assert.equal(broken.status, 'error');
 		assert.equal(broken.message, 'Error: Route "c/broken": no data-visual-block containers found.');
 		assert.deepEqual(report.errors, [
 			{ test: 'snapshot for c/broken', route: 'c/broken', message: 'Error: Route "c/broken": no data-visual-block containers found.' },
+			{ test: 'snapshot for c/broken', route: 'c/broken', message: 'Error: second problem' },
 		]);
 	});
 
 	it('only counts the last attempt of a retried test', () => {
 		const reporter = createReporter();
-		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
-		reporter.onTestEnd(fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png')] }), fakeResult());
+		reporter.onBegin(CONFIG, SUITE);
+		reporter.onTestEnd(
+			fakeTest('a/basic', { annotations: [annotation('a-basic--one.png'), annotation('a-basic--two.png'), annotation('a-basic--three.png')] }),
+			fakeResult(),
+		);
 		reporter.onTestEnd(fakeTest('c/broken'), fakeResult({ status: 'timedOut', errors: [{ message: 'Test timeout of 15000ms exceeded.' }] }));
 		reporter.onTestEnd(fakeTest('c/broken', { annotations: [annotation('c-broken--y.png')] }), fakeResult({ retry: 1 }));
 		reporter.onEnd();
 
 		const report = readReport();
-		assert.deepEqual(report.summary, { unchanged: 3, changed: 0, added: 0, removed: 1, error: 0 });
+		assert.deepEqual(report.summary, { unchanged: 4, changed: 0, added: 0, removed: 1, error: 0 });
 		assert.deepEqual(report.errors, []);
 	});
 
-	it('ignores tests of other spec files', () => {
+	it('ignores tests of other spec files, whatever their title', () => {
 		const reporter = createReporter();
-		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+		reporter.onBegin(CONFIG, SUITE);
 		reporter.onTestEnd(
-			{ id: 'axe', title: 'axe for a/basic', location: { file: path.join('tests', 'axe-snapshots.spec.js') }, annotations: [] },
-			fakeResult({ status: 'failed', errors: [{ message: 'axe violations' }] }),
+			{ id: 'other', title: 'snapshot for a/basic', location: { file: path.join('tests', 'other.spec.js') }, annotations: [annotation('a-basic--one.png')] },
+			fakeResult({ status: 'failed', errors: [{ message: 'unrelated' }] }),
 		);
 		reporter.onEnd();
-		assert.deepEqual(readReport().errors, []);
+		const report = readReport();
+		assert.deepEqual(report.errors, []);
+		assert.equal(report.summary.removed, 5, 'no snapshot test ran, so every baseline file counts as removed');
+	});
+
+	it('refuses to run for more than one Playwright project', () => {
+		const reporter = createReporter();
+		const twoProjects = { suites: [{ project: () => ({ name: 'firefox' }) }, { project: () => ({ name: 'chrome' }) }] };
+		assert.throws(() => reporter.onBegin(CONFIG, twoProjects), /exactly one Playwright project.*firefox, chrome/);
 	});
 
 	it('writes a manifest of the generated files in update mode', () => {
 		const reporter = createReporter();
-		reporter.onBegin({ updateSnapshots: 'changed', projects: [{ name: 'firefox' }] });
+		reporter.onBegin({ ...CONFIG, updateSnapshots: 'changed' }, SUITE);
 		fs.rmSync(path.join(baselineDir, `b-gone--x${SUFFIX}`));
 		write(path.join(baselineDir, `a-basic--new${SUFFIX}`), png(4, 3, 'new'));
+		write(path.join(baselineDir, `a-basic--newer${SUFFIX}`), png(4, 3, 'newer'));
 		reporter.onEnd();
 
 		const report = readReport();
 		assert.equal(report.mode, 'update');
-		assert.deepEqual(report.summary, { baseline: 4 });
+		assert.deepEqual(report.summary, { baseline: 6 });
+		assert.equal(report.baseline.files, 6, 'describes the folder after the run, like the items');
 		assert.deepEqual(
 			report.items.map((item) => item.name),
-			['a-basic--new', 'a-basic--one', 'a-basic--two', 'c-broken--y'],
+			['a-basic--new', 'a-basic--newer', 'a-basic--one', 'a-basic--three', 'a-basic--two', 'c-broken--y'],
 		);
 		assert.ok(report.items.every((item) => item.status === 'baseline'));
 		assert.match(report.digest, /^sha256:[0-9a-f]{64}$/);
@@ -217,7 +307,7 @@ describe('VisualReporter', () => {
 		write(path.join(outputDir, 'baseline.json'), JSON.stringify({ sha: 'abc' }));
 		write(path.join(outputDir, 'stale.txt'), 'old');
 		const reporter = createReporter();
-		reporter.onBegin({ updateSnapshots: 'missing', projects: [{ name: 'firefox' }] });
+		reporter.onBegin(CONFIG, SUITE);
 		reporter.onEnd();
 
 		assert.equal(fs.existsSync(path.join(outputDir, 'stale.txt')), false);

--- a/packages/tools/visual-tests/tests/theme-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/theme-snapshots.spec.js
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { SNAPSHOT_ANNOTATION } from '../src/visual-reporter.js';
 import { ROUTES } from './sample-app.routes.js';
 
 // https://playwright.dev/docs/emulation
@@ -51,6 +52,23 @@ const NARROW_SELECTOR = '[data-visual-block][data-visual-narrow]';
 const NARROW_VIEWPORT = { width: 320, height: 256 };
 const BLOCK_VISIBLE_TIMEOUT = 10000;
 
+/**
+ * A mismatch is a review case, not a reason to abort the route: soft expectations keep capturing the
+ * remaining blocks, so the report lists every changed block of a route at once. Retries are disabled
+ * because a deterministic diff re-renders identically – they would only triple the cost.
+ */
+test.describe.configure({ retries: 0 });
+
+/**
+ * Captures one screenshot and announces it to the visual reporter. A passing comparison leaves no
+ * attachment behind, so the annotation is the only signal that the snapshot was compared at all –
+ * without it the reporter could not tell an unchanged block from a removed one.
+ */
+async function captureSnapshot(target, fileName, options) {
+	await expect.soft(target).toHaveScreenshot(fileName, options);
+	test.info().annotations.push({ type: SNAPSHOT_ANNOTATION, description: fileName });
+}
+
 /** Reads the `data-visual-block` ids of all elements matching `selector`, in document order. */
 async function readBlockIds(page, selector) {
 	return page.$$eval(selector, (elements) => elements.map((element) => element.getAttribute('data-visual-block')));
@@ -70,7 +88,7 @@ async function captureBlocks(page, route, blockIds, snapshotName, suffix, option
 				`Route "${route}": data-visual-block "${blockId}" is not visible or has zero size${suffix ? ` at ${NARROW_VIEWPORT.width}px viewport width` : ''}`,
 			);
 		}
-		await expect(block).toHaveScreenshot(`${snapshotName}--${blockId}${suffix}.png`, options);
+		await captureSnapshot(block, `${snapshotName}--${blockId}${suffix}.png`, options);
 	}
 }
 
@@ -111,7 +129,7 @@ ROUTES.forEach((options, route) => {
 		const { fullPage: _fullPage, ...ELEMENT_SNAPSHOT_OPTIONS } = SNAPSHOT_OPTIONS; // fullPage is not allowed for element screenshots
 
 		if (options?.snapshot?.forceFullPage === true) {
-			await expect(page).toHaveScreenshot(`${snapshotName}.png`, SNAPSHOT_OPTIONS);
+			await captureSnapshot(page, `${snapshotName}.png`, SNAPSHOT_OPTIONS);
 			return; // Whole-page routes have no blocks, so there is nothing to capture at narrow width either.
 		}
 

--- a/packages/tools/visual-tests/tests/theme-snapshots.spec.js
+++ b/packages/tools/visual-tests/tests/theme-snapshots.spec.js
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { SNAPSHOT_ANNOTATION } from '../src/visual-reporter.js';
+import { SNAPSHOT_ANNOTATION, routeToSnapshotName } from '../src/visual-reporter.js';
 import { ROUTES } from './sample-app.routes.js';
 
 // https://playwright.dev/docs/emulation
@@ -53,16 +53,15 @@ const NARROW_VIEWPORT = { width: 320, height: 256 };
 const BLOCK_VISIBLE_TIMEOUT = 10000;
 
 /**
- * A mismatch is a review case, not a reason to abort the route: soft expectations keep capturing the
- * remaining blocks, so the report lists every changed block of a route at once. Retries are disabled
- * because a deterministic diff re-renders identically – they would only triple the cost.
- */
-test.describe.configure({ retries: 0 });
-
-/**
- * Captures one screenshot and announces it to the visual reporter. A passing comparison leaves no
- * attachment behind, so the annotation is the only signal that the snapshot was compared at all –
- * without it the reporter could not tell an unchanged block from a removed one.
+ * Captures one screenshot and announces it to the visual reporter. Every screenshot of this spec must go
+ * through here (guarded by a test in test/visual-reporter.test.mjs):
+ *
+ * - `expect.soft`: a mismatch is a review case, not a reason to abort the route, so the remaining blocks
+ *   are still captured and the report lists every changed block of a route at once. Retries stay at the
+ *   global setting – a differing route re-renders on retry, but so does a block that was slow to appear.
+ * - the annotation: a passing comparison leaves no attachment behind, so it is the only signal that the
+ *   snapshot was compared at all – without it the reporter could not tell an unchanged block from a
+ *   removed one.
  */
 async function captureSnapshot(target, fileName, options) {
 	await expect.soft(target).toHaveScreenshot(fileName, options);
@@ -117,10 +116,9 @@ ROUTES.forEach((options, route) => {
 			await page.waitForTimeout(options?.snapshot?.waitForTimeout);
 		}
 
-		/**
-		 * We would like to use a readable name for the snapshot file, e.g. `button-basic` for `button/basic`.
-		 */
-		const snapshotName = route.replace(/(\/|\?|&|=)/g, '-');
+		/* A readable file name, e.g. `button-basic` for `button/basic` – the reporter derives the same name from
+		   the test title to match baseline files, so both sides share the one function. */
+		const snapshotName = routeToSnapshotName(route);
 
 		const SNAPSHOT_OPTIONS = {
 			...DEFAULT_SNAPSHOT_OPTIONS,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,6 +33,24 @@ Host `node_modules` are never touched; the install inside the volume is reused a
 | `--reset`    | Drop the volume, forcing a fresh install on the next run                  |
 | `-- <args>`  | Everything after `--` is passed on to Playwright, e.g. `-- --grep Button` |
 
+## visual-review/
+
+Helpers around the visual report the Playwright runs write to `<package>/visual-report/report.json`
+(see [packages/tools/visual-tests](../packages/tools/visual-tests/README.md#visual-report-visual-reportreportjson)).
+
+- `snapshot-paths.mjs` – the one table that maps a visual-test package (`theme-default`, `unstyled`, …)
+  to its folder, its `snapshots/theme-<export>` sub folder and its report folder. The export-derived
+  folder names (`theme-desyv11`, `theme-kern_v2`) are not guessable from the directory, so every
+  script and workflow resolves them here; a unit test in `packages/tools/visual-tests` keeps the
+  table in sync with the packages' `test` scripts.
+- `assert-no-errors.mjs <package>` – prints the report summary (and appends it to the GitHub job
+  summary), then fails only if routes could not be compared at all. Screenshot differences are a
+  review case, not an error.
+
+```bash
+node scripts/visual-review/assert-no-errors.mjs theme-default
+```
+
 ## license-reports.mjs
 
 Generate and merge all package license reports into one Markdown file:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,11 +38,12 @@ Host `node_modules` are never touched; the install inside the volume is reused a
 Helpers around the visual report the Playwright runs write to `<package>/visual-report/report.json`
 (see [packages/tools/visual-tests](../packages/tools/visual-tests/README.md#visual-report-visual-reportreportjson)).
 
-- `snapshot-paths.mjs` – the one table that maps a visual-test package (`theme-default`, `unstyled`, …)
-  to its folder, its `snapshots/theme-<export>` sub folder and its report folder. The export-derived
-  folder names (`theme-desyv11`, `theme-kern_v2`) are not guessable from the directory, so every
-  script and workflow resolves them here; a unit test in `packages/tools/visual-tests` keeps the
-  table in sync with the packages' `test` scripts.
+- `snapshot-paths.mjs` – discovers every package whose `test` script runs `kolibri-visual-test`
+  (`theme-default`, `unstyled`, …) and maps it to its folder, its `snapshots/theme-<export>` sub
+  folder and its report folder. The export-derived folder names (`theme-desyv11`, `theme-kern_v2`)
+  are not guessable from the directory, so every script resolves them here; a new theme package
+  takes part without registration. The CI matrices in `ci.yml` and `visual-baseline.yml` still list
+  the packages by hand – a unit test in `packages/tools/visual-tests` pins the discovered set.
 - `assert-no-errors.mjs <package>` – prints the report summary (and appends it to the GitHub job
   summary), then fails only if routes could not be compared at all. Screenshot differences are a
   review case, not an error.

--- a/scripts/visual-review/assert-no-errors.mjs
+++ b/scripts/visual-review/assert-no-errors.mjs
@@ -1,0 +1,85 @@
+/**
+ * Summarises the visual report of one package and fails only on real errors.
+ *
+ * Screenshot differences are a review case, not a pipeline failure – they are approved (or rejected)
+ * on the review page. What must fail the job is everything that prevented a comparison: a route that
+ * threw, an invisible block, a timeout. Those show up as `errors` or items with status `error`.
+ *
+ *   node scripts/visual-review/assert-no-errors.mjs theme-default
+ *
+ * Exit codes: 0 no errors, 1 errors found, 2 report missing (the test run did not get that far).
+ * On GitHub Actions the summary is also appended to the job summary and errors become annotations.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { reportDir, resolvePackage } from './snapshot-paths.mjs';
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const MAX_LISTED_ITEMS = 50;
+
+const packageName = process.argv[2];
+if (!packageName) {
+	console.error('Usage: node scripts/visual-review/assert-no-errors.mjs <package>');
+	process.exit(2);
+}
+
+const pkg = resolvePackage(packageName);
+const reportFile = path.join(REPO_ROOT, reportDir(pkg), 'report.json');
+
+if (!fs.existsSync(reportFile)) {
+	fail(`No visual report found at ${path.relative(REPO_ROOT, reportFile)} – the Playwright run did not produce one.`);
+	process.exit(2);
+}
+
+const report = JSON.parse(fs.readFileSync(reportFile, 'utf8'));
+const lines = [];
+
+if (report.mode === 'update') {
+	lines.push(`### Visual baseline \`${report.package}\``, '', `${report.summary.baseline} snapshots generated, digest \`${report.digest}\`.`);
+} else {
+	const { summary } = report;
+	lines.push(
+		`### Visual review \`${report.package}\``,
+		'',
+		'| unchanged | changed | added | removed | error |',
+		'| --: | --: | --: | --: | --: |',
+		`| ${summary.unchanged} | ${summary.changed} | ${summary.added} | ${summary.removed} | ${summary.error} |`,
+		'',
+	);
+	if (report.baseline.files === 0) {
+		lines.push('_No baseline available – every screenshot counts as added._', '');
+	}
+	const listed = report.items.filter((item) => item.status !== 'unchanged');
+	for (const item of listed.slice(0, MAX_LISTED_ITEMS)) {
+		const detail = item.diffPixels !== undefined ? ` (${item.diffPixels} px)` : item.message ? ` – ${item.message}` : '';
+		lines.push(`- \`${item.status}\` ${item.name}${detail}`);
+	}
+	if (listed.length > MAX_LISTED_ITEMS) {
+		lines.push(`- … ${listed.length - MAX_LISTED_ITEMS} more`);
+	}
+}
+
+const errors = report.errors ?? [];
+if (errors.length > 0) {
+	lines.push('', `**${errors.length} route(s) failed before their blocks could be compared:**`, '');
+	for (const error of errors) {
+		lines.push(`- \`${error.route}\`: ${error.message}`);
+		fail(`${report.package} – route "${error.route}": ${error.message}`);
+	}
+}
+
+const text = lines.join('\n');
+console.log(text);
+if (process.env.GITHUB_STEP_SUMMARY) {
+	fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${text}\n\n`);
+}
+
+const errorItems = report.summary?.error ?? 0;
+if (errors.length > 0 || errorItems > 0) {
+	process.exit(1);
+}
+
+function fail(message) {
+	console.error(process.env.GITHUB_ACTIONS ? `::error::${message}` : message);
+}

--- a/scripts/visual-review/snapshot-paths.mjs
+++ b/scripts/visual-review/snapshot-paths.mjs
@@ -1,0 +1,41 @@
+/**
+ * Single source of truth for where the visual-test packages keep their snapshots and reports.
+ *
+ * The folder below `snapshots/` is derived from the theme's export name (THEME_EXPORT in the package's
+ * `test` script, lower-cased by playwright.config.js), which cannot be guessed from the directory name
+ * (`desy` → `theme-desyv11`, `kern` → `theme-kern_v2`). The test in
+ * packages/tools/visual-tests/test/snapshot-paths.test.mjs keeps this table in sync with the scripts.
+ *
+ * `test-tag-name-transformer` has no baseline of its own: its `prepare:snapshots` script copies the
+ * default theme's folder before every run.
+ */
+export const PACKAGES = [
+	{ name: 'theme-bwst', dir: 'packages/themes/bwst', themeDir: 'theme-bwst' },
+	{ name: 'theme-default', dir: 'packages/themes/default', themeDir: 'theme-default' },
+	{ name: 'theme-desy', dir: 'packages/themes/desy', themeDir: 'theme-desyv11' },
+	{ name: 'theme-ecl', dir: 'packages/themes/ecl', themeDir: 'theme-ecl_ec' },
+	{ name: 'theme-kern', dir: 'packages/themes/kern', themeDir: 'theme-kern_v2' },
+	{ name: 'unstyled', dir: 'packages/unstyled', themeDir: 'theme-unstyled' },
+	{ name: 'test-tag-name-transformer', dir: 'packages/test-tag-name-transformer', themeDir: 'theme-default', baselineFrom: 'theme-default' },
+];
+
+/** Packages that publish a baseline artifact (everything that generates its own snapshots). */
+export const BASELINE_PACKAGES = PACKAGES.filter((pkg) => !pkg.baselineFrom);
+
+export function resolvePackage(name) {
+	const pkg = PACKAGES.find((candidate) => candidate.name === name);
+	if (!pkg) {
+		throw new Error(`Unknown visual-test package "${name}". Known: ${PACKAGES.map((candidate) => candidate.name).join(', ')}`);
+	}
+	return pkg;
+}
+
+/** Repo-relative folder holding the baseline PNGs, e.g. `packages/themes/desy/snapshots/theme-desyv11`. */
+export function snapshotDir(pkg) {
+	return `${pkg.dir}/snapshots/${pkg.themeDir}`;
+}
+
+/** Repo-relative folder the visual reporter writes to. */
+export function reportDir(pkg) {
+	return `${pkg.dir}/visual-report`;
+}

--- a/scripts/visual-review/snapshot-paths.mjs
+++ b/scripts/visual-review/snapshot-paths.mjs
@@ -1,23 +1,68 @@
 /**
- * Single source of truth for where the visual-test packages keep their snapshots and reports.
+ * Where the visual-test packages keep their snapshots and reports – discovered from the packages
+ * themselves, so a new theme package needs no registration here.
  *
- * The folder below `snapshots/` is derived from the theme's export name (THEME_EXPORT in the package's
- * `test` script, lower-cased by playwright.config.js), which cannot be guessed from the directory name
- * (`desy` → `theme-desyv11`, `kern` → `theme-kern_v2`). The test in
- * packages/tools/visual-tests/test/snapshot-paths.test.mjs keeps this table in sync with the scripts.
- *
- * `test-tag-name-transformer` has no baseline of its own: its `prepare:snapshots` script copies the
- * default theme's folder before every run.
+ * A package takes part when its `test` script runs `kolibri-visual-test` (directly, or via an
+ * `npm-run-all2` delegate as the ecl theme does). The folder below `snapshots/` is derived from the
+ * script's THEME_EXPORT the same way playwright.config.js does (`DesyV11` → `theme-desyv11`); it cannot
+ * be guessed from the directory name. A package whose `prepare:snapshots` copies another theme's
+ * folder (test-tag-name-transformer) has no baseline of its own – `baselineFrom` names the owner.
  */
-export const PACKAGES = [
-	{ name: 'theme-bwst', dir: 'packages/themes/bwst', themeDir: 'theme-bwst' },
-	{ name: 'theme-default', dir: 'packages/themes/default', themeDir: 'theme-default' },
-	{ name: 'theme-desy', dir: 'packages/themes/desy', themeDir: 'theme-desyv11' },
-	{ name: 'theme-ecl', dir: 'packages/themes/ecl', themeDir: 'theme-ecl_ec' },
-	{ name: 'theme-kern', dir: 'packages/themes/kern', themeDir: 'theme-kern_v2' },
-	{ name: 'unstyled', dir: 'packages/unstyled', themeDir: 'theme-unstyled' },
-	{ name: 'test-tag-name-transformer', dir: 'packages/test-tag-name-transformer', themeDir: 'theme-default', baselineFrom: 'theme-default' },
-];
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const SCAN_DIRS = ['packages', 'packages/themes'];
+
+function readPackageJson(dir) {
+	try {
+		return JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+	} catch {
+		return null;
+	}
+}
+
+/** The script `test` ends up running, if it is a visual test. */
+function visualTestScript(scripts = {}) {
+	let script = scripts.test;
+	const delegate = script?.match(/^npm-run-all2 (\S+)$/);
+	if (delegate) script = scripts[delegate[1]];
+	return script?.includes('kolibri-visual-test') ? script : null;
+}
+
+export function discoverPackages(root = REPO_ROOT) {
+	const found = [];
+	for (const scanDir of SCAN_DIRS) {
+		const absolute = path.join(root, scanDir);
+		if (!fs.existsSync(absolute)) continue;
+		for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+			if (!entry.isDirectory()) continue;
+			const dir = `${scanDir}/${entry.name}`;
+			const pkg = readPackageJson(path.join(root, dir));
+			const script = pkg && visualTestScript(pkg.scripts);
+			if (!script) continue;
+			const themeExport = script.match(/THEME_EXPORT=(\S+)/)?.[1] ?? 'default';
+			const copiedFrom = pkg.scripts['prepare:snapshots']?.match(/\.\.\/themes\/([^/\s"']+)\/snapshots/)?.[1];
+			found.push({
+				name: pkg.name.replace(/^@public-ui\//, ''),
+				dir,
+				themeDir: `theme-${themeExport.toLocaleLowerCase()}`,
+				copiedFromDir: copiedFrom ? `packages/themes/${copiedFrom}` : undefined,
+			});
+		}
+	}
+	return found
+		.map(({ copiedFromDir, ...pkg }) => {
+			if (!copiedFromDir) return pkg;
+			const owner = found.find((candidate) => candidate.dir === copiedFromDir);
+			if (!owner) throw new Error(`${pkg.name} copies its snapshots from ${copiedFromDir}, which has no visual tests.`);
+			return { ...pkg, baselineFrom: owner.name };
+		})
+		.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export const PACKAGES = discoverPackages();
 
 /** Packages that publish a baseline artifact (everything that generates its own snapshots). */
 export const BASELINE_PACKAGES = PACKAGES.filter((pkg) => !pkg.baselineFrom);


### PR DESCRIPTION
## What changed?

This is PR A of the four-part visual-review rework (#9101). It adds a machine-readable visual report to the visual-tests tooling without changing how the pipeline judges a run; snapshots stay in git for now. A custom Playwright reporter (`packages/tools/visual-tests/src/visual-reporter.js`) writes `visual-report/report.json` per theme package, classifying every baseline snapshot as `unchanged`/`changed`/`added`/`removed`/`error`, attaching a content hash (`sha256:…`) and a `digest` over the whole set, and copying the expected/actual/diff PNGs of changed items next to the report (in `--update-snapshots` mode it writes a manifest of generated files instead). `theme-snapshots.spec.js` now captures via `expect.soft` with a `visual-snapshot` annotation per capture and retries disabled; `scripts/visual-review/snapshot-paths.mjs` centralizes the package→snapshot-folder mapping (kept in sync by a unit test); and `scripts/visual-review/assert-no-errors.mjs` prints the report to the job summary and fails only on routes that could not be compared. `ci.yml` runs that summary and uploads a `visual-review-<package>` artifact. This is CI/test tooling only, with no effect on any published component or public API.

## Linked issues

- Refs #9101 — Reduce repository size by moving visual snapshot baselines out of git; groundwork for the artifact-based visual review.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies ist PR A des vierteiligen Visual-Review-Umbaus (#9101). Er ergänzt einen maschinenlesbaren Visual-Report im Visual-Tests-Tooling, ohne zu ändern, wie die Pipeline einen Lauf bewertet; die Snapshots bleiben vorerst in git. Ein eigener Playwright-Reporter (`packages/tools/visual-tests/src/visual-reporter.js`) schreibt pro Theme-Paket eine `visual-report/report.json`, klassifiziert jeden Baseline-Snapshot als `unchanged`/`changed`/`added`/`removed`/`error`, hängt einen Content-Hash (`sha256:…`) sowie einen `digest` über die gesamte Menge an und kopiert die Expected/Actual/Diff-PNGs geänderter Einträge neben den Report (im `--update-snapshots`-Modus schreibt er stattdessen ein Manifest der generierten Dateien). `theme-snapshots.spec.js` erfasst nun via `expect.soft` mit einer `visual-snapshot`-Annotation pro Capture und deaktivierten Retries; `scripts/visual-review/snapshot-paths.mjs` bündelt das Mapping Paket→Snapshot-Ordner (per Unit-Test synchron gehalten); und `scripts/visual-review/assert-no-errors.mjs` gibt den Report in die Job-Summary aus und scheitert nur bei Routen, die gar nicht verglichen werden konnten. `ci.yml` führt diese Summary aus und lädt ein `visual-review-<package>`-Artefakt hoch. Ausschließlich CI-/Test-Tooling ohne Auswirkung auf veröffentlichte Komponenten oder öffentliche APIs.

### Verknüpfte Tickets

- Referenziert #9101 — Repository-Größe reduzieren durch Auslagern der Visual-Snapshot-Baselines aus git; Grundlage für das artefaktbasierte Visual Review.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/src/visual-reporter.js` — Neuer Playwright-Reporter, der `report.json` mit Klassifikation, Hashes und Digest schreibt.
- `packages/tools/visual-tests/.../theme-snapshots.spec.js` — Erfassung via `expect.soft` mit `visual-snapshot`-Annotation, Retries deaktiviert.
- `scripts/visual-review/snapshot-paths.mjs` — Zentrale Tabelle Paket→Snapshot-Ordner.
- `scripts/visual-review/assert-no-errors.mjs` — Gibt den Report in die Job-Summary aus, scheitert nur bei nicht vergleichbaren Routen.
- `.github/workflows/ci.yml` — Führt die Report-Summary aus und lädt `visual-review-<package>` als Artefakt hoch.

</details>
