### PR TITLE
ci(cla): match the Claude committer name in the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,7 +33,12 @@ jobs:
           remote-repository-name: '.github-private'
           # branch should not be protected
           branch: 'main'
-          allowlist: actions-user,bot*,Copilot,claude,codex,copilot-swe-agent[bot],mistral-vibe
+          # `Claude*` statt nur `claude`: die Allowlist wird case-sensitiv gegen den Commit-Autor-Namen
+          # verglichen (contributor-assistant/github-action, checkAllowList). Commits aus Claude Code
+          # tragen den Namen `Claude` bzw. `Claude Opus 5`, und ihre Adresse `noreply@anthropic.com`
+          # gehört zu keinem GitHub-Konto — der Bot kann sie also keinem Benutzer zuordnen und sie
+          # können den CLA nicht signieren. Der Eintrag `claude` traf deshalb nie zu.
+          allowlist: actions-user,bot*,Copilot,claude,Claude*,codex,copilot-swe-agent[bot],mistral-vibe
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)


### PR DESCRIPTION
Fixes the red `CLA Assistant / cla` check on #10750, and on every future pull request carrying commits from Claude Code.

## Why it fails

The bot reports **1 of 2 committers** signed: `deleonio` ✅, `@Claude` ❌, with the note "Claude seems not to be a GitHub user".

Two things combine:

1. The commits are authored as `Claude <noreply@anthropic.com>`. That address belongs to no GitHub account, so the action cannot resolve them to a user. Nobody can sign for them, and the bot's own suggestion (post the signature sentence) is not available to a non-user.
2. The allowlist is exactly the escape hatch for that case, and someone already added `claude` for it. But `contributor-assistant/github-action` compares allowlist entries against the commit author **name**, **case-sensitively** (`checkAllowList`: exact `pattern === committer`, or a `*` wildcard converted to a regex without the `i` flag). The commits are named `Claude`, so the lowercase entry never matched.

Author inventory of #10750 against `develop`:

| Author | Commits | Resolvable |
| --- | --: | --- |
| `Martin Oppitz <6279703+deleonio@users.noreply.github.com>` | 3 | yes, signed |
| `Claude <noreply@anthropic.com>` | 9 | no |
| `Claude <modevel@googlemail.com>` | 1 | no |

## The change

One allowlist entry:

```diff
-allowlist: actions-user,bot*,Copilot,claude,codex,copilot-swe-agent[bot],mistral-vibe
+allowlist: actions-user,bot*,Copilot,claude,Claude*,codex,copilot-swe-agent[bot],mistral-vibe
```

`Claude*` matches `Claude` and the model-suffixed names that appear in co-author trailers, in the same style as the existing `bot*`. The lowercase `claude` stays for a real GitHub user of that login. A comment above the line records why the case matters, so the entry is not "cleaned up" later.

## Why this has to be its own pull request

`pull_request_target` reads the workflow from the **base** branch. #10750 targets `develop`, so its check will keep using develop's copy of this file no matter what #10750 itself contains. The entry has to land on `develop` first; afterwards a `recheck` comment on #10750 re-runs the check.

## Alternative considered

Rewriting the authorship of the ten commits to a resolvable identity would also work, but it means a force-push over the head branch of an open pull request with CI in flight, and it fixes only this one case. The allowlist entry fixes the class.

## Validation

The workflow parses (`yaml.safe_load`) and the resulting `allowlist` value is the one shown above. Prettier is clean. No other input changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rf2QWBCWtXMMpTsCjLUfWG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rf2QWBCWtXMMpTsCjLUfWG)_