### PR TITLE
fix(scripts): close the skeleton guard's negation gap and stop the docker run from retrying

### DIFF
--- a/scripts/check-skeleton-selectors.mjs
+++ b/scripts/check-skeleton-selectors.mjs
@@ -21,7 +21,10 @@
  * 2. **State predicate on the carrier.** `:focus`, `:focus-visible` and `:disabled` never match the
  *    wrapper `div`, so those rules are dead. Worse, `:not(:disabled)` / `:not([disabled])` are
  *    always *true* on the wrapper, so a combined predicate like `.kol-button:not([disabled]):hover`
- *    does not merely stop matching — it inverts, and disabled buttons gain hover styling.
+ *    does not merely stop matching — it inverts, and disabled buttons gain hover styling. A
+ *    `:not(…)` is judged by its full argument list: it inverts only when *every* argument can match
+ *    the interactive element alone. One argument that can match the carrier (the block's
+ *    `--disabled` modifier, say) keeps the exclusion intact, so such a rule is not reported.
  *
  * `:hover`, `:active` and `:focus-within` are deliberately not flagged: they match the wrapper
  * through ancestor propagation, so they keep working where they are.
@@ -47,8 +50,12 @@ const WRAPPER_BLOCKS = ['kol-button', 'kol-link'];
 /** Pseudo-classes that never match the wrapper — they do not propagate to ancestors. */
 const DEAD_ON_WRAPPER = [':focus-visible', ':focus', ':disabled'];
 
-/** Negated predicates that are always true on the wrapper, so combined rules invert. */
-const INVERTING_ON_WRAPPER = [':not(:disabled)', ':not([disabled]'];
+/**
+ * Predicates that can only ever be true on the interactive element inside the wrapper, never on the
+ * class carrier itself: the disabled state lives on the `<button>` / `<a>`, not on the wrapper.
+ * Negating them on the carrier is therefore always true.
+ */
+const ELEMENT_ONLY_DISABLED = /^(?::disabled|\[(?:aria-)?disabled(?:\s*[~^$*|]?=\s*[^\]]*)?\])$/;
 
 /*
  * Interpolations are normalised to stable placeholders so the resolver can work on plain strings.
@@ -285,6 +292,52 @@ function compoundParts(compound) {
 	return parts;
 }
 
+/** Splits the argument list of a `:not(…)` / `:is(…)` at top level, ignoring nested brackets. */
+function selectorArguments(part) {
+	const open = part.indexOf('(');
+	if (open === -1 || !part.endsWith(')')) {
+		return [];
+	}
+	const inner = part.slice(open + 1, -1);
+	const args = [];
+	let current = '';
+	let depth = 0;
+	for (const char of inner) {
+		if (char === '(' || char === '[') {
+			depth++;
+		} else if (char === ')' || char === ']') {
+			depth = Math.max(0, depth - 1);
+		}
+		if (depth === 0 && char === ',') {
+			args.push(current.trim());
+			current = '';
+			continue;
+		}
+		current += char;
+	}
+	if (current.trim()) {
+		args.push(current.trim());
+	}
+	return args;
+}
+
+/**
+ * Whether a `:not(…)` attached to the carrier inverts the rule instead of switching it off.
+ *
+ * Every argument that can only match the interactive element is always false on the wrapper, so
+ * negating it is always true. When *all* arguments are of that kind, the rule never falls out for a
+ * disabled element — it starts applying to it. A single argument that can match the carrier (the
+ * block's `--disabled` modifier, or a `:has(:disabled)` asking the element inside) keeps the
+ * exclusion working, so those are left alone.
+ */
+function isInvertingNegation(part) {
+	if (!part.startsWith(':not(')) {
+		return false;
+	}
+	const args = selectorArguments(part);
+	return args.length > 0 && args.every((arg) => ELEMENT_ONLY_DISABLED.test(arg));
+}
+
 function findCarrierStatePredicate(selector, includeGeneric) {
 	const pattern = carrierPattern(includeGeneric);
 	let match;
@@ -294,10 +347,8 @@ function findCarrierStatePredicate(selector, includeGeneric) {
 			continue;
 		}
 		for (const part of compoundParts(compound)) {
-			for (const pseudo of INVERTING_ON_WRAPPER) {
-				if (part.startsWith(pseudo)) {
-					return { kind: 'inverting', pseudo, carrier: match[0] };
-				}
+			if (isInvertingNegation(part)) {
+				return { kind: 'inverting', pseudo: part, carrier: match[0] };
 			}
 			// `:focus-within` is legitimate on the wrapper and must not be caught by `:focus`.
 			if (part.startsWith(':focus-within')) {

--- a/scripts/snapshots-docker.mjs
+++ b/scripts/snapshots-docker.mjs
@@ -131,7 +131,10 @@ set -euo pipefail
 
 export HOME=/work/home
 export PATH="/work/npm-global/bin:$PATH"
-export CI=0                       # keine Retries + parallele Workers — für schnelle lokale Entwicklung
+# Leer, nicht 0: die Playwright-Config prüft process.env.CI auf Truthiness, und der String
+# "0" ist in JS wahr. Mit CI=0 lief der Container mit 2 Retries und 1 Worker — ein Lauf konnte
+# per Retry grün werden und wurde als grün gemeldet. Leer heißt: keine Retries, 4 Worker.
+export CI=""                      # keine Retries + parallele Workers — für schnelle lokale Entwicklung
 ${workersEnv}
 mkdir -p "$HOME" "${CONTAINER_WORKSPACE}"
 


### PR DESCRIPTION
## What changed?

Two internal build/validation scripts were hardened; no component, theme, or public API is touched.

- `scripts/check-skeleton-selectors.mjs`: the CSS-negation matcher no longer keys off two literal prefixes (`:not(:disabled)`, `:not([disabled]`). It now evaluates the **full** `:not(...)` argument list and treats the negation as inverting only when every argument can match the interactive element alone. Multi-argument inverting forms such as `.kol-link:hover:not([aria-disabled], [disabled])` are now reported, while legitimate exclusions that reference the wrapper (e.g. `:not(…, .kol-button--disabled)` or `:not(:has(:disabled))`) stay quiet. The repository is clean under the sharpened rule (512 files, 0 findings).
- `scripts/snapshots-docker.mjs`: the container run exported `CI=0` to disable retries, but `playwright.config.js` reads `process.env.CI` for truthiness and the string `'0'` is truthy in JS, so every `--check` acceptance run silently used 2 retries and 1 worker. The export now uses an empty value, restoring the documented "0 retries / 4 workers" behaviour.

## Why?

No linked issue; motivation derived from the diff and the two cross-review findings this PR resolves. The selector guard was reporting green on the exact bug class it was written to catch, and the Docker acceptance run masked flaky snapshots by retrying — both defeating the zero-visual-delta discipline these scripts exist to enforce.

## Linked issues

No linked issues. (Follow-up to PR #10845, whose merge resolved the other four review findings.)

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Zwei interne Build-/Validierungs-Skripte wurden robuster gemacht; keine Komponente, kein Theme und keine öffentliche API sind betroffen.

- `scripts/check-skeleton-selectors.mjs`: Der CSS-Negations-Matcher stützt sich nicht mehr auf zwei feste Präfixe, sondern wertet die **vollständige** `:not(...)`-Argumentliste aus. Eine Negation gilt nur dann als invertierend, wenn **jedes** Argument allein auf das interaktive Element passt. Mehrargumentige Formen wie `.kol-link:hover:not([aria-disabled], [disabled])` werden nun gemeldet, während zulässige Ausschlüsse mit Wrapper-Bezug (`:not(…, .kol-button--disabled)`, `:not(:has(:disabled))`) still bleiben (512 Dateien, 0 Treffer).
- `scripts/snapshots-docker.mjs`: Der Container-Lauf setzte `CI=0`, um Retries abzuschalten — doch `playwright.config.js` prüft `process.env.CI` auf Truthiness, und der String `'0'` ist in JS truthy. Dadurch liefen alle `--check`-Läufe mit 2 Retries und 1 Worker. Der Export nutzt jetzt einen leeren Wert und stellt das dokumentierte Verhalten (0 Retries / 4 Worker) wieder her.

### Warum?

Kein verknüpftes Issue; Motivation aus dem Diff und den beiden Cross-Review-Findings abgeleitet. Der Selector-Guard meldete Grün ausgerechnet für die Fehlerklasse, die er fangen sollte, und der Docker-Lauf verdeckte instabile Snapshots durch Retries — beides untergräbt die Zero-Visual-Delta-Disziplin, die diese Skripte durchsetzen sollen.

### Verknüpfte Tickets

Keine verknüpften Tickets. (Folge-PR zu #10845.)

### Art der Änderung

🔧 Intern

### Geänderte Dateien

- `scripts/check-skeleton-selectors.mjs` — Negations-Matcher wertet jetzt die gesamte `:not(...)`-Argumentliste aus statt zweier fester Präfixe.
- `scripts/snapshots-docker.mjs` — `CI`-Export von `0` auf leer geändert, damit Playwright Retries tatsächlich deaktiviert.

</details>