### PR TITLE
ci(visual-tests): publish snapshot baselines as artifacts

### DIFF
--- a/.github/workflows/visual-baseline.yml
+++ b/.github/workflows/visual-baseline.yml
@@ -1,0 +1,63 @@
+name: Visual Baseline
+
+# Publishes the visual-test baseline of every base branch as an artifact (visual-baseline-<package>).
+# Pull requests compare their screenshots against the artifact of the base commit they were merged
+# with, so the snapshot PNGs no longer have to live in git. Every push gets its own run on purpose –
+# no concurrency group – because a cancelled run would leave a base commit without baseline.
+on:
+  push:
+    branches:
+      - 'develop'
+      - 'main'
+      - 'release/*'
+  schedule:
+    # Monthly refresh so the artifacts (90 days retention) of a quiet branch never expire.
+    - cron: '17 3 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  baseline:
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ['unstyled', 'theme-bwst', 'theme-default', 'theme-desy', 'theme-kern', 'theme-ecl']
+    runs-on: ubuntu-latest
+    # Pinned Playwright image – must match the @playwright/test version in
+    # packages/tools/visual-tests/package.json (enforced by the "Verify Playwright version" step).
+    # --user 1001 (pwuser, same uid as the runner user): Firefox refuses to launch as root,
+    # see https://playwright.dev/docs/ci#via-containers
+    container:
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
+      options: --user 1001
+    env:
+      PLAYWRIGHT_IMAGE: mcr.microsoft.com/playwright:v1.60.0-noble
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/pnpm-setup
+      - name: Verify Playwright version matches container image
+        run: |
+          INSTALLED=$(pnpm --filter @public-ui/visual-tests exec node -p "require('@playwright/test/package.json').version")
+          [ "$INSTALLED" = "1.60.0" ] || { echo "::error::@playwright/test $INSTALLED does not match container image v1.60.0 – update the image tags in the workflows"; exit 1; }
+      - name: Build
+        run: pnpm --filter @public-ui/visual-tests^... build
+      - name: Purge existing snapshots
+        # Regenerate from scratch so the artifact reflects this commit alone, never a stale file.
+        run: find packages -name '*.png' -path '*/snapshots/*' -not -path '*/node_modules/*' -delete
+      - name: Generate snapshots
+        run: pnpm --filter=@public-ui/${{ matrix.package }} test:update:e2e
+      - name: Package baseline
+        id: pack
+        run: node scripts/visual-review/pack-baseline.mjs ${{ matrix.package }}
+      - name: Upload baseline artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-baseline-${{ matrix.package }}
+          path: ${{ steps.pack.outputs.dir }}
+          if-no-files-found: error
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 playwright-report/
 test-results/
 visual-report/
+visual-baseline/
 *.log
 *.tgz
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"pack": "pnpm -r exec pnpm pack",
 		"reinstall": "pnpm clean:pnpm && pnpm i",
 		"smoketest": "pnpm clean && pnpm i && pnpm build && pnpm format && pnpm lint && pnpm test:unit && pnpm test:e2e && pnpm unused",
+		"snapshots:pull": "node scripts/visual-review/pull-baseline.mjs",
 		"test": "pnpm -r test",
 		"test-reset-and-update": "rimraf packages/themes/**/snapshots/** && pnpm test:update",
 		"test:e2e": "pnpm -r test:e2e",

--- a/packages/tools/visual-tests/test/baseline-artifacts.test.mjs
+++ b/packages/tools/visual-tests/test/baseline-artifacts.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { artifactName, newestArtifact, selectArtifact, usableArtifacts } from '../../../../scripts/visual-review/baseline-artifacts.mjs';
+
+function artifact(id, { sha, branch = 'develop', repo = 1, created = '2026-09-01T00:00:00Z', expired = false } = {}) {
+	return {
+		id,
+		name: 'visual-baseline-theme-default',
+		expired,
+		created_at: created,
+		workflow_run: { id: id * 10, head_sha: sha, head_branch: branch, head_repository_id: repo, repository_id: 1 },
+	};
+}
+
+const ARTIFACTS = [
+	artifact(1, { sha: 'aaa', created: '2026-09-03T00:00:00Z' }),
+	artifact(2, { sha: 'bbb', created: '2026-09-02T00:00:00Z' }),
+	artifact(3, { sha: 'bbb', created: '2026-09-02T06:00:00Z' }),
+	artifact(4, { sha: 'ccc', created: '2026-09-01T00:00:00Z', expired: true }),
+	artifact(5, { sha: 'ddd', branch: 'main', created: '2026-09-04T00:00:00Z' }),
+	artifact(6, { sha: 'eee', repo: 99, created: '2026-09-05T00:00:00Z' }),
+];
+
+describe('baseline-artifacts', () => {
+	it('names artifacts after the package', () => {
+		assert.equal(artifactName({ name: 'theme-desy' }), 'visual-baseline-theme-desy');
+	});
+
+	it('drops expired artifacts, other branches and forks', () => {
+		const ids = usableArtifacts(ARTIFACTS, { branch: 'develop', repositoryId: 1 }).map((a) => a.id);
+		assert.deepEqual(ids, [1, 2, 3]);
+		assert.deepEqual(
+			usableArtifacts(ARTIFACTS, { branch: 'main' }).map((a) => a.id),
+			[5],
+		);
+		assert.deepEqual(
+			usableArtifacts(ARTIFACTS).map((a) => a.id),
+			[1, 2, 3, 5, 6],
+			'no filter besides expiry',
+		);
+	});
+
+	it('prefers the nearest candidate commit and the newest run for it', () => {
+		const selected = selectArtifact(ARTIFACTS, ['ccc', 'bbb', 'aaa'], { branch: 'develop', repositoryId: 1 });
+		assert.equal(selected.sha, 'bbb', 'ccc is expired, bbb is the next candidate');
+		assert.equal(selected.distance, 1);
+		assert.equal(selected.artifact.id, 3, 'newest of the two bbb artifacts');
+	});
+
+	it('returns null when no candidate has an artifact', () => {
+		assert.equal(selectArtifact(ARTIFACTS, ['zzz', 'ccc'], { branch: 'develop' }), null);
+		assert.equal(selectArtifact(ARTIFACTS, [], { branch: 'develop' }), null);
+	});
+
+	it('falls back to the newest usable artifact', () => {
+		assert.equal(newestArtifact(ARTIFACTS, { branch: 'develop', repositoryId: 1 }).id, 1);
+		assert.equal(newestArtifact(ARTIFACTS, { branch: 'release/3' }), null);
+	});
+});

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,9 +47,21 @@ Helpers around the visual report the Playwright runs write to `<package>/visual-
 - `assert-no-errors.mjs <package>` – prints the report summary (and appends it to the GitHub job
   summary), then fails only if routes could not be compared at all. Screenshot differences are a
   review case, not an error.
+- `pack-baseline.mjs <package>` – used by the "Visual Baseline" workflow after `test:update:e2e`:
+  copies the generated snapshots plus a `meta.json` (commit, Playwright image, digest) into
+  `<package>/visual-baseline/`, the layout of the `visual-baseline-<package>` artifact.
+- `baseline-artifacts.mjs` – the selection rules for those artifacts (branch, repository, nearest
+  candidate commit, newest run), shared by the local pull and the CI download.
+- `pull-baseline.mjs` – downloads the current baseline into the local `snapshots/` folders via the
+  GitHub CLI, so a local `pnpm --filter @public-ui/<package> test` compares against what the CI
+  compares against. Generating a baseline locally stays the job of `snapshots-docker.mjs`.
 
 ```bash
 node scripts/visual-review/assert-no-errors.mjs theme-default
+pnpm snapshots:pull                        # every package, newest baseline of develop
+pnpm snapshots:pull theme-default unstyled # selected packages
+pnpm snapshots:pull --branch release/3     # another base branch
+pnpm snapshots:pull --sha <commit>         # the baseline of one specific base commit
 ```
 
 ## license-reports.mjs

--- a/scripts/visual-review/baseline-artifacts.mjs
+++ b/scripts/visual-review/baseline-artifacts.mjs
@@ -1,0 +1,52 @@
+/**
+ * Selection rules for baseline artifacts – shared by the local `pull-baseline.mjs` and the CI
+ * download. Pure functions over the artifact objects the GitHub REST API returns
+ * (`GET /repos/{owner}/{repo}/actions/artifacts?name=…`), so they can be tested without network.
+ */
+export const ARTIFACT_PREFIX = 'visual-baseline-';
+export const META_FILE = 'meta.json';
+
+export function artifactName(pkg) {
+	return `${ARTIFACT_PREFIX}${pkg.name}`;
+}
+
+/**
+ * Keeps only artifacts that can serve as baseline: not expired, produced on `branch` (when given)
+ * and – unless `repositoryId` is unknown – by a push to this repository rather than to a fork whose
+ * branch happens to carry the same name.
+ */
+export function usableArtifacts(artifacts, { branch, repositoryId } = {}) {
+	return artifacts.filter((artifact) => {
+		if (artifact.expired) return false;
+		const run = artifact.workflow_run ?? {};
+		if (branch && run.head_branch !== branch) return false;
+		if (repositoryId !== undefined && run.head_repository_id !== undefined && run.head_repository_id !== repositoryId) return false;
+		return true;
+	});
+}
+
+/**
+ * Picks the artifact of the first commit in `candidates` (nearest first) that has one. Several runs
+ * for the same commit (re-runs, schedule) resolve to the newest artifact. Returns `null` when no
+ * candidate has an artifact.
+ */
+export function selectArtifact(artifacts, candidates, options = {}) {
+	const usable = usableArtifacts(artifacts, options);
+	for (const [distance, sha] of candidates.entries()) {
+		const matching = usable.filter((artifact) => artifact.workflow_run?.head_sha === sha);
+		if (matching.length > 0) {
+			return { artifact: newest(matching), sha, distance };
+		}
+	}
+	return null;
+}
+
+/** The most recently created usable artifact – the fallback when no candidate commit has one. */
+export function newestArtifact(artifacts, options = {}) {
+	const usable = usableArtifacts(artifacts, options);
+	return usable.length > 0 ? newest(usable) : null;
+}
+
+function newest(artifacts) {
+	return [...artifacts].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0];
+}

--- a/scripts/visual-review/pack-baseline.mjs
+++ b/scripts/visual-review/pack-baseline.mjs
@@ -1,0 +1,93 @@
+/**
+ * Turns freshly generated snapshots of one package into the baseline artifact layout:
+ *
+ *   <package>/visual-baseline/
+ *     meta.json                      – identity of the baseline (commit, image, digest, …)
+ *     snapshots/theme-<export>/*.png – the files Playwright compares against
+ *
+ * Runs after `test:update:e2e` in the "Visual Baseline" workflow. The digest and file count come
+ * from the manifest the visual reporter writes in update mode, so the artifact carries the same
+ * identity a comparison run derives.
+ *
+ *   node scripts/visual-review/pack-baseline.mjs theme-default
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { META_FILE } from './baseline-artifacts.mjs';
+import { reportDir, resolvePackage, snapshotDir } from './snapshot-paths.mjs';
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+export const BASELINE_DIR = 'visual-baseline';
+
+const packageName = process.argv[2];
+if (!packageName) {
+	console.error('Usage: node scripts/visual-review/pack-baseline.mjs <package>');
+	process.exit(2);
+}
+
+const pkg = resolvePackage(packageName);
+if (pkg.baselineFrom) {
+	console.error(`${pkg.name} uses the baseline of ${pkg.baselineFrom} and does not publish one itself.`);
+	process.exit(2);
+}
+
+const sourceDir = path.join(REPO_ROOT, snapshotDir(pkg));
+const reportFile = path.join(REPO_ROOT, reportDir(pkg), 'report.json');
+const targetRoot = path.join(REPO_ROOT, pkg.dir, BASELINE_DIR);
+const targetDir = path.join(targetRoot, 'snapshots', pkg.themeDir);
+
+const report = readReport(reportFile);
+const files = fs.existsSync(sourceDir) ? fs.readdirSync(sourceDir).filter((entry) => entry.endsWith('.png')) : [];
+if (files.length === 0) {
+	console.error(`::error::No snapshots found in ${snapshotDir(pkg)} – refusing to publish an empty baseline.`);
+	process.exit(1);
+}
+if (report.summary.baseline !== files.length) {
+	console.error(`::error::The reporter manifest lists ${report.summary.baseline} files, the folder holds ${files.length}.`);
+	process.exit(1);
+}
+
+fs.rmSync(targetRoot, { recursive: true, force: true });
+fs.mkdirSync(targetDir, { recursive: true });
+for (const file of files) {
+	fs.copyFileSync(path.join(sourceDir, file), path.join(targetDir, file));
+}
+
+const playwright = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'packages/tools/visual-tests/package.json'), 'utf8')).peerDependencies['@playwright/test'];
+const meta = {
+	schema: 1,
+	package: pkg.name,
+	themeDir: pkg.themeDir,
+	sha: process.env.GITHUB_SHA ?? null,
+	ref: process.env.GITHUB_REF_NAME ?? null,
+	runId: process.env.GITHUB_RUN_ID ? Number(process.env.GITHUB_RUN_ID) : null,
+	runAttempt: process.env.GITHUB_RUN_ATTEMPT ? Number(process.env.GITHUB_RUN_ATTEMPT) : null,
+	image: process.env.PLAYWRIGHT_IMAGE ?? `mcr.microsoft.com/playwright:v${playwright}-noble`,
+	playwright,
+	platform: report.platform,
+	projects: report.projects,
+	createdAt: new Date().toISOString(),
+	files: files.length,
+	digest: report.digest,
+};
+fs.writeFileSync(path.join(targetRoot, META_FILE), JSON.stringify(meta, null, '\t'));
+
+const relativeTarget = path.relative(REPO_ROOT, targetRoot).split(path.sep).join('/');
+console.log(`${pkg.name}: ${files.length} snapshots packed into ${relativeTarget} (digest ${meta.digest})`);
+if (process.env.GITHUB_OUTPUT) {
+	fs.appendFileSync(process.env.GITHUB_OUTPUT, `dir=${relativeTarget}\n`);
+}
+
+function readReport(file) {
+	if (!fs.existsSync(file)) {
+		console.error(`::error::No reporter manifest at ${path.relative(REPO_ROOT, file)} – did test:update:e2e run?`);
+		process.exit(1);
+	}
+	const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+	if (parsed.mode !== 'update') {
+		console.error(`::error::${path.relative(REPO_ROOT, file)} is a comparison report, not an update manifest.`);
+		process.exit(1);
+	}
+	return parsed;
+}

--- a/scripts/visual-review/pull-baseline.mjs
+++ b/scripts/visual-review/pull-baseline.mjs
@@ -1,0 +1,103 @@
+/**
+ * Downloads the current visual baseline from GitHub into the local snapshot folders, so
+ * `pnpm --filter @public-ui/<package> test` compares against the same files the CI uses.
+ *
+ *   pnpm snapshots:pull                        # every package, newest baseline of develop
+ *   pnpm snapshots:pull theme-default unstyled # selected packages
+ *   pnpm snapshots:pull --branch release/3     # baseline of another base branch
+ *   pnpm snapshots:pull --sha <commit>         # baseline of one specific base commit
+ *
+ * Requires the GitHub CLI (`gh auth login`). The artifacts are produced by the "Visual Baseline"
+ * workflow for every push to develop, main and release/*; `test:update:docker` remains the way to
+ * generate them locally.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { META_FILE, artifactName, newestArtifact, selectArtifact } from './baseline-artifacts.mjs';
+import { BASELINE_PACKAGES, reportDir, resolvePackage, snapshotDir } from './snapshot-paths.mjs';
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+
+function parseArgs(argv) {
+	const options = { packages: [], branch: 'develop', sha: null };
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === '--branch') options.branch = argv[++i];
+		else if (arg === '--sha') options.sha = argv[++i];
+		else if (arg.startsWith('--')) throw new Error(`Unknown option ${arg}`);
+		else options.packages.push(resolvePackage(arg));
+	}
+	if (options.packages.length === 0) options.packages = BASELINE_PACKAGES;
+	for (const pkg of options.packages) {
+		if (pkg.baselineFrom) throw new Error(`${pkg.name} has no baseline of its own – pull ${pkg.baselineFrom} instead.`);
+	}
+	if (options.sha && !/^[0-9a-f]{7,40}$/.test(options.sha)) throw new Error(`--sha expects a commit hash, got "${options.sha}"`);
+	return options;
+}
+
+function gh(args, { json = true } = {}) {
+	// No shell: query strings contain `&`, and gh.exe resolves through PATH without one.
+	const result = spawnSync('gh', args, { encoding: 'utf8', shell: false, windowsHide: true });
+	if (result.error) throw new Error(`Cannot run the GitHub CLI (gh): ${result.error.message}`);
+	if (result.status !== 0) throw new Error(`gh ${args.join(' ')} failed:\n${result.stderr}`);
+	return json ? JSON.parse(result.stdout) : result.stdout;
+}
+
+function repository() {
+	if (process.env.KOLIBRI_REPO) return process.env.KOLIBRI_REPO;
+	return gh(['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], { json: false }).trim();
+}
+
+/** Newest 100 artifacts of that name – enough for the recent history of a base branch. */
+function listArtifacts(repo, pkg) {
+	return gh(['api', '-X', 'GET', `repos/${repo}/actions/artifacts`, '-f', `name=${artifactName(pkg)}`, '-F', 'per_page=100']).artifacts ?? [];
+}
+
+function resolveSha(repo, sha) {
+	return gh(['api', `repos/${repo}/commits/${sha}`, '--jq', '.sha'], { json: false }).trim();
+}
+
+function pull(repo, pkg, options) {
+	const artifacts = listArtifacts(repo, pkg);
+	const filter = { branch: options.branch };
+	let chosen;
+	if (options.sha) {
+		const selected = selectArtifact(artifacts, [resolveSha(repo, options.sha)], filter);
+		if (!selected) throw new Error(`${pkg.name}: no baseline artifact for ${options.sha} on ${options.branch} among the newest ${artifacts.length}.`);
+		chosen = selected.artifact;
+	} else {
+		chosen = newestArtifact(artifacts, filter);
+		if (!chosen) throw new Error(`${pkg.name}: no baseline artifact on ${options.branch} – has the "Visual Baseline" workflow run there yet?`);
+	}
+
+	const download = fs.mkdtempSync(path.join(os.tmpdir(), 'visual-baseline-'));
+	try {
+		gh(['run', 'download', String(chosen.workflow_run.id), '--repo', repo, '--name', chosen.name, '--dir', download], { json: false });
+		const meta = JSON.parse(fs.readFileSync(path.join(download, META_FILE), 'utf8'));
+		const source = path.join(download, 'snapshots', pkg.themeDir);
+		const target = path.join(REPO_ROOT, snapshotDir(pkg));
+		fs.rmSync(target, { recursive: true, force: true });
+		fs.cpSync(source, target, { recursive: true });
+		// The reporter picks this up and records which baseline the next comparison ran against.
+		const reportFolder = path.join(REPO_ROOT, reportDir(pkg));
+		fs.mkdirSync(reportFolder, { recursive: true });
+		fs.writeFileSync(path.join(reportFolder, 'baseline.json'), JSON.stringify(meta, null, '\t'));
+		console.log(`${pkg.name}: ${meta.files} snapshots from ${meta.ref}@${meta.sha.slice(0, 10)} (${meta.createdAt}) → ${snapshotDir(pkg)}`);
+	} finally {
+		fs.rmSync(download, { recursive: true, force: true });
+	}
+}
+
+try {
+	const options = parseArgs(process.argv.slice(2));
+	const repo = repository();
+	for (const pkg of options.packages) {
+		pull(repo, pkg, options);
+	}
+} catch (error) {
+	console.error(error.message);
+	process.exit(1);
+}


### PR DESCRIPTION
## What changed?

This is PR B of the four-part visual-review rework (#9101) and adds the mechanism that publishes visual-test baselines as GitHub Actions artifacts instead of keeping snapshot PNGs in git. A new workflow `.github/workflows/visual-baseline.yml` regenerates the snapshots of the six theme packages in the pinned Playwright container on every push to `develop`/`main`/`release/*`, monthly by schedule and on dispatch, and uploads one `visual-baseline-<package>` artifact (90-day retention) per package. `scripts/visual-review/pack-baseline.mjs` builds the artifact layout (`meta.json` with commit, ref, run id, Playwright image/version, file count and reporter digest, plus `snapshots/theme-<export>/`) and refuses empty or inconsistent baselines. `scripts/visual-review/baseline-artifacts.mjs` holds the pure, unit-tested selection rules (not expired, right branch, this repo rather than a same-named fork branch, nearest candidate commit, newest run), and a new `pnpm snapshots:pull` script (`scripts/visual-review/pull-baseline.mjs`) downloads a baseline into the local `snapshots/` folders via the GitHub CLI. This is CI/test tooling only, with no effect on any published component or public API.

## Linked issues

- Refs #9101 — Reduce repository size by moving visual snapshot baselines out of git into CI artifacts.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies ist PR B des vierteiligen Visual-Review-Umbaus (#9101) und ergänzt den Mechanismus, der die Visual-Test-Baselines als GitHub-Actions-Artefakte veröffentlicht, statt die Snapshot-PNGs in git zu halten. Ein neuer Workflow `.github/workflows/visual-baseline.yml` regeneriert die Snapshots der sechs Theme-Pakete im gepinnten Playwright-Container bei jedem Push auf `develop`/`main`/`release/*`, monatlich per Zeitplan und per Dispatch und lädt pro Paket ein `visual-baseline-<package>`-Artefakt (90 Tage Aufbewahrung) hoch. `scripts/visual-review/pack-baseline.mjs` erzeugt das Artefakt-Layout (`meta.json` mit Commit, Ref, Run-ID, Playwright-Image/-Version, Dateianzahl und Reporter-Digest sowie `snapshots/theme-<export>/`) und verweigert leere oder inkonsistente Baselines. `scripts/visual-review/baseline-artifacts.mjs` enthält die reinen, unit-getesteten Auswahlregeln (nicht abgelaufen, richtiger Branch, dieses Repo statt eines gleichnamigen Fork-Branches, nächster Kandidaten-Commit, neuester Run), und ein neues `pnpm snapshots:pull`-Skript (`scripts/visual-review/pull-baseline.mjs`) lädt eine Baseline über die GitHub-CLI in die lokalen `snapshots/`-Ordner. Es handelt sich ausschließlich um CI-/Test-Tooling ohne Auswirkung auf veröffentlichte Komponenten oder öffentliche APIs.

### Verknüpfte Tickets

- Referenziert #9101 — Repository-Größe reduzieren, indem Visual-Snapshot-Baselines aus git in CI-Artefakte verlagert werden.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/visual-baseline.yml` — Neuer Workflow, der pro Theme-Paket eine Baseline generiert und als Artefakt hochlädt.
- `scripts/visual-review/pack-baseline.mjs` — Verpackt generierte Snapshots plus `meta.json` in das Baseline-Artefakt-Layout; lehnt leere/inkonsistente Baselines ab.
- `scripts/visual-review/baseline-artifacts.mjs` — Reine Auswahlregeln für Baseline-Artefakte (Branch, Repo, nächster Commit, neuester Run).
- `scripts/visual-review/pull-baseline.mjs` — Lädt die Baseline via GitHub-CLI in die lokalen `snapshots/`-Ordner.
- `packages/tools/visual-tests/test/baseline-artifacts.test.mjs` — 5 Unit-Tests für die Auswahlregeln.
- `package.json` — Neues Skript `snapshots:pull`.
- `scripts/README.md` — Dokumentiert die neuen Skripte.
- `.gitignore` — Ignoriert den lokalen `visual-baseline/`-Ordner.

</details>
