### PR TITLE
fix(visual-review): newest comment per reviewer wins, upper-case item keys

### DIFF
--- a/docs/visual-review.md
+++ b/docs/visual-review.md
@@ -48,7 +48,8 @@ Nothing has to be committed: the baseline is regenerated from `develop` after th
      for `public-ui/kolibri` at the bottom of the page. The page posts (and later edits) one comment
      in your name. The token stays in this browser session unless you tick "remember".
    - **without a token**: click _Copy comment for the pull request_ and paste it as a comment on the
-     pull request.
+     pull request. To change your verdict later, edit that comment or post a new one – only your
+     newest comment counts.
 
 The comment carries a machine-readable block, for example:
 

--- a/packages/tools/visual-tests/review-ui/src/App.tsx
+++ b/packages/tools/visual-tests/review-ui/src/App.tsx
@@ -364,7 +364,7 @@ export function App() {
 						<button type="submit" disabled={!token || !repository}>
 							Connect
 						</button>
-						<span className="hint">Without a token, copy the generated comment and post it on the pull request yourself.</span>
+						<span className="hint">Without a token, copy the generated comment and post it on the pull request yourself. Only your newest comment counts.</span>
 					</form>
 				)}
 			</footer>

--- a/packages/tools/visual-tests/review-ui/src/review-comment.ts
+++ b/packages/tools/visual-tests/review-ui/src/review-comment.ts
@@ -3,7 +3,8 @@ import type { ReviewDraft } from './types';
 
 const MARKER = 'visual-review:v1';
 const BLOCK = /<!--\s*visual-review:v1\s*([\s\S]*?)-->/;
-const ITEM_KEY = /^[a-z0-9-]+\/[a-z0-9-]+$/;
+// `<package>/<snapshot name>` – names keep the case of the sample route (`…-noColumns--label`).
+const ITEM_KEY = /^[a-z0-9-]+\/[A-Za-z0-9_-]+$/;
 const HASH = /^sha256:[0-9a-f]{64}$/;
 
 export function emptyDraft(): ReviewDraft {

--- a/packages/tools/visual-tests/test/review-status.test.mjs
+++ b/packages/tools/visual-tests/test/review-status.test.mjs
@@ -89,6 +89,24 @@ describe('computeStatus', () => {
 		assert.deepEqual(result.status.reviewers, ['alice', 'bob']);
 	});
 
+	it('counts only the newest comment of a reviewer', () => {
+		const reject = { ...review('bob', 'write', { rejects: [{ item: 'theme-default/a--y', hash: H(2) }] }), updatedAt: '2026-09-08T12:06:00Z' };
+		const approve = { ...review('bob', 'write', { approvals: [{ item: 'theme-default/a--y', hash: H(2) }] }), updatedAt: '2026-09-08T12:22:00Z' };
+		const alice = review('alice', 'write', { approveAll: { digest: H(9) } });
+
+		const later = computeStatus(report({ items: CHANGES }), [alice, reject, approve]);
+		assert.equal(later.state, 'success', 'the newer comment replaces the rejection');
+		assert.equal(later.status.items['theme-default/a--y'].state, 'approved');
+
+		const edited = computeStatus(report({ items: CHANGES }), [
+			alice,
+			{ ...approve, updatedAt: '2026-09-08T12:00:00Z' },
+			{ ...reject, updatedAt: '2026-09-08T12:30:00Z' },
+		]);
+		assert.equal(edited.state, 'failure', 'an edited older comment can be the newest one');
+		assert.deepEqual(later.status.reviewers, ['alice', 'bob']);
+	});
+
 	it('fails on routes that could not be compared', () => {
 		const result = computeStatus(
 			report({ items: [{ name: 'a--x', status: 'error', hash: H(1), message: 'boom' }], errors: [{ route: 'a', message: 'boom' }] }),
@@ -111,6 +129,12 @@ describe('review comment format', () => {
 		assert.match(body, /^<!-- visual-review:v1\n/);
 		assert.match(body, /\[review page\]\(https:\/\/example\.test\/\?pr=1\)/);
 		assert.deepEqual(parseReviewComment(body), data);
+	});
+
+	it('keeps item keys with upper-case snapshot names', () => {
+		const item = 'theme-default/input-color-basic-noColumns--label-hint';
+		const parsed = parseReviewComment(formatReviewComment({ approvals: [{ item, hash: H(1) }], rejects: [], notes: [] }, 'https://x', 'ok'));
+		assert.deepEqual(parsed.approvals, [{ item, hash: H(1) }]);
 	});
 
 	it('ignores comments without a block, broken JSON and malformed entries', () => {

--- a/scripts/visual-review/review-comment.mjs
+++ b/scripts/visual-review/review-comment.mjs
@@ -15,12 +15,16 @@
  * `approveAll.digest` approves the whole report whose digest matches – the way to approve hundreds of
  * changes (browser bump) without exceeding GitHub's comment size.
  *
+ * A reviewer may edit the comment or post a new one – the status workflow counts only the newest
+ * comment per reviewer (review-status.mjs).
+ *
  * The review page (packages/tools/visual-tests/review-ui) writes this format; the status workflow
  * reads it. Keep both in sync.
  */
 export const MARKER = 'visual-review:v1';
 const BLOCK = /<!--\s*visual-review:v1\s*([\s\S]*?)-->/;
-const ITEM_KEY = /^[a-z0-9-]+\/[a-z0-9-]+$/;
+// `<package>/<snapshot name>` – names keep the case of the sample route (`…-noColumns--label`).
+const ITEM_KEY = /^[a-z0-9-]+\/[A-Za-z0-9_-]+$/;
 const HASH = /^sha256:[0-9a-f]{64}$/;
 
 /** Parses the block of a comment body; `null` when the comment carries none or an invalid one. */

--- a/scripts/visual-review/review-status.mjs
+++ b/scripts/visual-review/review-status.mjs
@@ -6,6 +6,8 @@
  * - any route error → failure (the comparison itself is broken, nothing to approve)
  * - an item is approved when a reviewer with write access approved its hash (or the whole report
  *   digest) and nobody rejected that hash; a rejection wins over an approval → failure
+ * - only the newest comment of each reviewer counts: a reviewer who pastes a fresh comment instead
+ *   of editing the old one replaces their earlier verdicts, they do not accumulate
  * - success once every changed/added/removed item is approved; pending otherwise
  */
 export const NEEDS_APPROVAL = new Set(['changed', 'added', 'removed']);
@@ -22,7 +24,7 @@ export function itemKey(pkg, item) {
  *   the author's repository permission (`admin`, `maintain`, `write`, `triage`, `read`, `none`)
  */
 export function computeStatus(report, reviews) {
-	const trusted = reviews.filter((review) => review.data && WRITE_ROLES.has(review.role));
+	const trusted = latestPerAuthor(reviews.filter((review) => review.data && WRITE_ROLES.has(review.role)));
 	const items = {};
 	let open = 0;
 	let approved = 0;
@@ -95,6 +97,16 @@ export function computeStatus(report, reviews) {
 			items,
 		},
 	};
+}
+
+/** One review per author – the most recently updated comment; on equal timestamps the later one. */
+function latestPerAuthor(reviews) {
+	const latest = new Map();
+	for (const review of reviews) {
+		const current = latest.get(review.author);
+		if (!current || Date.parse(review.updatedAt ?? 0) >= Date.parse(current.updatedAt ?? 0)) latest.set(review.author, review);
+	}
+	return [...latest.values()];
 }
 
 function describeChanges(report) {


### PR DESCRIPTION
## What changed?

Fixes two defects in the internal visual-review tooling, found while testing #10793 with two reviewers. In `scripts/visual-review/review-status.mjs`, `computeStatus` now counts only the most recently updated comment per reviewer (on equal timestamps the later one wins) via a new `latestPerAuthor` helper, so a reviewer who pastes a fresh comment instead of editing the previous one replaces their earlier verdict rather than accumulating both. The item-key pattern in both `packages/tools/visual-tests/review-ui/src/review-comment.ts` and `scripts/visual-review/review-comment.mjs` now accepts upper-case letters and underscores in the snapshot name (`^[a-z0-9-]+\/[A-Za-z0-9_-]+$`), so approvals of single snapshots with camel-case route parts are no longer silently dropped. Documentation and the review page hint were updated and unit tests added for both cases. This affects only internal test tooling — there is no change to the published component library.

## Linked issues

- Refs #10793 — visual-review test scenario in which both defects were found
- Refs #10792 — same item-key root cause (upper-case snapshot names)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format
- [x] Linked issues are referenced
- [ ] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt zwei Fehler im internen Visual-Review-Tooling, entdeckt beim Testen von #10793 mit zwei Reviewern. In `scripts/visual-review/review-status.mjs` wertet `computeStatus` über den neuen Helfer `latestPerAuthor` nur noch den zuletzt aktualisierten Kommentar je Reviewer aus (bei gleichem Zeitstempel gewinnt der spätere); wer statt einer Bearbeitung einen neuen Kommentar einfügt, ersetzt damit sein früheres Urteil, statt dass sich beide summieren. Das Item-Key-Muster in `packages/tools/visual-tests/review-ui/src/review-comment.ts` und `scripts/visual-review/review-comment.mjs` akzeptiert nun Großbuchstaben und Unterstriche im Snapshot-Namen (`^[a-z0-9-]+\/[A-Za-z0-9_-]+$`), sodass Freigaben einzelner Snapshots mit camelCase-Routenteilen nicht mehr stillschweigend verworfen werden. Dokumentation und der Hinweis auf der Review-Seite wurden angepasst, Unit-Tests für beide Fälle ergänzt. Betroffen ist ausschließlich internes Test-Tooling — die veröffentlichte Komponentenbibliothek ändert sich nicht.

### Verknüpfte Tickets

- Referenziert #10793 — Visual-Review-Szenario, in dem beide Fehler gefunden wurden
- Referenziert #10792 — gleiche Ursache beim Item-Key (Großbuchstaben in Snapshot-Namen)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `scripts/visual-review/review-status.mjs` — `latestPerAuthor` eingeführt; nur der neueste Kommentar je Reviewer zählt
- `scripts/visual-review/review-comment.mjs` — Item-Key akzeptiert Großbuchstaben/Unterstriche; Kommentar-Format-Header dokumentiert die Neueste-Kommentar-Regel
- `packages/tools/visual-tests/review-ui/src/review-comment.ts` — gleiches gelockertes Item-Key-Muster im Review-UI
- `packages/tools/visual-tests/review-ui/src/App.tsx` — Hinweistext ergänzt („Only your newest comment counts")
- `packages/tools/visual-tests/test/review-status.test.mjs` — Tests für Neueste-Kommentar-Regel und Großbuchstaben-Item-Keys
- `docs/visual-review.md` — beschreibt den Kopier-Pfad und die Neueste-Kommentar-Regel

</details>