### PR TITLE
fix(input-text): propagate cleared value from search clear button

### DIFF
--- a/packages/components/src/components/combobox/shadow.tsx
+++ b/packages/components/src/components/combobox/shadow.tsx
@@ -41,6 +41,7 @@ import type { EventDetail } from '../../schema/interfaces/EventDetail';
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
 import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
+import { createEventWithTarget, KolEvent } from '../../utils/events';
 import { ComboboxController } from './controller';
 
 /**
@@ -107,12 +108,12 @@ export class KolCombobox implements ClickableElement, ComboboxAPI, FocusableElem
 	};
 	private selectOption(option: string) {
 		this.controller.onFacade.onInput(
-			new CustomEvent<EventDetail>('input', { bubbles: true, detail: { name: this.state._name as string, value: option } }),
+			createEventWithTarget<EventDetail>(KolEvent.input, { name: this.state._name as string, value: option }, this.ctaRef.el),
 			true,
 			option,
 		);
 		this.controller.onFacade.onChange(
-			new CustomEvent<EventDetail>('change', { bubbles: true, detail: { name: this.state._name as string, value: option } }),
+			createEventWithTarget<EventDetail>(KolEvent.change, { name: this.state._name as string, value: option }, this.ctaRef.el),
 			option,
 		);
 		this.controller.setFormAssociatedValue(option);
@@ -135,8 +136,8 @@ export class KolCombobox implements ClickableElement, ComboboxAPI, FocusableElem
 		this._isOpen = false;
 
 		const detail = { name: this.state._name as string, value: emptyValue };
-		this.controller.onFacade.onInput(new CustomEvent('input', { bubbles: true, detail }), true, emptyValue);
-		this.controller.onFacade.onChange(new CustomEvent('change', { bubbles: true, detail }), emptyValue);
+		this.controller.onFacade.onInput(createEventWithTarget<EventDetail>(KolEvent.input, detail, this.ctaRef.el), true, emptyValue);
+		this.controller.onFacade.onChange(createEventWithTarget<EventDetail>(KolEvent.change, detail, this.ctaRef.el), emptyValue);
 		this.controller.setFormAssociatedValue(emptyValue);
 
 		this.ctaRef.el?.focus();

--- a/packages/components/src/components/input-text/input-text.clear-button.e2e.ts
+++ b/packages/components/src/components/input-text/input-text.clear-button.e2e.ts
@@ -1,6 +1,15 @@
 import { expect } from '@playwright/test';
 import { test } from '@stencil/playwright';
 
+type RecordedEvent = { detail: unknown; type: string };
+type TestWindow = Window & {
+	changeCallbackValue?: unknown;
+	changeEventValue?: unknown;
+	inputCallbackValue?: unknown;
+	inputEventValue?: unknown;
+	recordedEvents?: RecordedEvent[];
+};
+
 test.describe('kol-input-text clear button', () => {
 	test('should render clear button when type is search and input has value', async ({ page }) => {
 		await page.setContent('<kol-input-text _label="Search" _type="search" _value="test"></kol-input-text>');
@@ -55,5 +64,123 @@ test.describe('kol-input-text clear button', () => {
 		await page.setContent('<kol-input-text _label="Search" _type="search" _value="test"></kol-input-text>');
 		const clearButton = page.getByTestId('kol-input-text-clear-button').locator('button');
 		await expect(clearButton).toHaveAccessibleName('Suche löschen');
+	});
+
+	test.describe('Callbacks and Events', () => {
+		const SEARCH_WITH_VALUE = '<kol-input-text _label="Search" _type="search" _name="query" _value="test"></kol-input-text>';
+
+		test('should fire input and change events and call the callbacks when clear button is clicked', async ({ page }) => {
+			await page.setContent(SEARCH_WITH_VALUE);
+			const component = page.locator('kol-input-text');
+			const clearButton = page.getByTestId('kol-input-text-clear-button');
+
+			await component.evaluate((element: HTMLKolInputTextElement) => {
+				const testWindow = window as TestWindow;
+				testWindow.inputCallbackValue = '__unset__';
+				testWindow.changeCallbackValue = '__unset__';
+				testWindow.inputEventValue = '__unset__';
+				testWindow.changeEventValue = '__unset__';
+
+				element._on = {
+					onInput: (_event: Event, value?: unknown) => {
+						testWindow.inputCallbackValue = value;
+					},
+					onChange: (_event: Event, value?: unknown) => {
+						testWindow.changeCallbackValue = value;
+					},
+				};
+				element.addEventListener('input', (event: Event) => {
+					testWindow.inputEventValue = (event as CustomEvent).detail;
+				});
+				element.addEventListener('change', (event: Event) => {
+					testWindow.changeEventValue = (event as CustomEvent).detail;
+				});
+			});
+
+			await clearButton.click();
+			await page.waitForChanges();
+
+			await expect(await page.evaluate(() => (window as TestWindow).inputCallbackValue)).toBe('');
+			await expect(await page.evaluate(() => (window as TestWindow).changeCallbackValue)).toBe('');
+			await expect(await page.evaluate(() => (window as TestWindow).inputEventValue)).toBe('');
+			await expect(await page.evaluate(() => (window as TestWindow).changeEventValue)).toBe('');
+		});
+
+		test('should fire input and change exactly once when clear button is clicked', async ({ page }) => {
+			await page.setContent(SEARCH_WITH_VALUE);
+			const component = page.locator('kol-input-text');
+			const clearButton = page.getByTestId('kol-input-text-clear-button');
+
+			await component.evaluate((element: HTMLKolInputTextElement) => {
+				const recordedEvents: RecordedEvent[] = [];
+				(window as TestWindow).recordedEvents = recordedEvents;
+
+				const record = (event: Event) => {
+					recordedEvents.push({ detail: (event as CustomEvent).detail, type: event.type });
+				};
+				element.addEventListener('input', record);
+				element.addEventListener('change', record);
+			});
+
+			await clearButton.click();
+			await page.waitForChanges();
+
+			await expect(await page.evaluate(() => (window as TestWindow).recordedEvents)).toEqual([
+				{ detail: '', type: 'input' },
+				{ detail: '', type: 'change' },
+			]);
+		});
+
+		test('should report the cleared value via getValue()', async ({ page }) => {
+			await page.setContent(SEARCH_WITH_VALUE);
+			const component = page.locator('kol-input-text');
+			const clearButton = page.getByTestId('kol-input-text-clear-button');
+
+			await clearButton.click();
+			await page.waitForChanges();
+
+			await expect(await component.evaluate((element: HTMLKolInputTextElement) => element.getValue())).toBe('');
+		});
+
+		test('should fire input and change with the cleared value after the user typed', async ({ page }) => {
+			await page.setContent('<kol-input-text _label="Search" _type="search" _name="query"></kol-input-text>');
+			const component = page.locator('kol-input-text');
+			const input = page.locator('kol-input-text input');
+			const clearButton = page.getByTestId('kol-input-text-clear-button');
+
+			await component.evaluate((element: HTMLKolInputTextElement) => {
+				const recordedEvents: RecordedEvent[] = [];
+				(window as TestWindow).recordedEvents = recordedEvents;
+
+				const record = (event: Event) => {
+					recordedEvents.push({ detail: (event as CustomEvent).detail, type: event.type });
+				};
+				element.addEventListener('input', record);
+				element.addEventListener('change', record);
+			});
+
+			await input.fill('test');
+			await clearButton.click();
+			await page.waitForChanges();
+
+			/**
+			 * Clicking the button moves focus out of the input, so the browser fires a native change with the old
+			 * value beforehand. Only the final state matters here, hence the assertion on the last event of each type.
+			 */
+			const recordedEvents = (await page.evaluate(() => (window as TestWindow).recordedEvents)) ?? [];
+			await expect(recordedEvents.filter(({ type }) => type === 'input').pop()).toEqual({ detail: '', type: 'input' });
+			await expect(recordedEvents.filter(({ type }) => type === 'change').pop()).toEqual({ detail: '', type: 'change' });
+		});
+
+		test('should keep focus on the input after clearing', async ({ page }) => {
+			await page.setContent(SEARCH_WITH_VALUE);
+			const component = page.locator('kol-input-text');
+			const clearButton = page.getByTestId('kol-input-text-clear-button');
+
+			await clearButton.click();
+			await page.waitForChanges();
+
+			await expect(await component.evaluate((element: HTMLKolInputTextElement) => element.shadowRoot?.activeElement?.tagName)).toBe('INPUT');
+		});
 	});
 });

--- a/packages/components/src/components/input-text/shadow.tsx
+++ b/packages/components/src/components/input-text/shadow.tsx
@@ -44,6 +44,7 @@ import type {
 import { CounterDomUpdater } from '../../utils/counter-dom-updater';
 import { createRelatedUniqueId, createUniqueId } from '../../utils/dev.utils';
 import { createCtaRef, delegateClick, delegateFocus } from '../../utils/element-interaction';
+import { createEventWithTarget, KolEvent } from '../../utils/events';
 import { propagateSubmitEventToForm } from '../form/controller';
 import { InputTextController } from './controller';
 
@@ -106,6 +107,31 @@ export class KolInputText implements ClickableElement, FocusableElement, InputTe
 
 	private readonly translateClearSearch = translate('kol-clear-search');
 
+	private readonly onClearButtonClick = (): void => {
+		if (this._disabled === true || this.state._hasValue !== true) {
+			return;
+		}
+
+		const value = '';
+		const detail = { name: (this.state._name as string) ?? '', value };
+
+		/* Updates state, `_hasValue`, the counter and the form-associated value synchronously through the `_value` watcher. */
+		this._value = value;
+
+		/**
+		 * Stencil re-renders asynchronously, so the native input still holds the previous value here. Setting it
+		 * imperatively keeps `getValue()` and `event.target.value` in sync with the value the events carry.
+		 */
+		if (this.ctaRef.el) {
+			this.ctaRef.el.value = value;
+		}
+
+		this.controller.onFacade.onInput(createEventWithTarget(KolEvent.input, detail, this.ctaRef.el), true, value);
+		this.controller.onFacade.onChange(createEventWithTarget(KolEvent.change, detail, this.ctaRef.el), value);
+
+		this.ctaRef.el?.focus();
+	};
+
 	private getClearButton(): VNode | null {
 		if (this.state._type === 'search' && !this._disabled) {
 			const canClear = this.state._hasValue === true;
@@ -119,10 +145,7 @@ export class KolInputText implements ClickableElement, FocusableElement, InputTe
 					label={this.translateClearSearch}
 					buttonVariant="ghost"
 					disabled={!canClear}
-					onClick={(): void => {
-						this._value = '';
-						this.ctaRef.el?.focus();
-					}}
+					onClick={this.onClearButtonClick}
 					icon="kolicon-cross"
 				/>
 			);

--- a/packages/components/src/components/single-select/shadow.tsx
+++ b/packages/components/src/components/single-select/shadow.tsx
@@ -43,6 +43,7 @@ import type { EventDetail } from '../../schema/interfaces/EventDetail';
 import clsx from '../../utils/clsx';
 import { createUniqueId } from '../../utils/dev.utils';
 import { createCtaRef, delegateFocus } from '../../utils/element-interaction';
+import { createEventWithTarget, KolEvent } from '../../utils/events';
 import { SingleSelectController } from './controller';
 
 /**
@@ -114,24 +115,6 @@ export class KolSingleSelect implements FocusableElement, SingleSelectAPI {
 		}
 	}
 
-	private createEventWithTarget(type: string, detail: EventDetail): CustomEvent<EventDetail> {
-		const event = new CustomEvent<EventDetail>(type, {
-			bubbles: true,
-			detail,
-		});
-
-		if (this.ctaRef.el) {
-			Object.defineProperty(event, 'target', {
-				value: this.ctaRef.el,
-			});
-
-			Object.defineProperty(event, 'currentTarget', {
-				value: this.ctaRef.el,
-			});
-		}
-		return event;
-	}
-
 	private clearSelection() {
 		if (this.state._disabled) {
 			return;
@@ -143,14 +126,22 @@ export class KolSingleSelect implements FocusableElement, SingleSelectAPI {
 		this._inputValue = '';
 		this._filteredOptions = [...this.state._options];
 
-		const inputEvent = this.createEventWithTarget('input', {
-			name: this.state._name as string,
-			value: emptyValue,
-		});
-		const changeEvent = this.createEventWithTarget('change', {
-			name: this.state._name as string,
-			value: emptyValue,
-		});
+		const inputEvent = createEventWithTarget<EventDetail>(
+			KolEvent.input,
+			{
+				name: this.state._name as string,
+				value: emptyValue,
+			},
+			this.ctaRef.el,
+		);
+		const changeEvent = createEventWithTarget<EventDetail>(
+			KolEvent.change,
+			{
+				name: this.state._name as string,
+				value: emptyValue,
+			},
+			this.ctaRef.el,
+		);
 
 		this.controller.onFacade.onInput(inputEvent, true, { value: emptyValue });
 		this.controller.onFacade.onChange(changeEvent, { value: emptyValue });
@@ -169,14 +160,22 @@ export class KolSingleSelect implements FocusableElement, SingleSelectAPI {
 		this._value = option.value;
 		this._inputValue = option.label as string;
 
-		const inputEvent = this.createEventWithTarget('input', {
-			name: this.state._name ?? '',
-			value: option.value,
-		});
-		const changeEvent = this.createEventWithTarget('change', {
-			name: this.state._name ?? '',
-			value: option.value,
-		});
+		const inputEvent = createEventWithTarget<EventDetail>(
+			KolEvent.input,
+			{
+				name: this.state._name ?? '',
+				value: option.value,
+			},
+			this.ctaRef.el,
+		);
+		const changeEvent = createEventWithTarget<EventDetail>(
+			KolEvent.change,
+			{
+				name: this.state._name ?? '',
+				value: option.value,
+			},
+			this.ctaRef.el,
+		);
 
 		this.controller.onFacade.onInput(inputEvent, false, option.value);
 		this.controller.onFacade.onChange(changeEvent, option.value);

--- a/packages/components/src/utils/events.ts
+++ b/packages/components/src/utils/events.ts
@@ -39,4 +39,22 @@ function dispatchDomEvent<T>(target: EventTarget, event: KolEvent, detail?: T): 
 	return target.dispatchEvent(createKoliBriEvent<T>(event, detail));
 }
 
-export { KolEvent, dispatchDomEvent };
+/**
+ * Creates a synthetic event for value changes that are not triggered by a real DOM event, e.g. clicking a
+ * clear button. The event itself is never dispatched: it is only handed to the controller's onFacade methods,
+ * which dispatch the public CustomEvent on the host themselves. Consumers receive it as the `event` argument
+ * of `_on.onInput` / `_on.onChange`, so `target` and `currentTarget` are patched to the interactive element
+ * they would expect - an undispatched event would report `null` there.
+ */
+function createEventWithTarget<T>(event: KolEvent, detail: T | null = null, target?: EventTarget | null): CustomEvent<T | null> {
+	const customEvent = createKoliBriEvent<T>(event, detail);
+
+	if (target) {
+		Object.defineProperty(customEvent, 'target', { value: target });
+		Object.defineProperty(customEvent, 'currentTarget', { value: target });
+	}
+
+	return customEvent;
+}
+
+export { KolEvent, createEventWithTarget, dispatchDomEvent };


### PR DESCRIPTION
## What changed?

The search-input clear button in `kol-input-text` (`_type="search"`) now routes the cleared value through `controller.onFacade.onInput` / `onChange` instead of only assigning `_value = ''`. A named `onClearButtonClick` handler emits the `input` / `change` events, imperatively syncs the native input value (Stencil renders asynchronously) so `getValue()` and `event.target.value` agree with the emitted value, and guards against emitting on a disabled or already-empty field. A shared helper `createEventWithTarget` was added to `utils/events.ts`; `combobox` and `single-select` were refactored to use it (behaviour there unchanged), and single-select's private copy of the helper was removed. Five new e2e tests cover the clear-button events.

## Why?

Clicking the search clear button emptied the field visually but never told the consuming application, so on the next action the app wrote its unchanged state back and the old value reappeared. The typing path and the `combobox` / `single-select` clear buttons already went through this event path — only the search clear button was missing it.

## Linked issues

No linked issues; motivation derived from the PR description and the diff.

## Type of change

- [ ] ✨ New feature
- [ ] 🔼 Improvement
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🔧 Internal (no release note needed)

## Checklist

- [x] PR title follows Conventional Commits format and states what changed and why
- [x] Linked issues are referenced
- [x] Breaking changes are documented

---

<details>
<summary>🇩🇪 Deutsche Zusammenfassung</summary>

### Was wurde geändert?

Der Clear-Button eines Such-Eingabefelds (`kol-input-text` mit `_type="search"`) leitet den geleerten Wert jetzt über `controller.onFacade.onInput` / `onChange`, statt nur `_value = ''` zu setzen. Ein benannter `onClearButtonClick`-Handler löst die `input`- / `change`-Events aus, synchronisiert den nativen Input-Wert imperativ (Stencil rendert asynchron), sodass `getValue()` und `event.target.value` zum ausgelösten Wert passen, und verhindert per Guard das Auslösen bei deaktiviertem oder bereits leerem Feld. Ein gemeinsamer Helper `createEventWithTarget` wurde in `utils/events.ts` ergänzt; `combobox` und `single-select` nutzen ihn nun (Verhalten dort unverändert), die private Kopie in single-select entfällt. Fünf neue e2e-Tests decken die Clear-Button-Events ab.

### Warum?

Der Clear-Button leerte das Feld nur visuell, ohne die konsumierende Anwendung zu benachrichtigen — beim nächsten Vorgang schrieb die Anwendung ihren alten Zustand zurück und der alte Wert erschien erneut. Der Tipp-Pfad sowie die Clear-Buttons von `combobox` und `single-select` liefen bereits über diesen Event-Pfad; nur dem Such-Clear-Button fehlte er.

### Verknüpfte Tickets

Keine verknüpften Tickets; Motivation aus der PR-Beschreibung und dem Diff abgeleitet.

### Art der Änderung

🐛 Fehlerbehebung

### Geänderte Dateien

- `packages/components/src/components/input-text/shadow.tsx` — Kernfix: neuer `onClearButtonClick`-Handler leitet den geleerten Wert über `onFacade`, synchronisiert den nativen Input und schützt gegen deaktivierte/leere Fälle.
- `packages/components/src/utils/events.ts` — neuer, exportierter Helper `createEventWithTarget` für synthetische Wertänderungs-Events mit gepatchtem `target` / `currentTarget`.
- `packages/components/src/components/input-text/input-text.clear-button.e2e.ts` — fünf neue e2e-Tests (Events/Callbacks feuern, genau einmal, `getValue()`, Clear nach Eingabe, Fokus bleibt).
- `packages/components/src/components/combobox/shadow.tsx` — Refactoring: nutzt den gemeinsamen Helper statt Inline-`CustomEvent`.
- `packages/components/src/components/single-select/shadow.tsx` — Refactoring: nutzt den gemeinsamen Helper, private Kopie entfernt.

</details>