### PR TITLE
fix(sample): link the input-date copy button to its description - it was unassociated fine print

### DIFF
--- a/packages/samples/react/src/components/input-date/copy-paste.tsx
+++ b/packages/samples/react/src/components/input-date/copy-paste.tsx
@@ -152,10 +152,12 @@ export const InputDateCopyPaste: React.FC = () => {
 							}}
 						/>
 
-						<small className="opacity-80">Click the button to copy the exact German date, then paste it into the date field below.</small>
+						<p className="opacity-80" id="button-desc">
+							Click the button to copy the exact German date, then paste it into the date field below.
+						</p>
 
 						<div className="flex items-center gap-2">
-							<KolButton _label="Copy to Clipboard" _on={{ onClick: () => copyToClipboard(deValue) }} />
+							<KolButton _label="Copy to Clipboard" _on={{ onClick: () => copyToClipboard(deValue) }} aria-describedby="button-desc" />
 							{!isoFromDe && <span className="text-red-600">Invalid date</span>}
 						</div>
 


### PR DESCRIPTION
## What changed?

The React sample `input-date/copy-paste` moves the "Copy to Clipboard" button's explanatory text out of a semantically wrong `<small>` element into a `<p id="button-desc">`, and adds `aria-describedby="button-desc"` to the `KolButton`. The existing `opacity-80` styling is preserved on the new paragraph. It is a single-file, DOM/accessibility-only change with no visual delta (visual review reported zero changes across all themes).

## Why?

The `<small>` element is meant for fine print, not for a functional button description, and the text was not programmatically associated with the button — so assistive technology did not announce it as the button's description. The linked issue asked for the description to move into a `<p>` and be linked to the button via `aria-describedby`.

## Linked issues

- Closes #10541 — 🐞 Bug: input-date copy-paste sample – button description should be linked to the button and moved from a `<small>` into a `<p>`: the description was unassociated fine print and needed a proper `aria-describedby` link.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Im React-Beispiel `input-date/copy-paste` wandert der erklärende Text des „Copy to Clipboard"-Buttons aus einem semantisch falschen `<small>`-Element in ein `<p id="button-desc">`, und der `KolButton` erhält `aria-describedby="button-desc"`. Die bestehende `opacity-80`-Klasse bleibt am neuen Absatz erhalten. Es ist eine reine DOM-/Barrierefreiheits-Änderung in einer einzigen Datei ohne visuelle Abweichung (Visual-Review meldete null Änderungen über alle Themes).

### Warum?

Das `<small>`-Element ist für Kleingedrucktes gedacht, nicht für eine funktionale Button-Beschreibung, und der Text war nicht programmatisch mit dem Button verknüpft — assistive Technik hat ihn deshalb nicht als Beschreibung des Buttons angesagt. Das verknüpfte Ticket forderte, die Beschreibung in ein `<p>` zu verschieben und per `aria-describedby` mit dem Button zu verbinden.

### Verknüpfte Tickets

- Schließt #10541 — 🐞 Bug: input-date copy-paste Beispiel – Button-Beschreibung soll mit dem Button verknüpft und vom `<small>`- in ein `<p>`-Tag verschoben werden: die Beschreibung war unverknüpftes Kleingedrucktes und brauchte eine `aria-describedby`-Verknüpfung.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/samples/react/src/components/input-date/copy-paste.tsx` — Button-Beschreibung vom `<small>`- in ein `<p id="button-desc">`-Element verschoben und `aria-describedby="button-desc"` am Button ergänzt.

</details>