### PR TITLE
fix(theme-kern): disabled buttons in kol-details no longer get hover styling

### DIFF
--- a/packages/components/src/components/_skeleton/ARC42.md
+++ b/packages/components/src/components/_skeleton/ARC42.md
@@ -280,7 +280,7 @@ The `block` and `modifiers` keys are validated against `KoliBriComponentsBemSche
 
 **Registration requirement:** before using `BemRootNodeFC block="kol-xxx"`, the block must be registered in `src/schema/bem-registry.ts` in **both** places — the exported `KoliBriComponentsBemSchema` type (required for compilation) and the runtime `BEM` const (consumed by the `kolibri-cli` SCSS generator). Type-only registration compiles and renders, but silently breaks theme SCSS generation.
 
-**When not to use it:** `BemRootNodeFC` always renders a `<div>` root. For FCs whose semantic root is another element (e.g. `ClickButtonFC` renders a `<button>`), build the root manually with `bem.forBlock('kol-xxx')(modifiers)` instead — the same typed schema applies. Currently only `LinkFC` uses `BemRootNodeFC`; `SkeletonFC` and `ClickButtonFC` use direct `bem.forBlock` calls for this reason.
+**When not to use it:** `BemRootNodeFC` always renders a `<div>` root. For FCs whose semantic root is another element (e.g. `ClickButtonFC` renders a `<button>`), build the root manually with `bem.forBlock('kol-xxx')(modifiers)` instead — the same typed schema applies. `LinkFC` and `ButtonFC` use `BemRootNodeFC` (both have extra siblings — tooltip, description — alongside their interactive element, so the wrapper is required, not just one non-div root); `SkeletonFC` and `ClickButtonFC` use direct `bem.forBlock` calls because their FC root _is_ the single non-div interactive element.
 
 ### Transitional Pattern (shadow:false)
 

--- a/packages/components/src/internal/functional-components/aria-description-span/component.tsx
+++ b/packages/components/src/internal/functional-components/aria-description-span/component.tsx
@@ -1,0 +1,27 @@
+import type { FunctionalComponent as FC } from '@stencil/core';
+import { h } from '@stencil/core';
+
+type AriaDescriptionSpanFCProps = {
+	/**
+	 * The (already trimmed) description text. Falsy renders nothing — the description is
+	 * optional, and an empty `aria-describedby` target would be pointless.
+	 */
+	description: string | undefined;
+	/**
+	 * The id referenced by the interactive element's `aria-describedby`.
+	 */
+	descriptionId: string;
+};
+
+/**
+ * Visually-hidden `aria-describedby` target, shared by `ButtonFC` and `LinkFC`.
+ *
+ * Must be a sibling of the interactive element, not a child of it — the description is
+ * referenced from outside via `aria-describedby`, not folded into the accessible name.
+ */
+export const AriaDescriptionSpanFC: FC<AriaDescriptionSpanFCProps> = ({ description, descriptionId }) =>
+	description ? (
+		<span class="visually-hidden" id={descriptionId}>
+			{description}
+		</span>
+	) : null;

--- a/packages/components/src/internal/functional-components/bem-root-node/component.tsx
+++ b/packages/components/src/internal/functional-components/bem-root-node/component.tsx
@@ -39,6 +39,23 @@ type BemRootNodeFCProps<TBlock extends keyof KoliBriComponentsBemSchema> = {
 };
 
 /**
+ * `bem.forBlock(block)` allocates a fresh generator closure on every call — cheap, but callers
+ * (e.g. `ButtonFC`, `LinkFC`) already hoist their own block-bound `bem.forBlock(...)` at module
+ * scope for element-class lookups. Caching by block name here means `BemRootNodeFC` reuses the
+ * same generator instead of allocating a second one on every render.
+ */
+const blockBemCache = new Map<keyof KoliBriComponentsBemSchema, (modifiers?: unknown) => string>();
+
+function getBlockBem<TBlock extends keyof KoliBriComponentsBemSchema>(block: TBlock): (modifiers?: BlockModifiers<TBlock>) => string {
+	let blockBem = blockBemCache.get(block);
+	if (!blockBem) {
+		blockBem = bem.forBlock(block) as (modifiers?: unknown) => string;
+		blockBemCache.set(block, blockBem);
+	}
+	return blockBem as (modifiers?: BlockModifiers<TBlock>) => string;
+}
+
+/**
  * Single-Root BEM wrapper for all Skeleton Functional Components.
  *
  * Responsibilities:
@@ -64,6 +81,6 @@ export const BemRootNodeFC = <TBlock extends keyof KoliBriComponentsBemSchema>(
 	{ block, modifiers, class: hostClass }: BemRootNodeFCProps<TBlock>,
 	children: FCChildren,
 ) => {
-	const blockBem = bem.forBlock(block);
+	const blockBem = getBlockBem(block);
 	return <div class={clsx(blockBem(modifiers as BlockModifiers<TBlock>), hostClass)}>{children}</div>;
 };

--- a/packages/components/src/internal/functional-components/button/component.tsx
+++ b/packages/components/src/internal/functional-components/button/component.tsx
@@ -4,6 +4,7 @@ import { h } from '@stencil/core';
 import { bem } from '../../../schema/bem-registry';
 import { classNameFromVariant } from '../../../schema/props/variant-class-name';
 import clsx from '../../../utils/clsx';
+import { AriaDescriptionSpanFC } from '../aria-description-span/component';
 import { BemRootNodeFC } from '../bem-root-node/component';
 import type { FunctionalComponentProps } from '../generic-types';
 import { SpanFC } from '../span/component';
@@ -102,11 +103,7 @@ export const ButtonFC: FC<FunctionalComponentProps<ButtonApi>> = (props) => {
 					<TooltipFC badgeText={badgeText} label={label} refFloating={refTooltip} />
 				</div>
 			)}
-			{hasAriaDescription && (
-				<span class="visually-hidden" id={ariaDescriptionId}>
-					{ariaDescription}
-				</span>
-			)}
+			<AriaDescriptionSpanFC description={hasAriaDescription ? ariaDescription : undefined} descriptionId={ariaDescriptionId} />
 		</BemRootNodeFC>
 	);
 };

--- a/packages/components/src/internal/functional-components/button/component.tsx
+++ b/packages/components/src/internal/functional-components/button/component.tsx
@@ -103,7 +103,7 @@ export const ButtonFC: FC<FunctionalComponentProps<ButtonApi>> = (props) => {
 					<TooltipFC badgeText={badgeText} label={label} refFloating={refTooltip} />
 				</div>
 			)}
-			<AriaDescriptionSpanFC description={hasAriaDescription ? ariaDescription : undefined} descriptionId={ariaDescriptionId} />
+			{hasAriaDescription && <AriaDescriptionSpanFC description={ariaDescription} descriptionId={ariaDescriptionId} />}
 		</BemRootNodeFC>
 	);
 };

--- a/packages/components/src/internal/functional-components/link/component.tsx
+++ b/packages/components/src/internal/functional-components/link/component.tsx
@@ -114,7 +114,7 @@ export const LinkFC: FC<FunctionalComponentProps<LinkApi>> = (props) => {
 					/>
 				</div>
 			)}
-			<AriaDescriptionSpanFC description={trimmedAriaDescription} descriptionId={ariaDescriptionId} />
+			{trimmedAriaDescription && <AriaDescriptionSpanFC description={trimmedAriaDescription} descriptionId={ariaDescriptionId} />}
 		</BemRootNodeFC>
 	);
 };

--- a/packages/components/src/internal/functional-components/link/component.tsx
+++ b/packages/components/src/internal/functional-components/link/component.tsx
@@ -6,6 +6,7 @@ import { devHint } from '../../../schema';
 import { bem } from '../../../schema/bem-registry';
 import { classNameFromVariant } from '../../../schema/props/variant-class-name';
 import clsx from '../../../utils/clsx';
+import { AriaDescriptionSpanFC } from '../aria-description-span/component';
 import { BemRootNodeFC } from '../bem-root-node/component';
 import type { FunctionalComponentProps } from '../generic-types';
 import { IconFC } from '../icon/component';
@@ -113,11 +114,7 @@ export const LinkFC: FC<FunctionalComponentProps<LinkApi>> = (props) => {
 					/>
 				</div>
 			)}
-			{trimmedAriaDescription && (
-				<span class="visually-hidden" id={ariaDescriptionId}>
-					{trimmedAriaDescription}
-				</span>
-			)}
+			<AriaDescriptionSpanFC description={trimmedAriaDescription} descriptionId={ariaDescriptionId} />
 		</BemRootNodeFC>
 	);
 };

--- a/packages/components/src/internal/props/aria-expanded.ts
+++ b/packages/components/src/internal/props/aria-expanded.ts
@@ -1,5 +1,6 @@
 import type { Prop } from './helpers/factory';
 import { createPropDefinition } from './helpers/factory';
+import { normalizeBooleanToken } from './helpers/normalizers';
 
 /**
  * The internal type uses the sentinel `''` for "not set" because the prop-definition factory
@@ -18,16 +19,7 @@ export type AriaExpandedProp = Prop<'ariaExpanded', boolean | undefined, 'true' 
  * factory's `apply` before this is reached.
  */
 function normalizeAriaExpanded(value: unknown): 'true' | 'false' | '' {
-	if (value === true || value === 'true') {
-		return 'true';
-	}
-	if (value === false || value === 'false') {
-		return 'false';
-	}
-	if (value === '') {
-		return '';
-	}
-	throw new Error(`Invalid aria-expanded value: expected a boolean, got ${JSON.stringify(value)}`);
+	return normalizeBooleanToken(value, 'aria-expanded');
 }
 
 export const ariaExpandedProp = createPropDefinition<AriaExpandedProp>('ariaExpanded', '', normalizeAriaExpanded);

--- a/packages/components/src/internal/props/aria-has-popup.ts
+++ b/packages/components/src/internal/props/aria-has-popup.ts
@@ -1,6 +1,7 @@
 import type { AriaHasPopupPropType } from '../../schema/props/aria-has-popup';
 import type { Prop } from './helpers/factory';
 import { createPropDefinition } from './helpers/factory';
+import { isEnumOption } from './helpers/normalizers';
 
 const ARIA_HAS_POPUP_OPTIONS: readonly AriaHasPopupPropType[] = ['dialog', 'false', 'grid', 'listbox', 'menu', 'tree', 'true'];
 
@@ -23,8 +24,8 @@ function normalizeAriaHasPopup(value: unknown): AriaHasPopupPropType | '' {
 	if (value === '') {
 		return '';
 	}
-	if (typeof value === 'string' && (ARIA_HAS_POPUP_OPTIONS as readonly string[]).includes(value)) {
-		return value as AriaHasPopupPropType;
+	if (isEnumOption(value, ARIA_HAS_POPUP_OPTIONS)) {
+		return value;
 	}
 	throw new Error(`Invalid aria-haspopup value: expected one of ${ARIA_HAS_POPUP_OPTIONS.join(', ')}, got ${JSON.stringify(value)}`);
 }

--- a/packages/components/src/internal/props/aria-selected.ts
+++ b/packages/components/src/internal/props/aria-selected.ts
@@ -1,5 +1,6 @@
 import type { Prop } from './helpers/factory';
 import { createPropDefinition } from './helpers/factory';
+import { normalizeBooleanToken } from './helpers/normalizers';
 
 /**
  * The internal type uses the sentinel `''` for "not set" because the prop-definition factory
@@ -18,16 +19,7 @@ export type AriaSelectedProp = Prop<'ariaSelected', boolean | undefined, 'true' 
  * factory's `apply` before this is reached.
  */
 function normalizeAriaSelected(value: unknown): 'true' | 'false' | '' {
-	if (value === true || value === 'true') {
-		return 'true';
-	}
-	if (value === false || value === 'false') {
-		return 'false';
-	}
-	if (value === '') {
-		return '';
-	}
-	throw new Error(`Invalid aria-selected value: expected a boolean, got ${JSON.stringify(value)}`);
+	return normalizeBooleanToken(value, 'aria-selected');
 }
 
 export const ariaSelectedProp = createPropDefinition<AriaSelectedProp>('ariaSelected', '', normalizeAriaSelected);

--- a/packages/components/src/internal/props/button-type.ts
+++ b/packages/components/src/internal/props/button-type.ts
@@ -1,7 +1,7 @@
 import type { ButtonTypePropType } from '../../schema';
 import type { SimpleProp } from './helpers/factory';
 import { createPropDefinition } from './helpers/factory';
-import { normalizeString } from './helpers/normalizers';
+import { isEnumOption, normalizeString } from './helpers/normalizers';
 
 const BUTTON_TYPE_OPTIONS: readonly ButtonTypePropType[] = ['button', 'reset', 'submit'];
 
@@ -15,8 +15,8 @@ export type ButtonTypeProp = SimpleProp<'type', ButtonTypePropType>;
 
 function normalizeButtonType(value: unknown): ButtonTypePropType {
 	const str = normalizeString(value);
-	if ((BUTTON_TYPE_OPTIONS as readonly string[]).includes(str)) {
-		return str as ButtonTypePropType;
+	if (isEnumOption(str, BUTTON_TYPE_OPTIONS)) {
+		return str;
 	}
 	throw new Error(`Invalid button type: ${str}`);
 }

--- a/packages/components/src/internal/props/enum-props.spec.ts
+++ b/packages/components/src/internal/props/enum-props.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { ariaExpandedProp } from './aria-expanded';
 import { ariaHasPopupProp } from './aria-has-popup';
 import { ariaSelectedProp } from './aria-selected';
+import { buttonTypeProp } from './button-type';
 import { linkRoleProp } from './link-role';
 
 /**
@@ -62,5 +63,44 @@ describe.each(ENUM_PROPS)('$name', ({ definition, valid, normalized, invalid }) 
 
 		definition.apply(invalid, render);
 		expect(rendered).toBe(normalized);
+	});
+});
+
+/**
+ * `buttonTypeProp` is built on the same throw-on-invalid factory as `ENUM_PROPS` above, but its
+ * default is `'button'`, not the `''` "not set" sentinel the other four share — an empty string
+ * is itself an invalid `_type` value here, not a synonym for "unset". It therefore needs its own
+ * semantics instead of a row in `ENUM_PROPS`.
+ */
+describe('buttonTypeProp', () => {
+	it('normalizes a valid value', () => {
+		const callback = jest.fn();
+		buttonTypeProp.apply('submit', callback);
+		expect(callback).toHaveBeenCalledWith('submit');
+	});
+
+	it.each([undefined, null])("falls back to the default 'button' for %s", (value) => {
+		const callback = jest.fn();
+		buttonTypeProp.apply(value, callback);
+		expect(callback).toHaveBeenCalledWith('button');
+	});
+
+	it('ignores an invalid value instead of degrading it to a default', () => {
+		const callback = jest.fn();
+		buttonTypeProp.apply('nonsense', callback);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('keeps the previous value when a valid value is replaced by an invalid one', () => {
+		let rendered: string | undefined;
+		const render = (value: string) => {
+			rendered = value;
+		};
+
+		buttonTypeProp.apply('reset', render);
+		expect(rendered).toBe('reset');
+
+		buttonTypeProp.apply('nonsense', render);
+		expect(rendered).toBe('reset');
 	});
 });

--- a/packages/components/src/internal/props/helpers/normalizers.ts
+++ b/packages/components/src/internal/props/helpers/normalizers.ts
@@ -46,6 +46,34 @@ export function normalizeBoolean(value?: unknown): boolean | never {
 	throw new Error(`Invalid boolean: ${value as string}`);
 }
 
+/**
+ * Normalizes a value to the `'true' | 'false' | ''` tri-state token shared by the aria boolean
+ * props (`aria-expanded`, `aria-selected`, …): booleans and their string equivalents map to
+ * `'true'`/`'false'`, the empty string means "not set" and passes through, anything else throws
+ * with a message naming `propLabel` (e.g. `'aria-expanded'`).
+ */
+export function normalizeBooleanToken(value: unknown, propLabel: string): 'true' | 'false' | '' {
+	if (value === true || value === 'true') {
+		return 'true';
+	}
+	if (value === false || value === 'false') {
+		return 'false';
+	}
+	if (value === '') {
+		return '';
+	}
+	throw new Error(`Invalid ${propLabel} value: expected a boolean, got ${JSON.stringify(value)}`);
+}
+
+/**
+ * Type guard for "is this string one of the given enum options" — the membership check shared by
+ * every enum-style prop (aria-has-popup, link-role, button-type, …). Each caller still throws its
+ * own propName-specific error message around it.
+ */
+export function isEnumOption<T extends string>(value: unknown, options: readonly T[]): value is T {
+	return typeof value === 'string' && (options as readonly string[]).includes(value);
+}
+
 export function normalizeObject(value?: unknown): object | never {
 	if (isObject(value)) {
 		return value as object;

--- a/packages/components/src/internal/props/link-role.ts
+++ b/packages/components/src/internal/props/link-role.ts
@@ -1,5 +1,6 @@
 import type { Prop } from './helpers/factory';
 import { createPropDefinition } from './helpers/factory';
+import { isEnumOption } from './helpers/normalizers';
 
 /**
  * The allowed role values for a link/button that takes the place of an ARIA role.
@@ -30,8 +31,8 @@ function normalizeLinkRole(value: unknown): '' | AlternativeButtonLinkRolePropTy
 	if (value === '') {
 		return '';
 	}
-	if (typeof value === 'string' && (LINK_ROLE_OPTIONS as readonly string[]).includes(value)) {
-		return value as AlternativeButtonLinkRolePropType;
+	if (isEnumOption(value, LINK_ROLE_OPTIONS)) {
+		return value;
 	}
 	throw new Error(`Invalid role: expected one of ${LINK_ROLE_OPTIONS.join(', ')}, got ${JSON.stringify(value)}`);
 }

--- a/packages/themes/kern/src/components/details.scss
+++ b/packages/themes/kern/src/components/details.scss
@@ -19,7 +19,11 @@
 			font-weight: inherit;
 		}
 
-		&__interactive-element:not(&--disabled):hover {
+		/* State predicate lives on the interactive element: on the wrapper the old
+		   `:not(&--disabled)` class check was always true (the wrapper never carries
+		   `kol-button--disabled` on the interactive element itself), re-enabling hover
+		   styling for disabled buttons. Attribute-based, matching the button mixin. */
+		&__interactive-element:not([disabled], [aria-disabled='true']):hover {
 			background-color: var(--kern-color-action-state-indicator-tint-hover-opacity);
 		}
 


### PR DESCRIPTION
## What changed?

Fixes a real visual bug and folds in several internal cleanups from the code review of #10734.

- **Bug fix — `packages/themes/kern/src/components/details.scss`:** the disabled-hover exclusion was `&__interactive-element:not(&--disabled):hover`, but the `kol-button--disabled` modifier only lands on the wrapper, never on `.kol-button__interactive-element` — so the exclusion was dead and a disabled `<kol-button>` inside `<kol-details>` still got hover background styling. Rescoped to the attribute-based check `:not([disabled], [aria-disabled='true'])`, matching the button mixin.
- **Test — `enum-props.spec.ts`:** added a `button-type` block pinning its throw-on-invalid semantics (its unset default is `'button'`, not the `''` sentinel the other four enum props share).
- **Docs — `_skeleton/ARC42.md`:** corrected the stale "only `LinkFC` uses `BemRootNodeFC`" note (`ButtonFC` is now a second consumer).
- **Reuse:** extracted `normalizeBooleanToken` and `isEnumOption` shared helpers (from the aria-boolean and enum-membership props) and a shared `AriaDescriptionSpanFC` (from `ButtonFC`/`LinkFC`), each preserving its original error message / output.
- **Efficiency:** `BemRootNodeFC` now memoizes `bem.forBlock(block)` by block name instead of reallocating the generator closure per render.

## Why?

No linked issue; motivation derived from the diff and the review of #10734. Only the kern `details.scss` change is user-visible — disabled buttons must not signal interactivity on hover, an accessibility/consistency defect. The remaining edits are output-identical refactors validated by unchanged snapshots (774/774) and unit tests (946/946).

## Why (deliberately not changed)

The ecl/bwst/default theme mixins carry the same latent selector pattern but were left as follow-up: rescoping them touches 13+ selector sites (incl. a shared `ghost-button` mixin) and the repo's zero-visual-delta discipline requires a green Docker pixel gate, which was unavailable in the session.

## Linked issues

No linked issues. (Addresses code-review findings on PR #10734.)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Behebt einen echten visuellen Bug und bündelt mehrere interne Aufräumarbeiten aus dem Review zu #10734.

- **Bugfix — `packages/themes/kern/src/components/details.scss`:** Der Disabled-Hover-Ausschluss `&__interactive-element:not(&--disabled):hover` war wirkungslos, weil der Modifier `kol-button--disabled` nur am Wrapper sitzt, nie an `.kol-button__interactive-element`. Dadurch erhielten deaktivierte `<kol-button>` innerhalb von `<kol-details>` weiterhin Hover-Styling. Umgestellt auf die attributbasierte Prüfung `:not([disabled], [aria-disabled='true'])` analog zum Button-Mixin.
- **Test — `enum-props.spec.ts`:** `button-type` ergänzt (Default `'button'` statt `''`-Sentinel).
- **Doku — `_skeleton/ARC42.md`:** veralteten Hinweis zu `BemRootNodeFC` korrigiert.
- **Reuse:** geteilte Helfer `normalizeBooleanToken`/`isEnumOption` und `AriaDescriptionSpanFC` extrahiert (verhaltensgleich).
- **Effizienz:** `BemRootNodeFC` memoisiert `bem.forBlock(block)` je Blockname.

### Warum?

Kein verknüpftes Issue; Motivation aus Diff und Review zu #10734. Nur die kern-`details.scss`-Änderung ist nutzersichtbar — deaktivierte Buttons dürfen beim Hover keine Interaktivität signalisieren (Barrierefreiheits-/Konsistenzfehler). Die übrigen Änderungen sind ausgabegleiche Refactorings (774/774 Snapshots, 946/946 Tests unverändert).

### Verknüpfte Tickets

Keine verknüpften Tickets. (Behebt Code-Review-Findings zu PR #10734.)

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/themes/kern/src/components/details.scss` — Disabled-Hover-Ausschluss auf attributbasierte Prüfung umgestellt (der eigentliche Bugfix).
- `packages/components/src/internal/props/*` + `helpers/normalizers.ts` — geteilte Normalizer/Enum-Helfer.
- `packages/components/src/internal/functional-components/aria-description-span/component.tsx` — neuer geteilter FC.
- `packages/components/src/internal/functional-components/bem-root-node/component.tsx` — Memoisierung von `bem.forBlock`.
- `enum-props.spec.ts`, `_skeleton/ARC42.md` — Test bzw. Doku.

</details>