### PR TITLE
fix(visual-tests): serve the build with the local http-server instead of npx

### DIFF
--- a/packages/tools/visual-tests/playwright.config.js
+++ b/packages/tools/visual-tests/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { createRequire } from 'module';
 import * as path from 'path';
 import * as process from 'process';
 
@@ -22,6 +23,12 @@ if (!VALID_COLOR_SCHEMES.includes(colorSchema)) {
 		`Environment variable KOLIBRI_VISUAL_TESTS_COLOR_SCHEME must be one of "${VALID_COLOR_SCHEMES.join('", "')}" (received "${colorSchemeInput}").`,
 	);
 }
+
+/* The web server runs with the build folder as cwd, which lies outside the workspace (RUNNER_TEMP). There
+   `npx http-server` finds no local binary and downloads the package from the registry at test time –
+   since 2026-09-04 that download times out in the CI container. Resolve the dependency of this package
+   instead and run it with the current node. */
+const HTTP_SERVER_BIN = createRequire(import.meta.url).resolve('http-server/bin/http-server');
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -74,7 +81,7 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: `npx http-server -p ${PORT}`,
+		command: `node "${HTTP_SERVER_BIN}" -p ${PORT}`,
 		cwd: path.resolve(BUILD_PATH),
 		url: BASE_URL,
 		reuseExistingServer: false,


### PR DESCRIPTION
## What changed?

This fixes the Playwright web server startup in the visual-tests tooling package. In `packages/tools/visual-tests/playwright.config.js`, the `webServer.command` no longer runs `npx http-server`; instead it resolves the package's own `http-server` binary via `createRequire(import.meta.url).resolve('http-server/bin/http-server')` and launches it with `node`. Because the server's `cwd` is the build folder in `RUNNER_TEMP` (outside the workspace), `npx` found no local binary and downloaded `http-server@14.1.1` from the registry at test time, which began timing out in the CI container on 2026-09-04 and broke every `visual-tests` job before any test ran. The change removes the network access at test time while keeping the same server and port handling. No runtime or consumer-facing behavior is affected.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Dies behebt den Start des Playwright-Webservers im Visual-Tests-Tooling-Paket. In `packages/tools/visual-tests/playwright.config.js` startet der `webServer.command` nicht mehr `npx http-server`, sondern löst die paketeigene `http-server`-Binary über `createRequire(import.meta.url).resolve('http-server/bin/http-server')` auf und führt sie mit `node` aus. Da der `cwd` des Servers der Build-Ordner in `RUNNER_TEMP` (außerhalb des Workspace) ist, fand `npx` dort keine lokale Binary und lud `http-server@14.1.1` zur Testlaufzeit aus der Registry – dieser Download lief seit dem 2026-09-04 in einen Timeout im CI-Container und ließ jeden `visual-tests`-Job scheitern, bevor überhaupt ein Test lief. Die Änderung entfernt den Netzwerkzugriff zur Testlaufzeit bei identischem Server und Port-Handling. Kein Laufzeit- oder Nutzer-Impact.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `packages/tools/visual-tests/playwright.config.js` — Startet den Playwright-Webserver über die aufgelöste lokale `http-server`-Binary mit `node` statt über `npx`, um den Registry-Download zur Testlaufzeit zu vermeiden.

</details>
