### PR TITLE
fix(visual-review): accept upper-case snapshot names, report failed publishes

### DIFF
--- a/.github/workflows/visual-review.yml
+++ b/.github/workflows/visual-review.yml
@@ -133,3 +133,9 @@ jobs:
           force: false
           attempt-limit: 10
           commit-message: 'visual review: status of PR #${{ env.PR }}'
+
+      # A broken publish must not leave the pull request on "pending" forever: report the failure as
+      # the status itself, with the run as target, so the reviewer sees what to fix.
+      - name: Report a failed publish
+        if: failure() && env.MODE == 'publish'
+        run: node scripts/visual-review/update-review.mjs --mode failed --pr "$PR" --head "$HEAD" --page-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/packages/tools/visual-tests/test/merge-reports.test.mjs
+++ b/packages/tools/visual-tests/test/merge-reports.test.mjs
@@ -126,6 +126,19 @@ describe('mergeReports', () => {
 		}
 	});
 
+	it('accepts the names the spec produces: route segments in either case plus the block id', () => {
+		const names = ['combobox-basic-noColumns--hide-label-error', 'input-checkbox-basic-noColumns', 'button-basic--variants-320', 'abbr_basic--x'];
+		artifact(downloadDir, 'theme-default', {
+			summary: { unchanged: names.length, changed: 0, added: 0, removed: 0, error: 0 },
+			digest: H(1),
+			items: names.map((name) => ({ name, status: 'unchanged', hash: H(2) })),
+		});
+		assert.deepEqual(
+			mergeReports(downloadDir, outDir, { pr: 1, head: 'x' }).packages[0].items.map((item) => item.name),
+			names,
+		);
+	});
+
 	it('fails without artifacts', () => {
 		assert.throws(() => mergeReports(downloadDir, outDir, { pr: 1, head: 'x' }), /No visual-review-\* artifacts/);
 	});

--- a/scripts/visual-review/merge-reports.mjs
+++ b/scripts/visual-review/merge-reports.mjs
@@ -17,7 +17,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-export const NAME = /^[a-z0-9]+(-[a-z0-9]+)*(--[a-z0-9]+(-[a-z0-9]+)*)?$/;
+// Snapshot names are the route (`combobox/basic?noColumns` → `combobox-basic-noColumns`) plus `--<block>`:
+// letters of either case, digits, `_` and `-` – never `/`, `.` or whitespace, which keeps them safe as file names.
+export const NAME = /^[A-Za-z0-9_]+(-+[A-Za-z0-9_]+)*$/;
 export const PACKAGE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 export const STATUSES = new Set(['unchanged', 'changed', 'added', 'removed', 'error']);
 const KINDS = ['expected', 'actual', 'diff'];

--- a/scripts/visual-review/update-review.mjs
+++ b/scripts/visual-review/update-review.mjs
@@ -2,7 +2,7 @@
  * Sets the `Visual Review` commit status of a pull request and keeps the bot comment current.
  *
  *   node scripts/visual-review/update-review.mjs --mode publish|status --pr <n> --head <sha> --report <report.json> --status-out <status.json> --page-url <url>
- *   node scripts/visual-review/update-review.mjs --mode pending|docs-only|no-visual --pr <n> --head <sha> --page-url <url>
+ *   node scripts/visual-review/update-review.mjs --mode pending|docs-only|no-visual|failed --pr <n> --head <sha> --page-url <url>
  *
  * publish/status: reads the reviewers' comments, checks their repository permission, computes the
  * status (review-status.mjs), writes status.json next to the report and upserts the summary comment.
@@ -21,10 +21,13 @@ const EARLY_STATES = {
 	pending: { state: 'pending', description: 'Waiting for the visual tests' },
 	'docs-only': { state: 'success', description: 'No visual-relevant changes' },
 	'no-visual': { state: 'success', description: 'Visual tests were skipped for this change' },
+	// The workflow itself broke (invalid report, download error, …) – say so instead of leaving "pending" forever.
+	failed: { state: 'error', description: 'The Visual Review workflow failed – see its run' },
 };
 
 export async function updateReview({ api, repository, mode, pr, head, reportFile, statusOut, pageUrl }) {
-	const targetUrl = `${pageUrl}?pr=${pr}`;
+	// A failed publish points at its workflow run instead of the review page.
+	const targetUrl = mode === 'failed' ? pageUrl : `${pageUrl}?pr=${pr}`;
 	if (EARLY_STATES[mode]) {
 		await setCommitStatus(api, repository, head, { ...EARLY_STATES[mode], targetUrl });
 		return EARLY_STATES[mode];


### PR DESCRIPTION
## What changed?

Fixes the internal "Visual Review" publish workflow, which failed for every run since #10781 and left pull requests stuck on *Visual Review – pending* forever. In `scripts/visual-review/merge-reports.mjs` the `NAME` validation pattern was rejecting snapshot names derived from sample routes (e.g. `combobox-basic-noColumns--hide-label-error`) because it only allowed lower-case kebab-case; the pattern now accepts letters of either case, digits, `_` and `-` while still excluding `/`, `.` and whitespace so names stay safe as file names. `scripts/visual-review/update-review.mjs` gains a new `failed` mode that sets the commit status to `error` (targeting the workflow run) so a broken publish reports the failure instead of leaving "pending", and `.github/workflows/visual-review.yml` invokes it on `failure()` during publish. A unit test with the real name shapes was added. This affects only internal test tooling — the published component library is unchanged.

## Linked issues

- Refs #10781 — introduced the route-derived snapshot names that broke the pattern
- Refs #10788, #10783 — pull requests left stuck on "pending" by the failing workflow

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt den internen „Visual Review"-Publish-Workflow, der seit #10781 bei jedem Lauf fehlschlug und Pull Requests dauerhaft auf *Visual Review – pending* stehen ließ. In `scripts/visual-review/merge-reports.mjs` verwarf das `NAME`-Muster die aus Sample-Routen abgeleiteten Snapshot-Namen (z. B. `combobox-basic-noColumns--hide-label-error`), weil es nur Kleinbuchstaben-Kebab-Case zuließ; das Muster akzeptiert nun Buchstaben beider Schreibweisen, Ziffern, `_` und `-`, schließt aber weiterhin `/`, `.` und Leerzeichen aus, damit die Namen als Dateinamen sicher bleiben. `scripts/visual-review/update-review.mjs` erhält den neuen Modus `failed`, der den Commit-Status auf `error` (mit dem Workflow-Lauf als Ziel) setzt, sodass ein fehlgeschlagener Publish den Fehler meldet, statt „pending" zu hinterlassen; `.github/workflows/visual-review.yml` ruft dies bei `failure()` im Publish-Schritt auf. Ein Unit-Test mit den echten Namensformen wurde ergänzt. Betroffen ist ausschließlich internes Test-Tooling — die veröffentlichte Komponentenbibliothek ändert sich nicht.

### Verknüpfte Tickets

- Referenziert #10781 — führte die routenbasierten Snapshot-Namen ein, die das Muster brachen
- Referenziert #10788, #10783 — durch den fehlschlagenden Workflow auf „pending" hängengebliebene Pull Requests

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `scripts/visual-review/merge-reports.mjs` — `NAME`-Muster akzeptiert Groß-/Kleinbuchstaben, Ziffern, `_` und `-`
- `scripts/visual-review/update-review.mjs` — neuer Modus `failed` (Commit-Status `error`, Ziel = Workflow-Lauf)
- `.github/workflows/visual-review.yml` — meldet fehlgeschlagenen Publish per neuem `failed`-Modus
- `packages/tools/visual-tests/test/merge-reports.test.mjs` — Test mit den realen Snapshot-Namensformen

</details>