### PR TITLE
ci: run PR title validation on synchronize

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -2,7 +2,10 @@ name: PR Title Validation
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    # `synchronize` is required: check runs are attached to a head SHA. Without it,
+    # every push creates a new SHA for which this required check never reports and the
+    # PR stays stuck on "Expected — Waiting for status to be reported".
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
## What changed?

`.github/workflows/pr-title-validation.yml` now also triggers on the `synchronize` pull-request event (previously only `opened`, `edited`, `reopened`). This is a single-line change to the workflow's `on.pull_request.types` list, with an explanatory comment added. No application code, component, or public API is affected.

## Why?

No linked issue; motivation derived from the diff and PR discussion. The `validate-pr-title` check is a required status check, but because check runs are attached to a head SHA and the workflow did not run on `synchronize`, every new push produced a SHA for which the required check never reported — leaving PRs permanently stuck on "Expected — Waiting for status to be reported". Adding `synchronize` (the configuration `amannn/action-semantic-pull-request` prescribes for required checks) makes the check report on every push, matching the other PR gates (`ci.yml`, `cla.yml`, `pr-release-label-validation.yml`).

## Linked issues

No linked issues. (PR #10734 is cited only as diagnostic evidence of the stuck check.)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

`.github/workflows/pr-title-validation.yml` löst jetzt zusätzlich beim `synchronize`-Event aus (vorher nur `opened`, `edited`, `reopened`). Eine einzeilige Änderung an der `on.pull_request.types`-Liste samt erklärendem Kommentar. Kein Anwendungscode, keine Komponente und keine öffentliche API betroffen.

### Warum?

Kein verknüpftes Issue; Motivation aus Diff und PR-Diskussion. Der `validate-pr-title`-Check ist als Required Status Check hinterlegt. Da Check Runs an einer Head-SHA hängen und der Workflow nicht bei `synchronize` lief, meldete jeder neue Push eine SHA, für die der Required Check nie berichtete — der PR blieb dauerhaft auf "Expected — Waiting for status to be reported" hängen. Das Ergänzen von `synchronize` (die von `amannn/action-semantic-pull-request` empfohlene Konfiguration) lässt den Check bei jedem Push berichten und gleicht ihn an die übrigen PR-Gates an.

### Verknüpfte Tickets

Keine verknüpften Tickets. (PR #10734 dient nur als Diagnose-Beleg.)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `.github/workflows/pr-title-validation.yml` — `synchronize` zur Event-Trigger-Liste hinzugefügt, damit der Required Check auf jeder Head-SHA berichtet.

</details>