### PR TITLE
ci: filter visual-review workflow to prevent unnecessary runs

### DIFF
--- a/.github/workflows/visual-review.yml
+++ b/.github/workflows/visual-review.yml
@@ -15,6 +15,12 @@ on:
   workflow_run:
     workflows: ['CI-Pipeline']
     types: [completed]
+    # CI-Pipeline also runs on push to these branches; without this filter every such push would
+    # start this workflow too (it would end up skipped, but still show up as a run).
+    branches-ignore:
+      - develop
+      - main
+      - 'release/*'
   issue_comment:
     types: [created, edited, deleted]
   pull_request_target:


### PR DESCRIPTION
## Summary
Updated the visual-review workflow to filter out workflow_run triggers from certain branches, preventing unnecessary workflow executions that would ultimately be skipped.

## Key Changes
- Added `branches-ignore` filter to the `workflow_run` trigger in the visual-review workflow
- Configured the filter to ignore pushes to `develop`, `main`, and `release/*` branches
- Added explanatory comment clarifying that this prevents redundant workflow runs that would show up in the UI despite being skipped

## Details
The CI-Pipeline workflow runs on pushes to develop, main, and release branches. Without this filter, the visual-review workflow would be triggered on every such push via the `workflow_run` event, creating unnecessary run entries in the GitHub Actions UI even though they would be skipped. This change reduces noise in the workflow runs history while maintaining the intended visual review functionality for other branches.

https://claude.ai/code/session_01TvT7fy2GyedUH3Hb9wvWtZ