### PR TITLE
feat(visual-tests): review page and status workflow for the visual review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,8 @@ jobs:
           folder: nojekyll-root
           branch: gh-pages
           clean: false
+          force: false
+          attempt-limit: 10
       - name: Deploy reports to GitHub Pages
         if: ${{ steps.stage.outputs.count != '0' }}
         uses: JamesIves/github-pages-deploy-action@v4
@@ -221,6 +223,8 @@ jobs:
           target-folder: pr-${{ github.event.pull_request.number }}
           branch: gh-pages
           clean: false
+          force: false
+          attempt-limit: 10
       - name: Post consolidated PR comment with report links
         if: ${{ !cancelled() }}
         uses: actions/github-script@v9

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -33,16 +33,27 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Remove preview for the closed PR
+      - name: Remove preview and visual review for the closed PR
         if: github.event_name == 'pull_request'
         run: |
-          PR_FOLDER="pr-${{ github.event.pull_request.number }}"
-          if [ -d "$PR_FOLDER" ]; then
-            git rm -rf "$PR_FOLDER"
-            git commit -m "chore: remove preview for PR #${{ github.event.pull_request.number }}"
-            git push
+          PR="${{ github.event.pull_request.number }}"
+          REMOVED=0
+          for FOLDER in "pr-$PR" "visual/pr-$PR"; do
+            if [ -d "$FOLDER" ]; then
+              git rm -rfq "$FOLDER"
+              REMOVED=1
+            fi
+          done
+          if [ "$REMOVED" = "1" ]; then
+            git commit -m "chore: remove preview and visual review for PR #$PR"
+            # Other workflows push to gh-pages concurrently – rebase and retry instead of failing.
+            for ATTEMPT in 1 2 3 4 5; do
+              git pull --rebase -q origin gh-pages && git push && break
+              echo "push attempt $ATTEMPT failed, retrying"
+              sleep 5
+            done
           else
-            echo "No preview folder found for PR #${{ github.event.pull_request.number }}, skipping."
+            echo "Nothing published for PR #$PR, skipping."
           fi
 
       - name: Remove all PR previews

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -59,12 +59,17 @@ jobs:
       - name: Ensure .nojekyll at gh-pages root
         run: mkdir -p /tmp/nojekyll-root && touch /tmp/nojekyll-root/.nojekyll
 
+      # force: false – several workflows push to gh-pages concurrently (previews, visual reviews,
+      # benchmarks); a forced push would silently drop another workflow's commit. The action
+      # rebases and retries instead.
       - name: Deploy .nojekyll to gh-pages root
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: /tmp/nojekyll-root
           branch: gh-pages
           clean: false
+          force: false
+          attempt-limit: 10
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
@@ -73,6 +78,8 @@ jobs:
           target-folder: pr-${{ github.event.pull_request.number }}
           branch: gh-pages
           clean: true
+          force: false
+          attempt-limit: 10
 
       - name: Post PR comment
         uses: actions/github-script@v9

--- a/.github/workflows/visual-review-ui.yml
+++ b/.github/workflows/visual-review-ui.yml
@@ -1,0 +1,42 @@
+name: Visual Review UI
+
+# Deploys the review page (packages/tools/visual-tests/review-ui) to GitHub Pages under visual/.
+# The per-pull-request data lives next to it in visual/pr-<n>/ and is left untouched.
+on:
+  push:
+    branches:
+      - 'develop'
+    paths:
+      - 'packages/tools/visual-tests/review-ui/**'
+      - '.github/workflows/visual-review-ui.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: visual-review-ui
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/pnpm-setup
+      - name: Build the review page
+        run: pnpm --filter @public-ui/visual-tests review-ui:build
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: packages/tools/visual-tests/review-ui/dist
+          target-folder: visual
+          branch: gh-pages
+          clean: true
+          clean-exclude: |
+            pr-*
+          force: false
+          attempt-limit: 10
+          commit-message: 'visual review: deploy the review page'

--- a/.github/workflows/visual-review.yml
+++ b/.github/workflows/visual-review.yml
@@ -1,0 +1,135 @@
+name: Visual Review
+
+# Publishes the visual report of a pull request to GitHub Pages (visual/pr-<n>/), evaluates the
+# reviewers' approvals and sets the commit status "Visual Review".
+#
+# Runs in the context of the base repository, so it works for forks. It never checks out or executes
+# pull-request code: the reports come from artifacts of the pull request's CI run and are validated
+# field by field before anything is published (scripts/visual-review/merge-reports.mjs).
+#
+#   workflow_run          CI-Pipeline finished for a pull request → publish report, compute status
+#   issue_comment         a reviewer comment changed → recompute the status from the published report
+#   pull_request_target   a pull request was pushed → status "pending" (or "success" for docs-only)
+#   workflow_dispatch     recompute the status of one pull request by hand
+on:
+  workflow_run:
+    workflows: ['CI-Pipeline']
+    types: [completed]
+  issue_comment:
+    types: [created, edited, deleted]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Pull request number whose status should be recomputed'
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  statuses: write
+  pull-requests: write
+  actions: read
+
+env:
+  PAGE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/visual/
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.context.outputs.mode }}
+      pr: ${{ steps.context.outputs.pr }}
+      head: ${{ steps.context.outputs.head }}
+      run_id: ${{ steps.context.outputs.run_id }}
+    steps:
+      # Always the base branch – never the pull request's code.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Resolve pull request and mode
+        id: context
+        run: node scripts/visual-review/resolve-context.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  review:
+    needs: resolve
+    if: needs.resolve.outputs.mode != 'skip'
+    runs-on: ubuntu-latest
+    # One publish at a time per pull request, none dropped: a cancelled run would leave a stale status.
+    concurrency:
+      group: visual-review-${{ needs.resolve.outputs.pr }}
+      cancel-in-progress: false
+    env:
+      MODE: ${{ needs.resolve.outputs.mode }}
+      PR: ${{ needs.resolve.outputs.pr }}
+      HEAD: ${{ needs.resolve.outputs.head }}
+      RUN_ID: ${{ needs.resolve.outputs.run_id }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Download the reports of the CI run
+        if: env.MODE == 'publish'
+        uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ env.RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: visual-review-*
+          path: downloads
+
+      - name: Merge and validate the reports
+        if: env.MODE == 'publish'
+        run: node scripts/visual-review/merge-reports.mjs downloads "out/pr-$PR" --pr "$PR" --head "$HEAD" --repository "${{ github.repository }}" --run "$RUN_ID"
+
+      - name: Fetch the published report
+        if: env.MODE == 'status'
+        run: |
+          git fetch --depth=1 origin gh-pages
+          mkdir -p "out/pr-$PR"
+          if ! git show "origin/gh-pages:visual/pr-$PR/report.json" > "out/pr-$PR/report.json" 2>/dev/null; then
+            echo "No published report for #$PR yet – nothing to recompute."
+            echo "NO_REPORT=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Compute the status and update the comment
+        if: (env.MODE == 'publish' || env.MODE == 'status') && env.NO_REPORT != '1'
+        run: node scripts/visual-review/update-review.mjs --mode "$MODE" --pr "$PR" --head "$HEAD" --report "out/pr-$PR/report.json" --status-out "out/pr-$PR/status.json" --page-url "$PAGE_URL"
+
+      - name: Set the status
+        if: env.MODE == 'pending' || env.MODE == 'docs-only' || env.MODE == 'no-visual'
+        run: node scripts/visual-review/update-review.mjs --mode "$MODE" --pr "$PR" --head "$HEAD" --page-url "$PAGE_URL"
+
+      - name: Publish the report
+        if: env.MODE == 'publish'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: out/pr-${{ env.PR }}
+          target-folder: visual/pr-${{ env.PR }}
+          branch: gh-pages
+          clean: true
+          force: false
+          attempt-limit: 10
+          commit-message: 'visual review: PR #${{ env.PR }} @ ${{ env.HEAD }}'
+
+      - name: Publish the status
+        if: env.MODE == 'status' && env.NO_REPORT != '1'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: out/pr-${{ env.PR }}
+          target-folder: visual/pr-${{ env.PR }}
+          branch: gh-pages
+          clean: false
+          force: false
+          attempt-limit: 10
+          commit-message: 'visual review: status of PR #${{ env.PR }}'

--- a/docs/visual-review.md
+++ b/docs/visual-review.md
@@ -1,0 +1,100 @@
+# Visual Review
+
+How screenshot changes of the KoliBri themes are detected, published and approved.
+
+## In one picture
+
+```
+push to develop ──► Visual Baseline workflow ──► artifact visual-baseline-<package> (per commit, 90 days)
+
+pull request push ──► CI-Pipeline, job visual-tests (<package>)
+                        compares against the baseline of the base commit
+                        ──► artifact visual-review-<package> (report.json + changed images)
+                                  │
+                                  ▼
+                       Visual Review workflow (base repository context)
+                         publishes visual/pr-<n>/ on GitHub Pages
+                         reads the reviewers' comments
+                         sets the commit status "Visual Review"
+                                  │
+                                  ▼
+reviewer ──► https://public-ui.github.io/kolibri/visual/?pr=<n>
+               inspects baseline / actual / diff, approves or rejects, leaves notes
+               saves the review as a pull-request comment (directly with a token, or by pasting it)
+```
+
+## What a contributor sees
+
+- The job `visual-tests (<package>)` of the CI-Pipeline fails when screenshots differ – that is
+  expected and not something to "fix" by regenerating snapshots. The job summary lists what changed.
+- The bot comment **📸 Visual Review** on the pull request links the review page and shows the counts
+  per package.
+- The commit status **Visual Review** stays `pending` until a reviewer with write access approved every
+  changed, added and removed screenshot, turns `success` then, and `failure` when a screenshot was
+  rejected or a route could not be compared at all (missing block, timeout).
+- Docs-only pull requests get `success` immediately; nothing to review.
+
+Nothing has to be committed: the baseline is regenerated from `develop` after the merge.
+
+## What a reviewer does
+
+1. Open the review page from the bot comment (or the status link).
+2. Walk through the changed, added and removed snapshots (`j`/`k` or the list). Compare with
+   _side by side_, _slider_, _onion skin_, _diff_ or _blink_; zoom in for subpixel changes.
+3. Approve (`a`), reject or annotate each one – or **Approve all open changes** for an intentional
+   sweep such as a browser upgrade.
+4. Save the review:
+   - **with a token**: enter a fine-grained personal access token with _Pull requests: read and write_
+     for `public-ui/kolibri` at the bottom of the page. The page posts (and later edits) one comment
+     in your name. The token stays in this browser session unless you tick "remember".
+   - **without a token**: click _Copy comment for the pull request_ and paste it as a comment on the
+     pull request.
+
+The comment carries a machine-readable block, for example:
+
+```markdown
+<!-- visual-review:v1
+{"approveAll":{"digest":"sha256:…"},"approvals":[{"item":"theme-default/button-basic--variants","hash":"sha256:…"}],"rejects":[],"notes":[]}
+-->
+
+**Visual Review** – all changes approved ([review page](…))
+```
+
+Approvals bind to the **content hash** of a screenshot, not to a commit: a later push that leaves an
+approved screenshot untouched keeps its approval, a push that changes it again reopens exactly that
+one. `approveAll` binds to the digest of the whole report and therefore expires with the next change.
+
+Only comments of users with write access count. Bots are ignored. A rejection wins over an approval.
+
+## Where things live
+
+| What                             | Where                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------- |
+| Report per package (CI artifact) | `visual-review-<package>` – `report.json` + PNGs of changed items, 14 days            |
+| Baseline per base commit         | `visual-baseline-<package>` – snapshots + `meta.json`, 90 days                        |
+| Published review data            | `gh-pages`: `visual/pr-<n>/report.json`, `status.json`, `<package>/<name>.<kind>.png` |
+| Review page                      | `gh-pages`: `visual/` (built from `packages/tools/visual-tests/review-ui`)            |
+| Reporter                         | `packages/tools/visual-tests/src/visual-reporter.js`                                  |
+| Workflow scripts                 | `scripts/visual-review/` (see `scripts/README.md`)                                    |
+| Workflows                        | `visual-baseline.yml`, `visual-review.yml`, `visual-review-ui.yml`, job in `ci.yml`   |
+
+The folder `visual/pr-<n>/` is removed when the pull request closes (`pr-preview-cleanup.yml`).
+
+## Trust boundary
+
+The reports come from the pull request's own CI run, i.e. from code the pull request controls. The
+Visual Review workflow never executes that code: it downloads the artifacts, validates every field and
+file name (`merge-reports.mjs`) and publishes only what passes. A pull request could still upload a
+report that claims "no changes" – the human review of the code and the branch protection remain the
+actual safeguard; the visual review makes intentional changes visible and reviewable, it does not
+replace code review.
+
+## Local work
+
+```bash
+pnpm snapshots:pull                        # fetch the current develop baseline into the snapshot folders
+pnpm --filter @public-ui/theme-default test
+pnpm --filter @public-ui/visual-tests review-ui:dev   # the review page against a local report: ?src=<folder>
+```
+
+`pnpm test:update:docker <theme>` regenerates a baseline locally in the pinned Playwright container.

--- a/packages/tools/visual-tests/package.json
+++ b/packages/tools/visual-tests/package.json
@@ -23,11 +23,14 @@
 	"scripts": {
 		"build": "vite build --config app/vite.config.ts",
 		"build:deps": "pnpm --filter @public-ui/visual-tests^... build",
-		"prebuild": "npm-run-all2 prebuild:*",
-		"prebuild:components": "kolibri-copy-assets --dest app/public/assets @public-ui/components @public-ui/sample-react",
-		"format": "prettier --check src app/src",
+		"format": "prettier --check src app/src review-ui/src",
 		"lint": "pnpm lint:eslint",
 		"lint:eslint": "eslint src",
+		"lint:tsc": "tsc -p review-ui/tsconfig.json",
+		"prebuild": "npm-run-all2 prebuild:*",
+		"prebuild:components": "kolibri-copy-assets --dest app/public/assets @public-ui/components @public-ui/sample-react",
+		"review-ui:build": "vite build --config review-ui/vite.config.ts",
+		"review-ui:dev": "vite --config review-ui/vite.config.ts",
 		"serve": "vite --config app/vite.config.ts",
 		"test:unit": "node --test test/*.test.mjs",
 		"unused": "knip"

--- a/packages/tools/visual-tests/review-ui/index.html
+++ b/packages/tools/visual-tests/review-ui/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
+		<title>Visual Review | KoliBri</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/main.tsx"></script>
+		<noscript>This page requires JavaScript.</noscript>
+	</body>
+</html>

--- a/packages/tools/visual-tests/review-ui/src/App.tsx
+++ b/packages/tools/visual-tests/review-ui/src/App.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { findOwnReview, getLogin, listComments, saveReview } from './github';
+import { ItemList } from './ItemList';
+import { emptyDraft, formatReviewComment, summarize } from './review-comment';
+import { draftState, ReviewPanel } from './ReviewPanel';
+import { entryKey, type Entry, type ItemStatus, type Report, type ReviewDraft, type ReviewState, type StatusFile } from './types';
+import { MODES, Viewer, type Mode } from './Viewer';
+
+const TOKEN_KEY = 'visual-review.token';
+const DEFAULT_FILTER: Record<ItemStatus, boolean> = { changed: true, added: true, removed: true, error: true, unchanged: false };
+
+function readToken(): string {
+	try {
+		return sessionStorage.getItem(TOKEN_KEY) ?? localStorage.getItem(TOKEN_KEY) ?? '';
+	} catch {
+		return '';
+	}
+}
+
+function storeToken(token: string, remember: boolean) {
+	try {
+		sessionStorage.setItem(TOKEN_KEY, token);
+		if (remember) localStorage.setItem(TOKEN_KEY, token);
+		else localStorage.removeItem(TOKEN_KEY);
+	} catch {
+		/* storage unavailable – token lives in memory only */
+	}
+}
+
+function draftKey(pr: number) {
+	return `visual-review.draft.${pr}`;
+}
+
+export function App() {
+	const params = new URLSearchParams(window.location.search);
+	const pr = Number(params.get('pr'));
+	/* `src` lets a local run point at any folder that holds report.json; the deployed page reads pr-<n>/. */
+	const base = params.get('src') ?? `pr-${pr}`;
+	const pageUrl = `${window.location.origin}${window.location.pathname}?pr=${pr}`;
+
+	const [report, setReport] = useState<Report | null>(null);
+	const [status, setStatus] = useState<StatusFile | null>(null);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [filter, setFilter] = useState(DEFAULT_FILTER);
+	const [onlyOpen, setOnlyOpen] = useState(false);
+	const [search, setSearch] = useState('');
+	const [selected, setSelected] = useState<string | null>(window.location.hash.replace(/^#/, '') || null);
+	const [mode, setMode] = useState<Mode>('side-by-side');
+	const [zoom, setZoom] = useState(1);
+	const [draft, setDraft] = useState<ReviewDraft>(emptyDraft);
+	const [savedDraft, setSavedDraft] = useState<string>(JSON.stringify(emptyDraft()));
+	const [token, setToken] = useState(readToken);
+	const [remember, setRemember] = useState(false);
+	const [login, setLogin] = useState<string | null>(null);
+	const [ownCommentId, setOwnCommentId] = useState<number | null>(null);
+	const [saving, setSaving] = useState(false);
+	const [authError, setAuthError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!pr && !params.get('src')) {
+			setLoadError('Add ?pr=<number> to the address to open the review of a pull request.');
+			return;
+		}
+		fetch(`${base}/report.json?ts=${Date.now()}`)
+			.then((response) => (response.ok ? response.json() : Promise.reject(new Error(`${response.status} ${response.statusText}`))))
+			.then((data: Report) => setReport(data))
+			.catch((error: Error) => setLoadError(`No report found under ${base}/ (${error.message}). Has the CI run of the pull request finished?`));
+		fetch(`${base}/status.json?ts=${Date.now()}`)
+			.then((response) => (response.ok ? response.json() : null))
+			.then((data: StatusFile | null) => setStatus(data))
+			.catch(() => setStatus(null));
+		try {
+			const stored = localStorage.getItem(draftKey(pr));
+			if (stored) setDraft(JSON.parse(stored) as ReviewDraft);
+		} catch {
+			/* ignore */
+		}
+	}, [base, pr]);
+
+	useEffect(() => {
+		try {
+			localStorage.setItem(draftKey(pr), JSON.stringify(draft));
+		} catch {
+			/* ignore */
+		}
+	}, [draft, pr]);
+
+	const repository = report?.repository ?? null;
+
+	const connect = useCallback(async () => {
+		if (!token || !repository || !pr) return;
+		setAuthError(null);
+		try {
+			const user = await getLogin(token);
+			setLogin(user);
+			storeToken(token, remember);
+			const comments = await listComments(token, repository, pr);
+			const own = findOwnReview(comments, user);
+			if (own) {
+				setOwnCommentId(own.comment.id);
+				setDraft(own.draft);
+				setSavedDraft(JSON.stringify(own.draft));
+			} else {
+				setOwnCommentId(null);
+			}
+		} catch (error) {
+			setLogin(null);
+			setAuthError(`Token rejected: ${(error as Error).message}`);
+		}
+	}, [token, repository, pr, remember]);
+
+	/* Connect a stored token once the report (and with it the repository) is known – not on every keystroke. */
+	useEffect(() => {
+		if (token && repository && !login) void connect();
+	}, [repository]); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const save = useCallback(async () => {
+		if (!login || !repository) return;
+		setSaving(true);
+		setAuthError(null);
+		try {
+			const body = formatReviewComment(draft, pageUrl, summarize(draft));
+			await saveReview(token, repository, pr, body, ownCommentId);
+			setSavedDraft(JSON.stringify(draft));
+			const comments = await listComments(token, repository, pr);
+			setOwnCommentId(findOwnReview(comments, login)?.comment.id ?? null);
+		} catch (error) {
+			setAuthError(`Saving failed: ${(error as Error).message}`);
+		} finally {
+			setSaving(false);
+		}
+	}, [draft, login, repository, pr, token, ownCommentId, pageUrl]);
+
+	const entries = useMemo<Entry[]>(() => {
+		if (!report) return [];
+		return report.packages.flatMap((pkg) => pkg.items.map((item) => ({ key: entryKey(pkg, item), pkg, item })));
+	}, [report]);
+
+	const reviewStates = useMemo(() => {
+		const states: Record<string, { state: ReviewState; unsaved: boolean }> = {};
+		const saved = JSON.parse(savedDraft) as ReviewDraft;
+		for (const entry of entries) {
+			const local = draftState(draft, entry.key, entry.item.hash, report?.digest ?? '');
+			const persisted = draftState(saved, entry.key, entry.item.hash, report?.digest ?? '');
+			const server = status?.items[entry.key]?.state ?? 'open';
+			states[entry.key] = local !== 'open' ? { state: local, unsaved: local !== persisted } : { state: server, unsaved: false };
+		}
+		return states;
+	}, [entries, draft, savedDraft, status, report]);
+
+	const visible = useMemo(() => {
+		const needle = search.trim().toLowerCase();
+		return entries.filter((entry) => {
+			if (!filter[entry.item.status]) return false;
+			if (onlyOpen && reviewStates[entry.key]?.state !== 'open') return false;
+			if (needle && !entry.key.toLowerCase().includes(needle)) return false;
+			return true;
+		});
+	}, [entries, filter, onlyOpen, search, reviewStates]);
+
+	const current = entries.find((entry) => entry.key === selected) ?? null;
+
+	const select = useCallback((key: string | null) => {
+		setSelected(key);
+		window.history.replaceState(null, '', key ? `#${key}` : window.location.pathname + window.location.search);
+	}, []);
+
+	useEffect(() => {
+		const handler = (event: KeyboardEvent) => {
+			if ((event.target as HTMLElement | null)?.closest('input, textarea, select')) return;
+			const index = visible.findIndex((entry) => entry.key === selected);
+			if (event.key === 'j' || event.key === 'ArrowDown') {
+				event.preventDefault();
+				select(visible[Math.min(index + 1, visible.length - 1)]?.key ?? null);
+			} else if (event.key === 'k' || event.key === 'ArrowUp') {
+				event.preventDefault();
+				select(visible[Math.max(index - 1, 0)]?.key ?? null);
+			} else if (event.key === 'a' && current && current.item.status !== 'unchanged' && current.item.status !== 'error') {
+				setDraft((value) => ({
+					...value,
+					approvals: [...value.approvals.filter((entry) => entry.item !== current.key), { item: current.key, hash: current.item.hash }],
+					rejects: value.rejects.filter((entry) => entry.item !== current.key),
+				}));
+			}
+		};
+		window.addEventListener('keydown', handler);
+		return () => window.removeEventListener('keydown', handler);
+	}, [visible, selected, current, select]);
+
+	const dirty = JSON.stringify(draft) !== savedDraft;
+	const openCount = entries.filter(
+		(entry) => reviewStates[entry.key]?.state === 'open' && entry.item.status !== 'unchanged' && entry.item.status !== 'error',
+	).length;
+
+	if (loadError) {
+		return (
+			<main className="page">
+				<h1>Visual Review</h1>
+				<p className="error" role="alert">
+					{loadError}
+				</p>
+			</main>
+		);
+	}
+	if (!report) {
+		return (
+			<main className="page">
+				<h1>Visual Review</h1>
+				<p>Loading report…</p>
+			</main>
+		);
+	}
+
+	const prUrl = repository ? `https://github.com/${repository}/pull/${report.pr}` : null;
+
+	return (
+		<div className="layout">
+			<header className="header">
+				<h1>
+					Visual Review{' '}
+					{prUrl ? (
+						<a href={prUrl} target="_blank" rel="noreferrer">
+							#{report.pr}
+						</a>
+					) : (
+						`#${report.pr}`
+					)}
+				</h1>
+				<p className="header-meta">
+					Commit <code>{report.head.slice(0, 10)}</code>
+					{report.baseline?.sha && (
+						<>
+							{' '}
+							· baseline <code>{report.baseline.sha.slice(0, 10)}</code> ({report.baseline.ref})
+							{report.baseline.fallback && <span className="warn"> · fallback: {report.baseline.fallback}</span>}
+							{report.baseline.imageMismatch && <span className="warn"> · Playwright image differs from the baseline</span>}
+						</>
+					)}
+					{' · '}
+					{report.summary.changed} changed, {report.summary.added} added, {report.summary.removed} removed, {report.summary.error} error,{' '}
+					{report.summary.unchanged} unchanged
+				</p>
+				<p className={`header-status state-${status?.state ?? 'unknown'}`}>
+					{status ? `${status.state}: ${status.description}` : 'Status not computed yet'}
+					{status && status.head !== report.head && <span className="warn"> · status belongs to an older commit</span>}
+				</p>
+			</header>
+
+			<aside className="sidebar">
+				<div className="filters">
+					<input type="search" placeholder="Filter by name" value={search} onChange={(event) => setSearch(event.target.value)} aria-label="Filter by name" />
+					<div className="filter-row">
+						{(Object.keys(DEFAULT_FILTER) as ItemStatus[]).map((statusName) => (
+							<label key={statusName}>
+								<input type="checkbox" checked={filter[statusName]} onChange={(event) => setFilter({ ...filter, [statusName]: event.target.checked })} />
+								{statusName} ({report.summary[statusName]})
+							</label>
+						))}
+						<label>
+							<input type="checkbox" checked={onlyOpen} onChange={(event) => setOnlyOpen(event.target.checked)} />
+							only open ({openCount})
+						</label>
+					</div>
+					<button
+						type="button"
+						onClick={() => setDraft((value) => ({ ...value, approveAll: { digest: report.digest } }))}
+						disabled={openCount === 0 || draft.approveAll?.digest === report.digest}
+					>
+						Approve all open changes
+					</button>
+				</div>
+				<ItemList entries={visible} selected={selected} reviewStates={reviewStates} onSelect={select} />
+				<p className="hint">Keys: j / k next and previous, a approve.</p>
+			</aside>
+
+			<main className="main">
+				{current ? (
+					<>
+						<div className="toolbar" role="toolbar" aria-label="View">
+							{MODES.map((candidate) => (
+								<button key={candidate.id} type="button" aria-pressed={mode === candidate.id} onClick={() => setMode(candidate.id)}>
+									{candidate.label}
+								</button>
+							))}
+							<label>
+								Zoom {Math.round(zoom * 100)}%
+								<input type="range" min={0.25} max={4} step={0.25} value={zoom} onChange={(event) => setZoom(Number(event.target.value))} />
+							</label>
+						</div>
+						<div className="viewer">
+							<Viewer entry={current} base={base} mode={mode} zoom={zoom} />
+						</div>
+						<ReviewPanel
+							entry={current}
+							draft={draft}
+							status={status}
+							onChange={setDraft}
+							pageUrl={pageUrl}
+							prUrl={prUrl}
+							auth={{ login, saving, error: authError, dirty, onSave: save }}
+						/>
+					</>
+				) : (
+					<p className="viewer-note">Select a snapshot from the list.</p>
+				)}
+				{report.packages.some((pkg) => pkg.errors.length > 0) && (
+					<section className="errors" aria-label="Failed routes">
+						<h2>Routes that could not be compared</h2>
+						<ul>
+							{report.packages.flatMap((pkg) =>
+								pkg.errors.map((error, index) => (
+									<li key={`${pkg.package}-${index}`}>
+										<code>{pkg.package}</code> {error.route}: {error.message}
+									</li>
+								)),
+							)}
+						</ul>
+					</section>
+				)}
+			</main>
+
+			<footer className="auth">
+				{login ? (
+					<span>
+						Connected as <strong>{login}</strong>.{' '}
+						<button
+							type="button"
+							onClick={() => {
+								setLogin(null);
+								setToken('');
+								storeToken('', false);
+							}}
+						>
+							Disconnect
+						</button>
+					</span>
+				) : (
+					<form
+						onSubmit={(event) => {
+							event.preventDefault();
+							void connect();
+						}}
+					>
+						<label>
+							GitHub token (fine-grained, <em>Pull requests: read and write</em> on this repository) to save your review directly
+							<input type="password" value={token} onChange={(event) => setToken(event.target.value)} autoComplete="off" />
+						</label>
+						<label>
+							<input type="checkbox" checked={remember} onChange={(event) => setRemember(event.target.checked)} /> remember in this browser
+						</label>
+						<button type="submit" disabled={!token || !repository}>
+							Connect
+						</button>
+						<span className="hint">Without a token, copy the generated comment and post it on the pull request yourself.</span>
+					</form>
+				)}
+			</footer>
+		</div>
+	);
+}

--- a/packages/tools/visual-tests/review-ui/src/App.tsx
+++ b/packages/tools/visual-tests/review-ui/src/App.tsx
@@ -31,11 +31,24 @@ function draftKey(pr: number) {
 	return `visual-review.draft.${pr}`;
 }
 
+/* A folder path relative to the page: plain segments, no scheme, host, `..` or query. */
+const FOLDER = /^[A-Za-z0-9_-]+(\/[A-Za-z0-9_-]+)*$/;
+
+/**
+ * The folder that holds report.json, always resolved relative to the page. The deployed page reads
+ * `pr-<n>/`; `src` lets a local run point at any folder – but never at another origin or a
+ * `javascript:` URL, because the value ends up in `<img src>` and `fetch()`.
+ */
+function reportFolder(params: URLSearchParams, pr: number): string | null {
+	const src = params.get('src');
+	if (src !== null) return FOLDER.test(src) ? `./${src}` : null;
+	return Number.isInteger(pr) && pr > 0 ? `./pr-${pr}` : null;
+}
+
 export function App() {
 	const params = new URLSearchParams(window.location.search);
 	const pr = Number(params.get('pr'));
-	/* `src` lets a local run point at any folder that holds report.json; the deployed page reads pr-<n>/. */
-	const base = params.get('src') ?? `pr-${pr}`;
+	const base = reportFolder(params, pr);
 	const pageUrl = `${window.location.origin}${window.location.pathname}?pr=${pr}`;
 
 	const [report, setReport] = useState<Report | null>(null);
@@ -57,8 +70,8 @@ export function App() {
 	const [authError, setAuthError] = useState<string | null>(null);
 
 	useEffect(() => {
-		if (!pr && !params.get('src')) {
-			setLoadError('Add ?pr=<number> to the address to open the review of a pull request.');
+		if (base === null) {
+			setLoadError('Add ?pr=<number> to the address to open the review of a pull request (or ?src=<folder> for a local report).');
 			return;
 		}
 		fetch(`${base}/report.json?ts=${Date.now()}`)
@@ -288,7 +301,7 @@ export function App() {
 							</label>
 						</div>
 						<div className="viewer">
-							<Viewer entry={current} base={base} mode={mode} zoom={zoom} />
+							<Viewer entry={current} base={base ?? '.'} mode={mode} zoom={zoom} />
 						</div>
 						<ReviewPanel
 							entry={current}

--- a/packages/tools/visual-tests/review-ui/src/ItemList.tsx
+++ b/packages/tools/visual-tests/review-ui/src/ItemList.tsx
@@ -1,0 +1,59 @@
+import type { ReactElement } from 'react';
+import type { Entry, ItemStatus, ReviewState } from './types';
+
+interface Props {
+	entries: Entry[];
+	selected: string | null;
+	reviewStates: Record<string, { state: ReviewState; unsaved: boolean }>;
+	onSelect: (key: string) => void;
+}
+
+const STATUS_LABEL: Record<ItemStatus, string> = { unchanged: '=', changed: '≠', added: '+', removed: '−', error: '!' };
+const REVIEW_ICON: Record<ReviewState, string> = { open: '', approved: '✓', rejected: '✗' };
+
+export function ItemList({ entries, selected, reviewStates, onSelect }: Props) {
+	if (entries.length === 0) {
+		return <p className="list-empty">No snapshots match the current filter.</p>;
+	}
+	let currentPackage = '';
+	const rows: ReactElement[] = [];
+	for (const entry of entries) {
+		if (entry.pkg.package !== currentPackage) {
+			currentPackage = entry.pkg.package;
+			rows.push(
+				<li key={`pkg:${currentPackage}`} className="list-package" role="presentation">
+					{currentPackage}
+				</li>,
+			);
+		}
+		const review = reviewStates[entry.key];
+		rows.push(
+			<li key={entry.key}>
+				<button
+					type="button"
+					className={`list-item status-${entry.item.status}${entry.key === selected ? ' is-selected' : ''}`}
+					aria-current={entry.key === selected ? 'true' : undefined}
+					onClick={() => onSelect(entry.key)}
+				>
+					<span className="list-status" aria-label={entry.item.status} title={entry.item.status}>
+						{STATUS_LABEL[entry.item.status]}
+					</span>
+					<span className="list-name">{entry.item.name}</span>
+					{review && review.state !== 'open' && (
+						<span
+							className={`list-review review-${review.state}${review.unsaved ? ' is-unsaved' : ''}`}
+							title={review.unsaved ? `${review.state} (not saved yet)` : review.state}
+						>
+							{REVIEW_ICON[review.state]}
+						</span>
+					)}
+				</button>
+			</li>,
+		);
+	}
+	return (
+		<ul className="list" aria-label="Snapshots">
+			{rows}
+		</ul>
+	);
+}

--- a/packages/tools/visual-tests/review-ui/src/ReviewPanel.tsx
+++ b/packages/tools/visual-tests/review-ui/src/ReviewPanel.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { formatReviewComment, summarize } from './review-comment';
+import type { Entry, ReviewDraft, ReviewState, StatusFile } from './types';
+
+interface Props {
+	entry: Entry;
+	draft: ReviewDraft;
+	status: StatusFile | null;
+	onChange: (draft: ReviewDraft) => void;
+	pageUrl: string;
+	prUrl: string | null;
+	auth: { login: string | null; saving: boolean; error: string | null; dirty: boolean; onSave: () => void };
+}
+
+export function draftState(draft: ReviewDraft, key: string, hash: string, digest: string): ReviewState {
+	if (draft.rejects.some((entry) => entry.item === key && entry.hash === hash)) return 'rejected';
+	if (draft.approveAll?.digest === digest || draft.approvals.some((entry) => entry.item === key && entry.hash === hash)) return 'approved';
+	return 'open';
+}
+
+function without<T extends { item: string }>(list: T[], key: string): T[] {
+	return list.filter((entry) => entry.item !== key);
+}
+
+export function ReviewPanel({ entry, draft, status, onChange, pageUrl, prUrl, auth }: Props) {
+	const { key, item } = entry;
+	const [noteText, setNoteText] = useState('');
+	const [copied, setCopied] = useState(false);
+	const serverState = status?.items[key];
+	const note = draft.notes.find((candidate) => candidate.item === key);
+	const needsDecision = item.status !== 'unchanged' && item.status !== 'error';
+
+	const approve = () =>
+		onChange({ ...draft, approvals: [...without(draft.approvals, key), { item: key, hash: item.hash }], rejects: without(draft.rejects, key) });
+	const reject = () =>
+		onChange({ ...draft, rejects: [...without(draft.rejects, key), { item: key, hash: item.hash }], approvals: without(draft.approvals, key) });
+	const clear = () => onChange({ ...draft, approvals: without(draft.approvals, key), rejects: without(draft.rejects, key) });
+	const saveNote = () => {
+		const notes = without(draft.notes, key);
+		if (noteText.trim()) notes.push({ item: key, hash: item.hash, text: noteText.trim() });
+		onChange({ ...draft, notes });
+		setNoteText('');
+	};
+	const copyComment = async () => {
+		const body = formatReviewComment(draft, pageUrl, summarize(draft));
+		try {
+			await navigator.clipboard.writeText(body);
+			setCopied(true);
+			window.setTimeout(() => setCopied(false), 2000);
+		} catch {
+			window.prompt('Copy the comment and post it on the pull request:', body);
+		}
+	};
+
+	return (
+		<section className="review" aria-label="Review">
+			<h2 className="review-title">
+				<code>{key}</code>
+			</h2>
+			<dl className="review-facts">
+				<dt>Route</dt>
+				<dd>{item.route}</dd>
+				<dt>Status</dt>
+				<dd>
+					{item.status}
+					{item.diffPixels !== undefined && ` – ${item.diffPixels} px (${((item.diffRatio ?? 0) * 100).toFixed(2)} %)`}
+					{item.sizeMismatch && ` – size ${item.sizeMismatch.expected.join('×')} → ${item.sizeMismatch.actual.join('×')}`}
+				</dd>
+				<dt>Published review</dt>
+				<dd>
+					{serverState ? (
+						<>
+							{serverState.state}
+							{serverState.by && ` by ${serverState.by}`}
+						</>
+					) : (
+						'none'
+					)}
+					{serverState?.notes.map((serverNote, index) => (
+						<div key={index} className="review-note">
+							💬 <strong>{serverNote.by}</strong>: {serverNote.text}
+						</div>
+					))}
+				</dd>
+			</dl>
+
+			{needsDecision && (
+				<div className="review-actions" role="group" aria-label="Decision">
+					<button type="button" onClick={approve} aria-pressed={draftState(draft, key, item.hash, '') === 'approved'}>
+						Approve
+					</button>
+					<button type="button" onClick={reject} aria-pressed={draftState(draft, key, item.hash, '') === 'rejected'}>
+						Reject
+					</button>
+					<button type="button" onClick={clear}>
+						Clear
+					</button>
+				</div>
+			)}
+
+			<label className="review-note-input">
+				Note for this snapshot
+				<textarea value={noteText || note?.text || ''} onChange={(event) => setNoteText(event.target.value)} rows={2} />
+			</label>
+			<button type="button" onClick={saveNote}>
+				{note ? 'Update note' : 'Add note'}
+			</button>
+
+			<div className="review-submit">
+				<p>
+					Your review: <strong>{summarize(draft)}</strong>
+					{auth.dirty && <span className="is-unsaved"> – not saved yet</span>}
+				</p>
+				{auth.login ? (
+					<button type="button" onClick={auth.onSave} disabled={auth.saving || !auth.dirty}>
+						{auth.saving ? 'Saving…' : `Save to pull request as ${auth.login}`}
+					</button>
+				) : (
+					<>
+						<button type="button" onClick={copyComment}>
+							{copied ? 'Copied!' : 'Copy comment for the pull request'}
+						</button>
+						{prUrl && (
+							<a href={prUrl} target="_blank" rel="noreferrer">
+								Open the pull request
+							</a>
+						)}
+					</>
+				)}
+				{auth.error && (
+					<p className="error" role="alert">
+						{auth.error}
+					</p>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/packages/tools/visual-tests/review-ui/src/Viewer.tsx
+++ b/packages/tools/visual-tests/review-ui/src/Viewer.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import type { Entry } from './types';
+
+export type Mode = 'side-by-side' | 'slider' | 'onion' | 'diff' | 'blink';
+export const MODES: { id: Mode; label: string }[] = [
+	{ id: 'side-by-side', label: 'Side by side' },
+	{ id: 'slider', label: 'Slider' },
+	{ id: 'onion', label: 'Onion skin' },
+	{ id: 'diff', label: 'Diff' },
+	{ id: 'blink', label: 'Blink' },
+];
+
+interface Props {
+	entry: Entry;
+	base: string;
+	mode: Mode;
+	zoom: number;
+}
+
+function Image({ src, alt, zoom }: { src: string; alt: string; zoom: number }) {
+	return <img src={src} alt={alt} style={{ width: `${zoom * 100}%` }} className={zoom > 1 ? 'pixelated' : undefined} draggable={false} />;
+}
+
+export function Viewer({ entry, base, mode, zoom }: Props) {
+	const { item } = entry;
+	const expected = item.expected ? `${base}/${item.expected}` : null;
+	const actual = item.actual ? `${base}/${item.actual}` : null;
+	const diff = item.diff ? `${base}/${item.diff}` : null;
+	const [position, setPosition] = useState(50);
+	const [opacity, setOpacity] = useState(50);
+	const [blink, setBlink] = useState(false);
+
+	useEffect(() => {
+		if (mode !== 'blink') return undefined;
+		const timer = window.setInterval(() => setBlink((value) => !value), 600);
+		return () => window.clearInterval(timer);
+	}, [mode]);
+
+	if (item.status === 'unchanged') {
+		return <p className="viewer-note">This snapshot is identical to the baseline – nothing to review.</p>;
+	}
+	if (item.status === 'error') {
+		return (
+			<p className="viewer-note">
+				The route of this snapshot failed before it could be captured: <code>{item.message}</code>
+			</p>
+		);
+	}
+	if (!expected || !actual) {
+		const only = expected ?? actual;
+		return (
+			<figure className="viewer-single">
+				<figcaption>{expected ? 'Baseline (removed in this pull request)' : 'New snapshot (no baseline yet)'}</figcaption>
+				<Image src={only!} alt={`${item.name} – ${expected ? 'baseline' : 'actual'}`} zoom={zoom} />
+			</figure>
+		);
+	}
+
+	switch (mode) {
+		case 'side-by-side':
+			return (
+				<div className="viewer-columns">
+					<figure>
+						<figcaption>Baseline</figcaption>
+						<Image src={expected} alt={`${item.name} – baseline`} zoom={zoom} />
+					</figure>
+					<figure>
+						<figcaption>Actual</figcaption>
+						<Image src={actual} alt={`${item.name} – actual`} zoom={zoom} />
+					</figure>
+				</div>
+			);
+		case 'diff':
+			return (
+				<figure>
+					<figcaption>Diff (differing pixels highlighted)</figcaption>
+					{diff ? (
+						<Image src={diff} alt={`${item.name} – diff`} zoom={zoom} />
+					) : (
+						<p className="viewer-note">Playwright attached no diff image for this item.</p>
+					)}
+				</figure>
+			);
+		case 'blink':
+			return (
+				<figure>
+					<figcaption>{blink ? 'Actual' : 'Baseline'}</figcaption>
+					<Image src={blink ? actual : expected} alt={`${item.name} – ${blink ? 'actual' : 'baseline'}`} zoom={zoom} />
+				</figure>
+			);
+		case 'onion':
+			return (
+				<figure>
+					<figcaption>
+						<label>
+							Actual opacity {opacity}%
+							<input type="range" min={0} max={100} value={opacity} onChange={(event) => setOpacity(Number(event.target.value))} />
+						</label>
+					</figcaption>
+					<div className="viewer-stack">
+						<Image src={expected} alt={`${item.name} – baseline`} zoom={zoom} />
+						<div className="viewer-overlay" style={{ opacity: opacity / 100 }}>
+							<Image src={actual} alt={`${item.name} – actual`} zoom={zoom} />
+						</div>
+					</div>
+				</figure>
+			);
+		case 'slider':
+		default:
+			return (
+				<figure>
+					<figcaption>
+						<label>
+							Reveal actual {position}%
+							<input type="range" min={0} max={100} value={position} onChange={(event) => setPosition(Number(event.target.value))} />
+						</label>
+					</figcaption>
+					<div className="viewer-stack">
+						<Image src={expected} alt={`${item.name} – baseline`} zoom={zoom} />
+						<div className="viewer-overlay" style={{ clipPath: `inset(0 ${100 - position}% 0 0)` }}>
+							<Image src={actual} alt={`${item.name} – actual`} zoom={zoom} />
+						</div>
+						<div className="viewer-slider-line" style={{ left: `${position}%` }} aria-hidden="true" />
+					</div>
+				</figure>
+			);
+	}
+}

--- a/packages/tools/visual-tests/review-ui/src/github.ts
+++ b/packages/tools/visual-tests/review-ui/src/github.ts
@@ -1,0 +1,62 @@
+/* GitHub REST calls the page makes itself – only with a token the reviewer entered. Without one the
+   page reads nothing from the API (60 requests per hour per IP would not survive a team behind a proxy). */
+import { parseReviewComment } from './review-comment';
+import type { ReviewDraft } from './types';
+
+const API = 'https://api.github.com';
+
+export interface Comment {
+	id: number;
+	body: string;
+	user: { login: string; type: string };
+	updated_at: string;
+}
+
+async function request<T>(token: string, method: string, path: string, body?: unknown): Promise<T> {
+	const response = await fetch(`${API}/${path}`, {
+		method,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			Accept: 'application/vnd.github+json',
+			'X-GitHub-Api-Version': '2022-11-28',
+			...(body ? { 'Content-Type': 'application/json' } : {}),
+		},
+		body: body ? JSON.stringify(body) : undefined,
+	});
+	if (!response.ok) {
+		throw new Error(`${method} ${path}: ${response.status} ${response.statusText}`);
+	}
+	return (await response.json()) as T;
+}
+
+export async function getLogin(token: string): Promise<string> {
+	const user = await request<{ login: string }>(token, 'GET', 'user');
+	return user.login;
+}
+
+export async function listComments(token: string, repository: string, pr: number): Promise<Comment[]> {
+	const comments: Comment[] = [];
+	for (let page = 1; page < 20; page += 1) {
+		const batch = await request<Comment[]>(token, 'GET', `repos/${repository}/issues/${pr}/comments?per_page=100&page=${page}`);
+		comments.push(...batch);
+		if (batch.length < 100) break;
+	}
+	return comments;
+}
+
+export function findOwnReview(comments: Comment[], login: string): { comment: Comment; draft: ReviewDraft } | null {
+	for (const comment of comments) {
+		if (comment.user.login !== login) continue;
+		const draft = parseReviewComment(comment.body);
+		if (draft) return { comment, draft };
+	}
+	return null;
+}
+
+export async function saveReview(token: string, repository: string, pr: number, body: string, existingId: number | null): Promise<void> {
+	if (existingId) {
+		await request(token, 'PATCH', `repos/${repository}/issues/comments/${existingId}`, { body });
+	} else {
+		await request(token, 'POST', `repos/${repository}/issues/${pr}/comments`, { body });
+	}
+}

--- a/packages/tools/visual-tests/review-ui/src/main.tsx
+++ b/packages/tools/visual-tests/review-ui/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './style.css';
+
+createRoot(document.getElementById('app')!).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);

--- a/packages/tools/visual-tests/review-ui/src/review-comment.ts
+++ b/packages/tools/visual-tests/review-ui/src/review-comment.ts
@@ -1,0 +1,53 @@
+/* Mirror of scripts/visual-review/review-comment.mjs – the format the status workflow reads. Keep both in sync. */
+import type { ReviewDraft } from './types';
+
+const MARKER = 'visual-review:v1';
+const BLOCK = /<!--\s*visual-review:v1\s*([\s\S]*?)-->/;
+const ITEM_KEY = /^[a-z0-9-]+\/[a-z0-9-]+$/;
+const HASH = /^sha256:[0-9a-f]{64}$/;
+
+export function emptyDraft(): ReviewDraft {
+	return { approvals: [], rejects: [], notes: [] };
+}
+
+export function parseReviewComment(body: string | null | undefined): ReviewDraft | null {
+	const block = body?.match(BLOCK)?.[1];
+	if (!block) return null;
+	let data: Record<string, unknown>;
+	try {
+		data = JSON.parse(block) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+	if (!data || typeof data !== 'object') return null;
+	const entries = (list: unknown) =>
+		(Array.isArray(list) ? list : [])
+			.filter((entry): entry is { item: string; hash?: string; text?: unknown } => {
+				return Boolean(entry) && typeof entry === 'object' && ITEM_KEY.test(String((entry as { item?: unknown }).item ?? ''));
+			})
+			.filter((entry) => entry.hash === undefined || HASH.test(entry.hash));
+	const approveAll = data.approveAll as { digest?: string } | undefined;
+	return {
+		approveAll: HASH.test(approveAll?.digest ?? '') ? { digest: approveAll!.digest! } : undefined,
+		approvals: entries(data.approvals).map(({ item, hash }) => ({ item, hash: hash! })),
+		rejects: entries(data.rejects).map(({ item, hash }) => ({ item, hash: hash! })),
+		notes: entries(data.notes).map(({ item, hash, text }) => ({ item, hash, text: String(text ?? '').slice(0, 2000) })),
+	};
+}
+
+export function formatReviewComment(draft: ReviewDraft, pageUrl: string, summary: string): string {
+	const block = JSON.stringify({ approveAll: draft.approveAll, approvals: draft.approvals, rejects: draft.rejects, notes: draft.notes });
+	const lines = [`<!-- ${MARKER}`, block, '-->', `**Visual Review** – ${summary} ([review page](${pageUrl}))`];
+	for (const reject of draft.rejects) lines.push(`- ❌ \`${reject.item}\``);
+	for (const note of draft.notes) lines.push(`- 💬 \`${note.item}\`: ${note.text}`);
+	return lines.join('\n');
+}
+
+export function summarize(draft: ReviewDraft): string {
+	const parts: string[] = [];
+	if (draft.approveAll) parts.push('all changes approved');
+	else if (draft.approvals.length > 0) parts.push(`${draft.approvals.length} approved`);
+	if (draft.rejects.length > 0) parts.push(`${draft.rejects.length} rejected`);
+	if (draft.notes.length > 0) parts.push(`${draft.notes.length} note${draft.notes.length === 1 ? '' : 's'}`);
+	return parts.length > 0 ? parts.join(', ') : 'no decisions yet';
+}

--- a/packages/tools/visual-tests/review-ui/src/style.css
+++ b/packages/tools/visual-tests/review-ui/src/style.css
@@ -1,0 +1,458 @@
+:root {
+	--bg: #ffffff;
+	--fg: #1f2328;
+	--muted: #59636e;
+	--line: #d0d7de;
+	--panel: #f6f8fa;
+	--accent: #0969da;
+	--success: #1a7f37;
+	--pending: #9a6700;
+	--failure: #cf222e;
+	color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--bg: #0d1117;
+		--fg: #e6edf3;
+		--muted: #9198a1;
+		--line: #3d444d;
+		--panel: #161b22;
+		--accent: #4493f8;
+		--success: #3fb950;
+		--pending: #d29922;
+		--failure: #f85149;
+	}
+}
+
+* {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+	font:
+		14px/1.4 system-ui,
+		sans-serif;
+	color: var(--fg);
+	background: var(--bg);
+}
+
+a {
+	color: var(--accent);
+}
+
+code {
+	font-family: ui-monospace, monospace;
+	font-size: 0.95em;
+}
+
+button {
+	font: inherit;
+	color: inherit;
+	background: var(--panel);
+	border: 1px solid var(--line);
+	border-radius: 6px;
+	padding: 4px 10px;
+	cursor: pointer;
+}
+
+button:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+
+button[aria-pressed='true'] {
+	background: var(--accent);
+	color: #fff;
+	border-color: var(--accent);
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+input[type='search'],
+input[type='password'],
+textarea {
+	font: inherit;
+	color: inherit;
+	background: var(--bg);
+	border: 1px solid var(--line);
+	border-radius: 6px;
+	padding: 4px 8px;
+	width: 100%;
+}
+
+.page {
+	max-width: 60rem;
+	margin: 2rem auto;
+	padding: 0 1rem;
+}
+
+.error {
+	color: var(--failure);
+}
+
+.warn {
+	color: var(--pending);
+}
+
+.hint {
+	color: var(--muted);
+	font-size: 0.9em;
+}
+
+.is-unsaved {
+	color: var(--pending);
+}
+
+.layout {
+	display: grid;
+	grid-template-columns: 22rem 1fr;
+	grid-template-rows: auto 1fr auto;
+	grid-template-areas:
+		'header header'
+		'sidebar main'
+		'auth auth';
+	min-height: 100vh;
+}
+
+.header {
+	grid-area: header;
+	padding: 0.75rem 1rem;
+	border-bottom: 1px solid var(--line);
+}
+
+.header h1 {
+	margin: 0 0 0.25rem;
+	font-size: 1.25rem;
+}
+
+.header p {
+	margin: 0.15rem 0;
+}
+
+.header-meta {
+	color: var(--muted);
+}
+
+.header-status.state-success {
+	color: var(--success);
+}
+
+.header-status.state-pending {
+	color: var(--pending);
+}
+
+.header-status.state-failure {
+	color: var(--failure);
+}
+
+.sidebar {
+	grid-area: sidebar;
+	border-right: 1px solid var(--line);
+	overflow: auto;
+	background: var(--panel);
+	display: flex;
+	flex-direction: column;
+}
+
+.filters {
+	padding: 0.75rem;
+	border-bottom: 1px solid var(--line);
+	display: grid;
+	gap: 0.5rem;
+}
+
+.filter-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.25rem 0.75rem;
+	font-size: 0.9em;
+}
+
+.list {
+	list-style: none;
+	margin: 0;
+	padding: 0.25rem 0;
+	flex: 1;
+}
+
+.list-empty {
+	padding: 1rem;
+	color: var(--muted);
+}
+
+.list-package {
+	padding: 0.5rem 0.75rem 0.25rem;
+	font-weight: 600;
+	color: var(--muted);
+	font-size: 0.85em;
+	text-transform: uppercase;
+}
+
+.list-item {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	width: 100%;
+	text-align: left;
+	background: none;
+	border: 0;
+	border-radius: 0;
+	padding: 0.3rem 0.75rem;
+	font-family: ui-monospace, monospace;
+	font-size: 0.85em;
+}
+
+.list-item:hover {
+	background: var(--line);
+}
+
+.list-item.is-selected {
+	background: var(--accent);
+	color: #fff;
+}
+
+.list-status {
+	display: inline-block;
+	width: 1.2em;
+	text-align: center;
+	font-weight: 700;
+}
+
+.status-changed .list-status {
+	color: var(--pending);
+}
+
+.status-added .list-status {
+	color: var(--success);
+}
+
+.status-removed .list-status,
+.status-error .list-status {
+	color: var(--failure);
+}
+
+.is-selected .list-status {
+	color: inherit;
+}
+
+.list-name {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.list-review.review-approved {
+	color: var(--success);
+}
+
+.list-review.review-rejected {
+	color: var(--failure);
+}
+
+.list-review.is-unsaved {
+	opacity: 0.6;
+}
+
+.sidebar .hint {
+	padding: 0.5rem 0.75rem;
+	margin: 0;
+	border-top: 1px solid var(--line);
+}
+
+.main {
+	grid-area: main;
+	padding: 1rem;
+	overflow: auto;
+	display: grid;
+	grid-template-rows: auto 1fr auto;
+	gap: 1rem;
+	align-content: start;
+}
+
+.toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: center;
+}
+
+.toolbar label {
+	margin-left: auto;
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+}
+
+.viewer {
+	overflow: auto;
+	border: 1px solid var(--line);
+	border-radius: 6px;
+	padding: 0.75rem;
+	background: repeating-conic-gradient(var(--panel) 0 25%, transparent 0 50%) 0 0 / 16px 16px;
+}
+
+.viewer figure {
+	margin: 0;
+}
+
+.viewer figcaption {
+	margin-bottom: 0.5rem;
+	color: var(--muted);
+	font-size: 0.9em;
+}
+
+.viewer img {
+	display: block;
+	max-width: none;
+}
+
+.pixelated {
+	image-rendering: pixelated;
+}
+
+.viewer-columns {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1rem;
+}
+
+.viewer-stack {
+	position: relative;
+	display: inline-block;
+}
+
+.viewer-overlay {
+	position: absolute;
+	inset: 0;
+}
+
+.viewer-slider-line {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	background: var(--accent);
+	transform: translateX(-1px);
+}
+
+.viewer-note {
+	color: var(--muted);
+}
+
+.review {
+	border: 1px solid var(--line);
+	border-radius: 6px;
+	padding: 0.75rem 1rem;
+	display: grid;
+	gap: 0.75rem;
+}
+
+.review > button {
+	justify-self: start;
+}
+
+.review-title {
+	margin: 0;
+	font-size: 1rem;
+}
+
+.review-facts {
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	gap: 0.25rem 1rem;
+	margin: 0;
+}
+
+.review-facts dt {
+	color: var(--muted);
+}
+
+.review-facts dd {
+	margin: 0;
+}
+
+.review-note {
+	margin-top: 0.25rem;
+}
+
+.review-actions {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.review-note-input {
+	display: grid;
+	gap: 0.25rem;
+}
+
+.review-submit {
+	display: grid;
+	gap: 0.5rem;
+	justify-items: start;
+	border-top: 1px solid var(--line);
+	padding-top: 0.75rem;
+}
+
+.review-submit p {
+	margin: 0;
+}
+
+.errors {
+	border: 1px solid var(--failure);
+	border-radius: 6px;
+	padding: 0.75rem 1rem;
+}
+
+.errors h2 {
+	margin: 0 0 0.5rem;
+	font-size: 1rem;
+}
+
+.auth {
+	grid-area: auth;
+	border-top: 1px solid var(--line);
+	padding: 0.75rem 1rem;
+	background: var(--panel);
+}
+
+.auth form {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem 1rem;
+	align-items: end;
+}
+
+.auth form > label:first-child {
+	flex: 1 1 24rem;
+	display: grid;
+	gap: 0.25rem;
+}
+
+@media (max-width: 900px) {
+	.layout {
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			'header'
+			'sidebar'
+			'main'
+			'auth';
+	}
+
+	.sidebar {
+		max-height: 40vh;
+		border-right: 0;
+		border-bottom: 1px solid var(--line);
+	}
+
+	.viewer-columns {
+		grid-template-columns: 1fr;
+	}
+}

--- a/packages/tools/visual-tests/review-ui/src/types.ts
+++ b/packages/tools/visual-tests/review-ui/src/types.ts
@@ -1,0 +1,81 @@
+/* Shapes written by scripts/visual-review/merge-reports.mjs (report.json) and update-review.mjs (status.json). */
+
+export type ItemStatus = 'unchanged' | 'changed' | 'added' | 'removed' | 'error';
+export type ReviewState = 'open' | 'approved' | 'rejected';
+
+export interface Item {
+	name: string;
+	route: string;
+	status: ItemStatus;
+	hash: string;
+	diffPixels?: number;
+	diffRatio?: number;
+	sizeMismatch?: { expected: [number, number]; actual: [number, number] };
+	message?: string;
+	expected?: string;
+	actual?: string;
+	diff?: string;
+}
+
+export interface Package {
+	package: string;
+	themeDir: string;
+	summary: Record<ItemStatus, number>;
+	digest: string | null;
+	items: Item[];
+	errors: { test: string; route: string; message: string }[];
+}
+
+interface Baseline {
+	sha: string | null;
+	ref: string | null;
+	image: string | null;
+	playwright: string | null;
+	fallback: string | null;
+	distance: number | null;
+	imageMismatch: boolean;
+	consistent: boolean;
+}
+
+export interface Report {
+	schema: number;
+	pr: number;
+	head: string;
+	repository: string | null;
+	runId: number | null;
+	generatedAt: string;
+	digest: string;
+	baseline: Baseline | null;
+	summary: Record<ItemStatus, number>;
+	packages: Package[];
+}
+
+export interface StatusFile {
+	state: 'success' | 'pending' | 'failure';
+	description: string;
+	computedAt: string;
+	head: string;
+	digest: string;
+	counts: { changes: number; open: number; approved: number; rejected: number; routeErrors: number; errorItems: number };
+	reviewers: string[];
+	items: Record<string, { state: ReviewState; by?: string; notes: { by: string; text: string }[] }>;
+}
+
+/** One reviewer's decisions – the JSON block of the reviewer comment. */
+export interface ReviewDraft {
+	approveAll?: { digest: string };
+	approvals: { item: string; hash: string }[];
+	rejects: { item: string; hash: string }[];
+	notes: { item: string; hash?: string; text: string }[];
+}
+
+/** An item with the keys the review works with. */
+export interface Entry {
+	key: string;
+	pkg: Package;
+	item: Item;
+}
+
+export function entryKey(pkg: Package, item: Item): string {
+	return `${pkg.package}/${item.name}`;
+}

--- a/packages/tools/visual-tests/review-ui/tsconfig.json
+++ b/packages/tools/visual-tests/review-ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"jsx": "react-jsx",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"forceConsistentCasingInFileNames": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"types": ["vite/client"]
+	},
+	"include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/tools/visual-tests/review-ui/vite.config.ts
+++ b/packages/tools/visual-tests/review-ui/vite.config.ts
@@ -1,0 +1,17 @@
+import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite';
+
+/* The review page is deployed to gh-pages under visual/ next to the per-pull-request folders
+   visual/pr-<n>/ it reads. Relative asset paths keep it independent of the host path. */
+export default defineConfig({
+	root: __dirname,
+	base: './',
+	plugins: [react()],
+	build: {
+		emptyOutDir: true,
+		sourcemap: true,
+	},
+	server: {
+		port: 9292,
+	},
+});

--- a/packages/tools/visual-tests/test/github-api.test.mjs
+++ b/packages/tools/visual-tests/test/github-api.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { createApi } from '../../../../scripts/visual-review/github-api.mjs';
+
+function response(body, { status = 200, link } = {}) {
+	return {
+		ok: status < 400,
+		status,
+		statusText: status < 400 ? 'OK' : 'Error',
+		headers: { get: (name) => (name === 'link' ? (link ?? null) : null) },
+		json: async () => body,
+		text: async () => JSON.stringify(body),
+	};
+}
+
+describe('github-api', () => {
+	const original = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = original;
+	});
+
+	it('paginates bare arrays and total_count wrappers alike, following the Link header', async () => {
+		const calls = [];
+		globalThis.fetch = async (url, init) => {
+			calls.push({ url, auth: init.headers.Authorization });
+			if (url.endsWith('/issues/1/comments?per_page=100'))
+				return response([{ id: 1 }], { link: '<https://api.github.com/repos/o/r/issues/1/comments?per_page=100&page=2>; rel="next"' });
+			if (url.endsWith('page=2')) return response([{ id: 2 }]);
+			if (url.includes('/actions/artifacts')) return response({ total_count: 2, artifacts: [{ id: 'a' }, { id: 'b' }] });
+			if (url.includes('/jobs')) return response({ total_count: 1, jobs: [{ name: 'x' }] });
+			throw new Error(`unexpected ${url}`);
+		};
+		const api = createApi({ token: 't' });
+		assert.deepEqual(await api.paginate('repos/o/r/issues/1/comments'), [{ id: 1 }, { id: 2 }]);
+		assert.deepEqual(await api.paginate('repos/o/r/actions/artifacts?name=x'), [{ id: 'a' }, { id: 'b' }]);
+		assert.deepEqual(await api.paginate('repos/o/r/actions/runs/7/jobs'), [{ name: 'x' }]);
+		assert.ok(calls.every((call) => call.auth === 'Bearer t'));
+		assert.ok(calls[1].url.endsWith('page=2'), 'the Link header decides the next page');
+	});
+
+	it('throws with status and body on errors and returns null for 204', async () => {
+		globalThis.fetch = async (url) => (url.endsWith('/statuses/x') ? response({}, { status: 204 }) : response({ message: 'nope' }, { status: 403 }));
+		const api = createApi({ token: 't' });
+		await assert.rejects(api.get('repos/o/r/forbidden'), /403 Error: \{"message":"nope"\}/);
+		assert.equal(await api.post('repos/o/r/statuses/x', {}), null);
+	});
+});

--- a/packages/tools/visual-tests/test/merge-reports.test.mjs
+++ b/packages/tools/visual-tests/test/merge-reports.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { mergeReports } from '../../../../scripts/visual-review/merge-reports.mjs';
+
+const H = (n) => `sha256:${String(n).repeat(64)}`;
+
+function write(file, content) {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+}
+
+function artifact(downloadDir, pkg, report, images = []) {
+	const dir = path.join(downloadDir, `visual-review-${pkg}`);
+	write(
+		path.join(dir, 'report.json'),
+		JSON.stringify({ schema: 1, mode: 'compare', package: pkg, themeDir: `theme-${pkg}`, baseline: { files: 2, meta: null }, errors: [], ...report }),
+	);
+	for (const image of images) write(path.join(dir, pkg, image), `png-${image}`);
+	return dir;
+}
+
+describe('mergeReports', () => {
+	let root;
+	let downloadDir;
+	let outDir;
+
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-reports-'));
+		downloadDir = path.join(root, 'downloads');
+		outDir = path.join(root, 'out');
+		fs.mkdirSync(downloadDir);
+	});
+
+	afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+	it('merges the packages, copies only referenced images and aggregates the summary', () => {
+		artifact(
+			downloadDir,
+			'theme-default',
+			{
+				summary: { unchanged: 1, changed: 1, added: 0, removed: 0, error: 0 },
+				digest: H(1),
+				items: [
+					{ name: 'a--x', route: 'a', status: 'unchanged', hash: H(2) },
+					{
+						name: 'a--y',
+						route: 'a',
+						status: 'changed',
+						hash: H(3),
+						diffPixels: 4,
+						diffRatio: 0.5,
+						expected: 'theme-default/a--y.expected.png',
+						actual: 'theme-default/a--y.actual.png',
+						diff: 'theme-default/a--y.diff.png',
+					},
+				],
+			},
+			['a--y.expected.png', 'a--y.actual.png', 'a--y.diff.png', 'stray.png'],
+		);
+		artifact(
+			downloadDir,
+			'unstyled',
+			{
+				summary: { unchanged: 0, changed: 0, added: 0, removed: 1, error: 0 },
+				digest: H(4),
+				baseline: {
+					files: 1,
+					meta: {
+						sha: 'f'.repeat(40),
+						ref: 'develop',
+						runId: 7,
+						image: 'img',
+						playwright: '1.60.0',
+						createdAt: 'now',
+						digest: H(5),
+						fallback: null,
+						distance: 0,
+						imageMismatch: false,
+					},
+				},
+				items: [{ name: 'b', route: 'b', status: 'removed', hash: H(6), expected: 'unstyled/b.expected.png' }],
+			},
+			['b.expected.png'],
+		);
+		fs.mkdirSync(path.join(downloadDir, 'other-artifact'));
+
+		const merged = mergeReports(downloadDir, outDir, { pr: 12, head: 'abc', repository: 'o/r', runId: 99 });
+
+		assert.equal(merged.pr, 12);
+		assert.deepEqual(merged.summary, { unchanged: 1, changed: 1, added: 0, removed: 1, error: 0 });
+		assert.deepEqual(
+			merged.packages.map((pkg) => pkg.package),
+			['theme-default', 'unstyled'],
+		);
+		assert.match(merged.digest, /^sha256:[0-9a-f]{64}$/);
+		assert.equal(merged.baseline.sha, 'f'.repeat(40));
+		assert.equal(merged.baseline.consistent, true);
+		assert.equal(merged.packages[0].items[1].diffRatio, 0.5);
+		assert.ok(fs.existsSync(path.join(outDir, 'theme-default', 'a--y.diff.png')));
+		assert.ok(fs.existsSync(path.join(outDir, 'unstyled', 'b.expected.png')));
+		assert.equal(fs.existsSync(path.join(outDir, 'theme-default', 'stray.png')), false, 'unreferenced files are not published');
+		assert.deepEqual(JSON.parse(fs.readFileSync(path.join(outDir, 'report.json'), 'utf8')).summary, merged.summary);
+	});
+
+	it('rejects reports that point outside their own folder or lie about themselves', () => {
+		const base = { summary: { unchanged: 0, changed: 1, added: 0, removed: 0, error: 0 }, digest: H(1) };
+		const cases = [
+			{ items: [{ name: 'a--x', status: 'changed', hash: H(1), actual: '../../secret.png' }] },
+			{ items: [{ name: 'a--x', status: 'changed', hash: H(1), actual: 'theme-default/a--x.actual.png' }], missing: true },
+			{ items: [{ name: 'Bad Name', status: 'changed', hash: H(1) }] },
+			{ items: [{ name: 'a--x', status: 'weird', hash: H(1) }] },
+			{ items: [{ name: 'a--x', status: 'changed', hash: 'nope' }] },
+			{ items: [{ name: 'a--x', status: 'unchanged', hash: H(1) }] },
+			{ package: 'not/ok', items: [] },
+			{ mode: 'update', items: [] },
+		];
+		for (const [index, testCase] of cases.entries()) {
+			const dir = path.join(downloadDir, `case-${index}`);
+			fs.mkdirSync(dir);
+			const { missing, ...report } = testCase;
+			artifact(dir, 'theme-default', { ...base, ...report }, missing ? [] : ['a--x.actual.png']);
+			assert.throws(() => mergeReports(dir, path.join(outDir, String(index)), { pr: 1, head: 'x' }), `case ${index} must be rejected`);
+		}
+	});
+
+	it('fails without artifacts', () => {
+		assert.throws(() => mergeReports(downloadDir, outDir, { pr: 1, head: 'x' }), /No visual-review-\* artifacts/);
+	});
+});

--- a/packages/tools/visual-tests/test/resolve-context.test.mjs
+++ b/packages/tools/visual-tests/test/resolve-context.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { CI_IGNORED_PATHS, isIgnoredByCi, resolveContext } from '../../../../scripts/visual-review/resolve-context.mjs';
+
+const REPO = 'public-ui/kolibri';
+
+function fakeApi(routes) {
+	const lookup = (path) => {
+		const entry = Object.entries(routes).find(([prefix]) => path.startsWith(prefix));
+		if (!entry) throw new Error(`unexpected request ${path}`);
+		return entry[1];
+	};
+	return { get: async (path) => lookup(path), paginate: async (path) => lookup(path) };
+}
+
+const OPEN_PULL = { number: 42, state: 'open', head: { sha: 'head1' }, base: { repo: { full_name: REPO } } };
+
+describe('isIgnoredByCi', () => {
+	it('mirrors the paths-ignore list of ci.yml', () => {
+		assert.deepEqual(CI_IGNORED_PATHS, ['*.md', 'docs/**', 'LICENSE', '.github/ISSUE_TEMPLATE/**', '.github/PULL_REQUEST_TEMPLATE/**']);
+		assert.ok(isIgnoredByCi('README.md'));
+		assert.ok(isIgnoredByCi('docs/arc42/01.md'));
+		assert.ok(isIgnoredByCi('LICENSE'));
+		assert.ok(isIgnoredByCi('.github/ISSUE_TEMPLATE/bug.yml'));
+		assert.equal(isIgnoredByCi('packages/components/README.md'), false, '*.md only matches the repository root');
+		assert.equal(isIgnoredByCi('packages/themes/default/src/x.ts'), false);
+		assert.equal(isIgnoredByCi('docs-site/index.ts'), false);
+	});
+});
+
+describe('resolveContext', () => {
+	it('publishes a completed pull-request run with visual jobs', async () => {
+		const api = fakeApi({
+			'repos/public-ui/kolibri/commits/head1/pulls': [OPEN_PULL],
+			'repos/public-ui/kolibri/actions/runs/7/jobs': [
+				{ name: 'visual-tests (theme-default)', conclusion: 'success' },
+				{ name: 'build-and-check', conclusion: 'success' },
+			],
+		});
+		const context = await resolveContext({
+			eventName: 'workflow_run',
+			event: { workflow_run: { id: 7, event: 'pull_request', conclusion: 'failure', head_sha: 'head1' } },
+			api,
+			repository: REPO,
+		});
+		assert.deepEqual(context, { mode: 'publish', pr: 42, head: 'head1', runId: 7, reason: 'CI run 7 completed' });
+	});
+
+	it('reports success when the visual jobs were skipped and skips runs without a pull request', async () => {
+		const skippedApi = fakeApi({
+			'repos/public-ui/kolibri/commits/head1/pulls': [OPEN_PULL],
+			'repos/public-ui/kolibri/actions/runs/7/jobs': [{ name: 'visual-tests (theme-default)', conclusion: 'skipped' }],
+		});
+		const event = { workflow_run: { id: 7, event: 'pull_request', conclusion: 'success', head_sha: 'head1' } };
+		assert.equal((await resolveContext({ eventName: 'workflow_run', event, api: skippedApi, repository: REPO })).mode, 'no-visual');
+
+		const noPull = fakeApi({ 'repos/public-ui/kolibri/commits/head1/pulls': [{ ...OPEN_PULL, state: 'closed' }] });
+		assert.equal((await resolveContext({ eventName: 'workflow_run', event, api: noPull, repository: REPO })).mode, 'skip');
+
+		const push = { workflow_run: { id: 7, event: 'push', conclusion: 'success', head_sha: 'head1' } };
+		assert.equal((await resolveContext({ eventName: 'workflow_run', event: push, api: noPull, repository: REPO })).mode, 'skip');
+
+		const cancelled = { workflow_run: { id: 7, event: 'pull_request', conclusion: 'cancelled', head_sha: 'head1' } };
+		assert.equal((await resolveContext({ eventName: 'workflow_run', event: cancelled, api: noPull, repository: REPO })).mode, 'skip');
+	});
+
+	it('recomputes the status for human comments on open pull requests only', async () => {
+		const api = fakeApi({ 'repos/public-ui/kolibri/pulls/42': OPEN_PULL });
+		const human = { action: 'created', issue: { number: 42, pull_request: {} }, comment: { user: { login: 'alice', type: 'User' } } };
+		assert.deepEqual(await resolveContext({ eventName: 'issue_comment', event: human, api, repository: REPO }), {
+			mode: 'status',
+			pr: 42,
+			head: 'head1',
+			runId: null,
+			reason: 'comment created by alice',
+		});
+		const bot = { ...human, comment: { user: { login: 'github-actions[bot]', type: 'Bot' } } };
+		assert.equal((await resolveContext({ eventName: 'issue_comment', event: bot, api, repository: REPO })).mode, 'skip');
+		const issue = { ...human, issue: { number: 42 } };
+		assert.equal((await resolveContext({ eventName: 'issue_comment', event: issue, api, repository: REPO })).mode, 'skip');
+	});
+
+	it('marks a fresh push pending, unless only ignored files changed', async () => {
+		const event = { action: 'synchronize', pull_request: { number: 42, head: { sha: 'head2' } } };
+		const code = fakeApi({ 'repos/public-ui/kolibri/pulls/42/files': [{ filename: 'README.md' }, { filename: 'packages/x/y.ts' }] });
+		assert.equal((await resolveContext({ eventName: 'pull_request_target', event, api: code, repository: REPO })).mode, 'pending');
+		const docs = fakeApi({ 'repos/public-ui/kolibri/pulls/42/files': [{ filename: 'README.md' }, { filename: 'docs/a.md' }] });
+		const context = await resolveContext({ eventName: 'pull_request_target', event, api: docs, repository: REPO });
+		assert.equal(context.mode, 'docs-only');
+		assert.equal(context.head, 'head2');
+	});
+});

--- a/packages/tools/visual-tests/test/review-status.test.mjs
+++ b/packages/tools/visual-tests/test/review-status.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { formatReviewComment, parseReviewComment } from '../../../../scripts/visual-review/review-comment.mjs';
+import { computeStatus } from '../../../../scripts/visual-review/review-status.mjs';
+
+const H = (n) => `sha256:${String(n).repeat(64)}`;
+
+function report({ items = [], errors = [] } = {}) {
+	return {
+		pr: 1,
+		head: 'abc',
+		digest: H(9),
+		packages: [
+			{
+				package: 'theme-default',
+				summary: {
+					unchanged: items.filter((i) => i.status === 'unchanged').length,
+					changed: items.filter((i) => i.status === 'changed').length,
+					added: items.filter((i) => i.status === 'added').length,
+					removed: items.filter((i) => i.status === 'removed').length,
+					error: items.filter((i) => i.status === 'error').length,
+				},
+				items,
+				errors,
+			},
+		],
+	};
+}
+
+const CHANGES = [
+	{ name: 'a--x', status: 'changed', hash: H(1) },
+	{ name: 'a--y', status: 'added', hash: H(2) },
+	{ name: 'b--z', status: 'removed', hash: H(3) },
+	{ name: 'c--ok', status: 'unchanged', hash: H(4) },
+];
+
+function review(author, role, data) {
+	return { author, role, data: { approvals: [], rejects: [], notes: [], ...data }, updatedAt: '2026-09-04T10:00:00Z' };
+}
+
+describe('computeStatus', () => {
+	it('is green without visual changes', () => {
+		const result = computeStatus(report({ items: [{ name: 'c--ok', status: 'unchanged', hash: H(4) }] }), []);
+		assert.equal(result.state, 'success');
+		assert.equal(result.description, 'No visual changes');
+		assert.deepEqual(result.status.items, {});
+	});
+
+	it('is pending while changes wait for approval', () => {
+		const result = computeStatus(report({ items: CHANGES }), []);
+		assert.equal(result.state, 'pending');
+		assert.equal(result.description, '1 changed, 1 added, 1 removed – 0 of 3 approved, review pending');
+		assert.deepEqual(Object.keys(result.status.items), ['theme-default/a--x', 'theme-default/a--y', 'theme-default/b--z']);
+		assert.equal(result.status.counts.open, 3);
+	});
+
+	it('approves items by hash and the whole report by digest, but only for writers', () => {
+		const partial = computeStatus(report({ items: CHANGES }), [review('alice', 'write', { approvals: [{ item: 'theme-default/a--x', hash: H(1) }] })]);
+		assert.equal(partial.state, 'pending');
+		assert.equal(partial.status.items['theme-default/a--x'].state, 'approved');
+		assert.equal(partial.status.items['theme-default/a--x'].by, 'alice');
+		assert.equal(partial.status.counts.approved, 1);
+
+		const stale = computeStatus(report({ items: CHANGES }), [review('alice', 'write', { approvals: [{ item: 'theme-default/a--x', hash: H(5) }] })]);
+		assert.equal(stale.status.items['theme-default/a--x'].state, 'open', 'a changed screenshot invalidates the approval');
+
+		const all = computeStatus(report({ items: CHANGES }), [review('alice', 'maintain', { approveAll: { digest: H(9) } })]);
+		assert.equal(all.state, 'success');
+		assert.equal(all.description, '3 visual changes approved by alice');
+
+		const reader = computeStatus(report({ items: CHANGES }), [review('mallory', 'read', { approveAll: { digest: H(9) } })]);
+		assert.equal(reader.state, 'pending');
+		assert.deepEqual(reader.status.reviewers, []);
+
+		const otherDigest = computeStatus(report({ items: CHANGES }), [review('alice', 'write', { approveAll: { digest: H(8) } })]);
+		assert.equal(otherDigest.state, 'pending', 'approveAll of an older report does not carry over');
+	});
+
+	it('lets a rejection win over an approval and collects notes', () => {
+		const result = computeStatus(report({ items: CHANGES }), [
+			review('alice', 'write', { approveAll: { digest: H(9) } }),
+			review('bob', 'admin', { rejects: [{ item: 'theme-default/a--y', hash: H(2) }], notes: [{ item: 'theme-default/a--y', hash: H(2), text: 'too dark' }] }),
+		]);
+		assert.equal(result.state, 'failure');
+		assert.equal(result.description, '1 of 3 visual changes rejected');
+		assert.equal(result.status.items['theme-default/a--y'].state, 'rejected');
+		assert.equal(result.status.items['theme-default/a--y'].by, 'bob');
+		assert.deepEqual(result.status.items['theme-default/a--y'].notes, [{ by: 'bob', text: 'too dark' }]);
+		assert.deepEqual(result.status.reviewers, ['alice', 'bob']);
+	});
+
+	it('fails on routes that could not be compared', () => {
+		const result = computeStatus(
+			report({ items: [{ name: 'a--x', status: 'error', hash: H(1), message: 'boom' }], errors: [{ route: 'a', message: 'boom' }] }),
+			[review('alice', 'write', { approveAll: { digest: H(9) } })],
+		);
+		assert.equal(result.state, 'failure');
+		assert.match(result.description, /1 route\(s\) failed/);
+	});
+});
+
+describe('review comment format', () => {
+	it('round-trips through format and parse', () => {
+		const data = {
+			approveAll: { digest: H(9) },
+			approvals: [{ item: 'theme-default/a--x', hash: H(1) }],
+			rejects: [{ item: 'theme-kern/b--y', hash: H(2) }],
+			notes: [{ item: 'theme-kern/b--y', hash: H(2), text: 'border too thin' }],
+		};
+		const body = formatReviewComment(data, { pageUrl: 'https://example.test/?pr=1', summary: '1 approved' });
+		assert.match(body, /^<!-- visual-review:v1\n/);
+		assert.match(body, /\[review page\]\(https:\/\/example\.test\/\?pr=1\)/);
+		assert.deepEqual(parseReviewComment(body), data);
+	});
+
+	it('ignores comments without a block, broken JSON and malformed entries', () => {
+		assert.equal(parseReviewComment('just a comment'), null);
+		assert.equal(parseReviewComment('<!-- visual-review:v1\n{not json\n-->'), null);
+		const parsed = parseReviewComment(
+			`<!-- visual-review:v1\n${JSON.stringify({
+				approveAll: { digest: 'nope' },
+				approvals: [
+					{ item: '../etc', hash: H(1) },
+					{ item: 'theme-default/a--x', hash: 'bad' },
+					{ item: 'theme-default/a--x', hash: H(1) },
+				],
+				notes: [{ item: 'theme-default/a--x', text: 'x'.repeat(3000) }],
+			})}\n-->`,
+		);
+		assert.equal(parsed.approveAll, undefined);
+		assert.deepEqual(parsed.approvals, [{ item: 'theme-default/a--x', hash: H(1) }]);
+		assert.equal(parsed.notes[0].text.length, 2000);
+	});
+});

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,6 +56,21 @@ Helpers around the visual report the Playwright runs write to `<package>/visual-
   GitHub CLI, so a local `pnpm --filter @public-ui/<package> test` compares against what the CI
   compares against. Generating a baseline locally stays the job of `snapshots-docker.mjs`.
 
+The "Visual Review" workflow (`.github/workflows/visual-review.yml`) runs these in the context of
+the base repository – see [docs/visual-review.md](../docs/visual-review.md) for the process:
+
+- `resolve-context.mjs` – decides what the workflow has to do for its trigger (publish a finished CI
+  run, recompute after a reviewer comment, mark a fresh push pending, …) and which pull request it
+  belongs to. Its ignore list mirrors `paths-ignore` of `ci.yml`.
+- `merge-reports.mjs` – merges the `visual-review-<package>` artifacts of a CI run into the folder
+  published as `visual/pr-<n>/`, validating every field and file name before copying anything.
+- `review-comment.mjs` – parses and formats the reviewer comment (`<!-- visual-review:v1 … -->`).
+- `review-status.mjs` – the pure rules that turn a report and the reviewers' decisions into the
+  commit status (`success`, `pending`, `failure`) and `status.json`.
+- `update-review.mjs` – applies them: reads the comments, checks the authors' permission, writes
+  `status.json`, sets the commit status `Visual Review` and upserts the summary comment.
+- `github-api.mjs` – the small REST client the scripts share.
+
 ```bash
 node scripts/visual-review/assert-no-errors.mjs theme-default
 pnpm snapshots:pull                        # every package, newest baseline of develop

--- a/scripts/visual-review/github-api.mjs
+++ b/scripts/visual-review/github-api.mjs
@@ -30,13 +30,18 @@ export function createApi({ token = process.env.GITHUB_TOKEN, baseUrl = process.
 		return response.status === 204 ? null : response.json();
 	}
 
+	/**
+	 * Collects every page. List endpoints either return a bare array (comments, files) or an object
+	 * with `total_count` and one array property (`artifacts`, `jobs`, `workflow_runs`).
+	 */
 	async function paginate(path) {
 		const items = [];
 		let next = path.includes('per_page=') ? path : `${path}${path.includes('?') ? '&' : '?'}per_page=100`;
 		while (next) {
 			const response = await request('GET', next);
 			const page = await response.json();
-			items.push(...(Array.isArray(page) ? page : []));
+			const list = Array.isArray(page) ? page : (Object.values(page ?? {}).find(Array.isArray) ?? []);
+			items.push(...list);
 			next = response.headers.get('link')?.match(/<([^>]+)>;\s*rel="next"/)?.[1] ?? null;
 		}
 		return items;

--- a/scripts/visual-review/github-api.mjs
+++ b/scripts/visual-review/github-api.mjs
@@ -1,0 +1,67 @@
+/**
+ * Minimal GitHub REST client for the visual-review scripts – node's fetch, no dependency.
+ * Pagination follows the `Link: <…>; rel="next"` header.
+ */
+import * as fs from 'node:fs';
+
+export function createApi({ token = process.env.GITHUB_TOKEN, baseUrl = process.env.GITHUB_API_URL ?? 'https://api.github.com' } = {}) {
+	if (!token) throw new Error('GITHUB_TOKEN is required');
+
+	async function request(method, path, { body, accept = 'application/vnd.github+json' } = {}) {
+		const url = path.startsWith('http') ? path : `${baseUrl}/${path.replace(/^\//, '')}`;
+		const response = await fetch(url, {
+			method,
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: accept,
+				'X-GitHub-Api-Version': '2022-11-28',
+				...(body ? { 'Content-Type': 'application/json' } : {}),
+			},
+			body: body ? JSON.stringify(body) : undefined,
+		});
+		if (!response.ok) {
+			throw new Error(`${method} ${url} → ${response.status} ${response.statusText}: ${(await response.text()).slice(0, 500)}`);
+		}
+		return response;
+	}
+
+	async function json(method, path, options) {
+		const response = await request(method, path, options);
+		return response.status === 204 ? null : response.json();
+	}
+
+	async function paginate(path) {
+		const items = [];
+		let next = path.includes('per_page=') ? path : `${path}${path.includes('?') ? '&' : '?'}per_page=100`;
+		while (next) {
+			const response = await request('GET', next);
+			const page = await response.json();
+			items.push(...(Array.isArray(page) ? page : []));
+			next = response.headers.get('link')?.match(/<([^>]+)>;\s*rel="next"/)?.[1] ?? null;
+		}
+		return items;
+	}
+
+	return {
+		get: (path) => json('GET', path),
+		post: (path, body) => json('POST', path, { body }),
+		patch: (path, body) => json('PATCH', path, { body }),
+		paginate,
+	};
+}
+
+/** `owner/repo` of the current workflow run. */
+export function repositoryFromEnv() {
+	const repository = process.env.GITHUB_REPOSITORY;
+	if (!repository) throw new Error('GITHUB_REPOSITORY is not set');
+	return repository;
+}
+
+/** Appends `name=value` lines to $GITHUB_OUTPUT when running in Actions, always echoes them. */
+export function setOutputs(outputs) {
+	const lines = Object.entries(outputs).map(([name, value]) => `${name}=${value ?? ''}`);
+	console.log(lines.join('\n'));
+	if (process.env.GITHUB_OUTPUT) {
+		fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+	}
+}

--- a/scripts/visual-review/merge-reports.mjs
+++ b/scripts/visual-review/merge-reports.mjs
@@ -1,0 +1,180 @@
+/**
+ * Merges the per-package reports of one CI run (artifacts `visual-review-<package>`) into the folder
+ * that is published to gh-pages as `visual/pr-<n>/`:
+ *
+ *   report.json                       – one document for all packages (schema below)
+ *   <package>/<name>.<kind>.png       – expected/actual/diff of changed, added and removed items
+ *
+ * The artifacts come from the pull request's own CI run, i.e. from untrusted code. Everything is
+ * validated against a strict shape before a byte is copied: package and item names must match the
+ * kebab-case patterns of the spec, image paths must be exactly `<package>/<name>.<kind>.png`, and
+ * nothing outside the artifact folder is read.
+ *
+ *   node scripts/visual-review/merge-reports.mjs <downloadDir> <outDir> --pr <n> --head <sha> --repository owner/repo --run <id>
+ */
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const NAME = /^[a-z0-9]+(-[a-z0-9]+)*(--[a-z0-9]+(-[a-z0-9]+)*)?$/;
+export const PACKAGE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+export const STATUSES = new Set(['unchanged', 'changed', 'added', 'removed', 'error']);
+const KINDS = ['expected', 'actual', 'diff'];
+const HASH = /^sha256:[0-9a-f]{64}$/;
+
+export function mergeReports(downloadDir, outDir, context) {
+	const reports = [];
+	for (const entry of fs.readdirSync(downloadDir, { withFileTypes: true })) {
+		if (!entry.isDirectory() || !entry.name.startsWith('visual-review-')) continue;
+		const file = path.join(downloadDir, entry.name, 'report.json');
+		if (!fs.existsSync(file)) continue;
+		reports.push({ dir: path.join(downloadDir, entry.name), report: JSON.parse(fs.readFileSync(file, 'utf8')) });
+	}
+	if (reports.length === 0) throw new Error(`No visual-review-* artifacts with a report.json under ${downloadDir}`);
+
+	fs.rmSync(outDir, { recursive: true, force: true });
+	fs.mkdirSync(outDir, { recursive: true });
+
+	const packages = reports.map(({ dir, report }) => validateAndCopy(dir, report, outDir)).sort((a, b) => a.package.localeCompare(b.package));
+
+	const summary = { unchanged: 0, changed: 0, added: 0, removed: 0, error: 0 };
+	for (const pkg of packages) {
+		for (const status of Object.keys(summary)) summary[status] += pkg.summary[status];
+	}
+	const digest = `sha256:${crypto
+		.createHash('sha256')
+		.update(packages.map((pkg) => `${pkg.package}:${pkg.digest}`).join('\n'))
+		.digest('hex')}`;
+
+	const merged = {
+		schema: 1,
+		pr: context.pr,
+		head: context.head,
+		repository: context.repository,
+		runId: context.runId,
+		generatedAt: new Date().toISOString(),
+		digest,
+		baseline: baselineOf(packages),
+		summary,
+		packages,
+	};
+	fs.writeFileSync(path.join(outDir, 'report.json'), JSON.stringify(merged, null, '\t'));
+	return merged;
+}
+
+function validateAndCopy(dir, report, outDir) {
+	const name = report.package;
+	if (report.schema !== 1) throw new Error(`${dir}: unsupported report schema ${report.schema}`);
+	if (report.mode !== 'compare') throw new Error(`${name}: report is a "${report.mode}" manifest, not a comparison`);
+	if (typeof name !== 'string' || !PACKAGE.test(name)) throw new Error(`${dir}: invalid package name ${JSON.stringify(name)}`);
+	if (!Array.isArray(report.items)) throw new Error(`${name}: items missing`);
+
+	const summary = { unchanged: 0, changed: 0, added: 0, removed: 0, error: 0 };
+	const items = report.items.map((item) => {
+		if (typeof item.name !== 'string' || !NAME.test(item.name)) throw new Error(`${name}: invalid item name ${JSON.stringify(item.name)}`);
+		if (!STATUSES.has(item.status)) throw new Error(`${name}/${item.name}: invalid status ${JSON.stringify(item.status)}`);
+		if (!HASH.test(item.hash ?? '')) throw new Error(`${name}/${item.name}: invalid hash`);
+		summary[item.status] += 1;
+		const clean = { name: item.name, route: String(item.route ?? '').slice(0, 200), status: item.status, hash: item.hash };
+		if (Number.isFinite(item.diffPixels)) clean.diffPixels = item.diffPixels;
+		if (Number.isFinite(item.diffRatio)) clean.diffRatio = item.diffRatio;
+		if (item.sizeMismatch && Array.isArray(item.sizeMismatch.expected) && Array.isArray(item.sizeMismatch.actual)) {
+			clean.sizeMismatch = { expected: item.sizeMismatch.expected.slice(0, 2).map(Number), actual: item.sizeMismatch.actual.slice(0, 2).map(Number) };
+		}
+		if (typeof item.message === 'string') clean.message = item.message.slice(0, 500);
+		for (const kind of KINDS) {
+			if (item[kind] === undefined) continue;
+			const expectedPath = `${name}/${item.name}.${kind}.png`;
+			if (item[kind] !== expectedPath) throw new Error(`${name}/${item.name}: unexpected ${kind} path ${JSON.stringify(item[kind])}`);
+			const source = path.join(dir, name, `${item.name}.${kind}.png`);
+			if (!fs.existsSync(source)) throw new Error(`${name}/${item.name}: ${kind} image missing in artifact`);
+			const target = path.join(outDir, name, `${item.name}.${kind}.png`);
+			fs.mkdirSync(path.dirname(target), { recursive: true });
+			fs.copyFileSync(source, target);
+			clean[kind] = expectedPath;
+		}
+		return clean;
+	});
+	if (typeof report.summary === 'object') {
+		for (const status of Object.keys(summary)) {
+			if ((report.summary[status] ?? 0) !== summary[status]) throw new Error(`${name}: summary.${status} disagrees with the items`);
+		}
+	}
+	const errors = (Array.isArray(report.errors) ? report.errors : []).map((error) => ({
+		test: String(error.test ?? '').slice(0, 200),
+		route: String(error.route ?? '').slice(0, 200),
+		message: String(error.message ?? '').slice(0, 500),
+	}));
+	return {
+		package: name,
+		themeDir: String(report.themeDir ?? '').slice(0, 100),
+		baseline: {
+			files: Number(report.baseline?.files ?? 0),
+			meta: sanitizeMeta(report.baseline?.meta),
+		},
+		summary,
+		digest: HASH.test(report.digest ?? '') ? report.digest : null,
+		items,
+		errors,
+	};
+}
+
+function sanitizeMeta(meta) {
+	if (!meta || typeof meta !== 'object') return null;
+	const text = (value, max = 200) => (typeof value === 'string' ? value.slice(0, max) : null);
+	return {
+		sha: text(meta.sha, 40),
+		ref: text(meta.ref),
+		runId: Number.isFinite(meta.runId) ? meta.runId : null,
+		image: text(meta.image),
+		playwright: text(meta.playwright, 20),
+		createdAt: text(meta.createdAt, 40),
+		digest: HASH.test(meta.digest ?? '') ? meta.digest : null,
+		fallback: text(meta.fallback, 40),
+		distance: Number.isFinite(meta.distance) ? meta.distance : null,
+		imageMismatch: meta.imageMismatch === true,
+	};
+}
+
+/** The baseline the packages compared against – identical for all of them by construction. */
+function baselineOf(packages) {
+	const metas = packages.map((pkg) => pkg.baseline.meta).filter(Boolean);
+	if (metas.length === 0) return null;
+	const first = metas[0];
+	return {
+		sha: first.sha,
+		ref: first.ref,
+		image: first.image,
+		playwright: first.playwright,
+		fallback: first.fallback,
+		distance: first.distance,
+		imageMismatch: metas.some((meta) => meta.imageMismatch),
+		consistent: metas.every((meta) => meta.sha === first.sha),
+	};
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const [downloadDir, outDir, ...rest] = process.argv.slice(2);
+	const options = {};
+	for (let i = 0; i < rest.length; i += 2) options[rest[i].replace(/^--/, '')] = rest[i + 1];
+	if (!downloadDir || !outDir || !options.pr || !options.head) {
+		console.error('Usage: node merge-reports.mjs <downloadDir> <outDir> --pr <n> --head <sha> --repository owner/repo --run <id>');
+		process.exit(2);
+	}
+	try {
+		const merged = mergeReports(downloadDir, outDir, {
+			pr: Number(options.pr),
+			head: options.head,
+			repository: options.repository ?? process.env.GITHUB_REPOSITORY ?? null,
+			runId: options.run ? Number(options.run) : null,
+		});
+		const { summary } = merged;
+		console.log(
+			`PR #${merged.pr}: ${merged.packages.length} packages – ${summary.unchanged} unchanged, ${summary.changed} changed, ${summary.added} added, ${summary.removed} removed, ${summary.error} error`,
+		);
+	} catch (error) {
+		console.error(`::error::${error.message}`);
+		process.exit(1);
+	}
+}

--- a/scripts/visual-review/resolve-context.mjs
+++ b/scripts/visual-review/resolve-context.mjs
@@ -1,0 +1,91 @@
+/**
+ * Works out what the "Visual Review" workflow has to do for the event that triggered it:
+ *
+ *   publish    a CI run of a pull request finished → download its reports, publish, compute the status
+ *   no-visual  the CI run skipped the visual tests → nothing to review, status success
+ *   status     a reviewer comment changed → recompute the status from the published report
+ *   pending    a pull request was pushed → status pending until its CI run finishes
+ *   docs-only  the push touched only files ci.yml ignores → CI never runs, status success
+ *   skip       nothing to do (bot comment, closed pull request, cancelled run, …)
+ *
+ * Outputs: mode, pr, head, run_id, reason.
+ */
+import * as fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { createApi, repositoryFromEnv, setOutputs } from './github-api.mjs';
+
+/** Mirrors `paths-ignore` of the pull_request trigger in .github/workflows/ci.yml – keep in sync. */
+export const CI_IGNORED_PATHS = ['*.md', 'docs/**', 'LICENSE', '.github/ISSUE_TEMPLATE/**', '.github/PULL_REQUEST_TEMPLATE/**'];
+const VISUAL_JOB = /^visual-tests \(/;
+
+function globToRegExp(glob) {
+	const source = glob
+		.split('**')
+		.map((part) => part.split('*').map(escapeRegExp).join('[^/]*'))
+		.join('.*');
+	return new RegExp(`^${source}$`);
+}
+
+const IGNORED = CI_IGNORED_PATHS.map(globToRegExp);
+
+export function isIgnoredByCi(file) {
+	return IGNORED.some((pattern) => pattern.test(file));
+}
+
+export async function resolveContext({ eventName, event, api, repository }) {
+	const skip = (reason) => ({ mode: 'skip', pr: null, head: null, runId: null, reason });
+
+	switch (eventName) {
+		case 'workflow_run': {
+			const run = event.workflow_run;
+			if (run.event !== 'pull_request') return skip(`run of a ${run.event} event`);
+			if (run.conclusion === 'cancelled') return skip('run was cancelled');
+			const pulls = await api.get(`repos/${repository}/commits/${run.head_sha}/pulls`);
+			const pull = pulls.find((candidate) => candidate.state === 'open' && candidate.base.repo.full_name === repository && candidate.head.sha === run.head_sha);
+			if (!pull) return skip(`no open pull request for ${run.head_sha}`);
+			const jobs = await api.paginate(`repos/${repository}/actions/runs/${run.id}/jobs`);
+			const visual = jobs.filter((job) => VISUAL_JOB.test(job.name));
+			if (visual.length === 0 || visual.every((job) => job.conclusion === 'skipped')) {
+				return { mode: 'no-visual', pr: pull.number, head: run.head_sha, runId: run.id, reason: 'visual tests did not run' };
+			}
+			return { mode: 'publish', pr: pull.number, head: run.head_sha, runId: run.id, reason: `CI run ${run.id} completed` };
+		}
+		case 'issue_comment': {
+			if (!event.issue?.pull_request) return skip('comment on an issue');
+			if (event.comment?.user?.type === 'Bot') return skip('bot comment');
+			const pull = await api.get(`repos/${repository}/pulls/${event.issue.number}`);
+			if (pull.state !== 'open') return skip('pull request is closed');
+			return { mode: 'status', pr: pull.number, head: pull.head.sha, runId: null, reason: `comment ${event.action} by ${event.comment.user.login}` };
+		}
+		case 'pull_request_target': {
+			const pull = event.pull_request;
+			const files = await api.paginate(`repos/${repository}/pulls/${pull.number}/files`);
+			const docsOnly = files.length > 0 && files.every((file) => isIgnoredByCi(file.filename));
+			return { mode: docsOnly ? 'docs-only' : 'pending', pr: pull.number, head: pull.head.sha, runId: null, reason: `pull request ${event.action}` };
+		}
+		case 'workflow_dispatch': {
+			const number = Number(event.inputs?.pr);
+			if (!number) return skip('no pull request number given');
+			const pull = await api.get(`repos/${repository}/pulls/${number}`);
+			if (pull.state !== 'open') return skip('pull request is closed');
+			return { mode: 'status', pr: pull.number, head: pull.head.sha, runId: null, reason: 'manual run' };
+		}
+		default:
+			return skip(`unsupported event ${eventName}`);
+	}
+}
+
+function escapeRegExp(text) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	try {
+		const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+		const context = await resolveContext({ eventName: process.env.GITHUB_EVENT_NAME, event, api: createApi(), repository: repositoryFromEnv() });
+		setOutputs({ mode: context.mode, pr: context.pr, head: context.head, run_id: context.runId, reason: context.reason });
+	} catch (error) {
+		console.error(`::error::${error.message}`);
+		process.exit(1);
+	}
+}

--- a/scripts/visual-review/review-comment.mjs
+++ b/scripts/visual-review/review-comment.mjs
@@ -1,0 +1,61 @@
+/**
+ * The reviewer comment – one pull-request comment per reviewer that carries the approvals as a
+ * machine-readable block:
+ *
+ *   <!-- visual-review:v1
+ *   {"approveAll":{"digest":"sha256:…"},
+ *    "approvals":[{"item":"theme-default/button-basic--variants","hash":"sha256:…"}],
+ *    "rejects":[],
+ *    "notes":[{"item":"theme-kern/alert-basic--error","hash":"sha256:…","text":"1px border"}]}
+ *   -->
+ *   ✅ **Visual Review** – …human-readable summary…
+ *
+ * `item` is `<package>/<snapshot name>`, `hash` the content hash from report.json. Approvals bind to
+ * hashes, not to commits: a push that leaves an approved screenshot untouched keeps its approval.
+ * `approveAll.digest` approves the whole report whose digest matches – the way to approve hundreds of
+ * changes (browser bump) without exceeding GitHub's comment size.
+ *
+ * The review page (packages/tools/visual-tests/review-ui) writes this format; the status workflow
+ * reads it. Keep both in sync.
+ */
+export const MARKER = 'visual-review:v1';
+const BLOCK = /<!--\s*visual-review:v1\s*([\s\S]*?)-->/;
+const ITEM_KEY = /^[a-z0-9-]+\/[a-z0-9-]+$/;
+const HASH = /^sha256:[0-9a-f]{64}$/;
+
+/** Parses the block of a comment body; `null` when the comment carries none or an invalid one. */
+export function parseReviewComment(body) {
+	const block = body?.match(BLOCK)?.[1];
+	if (!block) return null;
+	let data;
+	try {
+		data = JSON.parse(block);
+	} catch {
+		return null;
+	}
+	if (!data || typeof data !== 'object') return null;
+	const entries = (list, withText = false) =>
+		(Array.isArray(list) ? list : [])
+			.filter((entry) => entry && typeof entry === 'object' && ITEM_KEY.test(entry.item ?? '') && (entry.hash === undefined || HASH.test(entry.hash)))
+			.map((entry) => ({ item: entry.item, hash: entry.hash, ...(withText ? { text: String(entry.text ?? '').slice(0, 2000) } : {}) }));
+	return {
+		approveAll: HASH.test(data.approveAll?.digest ?? '') ? { digest: data.approveAll.digest } : undefined,
+		approvals: entries(data.approvals),
+		rejects: entries(data.rejects),
+		notes: entries(data.notes, true),
+	};
+}
+
+/** Human-readable comment with the block in front – what the review page posts. */
+export function formatReviewComment(data, { pageUrl, summary }) {
+	const block = JSON.stringify({
+		approveAll: data.approveAll,
+		approvals: data.approvals ?? [],
+		rejects: data.rejects ?? [],
+		notes: data.notes ?? [],
+	});
+	const lines = [`<!-- ${MARKER}`, block, '-->', `**Visual Review** – ${summary} ([review page](${pageUrl}))`];
+	for (const reject of data.rejects ?? []) lines.push(`- ❌ \`${reject.item}\``);
+	for (const note of data.notes ?? []) lines.push(`- 💬 \`${note.item}\`: ${note.text}`);
+	return lines.join('\n');
+}

--- a/scripts/visual-review/review-status.mjs
+++ b/scripts/visual-review/review-status.mjs
@@ -1,0 +1,113 @@
+/**
+ * Turns a merged report plus the reviewers' comments into the state of the `Visual Review` commit
+ * status and the `status.json` the review page shows. Pure – no I/O.
+ *
+ * Rules:
+ * - any route error → failure (the comparison itself is broken, nothing to approve)
+ * - an item is approved when a reviewer with write access approved its hash (or the whole report
+ *   digest) and nobody rejected that hash; a rejection wins over an approval → failure
+ * - success once every changed/added/removed item is approved; pending otherwise
+ */
+export const NEEDS_APPROVAL = new Set(['changed', 'added', 'removed']);
+export const WRITE_ROLES = new Set(['write', 'maintain', 'admin']);
+const DESCRIPTION_LIMIT = 140;
+
+export function itemKey(pkg, item) {
+	return `${pkg.package}/${item.name}`;
+}
+
+/**
+ * @param report merged report.json
+ * @param reviews [{ author, role, data, updatedAt }] – `data` as parsed by review-comment.mjs, `role`
+ *   the author's repository permission (`admin`, `maintain`, `write`, `triage`, `read`, `none`)
+ */
+export function computeStatus(report, reviews) {
+	const trusted = reviews.filter((review) => review.data && WRITE_ROLES.has(review.role));
+	const items = {};
+	let open = 0;
+	let approved = 0;
+	let rejected = 0;
+	let errorItems = 0;
+
+	for (const pkg of report.packages) {
+		for (const item of pkg.items) {
+			if (item.status === 'error') errorItems += 1;
+			if (!NEEDS_APPROVAL.has(item.status)) continue;
+			const key = itemKey(pkg, item);
+			const state = { state: 'open', notes: [] };
+			for (const review of trusted) {
+				const approves =
+					review.data.approveAll?.digest === report.digest || review.data.approvals.some((entry) => entry.item === key && entry.hash === item.hash);
+				const rejects = review.data.rejects.some((entry) => entry.item === key && entry.hash === item.hash);
+				for (const note of review.data.notes) {
+					if (note.item === key) state.notes.push({ by: review.author, text: note.text });
+				}
+				if (rejects) {
+					state.state = 'rejected';
+					state.by = review.author;
+				} else if (approves && state.state !== 'rejected') {
+					state.state = 'approved';
+					state.by = review.author;
+				}
+			}
+			if (state.state === 'open') open += 1;
+			if (state.state === 'approved') approved += 1;
+			if (state.state === 'rejected') rejected += 1;
+			items[key] = state;
+		}
+	}
+
+	const routeErrors = report.packages.reduce((sum, pkg) => sum + (pkg.errors?.length ?? 0), 0);
+	const changes = open + approved + rejected;
+	const reviewers = [...new Set(trusted.map((review) => review.author))];
+	let state;
+	let description;
+	if (routeErrors > 0 || errorItems > 0) {
+		state = 'failure';
+		description = `${routeErrors} route(s) failed before the screenshots could be compared`;
+	} else if (rejected > 0) {
+		state = 'failure';
+		description = `${rejected} of ${changes} visual changes rejected`;
+	} else if (open > 0) {
+		state = 'pending';
+		description = `${describeChanges(report)} – ${approved} of ${changes} approved, review pending`;
+	} else if (changes > 0) {
+		state = 'success';
+		description = `${changes} visual changes approved by ${reviewers.join(', ')}`;
+	} else {
+		state = 'success';
+		description = 'No visual changes';
+	}
+
+	return {
+		state,
+		description: truncate(description),
+		status: {
+			schema: 1,
+			state,
+			description: truncate(description),
+			computedAt: new Date().toISOString(),
+			pr: report.pr,
+			head: report.head,
+			digest: report.digest,
+			counts: { changes, open, approved, rejected, routeErrors, errorItems },
+			reviewers,
+			items,
+		},
+	};
+}
+
+function describeChanges(report) {
+	const totals = { changed: 0, added: 0, removed: 0 };
+	for (const pkg of report.packages) {
+		for (const status of Object.keys(totals)) totals[status] += pkg.summary?.[status] ?? 0;
+	}
+	return Object.entries(totals)
+		.filter(([, count]) => count > 0)
+		.map(([status, count]) => `${count} ${status}`)
+		.join(', ');
+}
+
+function truncate(text) {
+	return text.length > DESCRIPTION_LIMIT ? `${text.slice(0, DESCRIPTION_LIMIT - 1)}…` : text;
+}

--- a/scripts/visual-review/update-review.mjs
+++ b/scripts/visual-review/update-review.mjs
@@ -1,0 +1,136 @@
+/**
+ * Sets the `Visual Review` commit status of a pull request and keeps the bot comment current.
+ *
+ *   node scripts/visual-review/update-review.mjs --mode publish|status --pr <n> --head <sha> --report <report.json> --status-out <status.json> --page-url <url>
+ *   node scripts/visual-review/update-review.mjs --mode pending|docs-only|no-visual --pr <n> --head <sha> --page-url <url>
+ *
+ * publish/status: reads the reviewers' comments, checks their repository permission, computes the
+ * status (review-status.mjs), writes status.json next to the report and upserts the summary comment.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { createApi, repositoryFromEnv } from './github-api.mjs';
+import { parseReviewComment } from './review-comment.mjs';
+import { computeStatus } from './review-status.mjs';
+
+export const STATUS_CONTEXT = 'Visual Review';
+export const COMMENT_MARKER = '<!-- visual-review -->';
+
+const EARLY_STATES = {
+	pending: { state: 'pending', description: 'Waiting for the visual tests' },
+	'docs-only': { state: 'success', description: 'No visual-relevant changes' },
+	'no-visual': { state: 'success', description: 'Visual tests were skipped for this change' },
+};
+
+export async function updateReview({ api, repository, mode, pr, head, reportFile, statusOut, pageUrl }) {
+	const targetUrl = `${pageUrl}?pr=${pr}`;
+	if (EARLY_STATES[mode]) {
+		await setCommitStatus(api, repository, head, { ...EARLY_STATES[mode], targetUrl });
+		return EARLY_STATES[mode];
+	}
+
+	const report = JSON.parse(fs.readFileSync(reportFile, 'utf8'));
+	const comments = await api.paginate(`repos/${repository}/issues/${pr}/comments`);
+	const reviews = await collectReviews(api, repository, comments);
+	const result = computeStatus(report, reviews);
+
+	fs.mkdirSync(path.dirname(statusOut), { recursive: true });
+	fs.writeFileSync(statusOut, JSON.stringify(result.status, null, '\t'));
+	// The status belongs to the commit the report describes. After a new push the published report can
+	// still be the previous one; the new head keeps the "pending" set on push until its own run publishes.
+	await setCommitStatus(api, repository, report.head ?? head, { state: result.state, description: result.description, targetUrl });
+	await upsertComment(api, repository, pr, comments, buildComment(report, result, targetUrl));
+	return result;
+}
+
+async function collectReviews(api, repository, comments) {
+	const roles = new Map();
+	const reviews = [];
+	for (const comment of comments) {
+		if (comment.user?.type === 'Bot') continue;
+		const data = parseReviewComment(comment.body);
+		if (!data) continue;
+		const login = comment.user.login;
+		if (!roles.has(login)) {
+			roles.set(
+				login,
+				await api
+					.get(`repos/${repository}/collaborators/${login}/permission`)
+					.then((permission) => permission.role_name ?? permission.permission ?? 'none')
+					.catch(() => 'none'),
+			);
+		}
+		reviews.push({ author: login, role: roles.get(login), data, updatedAt: comment.updated_at });
+	}
+	return reviews;
+}
+
+async function setCommitStatus(api, repository, sha, { state, description, targetUrl }) {
+	await api.post(`repos/${repository}/statuses/${sha}`, { state, description, context: STATUS_CONTEXT, target_url: targetUrl });
+	console.log(`${STATUS_CONTEXT} on ${sha.slice(0, 10)}: ${state} – ${description}`);
+}
+
+async function upsertComment(api, repository, pr, comments, body) {
+	const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+	if (existing) {
+		if (existing.body === body) return;
+		await api.patch(`repos/${repository}/issues/comments/${existing.id}`, { body });
+	} else {
+		await api.post(`repos/${repository}/issues/${pr}/comments`, { body });
+	}
+}
+
+const STATE_ICON = { success: '✅', pending: '🟡', failure: '❌' };
+
+export function buildComment(report, result, targetUrl) {
+	const lines = [COMMENT_MARKER, '## 📸 Visual Review', '', `${STATE_ICON[result.state]} **${result.description}**`, ''];
+	lines.push('| Package | unchanged | changed | added | removed | error |', '| --- | --: | --: | --: | --: | --: |');
+	for (const pkg of report.packages) {
+		const { summary } = pkg;
+		lines.push(`| \`${pkg.package}\` | ${summary.unchanged} | ${summary.changed} | ${summary.added} | ${summary.removed} | ${summary.error} |`);
+	}
+	lines.push('');
+	if (report.baseline?.sha) {
+		const extra = [report.baseline.fallback ? `fallback: ${report.baseline.fallback}` : null, report.baseline.imageMismatch ? 'Playwright image differs' : null]
+			.filter(Boolean)
+			.join(', ');
+		lines.push(`Baseline: \`${report.baseline.sha.slice(0, 10)}\` (${report.baseline.ref})${extra ? ` – ${extra}` : ''}`, '');
+	}
+	const failed = report.packages.flatMap((pkg) => pkg.errors.map((error) => `- \`${pkg.package}\` ${error.route}: ${error.message}`));
+	if (failed.length > 0) {
+		lines.push('Routes that could not be compared:', ...failed.slice(0, 20), '');
+	}
+	lines.push(`[Open the review page](${targetUrl}) to inspect the differences and approve them.`);
+	if (result.status?.counts?.changes > 0) {
+		lines.push('', `Approvals: ${result.status.counts.approved} approved, ${result.status.counts.open} open, ${result.status.counts.rejected} rejected.`);
+	}
+	lines.push('', `Commit: \`${report.head.slice(0, 10)}\``);
+	return lines.join('\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	const options = {};
+	const args = process.argv.slice(2);
+	for (let i = 0; i < args.length; i += 2) options[args[i].replace(/^--/, '')] = args[i + 1];
+	const mode = options.mode;
+	if (!mode || !options.pr || !options.head || !options['page-url'] || (!EARLY_STATES[mode] && (!options.report || !options['status-out']))) {
+		console.error('Usage: node update-review.mjs --mode <mode> --pr <n> --head <sha> --page-url <url> [--report <file> --status-out <file>]');
+		process.exit(2);
+	}
+	try {
+		await updateReview({
+			api: createApi(),
+			repository: repositoryFromEnv(),
+			mode,
+			pr: Number(options.pr),
+			head: options.head,
+			reportFile: options.report,
+			statusOut: options['status-out'],
+			pageUrl: options['page-url'],
+		});
+	} catch (error) {
+		console.error(`::error::${error.message}`);
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
## What changed?

Adds the review page and status workflow for the visual review (PR C of four, #9101). A new `.github/workflows/visual-review.yml` runs in the base-repository context (so it also works for forks and never checks out pull-request code): on the CI-Pipeline `workflow_run` it downloads, validates and merges the `visual-review-*` artifacts, publishes `visual/pr-<n>/` on gh-pages, computes the **Visual Review** commit status and upserts a summary comment; `issue_comment` and `pull_request_target` triggers recompute the status and handle the docs-only/pending cases. `scripts/visual-review/review-status.mjs` holds the (unit-tested) approval rules — an item is approved when a write-access user approved its content hash or the whole report digest, a rejection wins, any route error fails, and approvals survive pushes that leave the screenshot untouched. A new React + Vite review page under `packages/tools/visual-tests/review-ui` (deployed by `visual-review-ui.yml`) lets reviewers compare snapshots (side-by-side / slider / onion-skin / diff / blink, zoom, keyboard shortcuts, deep links) and approve/reject/note per item, saving via a fine-grained token or a copyable comment. gh-pages deploys switch to `force: false` with retries to stop concurrent workflows dropping each other's commits, and `pr-preview-cleanup.yml` also removes `visual/pr-<n>`. Docs (`docs/visual-review.md`, `scripts/README.md`) are added. This is internal test/review tooling — the published component library is unchanged.

## Linked issues

- Refs #9101 — visual review epic this series implements
- Refs #10768, #10769 — PRs A/B of the same series (reporter, baseline artifacts)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Ergänzt die Review-Seite und den Status-Workflow für das Visual Review (PR C von vier, #9101). Der neue Workflow `.github/workflows/visual-review.yml` läuft im Kontext des Basis-Repositories (funktioniert damit auch für Forks und checkt niemals Pull-Request-Code aus): beim `workflow_run` der CI-Pipeline lädt, validiert und mergt er die `visual-review-*`-Artefakte, veröffentlicht `visual/pr-<n>/` auf gh-pages, berechnet den Commit-Status **Visual Review** und aktualisiert einen Zusammenfassungs-Kommentar; die Trigger `issue_comment` und `pull_request_target` berechnen den Status neu bzw. behandeln Docs-only-/Pending-Fälle. `scripts/visual-review/review-status.mjs` enthält die (Unit-getesteten) Freigaberegeln — ein Item ist freigegeben, wenn ein Nutzer mit Schreibrechten seinen Content-Hash oder den gesamten Report-Digest freigibt, eine Ablehnung gewinnt, ein Routenfehler schlägt fehl, und Freigaben überstehen Pushes, die den Screenshot unverändert lassen. Eine neue React-+-Vite-Review-Seite unter `packages/tools/visual-tests/review-ui` (deployt durch `visual-review-ui.yml`) erlaubt den Vergleich von Snapshots (Side-by-side / Slider / Onion-Skin / Diff / Blink, Zoom, Tastenkürzel, Deep Links) und Freigabe/Ablehnung/Notiz je Item, gespeichert per feingranularem Token oder kopierbarem Kommentar. gh-pages-Deploys nutzen nun `force: false` mit Retries, damit gleichzeitige Workflows sich nicht gegenseitig überschreiben; `pr-preview-cleanup.yml` entfernt zusätzlich `visual/pr-<n>`. Dokumentation ergänzt. Internes Test-/Review-Tooling — die veröffentlichte Komponentenbibliothek ändert sich nicht.

### Verknüpfte Tickets

- Referenziert #9101 — Visual-Review-Epic, das diese Serie umsetzt
- Referenziert #10768, #10769 — PRs A/B derselben Serie (Reporter, Baseline-Artefakte)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/visual-review.yml` — Workflow für Publish/Status im Basis-Repo-Kontext
- `.github/workflows/visual-review-ui.yml` / `pr-preview-cleanup.yml` — Deploy der Review-Seite bzw. Cleanup, Push mit Retries
- `scripts/visual-review/review-status.mjs` / `review-comment.mjs` — Freigaberegeln und Kommentar-Format
- `packages/tools/visual-tests/review-ui/**` — React-+-Vite-Review-Seite mit Vergleichsansichten und Freigabe
- `docs/visual-review.md`, `scripts/README.md` — Dokumentation des Review-Flows

</details>