### PR TITLE
docs(renovate): document the app permissions the runner actually needs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,8 +10,12 @@ name: Renovate
 #
 # Auth: reuses the existing GitHub App (secrets.APP_ID / secrets.PRIVATE_KEY — the same app as
 #       "04 - Update pnpm Lock"). The app installation must grant:
-#         contents: write, pull-requests: write, issues: write (Dependency Dashboard)
-#         and workflows: write (so the github-actions manager can update .github/workflows/*).
+#         contents: write, pull-requests: write, issues: write (Dependency Dashboard),
+#         workflows: write (so the github-actions manager can update .github/workflows/*),
+#         statuses: write (minimumReleaseAge posts a renovate/stability-days commit status —
+#         without it POST /statuses returns 403 and Renovate aborts the whole run with
+#         result: "repository-changed" while the workflow still reports success)
+#         and Dependabot alerts: read (otherwise vulnerabilityAlerts stays inactive).
 # Alternative: drop the app-token step and pass a PAT via `token: ${{ secrets.RENOVATE_TOKEN }}`.
 
 on:

--- a/docs/RENOVATE.md
+++ b/docs/RENOVATE.md
@@ -132,9 +132,23 @@ App (`APP_ID` / `PRIVATE_KEY` secrets, shared with _04 - Update pnpm Lock_).
 To activate it:
 
 1. Ensure that GitHub App installation grants **contents: write**, **pull-requests: write**,
-   **issues: write** (for the Dependency Dashboard) and **workflows: write** (so the `github-actions`
-   manager may update `.github/workflows/*`). _Alternative:_ replace the app-token step with a
+   **issues: write** (for the Dependency Dashboard), **workflows: write** (so the `github-actions`
+   manager may update `.github/workflows/*`), **commit statuses: write** and
+   **Dependabot alerts: read**. _Alternative:_ replace the app-token step with a
    `RENOVATE_TOKEN` PAT/fine-grained token carrying the same scopes.
+
+   > **Commit statuses: write is not optional.** `minimumReleaseAge` makes Renovate post a
+   > `renovate/stability-days` commit status on every branch that still holds a pending release.
+   > Without the permission that `POST /repos/:owner/:repo/statuses/:sha` returns
+   > `403 integration-unauthorized`, which Renovate reports as `repository-changed` and which
+   > **aborts the whole run**. Because branches are processed sequentially, everything after the
+   > first affected branch is skipped: no automerge check for open PRs, and no PR creation for
+   > branches that already exist. The run still ends as a green workflow, so the failure is silent
+   > — look for `result: "repository-changed"` in the log.
+   >
+   > Without **Dependabot alerts: read** every run logs
+   > `Cannot access vulnerability alerts`, and `vulnerabilityAlerts` stays inactive; security PRs
+   > then only come from `osvVulnerabilityAlerts`.
 2. For automerge to work end to end, check three repository settings:
    - **Settings → General → Pull Requests → Allow auto-merge**: enabled (Renovate uses
      `platformAutomerge`, i.e. GitHub's native auto-merge).

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
 	"prHourlyLimit": 5,
 	"postUpdateOptions": ["pnpmDedupe"],
 	"platformAutomerge": true,
+	"branchNameStrict": true,
 	"minimumReleaseAge": "3 days",
 	"automergeStrategy": "squash",
 	"configMigration": true,
@@ -77,7 +78,7 @@
 			"description": "Angular toolchain: group within-major updates per adapter folder and automerge safe patch/minor bumps.",
 			"matchFileNames": ["packages/adapters/angular/v*/**"],
 			"matchPackageNames": ["@angular/*", "@angular-devkit/*", "ng-packagr", "zone.js"],
-			"groupName": "Angular toolchain ({{baseBranch}})",
+			"groupName": "Angular toolchain {{baseBranch}}",
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true
 		},

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,6 @@
 	"prHourlyLimit": 5,
 	"postUpdateOptions": ["pnpmDedupe"],
 	"platformAutomerge": true,
-	"branchNameStrict": true,
 	"minimumReleaseAge": "3 days",
 	"automergeStrategy": "squash",
 	"configMigration": true,
@@ -78,7 +77,7 @@
 			"description": "Angular toolchain: group within-major updates per adapter folder and automerge safe patch/minor bumps.",
 			"matchFileNames": ["packages/adapters/angular/v*/**"],
 			"matchPackageNames": ["@angular/*", "@angular-devkit/*", "ng-packagr", "zone.js"],
-			"groupName": "Angular toolchain {{baseBranch}}",
+			"groupName": "Angular toolchain ({{baseBranch}})",
 			"matchUpdateTypes": ["minor", "patch"],
 			"automerge": true
 		},


### PR DESCRIPTION
## What changed?

Documentation only. The permission list the Renovate runner needs is corrected in two places: the header comment of `.github/workflows/renovate.yml` and section §3 of `docs/RENOVATE.md`. Both previously listed only `contents`, `pull-requests`, `issues` and `workflows`; they now also require **commit statuses: write** and **Dependabot alerts: read**, together with an explanation of the symptom — a run that aborts with `result: "repository-changed"` while the workflow still reports `success`, so the failure is otherwise invisible. No code or configuration behaviour changes.

## Why?

Since 2026-09-07 every Renovate run aborted: `minimumReleaseAge` makes Renovate post a `renovate/stability-days` commit status, and without `statuses: write` that `POST /statuses` returned `403 integration-unauthorized`, which Renovate reports as `repository-changed` and which aborts the whole sequential run — no automerge checks, no PR creation for existing branches — while the workflow stayed green. The missing `Dependabot alerts: read` additionally kept `vulnerabilityAlerts` inactive. Documenting the real permissions is the prerequisite for the admin-side fix. No linked issue; motivation derived from the diff and PR description.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Reine Dokumentation. Die vom Renovate-Runner benötigte Berechtigungsliste wird an zwei Stellen korrigiert: im Header-Kommentar von `.github/workflows/renovate.yml` und in §3 von `docs/RENOVATE.md`. Beide nannten bisher nur `contents`, `pull-requests`, `issues` und `workflows`; ergänzt wurden **commit statuses: write** und **Dependabot alerts: read**, samt Beschreibung des Symptoms — ein Lauf bricht mit `result: "repository-changed"` ab, während der Workflow weiterhin `success` meldet, der Fehler ist also unsichtbar.

### Warum?

Seit dem 07.09.2026 brach jeder Renovate-Lauf ab: `minimumReleaseAge` setzt einen `renovate/stability-days`-Commit-Status, und ohne `statuses: write` läuft `POST /statuses` in ein `403 integration-unauthorized`, das Renovate als `repository-changed` meldet und den gesamten sequenziellen Lauf abbricht — kein Automerge-Check, keine PR-Erstellung — während der Workflow grün bleibt. Das fehlende `Dependabot alerts: read` hielt zusätzlich `vulnerabilityAlerts` inaktiv. Kein verknüpftes Issue; Motivation aus dem Diff abgeleitet.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/renovate.yml` — Header-Kommentar um `statuses: write` und `Dependabot alerts: read` ergänzt.
- `docs/RENOVATE.md` — §3 um dieselben Berechtigungen plus Fehlerbeschreibung (`repository-changed`) erweitert.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vwsLYixbH2eqJmr22uWqi