### PR TITLE
ci: merge commits for Renovate automerge, path filters for non-build changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,18 @@ on:
     types: [opened, reopened, synchronize]
     paths-ignore:
       - '*.md'
+      - '**/*.md'
       - 'docs/**'
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'renovate.json'
+      - 'publiccode.yml'
+      - '.vscode/**'
+      - 'license-reports/**'
+      - '*.jpg'
+      - '*.png'
+      - '*.svg'
   push:
     branches:
       - 'develop'
@@ -16,8 +24,18 @@ on:
       - 'release/*'
     paths-ignore:
       - '*.md'
+      - '**/*.md'
       - 'docs/**'
       - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'renovate.json'
+      - 'publiccode.yml'
+      - '.vscode/**'
+      - 'license-reports/**'
+      - '*.jpg'
+      - '*.png'
+      - '*.svg'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,19 +11,16 @@
 #
 name: 'CodeQL'
 
+# Deliberately without paths-ignore: "CodeQL" is a required status check of the ruleset
+# "Production branches" and is bound to the code-scanning App, so a skipped run reports
+# nothing, GitHub keeps waiting for the status and no substitute job can deliver it. The
+# analysis costs about a minute and a half, which is the price for docs-only pull requests
+# staying mergeable. See docs/RENOVATE.md, section Troubleshooting.
 on:
   push:
     branches: ['develop', 'release/*']
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - 'LICENSE'
   pull_request:
     branches: ['develop', 'release/*']
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - 'LICENSE'
   schedule:
     - cron: '23 1 * * 6'
 

--- a/.github/workflows/draft-deploy.yml
+++ b/.github/workflows/draft-deploy.yml
@@ -4,6 +4,20 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '*.md'
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'renovate.json'
+      - 'publiccode.yml'
+      - '.vscode/**'
+      - 'license-reports/**'
+      - '*.jpg'
+      - '*.png'
+      - '*.svg'
 
 concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -4,6 +4,20 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - '*.md'
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'renovate.json'
+      - 'publiccode.yml'
+      - '.vscode/**'
+      - 'license-reports/**'
+      - '*.jpg'
+      - '*.png'
+      - '*.svg'
 
 concurrency:
   group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'

--- a/docs/RENOVATE.md
+++ b/docs/RENOVATE.md
@@ -73,9 +73,9 @@ The committed [`renovate.json`](../renovate.json) is tailored to this repo. High
 - **`minimumReleaseAge: "3 days"`** — all updates (npm, Actions, …, including security fixes)
   are held back for three days after release before a PR is opened or auto-merged. This protects
   against compromised or quickly-revoked releases.
-- **Automerge all non-major updates (squash)** — the first package rule enables `automerge` for
-  `patch`/`minor`/`digest`/`pin`/lockfile updates; `automergeStrategy: squash` means each
-  dependency bump becomes a single commit. Known-risky rules below (Stencil, kern-ux, ESLint,
+- **Automerge all non-major updates (merge commit)** — the first package rule enables `automerge` for
+  `patch`/`minor`/`digest`/`pin`/lockfile updates; `automergeStrategy: merge` is the only method the
+  `Production branches` ruleset allows on `develop` (see [Troubleshooting](#troubleshooting-prs-stay-open-although-ci-is-green)). Known-risky rules below (Stencil, kern-ux, ESLint,
   TypeScript, typescript-eslint) override it back to manual. Majors always keep dashboard approval.
   Prerequisites: repo setting **Allow auto-merge** enabled, green pipelines enforced via required
   status checks on `develop`, and the runner GitHub App listed in the branch-protection bypass
@@ -155,7 +155,10 @@ To activate it:
      `platformAutomerge`, i.e. GitHub's native auto-merge).
    - **Branch protection for `develop` (and `release/2`, `release/1`, `release/3`) → required status
      checks**: add the CI gate jobs (`check-results`, `validate-pr-title`) so a PR is only merged
-     when the pipelines are green.
+     when the pipelines are green. As of 2026-09-09 the `Production branches` ruleset requires
+     `Visual Review`, `validate-pr-title`, `validate-release-label` and `CodeQL`, but **not**
+     `check-results` — a red pipeline blocks Renovate (it refuses to merge a red branch) but not a
+     human.
    - **Branch protection for `develop` (and `release/*`) → bypass pull request allowances**: the
      runner App (`publicuibot`) must be listed there, so its PRs can merge without a human
      code-owner review.
@@ -193,24 +196,30 @@ repository setting or a ruleset, never `renovate.json`. Renovate walks three str
 (the configured `automergeStrategy` first, then merge commit, then rebase); the debug log holds one
 `Failed to … PR` block per attempt, each with the HTTP status and GitHub's own message:
 
-| Response                                                  | Meaning                                                                  |
-| --------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `405` `Squash merges are not allowed on this repository.` | **Settings → General → Pull Requests → Allow squash merging** is off.    |
-| `405` `Rebase merges are not allowed on this repository.` | **Allow rebase merging** is off.                                         |
-| `405` `Repository rule violations found: …`               | A ruleset or branch protection blocks the bot — the text names the rule. |
-| `403` `Resource not accessible by integration`            | The App lacks **contents: write**.                                       |
+| Response                                                  | Meaning                                                                   |
+| --------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `405` `Squash merges are not allowed on this repository.` | The merge method is not allowed here — see `allowed_merge_methods` below. |
+| `405` `Rebase merges are not allowed on this repository.` | Same, for rebase.                                                         |
+| `405` `Repository rule violations found: …`               | A ruleset blocks the bot; the text names the rule.                        |
+| `403` `Resource not accessible by integration`            | The App lacks **contents: write**.                                        |
+
+Which rules actually apply to a branch is readable without admin rights:
+
+```sh
+gh api repos/public-ui/kolibri/rules/branches/develop
+```
 
 > **The case of 2026-09-09.** Every green dependency PR sat blocked with `mergeable_state: blocked`
-> while the pipelines were green and no review existed. All three attempts failed with `405`: squash
-> and rebase merges are disabled for this repository, so only a merge commit is left, and that one
-> hit a ruleset violation —
+> while the pipelines were green and no review existed. All three attempts failed with `405`. The
+> ruleset **Production branches** (it covers the default branch and `release/**`) carries a
+> `pull_request` rule whose `allowed_merge_methods` is `["merge"]`, which is what rejected squash
+> and rebase; `automergeStrategy` has been set to `merge` since. The merge commit itself was then
+> refused by the same rule:
 > `New changes require approval from someone other than the last pusher`.
-> The bot can never satisfy that rule: it pushed the branch itself, so its PRs need either a human
-> approval or a bypass entry for `publicuibot` in the ruleset that carries the rule
-> (**Settings → Rules → Rulesets → the ruleset for `develop` → Bypass list**). Note also that
-> `automergeStrategy: "squash"` in `renovate.json` names a method this repository does not allow;
-> Renovate only reaches the merge commit through its fallback, so either enable squash merging or
-> set the strategy to `"merge"`.
+> The bot can never satisfy that one on its own branches, because it is always the last pusher. It
+> needs an approval, or an entry in that ruleset's bypass list that covers the `pull_request` rule
+> (**Settings → Rules → Rulesets → Production branches → Bypass list**). A bypass on another
+> ruleset, or one added for the wrong actor, does not show up anywhere except in this 405.
 
 Two more silent failures show up as warnings rather than as a blocked PR:
 
@@ -253,7 +262,7 @@ fixierten Major-Version halten (`angular/v19|v20|v21`, `react*`), sichere Update
   `auto-dependency-updater.yml`).
 
 Neu hinzugekommen: `minimumReleaseAge: "3 Tage"` schützt vor kompromittierten Releases
-(inklusive Security-Updates), `automergeStrategy: squash` sorgt für saubere Commit-Historie,
+(inklusive Security-Updates), `automergeStrategy: merge` folgt der Merge-Commit-Konvention des Repos,
 und die `release/*`-Branches werden auf **Security-only** umgestellt — reguläre npm- und
 GitHub-Actions-Updates werden dort komplett deaktiviert, während Vulnerability-Alert-PRs
 weiterhin (bei Nicht-Major) automatisch mergen.

--- a/docs/RENOVATE.md
+++ b/docs/RENOVATE.md
@@ -218,8 +218,13 @@ gh api repos/public-ui/kolibri/rules/branches/develop
 > `New changes require approval from someone other than the last pusher`.
 > The bot can never satisfy that one on its own branches, because it is always the last pusher. It
 > needs an approval, or an entry in that ruleset's bypass list that covers the `pull_request` rule
-> (**Settings → Rules → Rulesets → Production branches → Bypass list**). A bypass on another
-> ruleset, or one added for the wrong actor, does not show up anywhere except in this 405.
+> (**Settings → Rules → Rulesets → Production branches → Bypass list**). Mind that a bypass entry
+> for the App did **not** end this: with `publicuibot` listed, two consecutive runs were refused
+> with this same rule and no other violation. So check the entry itself — `actor_type` has to be
+> `Integration` and `bypass_mode` `always`, readable with admin rights via
+> `gh api repos/public-ui/kolibri/rulesets/22621638 --jq .bypass_actors`. If it is already both,
+> the rule named in the 405 is the only remaining lever: **Require approval of the most recent
+> reviewable push** in that ruleset.
 
 Two more silent failures show up as warnings rather than as a blocked PR:
 

--- a/docs/RENOVATE.md
+++ b/docs/RENOVATE.md
@@ -158,7 +158,10 @@ To activate it:
      when the pipelines are green. As of 2026-09-09 the `Production branches` ruleset requires
      `Visual Review`, `validate-pr-title`, `validate-release-label` and `CodeQL`, but **not**
      `check-results` — a red pipeline blocks Renovate (it refuses to merge a red branch) but not a
-     human.
+     human. Two of those four are required and therefore may never be skipped by a path filter:
+     `codeql.yml` runs on every pull request for exactly that reason, and `visual-review.yml`
+     answers a skipped CI run with the status `success` (mode `docs-only`, see
+     `scripts/visual-review/resolve-context.mjs`).
    - **Branch protection for `develop` (and `release/*`) → bypass pull request allowances**: the
      runner App (`publicuibot`) must be listed there, so its PRs can merge without a human
      code-owner review.

--- a/docs/RENOVATE.md
+++ b/docs/RENOVATE.md
@@ -149,6 +149,7 @@ To activate it:
    > Without **Dependabot alerts: read** every run logs
    > `Cannot access vulnerability alerts`, and `vulnerabilityAlerts` stays inactive; security PRs
    > then only come from `osvVulnerabilityAlerts`.
+
 2. For automerge to work end to end, check three repository settings:
    - **Settings → General → Pull Requests → Allow auto-merge**: enabled (Renovate uses
      `platformAutomerge`, i.e. GitHub's native auto-merge).
@@ -172,6 +173,51 @@ If you would rather not self-host, delete `.github/workflows/renovate.yml` and i
    `public-ui` (or just on `public-ui/kolibri`).
 2. Renovate detects `renovate.json` and opens a Dependency Dashboard issue.
 3. Review the dashboard, then let it run on the weekly schedule.
+
+### Troubleshooting: PRs stay open although CI is green
+
+Renovate never explains a refused merge in the PR itself. The runner log does, but only at
+`LOG_LEVEL=debug`: start the workflow via **Run workflow** with `log_level: debug` (and `dry_run`
+off — a dry run logs `DRY-RUN: Would merge PR` and never sends the request that carries the error).
+
+At `info` level the only trace is one line per PR:
+
+```
+INFO: All merge attempts failed (repository=public-ui/kolibri, baseBranch=develop, branch=…)
+       "pr": 10833
+```
+
+It means Renovate did try. Automerge is configured correctly and the branch is green — GitHub
+rejected the `PUT /repos/:owner/:repo/pulls/:number/merge` call. The cause is therefore always a
+repository setting or a ruleset, never `renovate.json`. Renovate walks three strategies in order
+(the configured `automergeStrategy` first, then merge commit, then rebase); the debug log holds one
+`Failed to … PR` block per attempt, each with the HTTP status and GitHub's own message:
+
+| Response                                                  | Meaning                                                                  |
+| --------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `405` `Squash merges are not allowed on this repository.` | **Settings → General → Pull Requests → Allow squash merging** is off.    |
+| `405` `Rebase merges are not allowed on this repository.` | **Allow rebase merging** is off.                                         |
+| `405` `Repository rule violations found: …`               | A ruleset or branch protection blocks the bot — the text names the rule. |
+| `403` `Resource not accessible by integration`            | The App lacks **contents: write**.                                       |
+
+> **The case of 2026-09-09.** Every green dependency PR sat blocked with `mergeable_state: blocked`
+> while the pipelines were green and no review existed. All three attempts failed with `405`: squash
+> and rebase merges are disabled for this repository, so only a merge commit is left, and that one
+> hit a ruleset violation —
+> `New changes require approval from someone other than the last pusher`.
+> The bot can never satisfy that rule: it pushed the branch itself, so its PRs need either a human
+> approval or a bypass entry for `publicuibot` in the ruleset that carries the rule
+> (**Settings → Rules → Rulesets → the ruleset for `develop` → Bypass list**). Note also that
+> `automergeStrategy: "squash"` in `renovate.json` names a method this repository does not allow;
+> Renovate only reaches the merge commit through its fallback, so either enable squash merging or
+> set the strategy to `"merge"`.
+
+Two more silent failures show up as warnings rather than as a blocked PR:
+
+- `Cannot access vulnerability alerts` — **Dependabot alerts: read** is missing, `vulnerabilityAlerts`
+  stays inactive and security PRs come from `osvVulnerabilityAlerts` only.
+- `Could not ensure issue … integration-unauthorized` — the Dependency Dashboard issue is not being
+  updated any more. Check **Issues: write** for the App, and whether the issue itself is locked.
 
 ---
 

--- a/packages/tools/visual-tests/test/resolve-context.test.mjs
+++ b/packages/tools/visual-tests/test/resolve-context.test.mjs
@@ -17,14 +17,38 @@ const OPEN_PULL = { number: 42, state: 'open', head: { sha: 'head1' }, base: { r
 
 describe('isIgnoredByCi', () => {
 	it('mirrors the paths-ignore list of ci.yml', () => {
-		assert.deepEqual(CI_IGNORED_PATHS, ['*.md', 'docs/**', 'LICENSE', '.github/ISSUE_TEMPLATE/**', '.github/PULL_REQUEST_TEMPLATE/**']);
+		assert.deepEqual(CI_IGNORED_PATHS, [
+			'*.md',
+			'**/*.md',
+			'docs/**',
+			'LICENSE',
+			'.github/ISSUE_TEMPLATE/**',
+			'.github/PULL_REQUEST_TEMPLATE/**',
+			'renovate.json',
+			'publiccode.yml',
+			'.vscode/**',
+			'license-reports/**',
+			'*.jpg',
+			'*.png',
+			'*.svg',
+		]);
 		assert.ok(isIgnoredByCi('README.md'));
 		assert.ok(isIgnoredByCi('docs/arc42/01.md'));
 		assert.ok(isIgnoredByCi('LICENSE'));
 		assert.ok(isIgnoredByCi('.github/ISSUE_TEMPLATE/bug.yml'));
-		assert.equal(isIgnoredByCi('packages/components/README.md'), false, '*.md only matches the repository root');
+		// `*.md` stops at the root, `**/*.md` covers everything below it – both are needed because
+		// globToRegExp turns `**/*.md` into a pattern that always expects a slash.
+		assert.ok(isIgnoredByCi('packages/components/README.md'));
+		assert.ok(isIgnoredByCi('renovate.json'));
+		assert.ok(isIgnoredByCi('license-reports/components.csv'));
+		assert.ok(isIgnoredByCi('kolibri.logo.svg'));
 		assert.equal(isIgnoredByCi('packages/themes/default/src/x.ts'), false);
 		assert.equal(isIgnoredByCi('docs-site/index.ts'), false);
+		// Everything that can change what gets built has to keep triggering the pipeline.
+		assert.equal(isIgnoredByCi('package.json'), false);
+		assert.equal(isIgnoredByCi('pnpm-lock.yaml'), false);
+		assert.equal(isIgnoredByCi('packages/components/package.json'), false);
+		assert.equal(isIgnoredByCi('packages/components/src/icon.svg'), false);
 	});
 });
 

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
 	"postUpdateOptions": ["pnpmDedupe"],
 	"platformAutomerge": true,
 	"minimumReleaseAge": "3 days",
-	"automergeStrategy": "squash",
+	"automergeStrategy": "merge",
 	"configMigration": true,
 	"dependencyDashboardOSVVulnerabilitySummary": "all",
 	"baseBranchPatterns": ["develop"],

--- a/scripts/visual-review/resolve-context.mjs
+++ b/scripts/visual-review/resolve-context.mjs
@@ -15,7 +15,21 @@ import { pathToFileURL } from 'node:url';
 import { createApi, repositoryFromEnv, setOutputs } from './github-api.mjs';
 
 /** Mirrors `paths-ignore` of the pull_request trigger in .github/workflows/ci.yml – keep in sync. */
-export const CI_IGNORED_PATHS = ['*.md', 'docs/**', 'LICENSE', '.github/ISSUE_TEMPLATE/**', '.github/PULL_REQUEST_TEMPLATE/**'];
+export const CI_IGNORED_PATHS = [
+	'*.md',
+	'**/*.md',
+	'docs/**',
+	'LICENSE',
+	'.github/ISSUE_TEMPLATE/**',
+	'.github/PULL_REQUEST_TEMPLATE/**',
+	'renovate.json',
+	'publiccode.yml',
+	'.vscode/**',
+	'license-reports/**',
+	'*.jpg',
+	'*.png',
+	'*.svg',
+];
 const VISUAL_JOB = /^visual-tests \(/;
 
 function globToRegExp(glob) {


### PR DESCRIPTION
## What changed?

CI workflow triggers were reworked so docs- and config-only pull requests stop launching the full build and `visual-tests` pipelines. `ci.yml`, `draft-deploy.yml` and `pr-preview-deploy.yml` now share a longer `paths-ignore` list that adds Markdown anywhere in the tree (`**/*.md`), `renovate.json`, `publiccode.yml`, `.vscode/**`, `license-reports/**` and root images. `codeql.yml` deliberately *loses* its filter, because `CodeQL` is a required status check bound to the code-scanning App — a skipped run would leave the PR waiting for a status no substitute job can deliver. `scripts/visual-review/resolve-context.mjs` (and its test) mirror the same list so the required `Visual Review` check reports `success` for a skipped CI run. Finally `renovate.json` switches `automergeStrategy` from `squash` to `merge`, and `docs/RENOVATE.md` gains a troubleshooting section. No public component or API is touched.

## Why?

Renovate silently failed to auto-merge: every merge attempt was rejected with `405` by the `Production branches` ruleset, which only permits merge commits on `develop`. At the same time the pipeline ran on docs/config-only PRs — a Markdown + JSON change burned ~100 runner minutes, 81 of them in seven `visual-tests` jobs. No linked issue; motivation derived from the diff and the PR description.

## Linked issues

No linked issues.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Die CI-Trigger wurden so umgebaut, dass reine Doku- und Konfig-PRs die vollständige Build- und `visual-tests`-Pipeline nicht mehr auslösen. `ci.yml`, `draft-deploy.yml` und `pr-preview-deploy.yml` teilen sich jetzt eine längere `paths-ignore`-Liste, neu darin: Markdown im gesamten Baum (`**/*.md`), `renovate.json`, `publiccode.yml`, `.vscode/**`, `license-reports/**` und die Wurzel-Bilder. `codeql.yml` verliert seinen Filter bewusst, weil `CodeQL` ein Required Check der Code-Scanning-App ist — ein übersprungener Lauf ließe den PR ewig auf einen Status warten. `scripts/visual-review/resolve-context.mjs` und dessen Test spiegeln dieselbe Liste, damit der Required Check `Visual Review` bei übersprungenem CI-Lauf `success` meldet. `renovate.json` stellt `automergeStrategy` von `squash` auf `merge` um, und `docs/RENOVATE.md` erhält einen Troubleshooting-Abschnitt.

### Warum?

Renovate mergte nicht: alle Merge-Versuche wurden mit `405` vom Ruleset `Production branches` abgelehnt, das auf `develop` nur Merge-Commits erlaubt. Gleichzeitig lief die Pipeline auf reinen Doku-/Konfig-PRs — eine Markdown-+-JSON-Änderung verbrauchte rund 100 Runner-Minuten, davon 81 in sieben `visual-tests`-Jobs. Kein verknüpftes Issue; Motivation aus dem Diff abgeleitet.

### Verknüpfte Tickets

Keine verknüpften Tickets.

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/ci.yml` — `paths-ignore` beider Trigger auf eine gemeinsame, längere Liste erweitert.
- `.github/workflows/draft-deploy.yml`, `.github/workflows/pr-preview-deploy.yml` — dieselbe `paths-ignore`-Liste ergänzt, damit die Preview-Builds bei Doku-Änderungen entfallen.
- `.github/workflows/codeql.yml` — `paths-ignore` bewusst entfernt (Required Check darf nicht übersprungen werden); Begründung als Kommentar im Workflow.
- `renovate.json` — `automergeStrategy` von `squash` auf `merge` (einzige erlaubte Methode).
- `scripts/visual-review/resolve-context.mjs` + Test — Ignore-Liste gespiegelt, damit `Visual Review` bei übersprungenem CI `success` meldet.
- `docs/RENOVATE.md` — Troubleshooting-Abschnitt zu blockierten Renovate-Merges (405 aus dem Ruleset).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vwsLYixbH2eqJmr22uWqi